### PR TITLE
Pluggable-task-scheduler

### DIFF
--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -8,7 +8,9 @@
 import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
 import { TaskInput, Task, TaskOutput, TaskStatus } from "../task/Task";
 import { TaskGraph } from "./TaskGraph";
+import { DependencyBasedScheduler, TopologicalScheduler } from "./TaskGraphScheduler";
 import { nanoid } from "nanoid";
+import { CompoundTask } from "../task/CompoundTask";
 
 /**
  * Class for running a task graph
@@ -16,63 +18,28 @@ import { nanoid } from "nanoid";
  */
 export class TaskGraphRunner {
   /**
-   * Map of layers, where each layer contains an array of tasks
-   * @type {Map<number, Task[]>}
-   */
-  public layers: Map<number, Task[]>;
-
-  /**
    * Map of provenance input for each task
    * @type {Map<unknown, TaskInput>}
    */
   public provenanceInput: Map<unknown, TaskInput>;
 
+  private running = false;
+  private aborting = false;
+
   /**
    * Constructor for TaskGraphRunner
    * @param dag The task graph to run
    * @param repository The task output repository to use for caching task outputs
+   * @param processScheduler The scheduler to use for task execution
+   * @param reactiveScheduler The scheduler to use for reactive task execution
    */
   constructor(
     public dag: TaskGraph,
-    public repository?: TaskOutputRepository
+    public repository?: TaskOutputRepository,
+    public processScheduler = new DependencyBasedScheduler(dag),
+    public reactiveScheduler = new TopologicalScheduler(dag)
   ) {
-    this.layers = new Map();
     this.provenanceInput = new Map();
-  }
-
-  /**
-   * Assigns layers to tasks based on their dependencies. Each layer is a set of tasks
-   * that can be run in parallel as a set, the next layer is run after the previous layer has completed.
-   * @param sortedNodes The topologically sorted list of tasks
-   */
-  public assignLayers(sortedNodes: Task[]) {
-    this.layers = new Map();
-    const nodeToLayer = new Map<unknown, number>();
-
-    sortedNodes.forEach((node, _index) => {
-      let maxLayer = -1;
-
-      // Get all incoming edges (dependencies) of the node
-      const incomingEdges = this.dag.inEdges(node.config.id).map(([from]) => from);
-
-      incomingEdges.forEach((from) => {
-        // Find the layer of the dependency
-        const layer = nodeToLayer.get(from);
-        if (layer !== undefined) {
-          maxLayer = Math.max(maxLayer, layer);
-        }
-      });
-
-      // Assign the node to the next layer after the maximum layer of its dependencies
-      const assignedLayer = maxLayer + 1;
-      nodeToLayer.set(node.config.id, assignedLayer);
-
-      if (!this.layers.has(assignedLayer)) {
-        this.layers.set(assignedLayer, []);
-      }
-
-      this.layers.get(assignedLayer)?.push(node);
-    });
   }
 
   private copyInputFromEdgesToNode(node: Task) {
@@ -159,64 +126,86 @@ export class TaskGraphRunner {
     return results;
   }
 
-  private running = false;
-
   /**
    * Runs the task graph
    * @param parentProvenance The provenance input for the task graph
-   * @returns The output of the task graph
+   * @returns A promise that resolves when all tasks are complete
    */
   public async runGraph(parentProvenance: TaskInput = {}) {
+    if (this.running) {
+      throw new Error("Graph is already running");
+    }
+
+    this.running = true;
     this.aborting = false;
+    this.resetGraph(this.dag);
+    this.processScheduler.reset();
+
+    const inProgressTasks = new Map<unknown, Promise<TaskOutput>>();
+    const results: TaskOutput[] = [];
+
+    try {
+      for await (const task of this.processScheduler.tasks()) {
+        if (this.aborting) break;
+
+        // Start task execution without awaiting
+        const taskPromise = this.runTaskWithProvenance(task, parentProvenance);
+        inProgressTasks.set(task.config.id, taskPromise);
+
+        // Set up completion handler
+        taskPromise.then(
+          (taskResult) => {
+            this.processScheduler.onTaskCompleted(task.config.id);
+            inProgressTasks.delete(task.config.id);
+            if (this.dag.getTargetDataFlows(task.config.id).length === 0) {
+              results.push(taskResult);
+            }
+          },
+          async (error) => {
+            await this.abort();
+            throw error;
+          }
+        );
+      }
+
+      // Wait for all tasks to complete
+      await Promise.all(Array.from(inProgressTasks.values()));
+
+      if (this.aborting) {
+        throw new Error("Graph execution was aborted");
+      }
+    } catch (error) {
+      await this.abort();
+      throw error;
+    } finally {
+      this.running = false;
+    }
+    return results;
+  }
+
+  /**
+   * Resets the task graph, recursively
+   * @param dag The task graph to reset
+   */
+  private resetGraph(dag: TaskGraph) {
     const taskRunId = nanoid();
-    this.dag.getNodes().forEach((node) => {
+    dag.getNodes().forEach((node) => {
       if (node.config) {
         // @ts-ignore
         node.config.currentJobRunId = taskRunId;
       }
       node.status = TaskStatus.PENDING;
       node.resetInputData();
-    });
-    this.running = true;
-    this.provenanceInput = new Map();
-    const sortedNodes = this.dag.topologicallySortedNodes();
-    this.assignLayers(sortedNodes);
-
-    let results: TaskOutput[] = [];
-    for (const [layerNumber, nodes] of this.layers.entries()) {
-      if (!this.running) {
-        throw new Error("Task graph runner stopped unexpectedly");
-      }
-      if (this.aborting) {
-        nodes.forEach((node) => {});
-      } else {
-        const settledResults = await Promise.allSettled(
-          nodes.map((node) =>
-            this.runTaskWithProvenance(node, layerNumber === 0 ? parentProvenance : {})
-          )
-        );
-
-        for (const result of settledResults) {
-          if (result.status === "rejected") {
-            // Abort tasks that support aborting by calling their abort method
-            await this.abort();
-            throw new Error(
-              `Task graph aborted due to error in layer ${layerNumber}: ${result.reason}`
-            );
-          }
+      node.runOutputData = {};
+      if (node.isCompound) {
+        const subGraph = (node as CompoundTask).subGraph;
+        if (subGraph) {
+          this.resetGraph(subGraph);
         }
-
-        results = settledResults
-          .filter((r): r is PromiseFulfilledResult<TaskOutput> => r.status === "fulfilled") //ts
-          .map((r) => r.value);
       }
-    }
-    this.running = false;
-    this.aborting = false;
-    return results;
+    });
   }
 
-  private aborting = false;
   /**
    * Aborts the task graph
    */
@@ -237,32 +226,40 @@ export class TaskGraphRunner {
 
   /**
    * Runs the task graph in a reactive manner
-   * @returns The output of the task graph
-   */
-  private async runTasksReactive() {
-    let results: TaskOutput[] = [];
-    for (const [_layerNumber, nodes] of this.layers.entries()) {
-      const settledResults = await Promise.allSettled(
-        nodes.map(async (node) => {
-          this.copyInputFromEdgesToNode(node);
-          const results = await node.runReactive();
-          this.pushOutputFromNodeToEdges(node, results);
-          return results;
-        })
-      );
-      results = settledResults.map((r) => (r.status === "fulfilled" ? r.value : {}));
-    }
-    return results;
-  }
-
-  /**
-   * Runs the task graph in a reactive manner
-   * @returns The output of the task graph
+   * @returns A promise that resolves when all tasks are complete
    */
   public async runGraphReactive() {
-    this.dag.getNodes().forEach((node) => node.resetInputData());
-    const sortedNodes = this.dag.topologicallySortedNodes();
-    this.assignLayers(sortedNodes);
-    return await this.runTasksReactive();
+    if (this.running) {
+      throw new Error("Graph is already running");
+    }
+
+    this.running = true;
+    this.aborting = false;
+    this.resetGraph(this.dag);
+    this.reactiveScheduler.reset();
+
+    const results: TaskOutput[] = [];
+
+    try {
+      for await (const task of this.reactiveScheduler.tasks()) {
+        if (this.aborting) break;
+        this.copyInputFromEdgesToNode(task);
+        const taskResult = await task.runReactive();
+        this.pushOutputFromNodeToEdges(task, taskResult);
+        if (this.dag.getTargetDataFlows(task.config.id).length === 0) {
+          results.push(taskResult);
+        }
+      }
+
+      if (this.aborting) {
+        throw new Error("Graph execution was aborted");
+      }
+    } catch (error) {
+      await this.abort();
+      throw error;
+    } finally {
+      this.running = false;
+    }
+    return results;
   }
 }

--- a/packages/task-graph/src/task-graph/TaskGraphScheduler.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphScheduler.ts
@@ -1,0 +1,133 @@
+//    *******************************************************************************
+//    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import { Task } from "../task/Task";
+import { TaskGraph } from "./TaskGraph";
+
+/**
+ * Interface for task graph schedulers
+ */
+export interface ITaskGraphScheduler {
+  /**
+   * Gets an async iterator of tasks that can be executed
+   * @returns AsyncIterator of tasks that resolves to each task when it's ready
+   */
+  tasks(): AsyncIterableIterator<Task>;
+
+  /**
+   * Notifies the scheduler that a task has completed
+   * @param taskId The ID of the completed task
+   */
+  onTaskCompleted(taskId: unknown): void;
+
+  /**
+   * Resets the scheduler state
+   */
+  reset(): void;
+}
+
+/**
+ * Sequential scheduler that executes one task at a time in topological order
+ * Useful for debugging and understanding task execution flow
+ */
+export class TopologicalScheduler implements ITaskGraphScheduler {
+  private sortedNodes: Task[];
+  private currentIndex: number;
+
+  constructor(private dag: TaskGraph) {
+    this.sortedNodes = [];
+    this.currentIndex = 0;
+    this.reset();
+  }
+
+  async *tasks(): AsyncIterableIterator<Task> {
+    while (this.currentIndex < this.sortedNodes.length) {
+      yield this.sortedNodes[this.currentIndex++];
+    }
+  }
+
+  onTaskCompleted(taskId: unknown): void {
+    // Topological scheduler doesn't need to track individual task completion
+  }
+
+  reset(): void {
+    this.sortedNodes = this.dag.topologicallySortedNodes();
+    this.currentIndex = 0;
+  }
+}
+
+/**
+ * Event-driven scheduler that executes tasks as soon as their dependencies are satisfied
+ * Most efficient for parallel execution but requires completion notifications
+ */
+export class DependencyBasedScheduler implements ITaskGraphScheduler {
+  private completedTasks: Set<unknown>;
+  private pendingTasks: Set<Task>;
+  private nextResolver: ((task: Task | null) => void) | null = null;
+
+  constructor(private dag: TaskGraph) {
+    this.completedTasks = new Set();
+    this.pendingTasks = new Set();
+    this.reset();
+  }
+
+  private isTaskReady(task: Task): boolean {
+    const dependencies = this.dag.inEdges(task.config.id).map(([from]) => from);
+    return dependencies.every((dep) => this.completedTasks.has(dep));
+  }
+
+  private async waitForNextTask(): Promise<Task | null> {
+    if (this.pendingTasks.size === 0) return null;
+
+    const readyTask = Array.from(this.pendingTasks).find((task) => this.isTaskReady(task));
+    if (readyTask) {
+      this.pendingTasks.delete(readyTask);
+      return readyTask;
+    }
+
+    // If there are pending tasks but none are ready, wait for task completion
+    if (this.pendingTasks.size > 0) {
+      return new Promise((resolve) => {
+        this.nextResolver = resolve;
+      });
+    }
+
+    return null;
+  }
+
+  async *tasks(): AsyncIterableIterator<Task> {
+    while (this.pendingTasks.size > 0) {
+      const task = await this.waitForNextTask();
+      if (task) {
+        yield task;
+      } else {
+        break;
+      }
+    }
+  }
+
+  onTaskCompleted(taskId: unknown): void {
+    this.completedTasks.add(taskId);
+
+    // Check if any pending tasks are now ready
+    if (this.nextResolver) {
+      const readyTask = Array.from(this.pendingTasks).find((task) => this.isTaskReady(task));
+      if (readyTask) {
+        this.pendingTasks.delete(readyTask);
+        const resolver = this.nextResolver;
+        this.nextResolver = null;
+        resolver(readyTask);
+      }
+    }
+  }
+
+  reset(): void {
+    this.completedTasks.clear();
+    this.pendingTasks = new Set(this.dag.topologicallySortedNodes());
+    this.nextResolver = null;
+  }
+}

--- a/packages/task-graph/src/task-graph/test/TaskSubGraphRunner.test.ts
+++ b/packages/task-graph/src/task-graph/test/TaskSubGraphRunner.test.ts
@@ -137,9 +137,8 @@ describe("TaskGraphRunner", () => {
       const nodeRunSpy = spyOn(nodes[0], "run");
 
       const results = await runner.runGraph();
-
       expect(nodeRunSpy).toHaveBeenCalledTimes(1);
-      expect(results[0]).toEqual({ output: [36, 49] });
+      expect(results[2]).toEqual({ output: [36, 49] });
     });
 
     it("array input into ArrayTask", async () => {
@@ -149,15 +148,19 @@ describe("TaskGraphRunner", () => {
       graph.addDataFlow(new DataFlow("task3", "output", "task4", "input"));
 
       const nodeRunSpy = spyOn(task, "run");
-      const assignLayersSpy = spyOn(runner, "assignLayers");
 
-      await runner.runGraph();
-      await runner.runGraph();
-      const results = await runner.runGraph();
+      const results1 = await runner.runGraph();
+      const results2 = await runner.runGraph();
+      const results3 = await runner.runGraph();
 
-      expect(assignLayersSpy).toHaveBeenCalled();
       expect(nodeRunSpy).toHaveBeenCalledTimes(3);
-      expect(results[0].output).toEqual([625, 100]);
+      // different runs should return the same results
+      expect(results1[0]).toEqual(results2[0]);
+      expect(results2[0]).toEqual(results3[0]);
+      expect(results1[1]).toEqual(results2[1]);
+      expect(results2[1]).toEqual(results3[1]);
+      expect(results1[2]).toEqual(results2[2]);
+      expect(results2[2]).toEqual(results3[2]);
     });
   });
 });


### PR DESCRIPTION
- Pluggable scheduler for tasks
- Current scheduler is based on layers, easier to reason about and debug, and is good when the graph ui is based on columns (each column will finish before starting the next column)
- Another scheduler that simply does one task at a time in topological order (for debugging use cases mostly)
- New scheduler based solely on dependency graph and completion states as they happen. This means that the scheduler must receive events of completion etc which the layer system does not require as the runner deals with it
- the runner needs to pull tasks as fast as possible and not await before starting the next (rely on scheduler to withhold until ready)