### PR TITLE
refactor: Separate task type definitions and improve task interfaces

### DIFF
--- a/packages/task-graph/src/browser.ts
+++ b/packages/task-graph/src/browser.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-export * from "./task/Task";
+export * from "./task/TaskTypes";
 export * from "./task/TaskBase";
 export * from "./task/SingleTask";
 export * from "./task/CompoundTask";

--- a/packages/task-graph/src/bun.ts
+++ b/packages/task-graph/src/bun.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-export * from "./task/Task";
+export * from "./task/TaskTypes";
 export * from "./task/TaskBase";
 export * from "./task/SingleTask";
 export * from "./task/CompoundTask";

--- a/packages/task-graph/src/node.ts
+++ b/packages/task-graph/src/node.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-export * from "./task/Task";
+export * from "./task/TaskTypes";
 export * from "./task/TaskBase";
 export * from "./task/SingleTask";
 export * from "./task/CompoundTask";

--- a/packages/task-graph/src/storage/taskgraph/test/FileTaskGraphRepository.test.ts
+++ b/packages/task-graph/src/storage/taskgraph/test/FileTaskGraphRepository.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 import { rmdirSync } from "fs";
 import { FileTaskGraphRepository } from "../FileTaskGraphRepository";
-import { TaskOutput } from "../../../task/Task";
+import { TaskOutput } from "../../../task/TaskTypes";
 import { SingleTask } from "../../../task/SingleTask";
 import { TaskRegistry } from "../../../task/TaskRegistry";
 import { DataFlow } from "../../../task-graph/DataFlow";

--- a/packages/task-graph/src/storage/taskgraph/test/genericTaskGraphRepositoryTests.ts
+++ b/packages/task-graph/src/storage/taskgraph/test/genericTaskGraphRepositoryTests.ts
@@ -10,7 +10,7 @@ import { TaskGraphRepository } from "../TaskGraphRepository";
 import { DataFlow } from "../../../task-graph/DataFlow";
 import { TaskGraph } from "../../../task-graph/TaskGraph";
 import { TaskRegistry } from "../../../task/TaskRegistry";
-import { TaskOutput } from "../../../task/Task";
+import { TaskOutput } from "../../../task/TaskTypes";
 import { SingleTask } from "../../../task/SingleTask";
 
 class TestTask extends SingleTask {

--- a/packages/task-graph/src/storage/taskoutput/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/taskoutput/TaskOutputRepository.ts
@@ -8,7 +8,7 @@
 import { EventEmitter, EventParameters } from "@ellmers/util";
 import { DefaultValueType, type KVRepository } from "@ellmers/storage";
 import { makeFingerprint } from "@ellmers/util";
-import { TaskInput, TaskOutput } from "../../task/Task";
+import { TaskInput, TaskOutput } from "../../task/TaskTypes";
 
 export type TaskOutputEventListeners = {
   output_saved: (taskType: string) => void;

--- a/packages/task-graph/src/storage/taskoutput/test/FileTaskOutputRepository.test.ts
+++ b/packages/task-graph/src/storage/taskoutput/test/FileTaskOutputRepository.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, beforeEach } from "bun:test";
 import { FileTaskOutputRepository } from "../FileTaskOutputRepository";
-import { TaskInput, TaskOutput } from "../../../task/Task";
+import { TaskInput, TaskOutput } from "../../../task/TaskTypes";
 import { rmdirSync } from "node:fs";
 
 describe("FileTaskOutputRepository", () => {

--- a/packages/task-graph/src/storage/taskoutput/test/genericTaskOutputRepositoryTests.ts
+++ b/packages/task-graph/src/storage/taskoutput/test/genericTaskOutputRepositoryTests.ts
@@ -7,7 +7,7 @@
 
 import { expect, it, beforeEach } from "bun:test";
 import { TaskOutputRepository } from "../TaskOutputRepository";
-import { TaskInput, TaskOutput } from "../../../task/Task";
+import { TaskInput, TaskOutput } from "../../../task/TaskTypes";
 
 export function runGenericTaskOutputRepositoryTests(
   createRepository: () => Promise<TaskOutputRepository>

--- a/packages/task-graph/src/task-graph/DataFlow.ts
+++ b/packages/task-graph/src/task-graph/DataFlow.ts
@@ -1,5 +1,3 @@
-import { TaskInput, TaskOutput } from "../task/Task";
-
 //    *******************************************************************************
 //    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
 //    *                                                                             *
@@ -7,7 +5,7 @@ import { TaskInput, TaskOutput } from "../task/Task";
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import { TaskIdType } from "../task/Task";
+import { TaskIdType, TaskInput, TaskOutput } from "../task/TaskTypes";
 
 export type DataFlowIdType = string;
 

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { DirectedAcyclicGraph } from "@sroussey/typescript-graph";
-import { Task, TaskIdType, TaskInput, JsonTaskItem, TaskStream } from "../task/Task";
+import { Task, TaskIdType, TaskInput, JsonTaskItem } from "../task/TaskTypes";
 import { DataFlow, DataFlowIdType, DataFlowJson } from "./DataFlow";
 
 /**
@@ -195,16 +195,12 @@ export class TaskGraph extends DirectedAcyclicGraph<Task, DataFlow, TaskIdType, 
 /**
  * Super simple helper if you know the input and output handles, and there is only one each
  *
- * @param tasks TaskStream
+ * @param tasks Task[]
  * @param inputHandle  TaskIdType
  * @param outputHandle TaskIdType
  * @returns
  */
-function serialGraphEdges(
-  tasks: TaskStream,
-  inputHandle: string,
-  outputHandle: string
-): DataFlow[] {
+function serialGraphEdges(tasks: Task[], inputHandle: string, outputHandle: string): DataFlow[] {
   const edges: DataFlow[] = [];
   for (let i = 0; i < tasks.length - 1; i++) {
     edges.push(new DataFlow(tasks[i].config.id, inputHandle, tasks[i + 1].config.id, outputHandle));
@@ -215,16 +211,12 @@ function serialGraphEdges(
 /**
  * Super simple helper if you know the input and output handles, and there is only one each
  *
- * @param tasks TaskStream
+ * @param tasks Task[]
  * @param inputHandle  TaskIdType
  * @param outputHandle TaskIdType
  * @returns
  */
-export function serialGraph(
-  tasks: TaskStream,
-  inputHandle: string,
-  outputHandle: string
-): TaskGraph {
+export function serialGraph(tasks: Task[], inputHandle: string, outputHandle: string): TaskGraph {
   const graph = new TaskGraph();
   graph.addTasks(tasks);
   graph.addDataFlows(serialGraphEdges(tasks, inputHandle, outputHandle));

--- a/packages/task-graph/src/task-graph/TaskGraphBuilder.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphBuilder.ts
@@ -15,7 +15,7 @@ import {
   type TaskInput,
   type TaskInputDefinition,
   type TaskOutputDefinition,
-} from "../task/Task";
+} from "../task/TaskTypes";
 import { TaskBase } from "../task/TaskBase";
 import { DataFlow } from "./DataFlow";
 import { TaskGraph, TaskGraphJson } from "./TaskGraph";

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
-import { TaskInput, Task, TaskOutput, TaskStatus } from "../task/Task";
+import { TaskInput, Task, TaskOutput, TaskStatus } from "../task/TaskTypes";
 import { TaskGraph } from "./TaskGraph";
 import { DependencyBasedScheduler, TopologicalScheduler } from "./TaskGraphScheduler";
 import { nanoid } from "nanoid";

--- a/packages/task-graph/src/task-graph/TaskGraphScheduler.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphScheduler.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import { Task } from "../task/Task";
+import { Task } from "../task/TaskTypes";
 import { TaskGraph } from "./TaskGraph";
 
 /**

--- a/packages/task-graph/src/task-graph/test/TaskGraph.test.ts
+++ b/packages/task-graph/src/task-graph/test/TaskGraph.test.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { describe, expect, it, beforeEach } from "bun:test";
-import { Task, TaskOutput } from "../../task/Task";
+import { Task, TaskOutput } from "../../task/TaskTypes";
 import { SingleTask } from "../../task/SingleTask";
 import { DataFlow } from "../../task-graph/DataFlow";
 import { TaskGraph, serialGraph } from "../../task-graph/TaskGraph";

--- a/packages/task-graph/src/task-graph/test/TaskGraphRunner.test.ts
+++ b/packages/task-graph/src/task-graph/test/TaskGraphRunner.test.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { describe, expect, it, beforeEach, spyOn } from "bun:test";
-import { Task, TaskOutput } from "../../task/Task";
+import { Task, TaskOutput } from "../../task/TaskTypes";
 import { SingleTask } from "../../task/SingleTask";
 import { DataFlow } from "../DataFlow";
 import { TaskGraph } from "../TaskGraph";
@@ -147,7 +147,7 @@ describe("TaskGraphRunner", () => {
   describe("runGraph", () => {
     it("should run the graph in the correct order", async () => {
       const results = await runner.runGraph();
-
+      console.log(results);
       expect(results[1].output).toEqual(25);
       expect(results[2].output).toEqual(10);
     });

--- a/packages/task-graph/src/task-graph/test/TaskSubGraphRunner.test.ts
+++ b/packages/task-graph/src/task-graph/test/TaskSubGraphRunner.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, beforeEach, spyOn } from "bun:test";
 import { TaskGraphRunner } from "../../task-graph/TaskGraphRunner";
-import { Task } from "../../task/Task";
+import { Task } from "../../task/TaskTypes";
 import { SingleTask } from "../../task/SingleTask";
 import { DataFlow } from "../../task-graph/DataFlow";
 import { TaskGraph } from "../../task-graph/TaskGraph";

--- a/packages/task-graph/src/task/ArrayTask.ts
+++ b/packages/task-graph/src/task/ArrayTask.ts
@@ -14,7 +14,7 @@ import {
   TaskInputDefinition,
   TaskOutputDefinition,
   JsonTaskItem,
-} from "./Task";
+} from "./TaskTypes";
 import { SingleTask } from "./SingleTask";
 import { CompoundTask, RegenerativeCompoundTask } from "./CompoundTask";
 import { TaskRegistry } from "./TaskRegistry";

--- a/packages/task-graph/src/task/CompoundTask.ts
+++ b/packages/task-graph/src/task/CompoundTask.ts
@@ -24,6 +24,8 @@ import { TaskBase } from "./TaskBase";
  */
 export class CompoundTask extends TaskBase implements ICompoundTask {
   static readonly type: TaskTypeName = "CompoundTask";
+  static readonly category: string = "Hidden";
+  static readonly sideeffects: boolean = false;
 
   declare runOutputData: TaskOutput;
   readonly isCompound = true;

--- a/packages/task-graph/src/task/CompoundTask.ts
+++ b/packages/task-graph/src/task/CompoundTask.ts
@@ -8,26 +8,28 @@
 import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
 import { TaskGraph, type TaskGraphItemJson } from "../task-graph/TaskGraph";
 import { TaskGraphRunner } from "../task-graph/TaskGraphRunner";
+import type { ICompoundTask } from "./ITask";
 import {
-  type ITaskCompound,
   type TaskTypeName,
   type TaskOutput,
   type TaskInput,
   TaskStatus,
   type JsonTaskItem,
-} from "./Task";
+} from "./TaskTypes";
 import { TaskBase } from "./TaskBase";
 
 /**
- * Represents a compound task, which is a task that contains other tasks
+ * Represents a compound task, which is a task that contains other tasks.
+ * This is the base class for all compound tasks that manage subtasks.
  */
-
-export class CompoundTask extends TaskBase implements ITaskCompound {
+export class CompoundTask extends TaskBase implements ICompoundTask {
   static readonly type: TaskTypeName = "CompoundTask";
 
   declare runOutputData: TaskOutput;
   readonly isCompound = true;
-  _subGraph: TaskGraph | null = null;
+
+  public _subGraph: TaskGraph | null = null;
+
   /**
    * Sets the subtask graph for the compound task
    * @param subGraph The subtask graph to set

--- a/packages/task-graph/src/task/CompoundTask.ts
+++ b/packages/task-graph/src/task/CompoundTask.ts
@@ -99,11 +99,12 @@ export class CompoundTask extends TaskBase implements ICompoundTask {
     return this.runOutputData;
   }
 
-  async abort() {
-    super.abort();
-    this.subGraph.getNodes().forEach((node) => {
-      node.abort();
-    });
+  /**
+   * Aborts the compound task and all its subtasks
+   */
+  public async abort(): Promise<void> {
+    await super.abort();
+    await Promise.all(this.subGraph.getNodes().map((node) => node.abort()));
   }
 
   /**

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -1,0 +1,85 @@
+import type { EventEmitter } from "@ellmers/util";
+import type { TaskGraph } from "../task-graph/TaskGraph";
+import type {
+  TaskStatus,
+  TaskTypeName,
+  TaskInput,
+  TaskOutput,
+  TaskConfig,
+  TaskInputDefinition,
+  TaskOutputDefinition,
+  TaskEventListeners,
+  TaskEvents,
+  TaskEventListener,
+  TaskEventParameters,
+  JsonTaskItem,
+} from "./TaskTypes";
+
+/**
+ * Core interface that all tasks must implement
+ */
+export interface ITask {
+  // Static properties that should be implemented
+  readonly type: TaskTypeName;
+  readonly category: string;
+  readonly sideeffects: boolean;
+
+  // Instance properties
+  readonly isCompound: boolean;
+  readonly config: TaskConfig;
+  status: TaskStatus;
+  progress: number;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  error?: string;
+
+  // Input/Output definitions
+  readonly inputs: TaskInputDefinition[];
+  readonly outputs: TaskOutputDefinition[];
+
+  // Runtime data
+  defaults: TaskInput;
+  runInputData: TaskInput;
+  runOutputData: TaskOutput;
+
+  // Event handling
+  readonly events: EventEmitter<TaskEventListeners>;
+  on<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void;
+  off<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void;
+  once<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void;
+  emitted<Event extends TaskEvents>(name: Event): Promise<TaskEventParameters<Event>>;
+  emit<Event extends TaskEvents>(name: Event, ...args: TaskEventParameters<Event>): void;
+
+  // Core task methods
+  run(): Promise<TaskOutput>;
+  runReactive(): Promise<TaskOutput>;
+  abort(): Promise<void>;
+
+  handleStart(): void;
+  handleComplete(): void;
+  handleError(err: any): void;
+  getProvenance(): TaskInput;
+  resetInputData(): void;
+  addInputData<T extends TaskInput>(overrides: Partial<T> | undefined): ITask;
+  validateItem(valueType: string, item: any): Promise<boolean>;
+  validateInputItem(input: Partial<TaskInput>, inputId: keyof TaskInput): Promise<boolean>;
+  validateInputData(input: Partial<TaskInput>): Promise<boolean>;
+  toJSON(): JsonTaskItem;
+  toDependencyJSON(): JsonTaskItem;
+}
+
+/**
+ * Interface for tasks that can contain subtasks
+ */
+export interface ICompoundTask extends ITask {
+  readonly isCompound: true;
+  readonly subGraph: TaskGraph;
+}
+
+/**
+ * Interface for simple tasks without subtasks
+ */
+export interface ISimpleTask extends ITask {
+  readonly isCompound: false;
+}

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -19,11 +19,6 @@ import type {
  * Core interface that all tasks must implement
  */
 export interface ITask {
-  // Static properties that should be implemented
-  readonly type: TaskTypeName;
-  readonly category: string;
-  readonly sideeffects: boolean;
-
   // Instance properties
   readonly isCompound: boolean;
   readonly config: TaskConfig;

--- a/packages/task-graph/src/task/JobQueueTask.ts
+++ b/packages/task-graph/src/task/JobQueueTask.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { getTaskQueueRegistry } from "./TaskQueueRegistry";
-import { TaskConfig, TaskOutput, TaskEventListeners, TaskStatus } from "./Task";
+import { TaskConfig, TaskOutput, TaskEventListeners, TaskStatus } from "./TaskTypes";
 import { SingleTask } from "./SingleTask";
 import { EventEmitter } from "@ellmers/util";
 

--- a/packages/task-graph/src/task/JobQueueTask.ts
+++ b/packages/task-graph/src/task/JobQueueTask.ts
@@ -46,14 +46,13 @@ export abstract class JobQueueTask extends SingleTask {
   }
 
   async run(): Promise<TaskOutput> {
-    if (this.status === TaskStatus.ABORTING) {
-      throw new Error("Task aborted by run time");
-    }
-
     this.handleStart();
-    this.runOutputData = {};
 
     try {
+      if (this.status === TaskStatus.ABORTING) {
+        throw new Error("Task aborted by run time");
+      }
+
       if (!(await this.validateInputData(this.runInputData))) {
         throw new Error("Invalid input data");
       }

--- a/packages/task-graph/src/task/OutputTask.ts
+++ b/packages/task-graph/src/task/OutputTask.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import { TaskInput } from "./Task";
+import { TaskInput } from "./TaskTypes";
 import { SingleTask } from "./SingleTask";
 
 /**

--- a/packages/task-graph/src/task/SingleTask.ts
+++ b/packages/task-graph/src/task/SingleTask.ts
@@ -5,14 +5,15 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import type { ITaskSimple, TaskTypeName } from "./Task";
+import type { ISimpleTask } from "./ITask";
+import type { TaskOutput, TaskTypeName } from "./TaskTypes";
 import { TaskBase } from "./TaskBase";
 
 /**
- * Represents a single task, which is a basic unit of work in the task graph
+ * Represents a single task, which is a basic unit of work in the task graph.
+ * This is the base class for all simple (non-compound) tasks.
  */
-
-export class SingleTask extends TaskBase implements ITaskSimple {
+export class SingleTask extends TaskBase implements ISimpleTask {
   static readonly type: TaskTypeName = "SingleTask";
   readonly isCompound = false;
 }

--- a/packages/task-graph/src/task/TaskBase.ts
+++ b/packages/task-graph/src/task/TaskBase.ts
@@ -7,13 +7,13 @@
 
 import { EventEmitter } from "@ellmers/util";
 import { nanoid } from "nanoid";
+import type { ITask } from "./ITask";
 import {
   TaskStatus,
   type TaskTypeName,
   type TaskInputDefinition,
   type TaskOutputDefinition,
   type TaskEvents,
-  type IConfig,
   type TaskConfig,
   type TaskInput,
   type TaskOutput,
@@ -21,7 +21,7 @@ import {
   type TaskEventListener,
   type TaskEventParameters,
   type TaskEventListeners,
-} from "./Task";
+} from "./TaskTypes";
 
 /**
  * Base class for all tasks

--- a/packages/task-graph/src/task/TaskBase.ts
+++ b/packages/task-graph/src/task/TaskBase.ts
@@ -25,46 +25,21 @@ import {
 } from "./TaskTypes";
 
 /**
- * Base class for all tasks
+ * Base class for all tasks that implements the ITask interface
  */
-
-export abstract class TaskBase {
-  // information about the task that should be overriden by the subclasses
+export abstract class TaskBase implements ITask {
+  // Static properties that should be overridden by subclasses
   static readonly type: TaskTypeName = "TaskBase";
   static readonly category: string = "Hidden";
   static readonly sideeffects: boolean = false;
 
-  get inputs(): TaskInputDefinition[] {
-    return ((this.constructor as typeof TaskBase).inputs as TaskInputDefinition[]) ?? [];
-  }
-  get outputs(): TaskOutputDefinition[] {
-    return ((this.constructor as typeof TaskBase).outputs as TaskOutputDefinition[]) ?? [];
-  }
+  // Instance properties from static
+  // readonly type: TaskTypeName = (this.constructor as typeof TaskBase).type;
+  // readonly category: string = (this.constructor as typeof TaskBase).category;
+  // readonly sideeffects: boolean = (this.constructor as typeof TaskBase).sideeffects;
 
-  public events = new EventEmitter<TaskEventListeners>();
-  public on<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>) {
-    this.events.on(name, fn);
-  }
-  public off<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>) {
-    this.events.off(name, fn);
-  }
-  public once<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>) {
-    this.events.once(name, fn);
-  }
-  public emitted<Event extends TaskEvents>(name: Event) {
-    return this.events.emitted(name) as Promise<TaskEventParameters<Event>>;
-  }
-  public emit<Event extends TaskEvents>(name: Event, ...args: TaskEventParameters<Event>) {
-    this.events.emit(name, ...args);
-  }
-
-  /**
-   * Does this task have subtasks?
-   */
+  // Instance properties
   abstract readonly isCompound: boolean;
-  /**
-   * Configuration for the task, might include things like name and id for the database
-   */
   config: IConfig;
   status: TaskStatus = TaskStatus.PENDING;
   progress: number = 0;
@@ -73,8 +48,11 @@ export abstract class TaskBase {
   completedAt?: Date;
   error?: string;
 
+  // Event handling
+  public readonly events = new EventEmitter<TaskEventListeners>();
+
   constructor(config: TaskConfig = {}) {
-    // pull out input data from the config
+    // Extract input data from config
     const { input = {}, ...rest } = config;
     const inputDefaults = this.inputs.reduce<Record<string, any>>((acc, cur) => {
       if (cur.defaultValue !== undefined) {
@@ -85,7 +63,7 @@ export abstract class TaskBase {
     this.defaults = Object.assign(inputDefaults, input);
     this.resetInputData();
 
-    // setup the configuration
+    // Setup configuration
     const name = new.target.type || new.target.name;
     this.config = Object.assign(
       {
@@ -94,31 +72,43 @@ export abstract class TaskBase {
       },
       rest
     );
-    Object.defineProperty(this, "events", { enumerable: false }); // in case it is serialized
+    Object.defineProperty(this, "events", { enumerable: false }); // Prevent serialization
   }
 
-  public handleStart() {
-    this.startedAt = new Date();
-    this.progress = 0;
-    this.status = TaskStatus.PROCESSING;
-    this.events.emit("start");
+  // Input/Output definitions
+  public static inputs: readonly TaskInputDefinition[];
+  public static outputs: readonly TaskOutputDefinition[];
+
+  get inputs(): TaskInputDefinition[] {
+    return ((this.constructor as typeof TaskBase).inputs as TaskInputDefinition[]) ?? [];
   }
 
-  public handleComplete() {
-    this.completedAt = new Date();
-    this.progress = 100;
-    this.status = TaskStatus.COMPLETED;
-    this.events.emit("complete");
+  get outputs(): TaskOutputDefinition[] {
+    return ((this.constructor as typeof TaskBase).outputs as TaskOutputDefinition[]) ?? [];
   }
 
-  public handleError(err: any) {
-    this.completedAt = new Date();
-    this.progress = 100;
-    this.status = TaskStatus.FAILED;
-    this.error = err?.message || "Task failed";
-    this.events.emit("error", this.error!);
+  // Event handling methods
+  public on<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void {
+    this.events.on(name, fn);
   }
 
+  public off<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void {
+    this.events.off(name, fn);
+  }
+
+  public once<Event extends TaskEvents>(name: Event, fn: TaskEventListener<Event>): void {
+    this.events.once(name, fn);
+  }
+
+  public emitted<Event extends TaskEvents>(name: Event): Promise<TaskEventParameters<Event>> {
+    return this.events.emitted(name) as Promise<TaskEventParameters<Event>>;
+  }
+
+  public emit<Event extends TaskEvents>(name: Event, ...args: TaskEventParameters<Event>): void {
+    this.events.emit(name, ...args);
+  }
+
+  // Runtime data
   /**
    * The defaults for the task. If no overrides at run time, then this would be equal to the
    * input
@@ -135,19 +125,39 @@ export abstract class TaskBase {
    */
   runOutputData: TaskOutput = {};
 
-  public static inputs: readonly TaskInputDefinition[];
-  public static outputs: readonly TaskOutputDefinition[];
+  // Core task methods
+  public handleStart(): void {
+    if (this.status === TaskStatus.PROCESSING) return;
+    // this.runOutputData = {};
+    this.startedAt = new Date();
+    this.progress = 0;
+    this.status = TaskStatus.PROCESSING;
+    this.events.emit("start");
+  }
 
-  /**
-   *
-   * @returns TaskInput Values that are used by the task runner, usually for storing results
-   */
-  getProvenance(): TaskInput {
+  public handleComplete(): void {
+    if (this.status === TaskStatus.COMPLETED) return;
+    this.completedAt = new Date();
+    this.progress = 100;
+    this.status = TaskStatus.COMPLETED;
+    this.events.emit("complete");
+  }
+
+  public handleError(err: any): void {
+    if (this.status === TaskStatus.FAILED) return;
+    this.completedAt = new Date();
+    this.progress = 100;
+    this.status = TaskStatus.FAILED;
+    this.error = err?.message || "Task failed";
+    this.events.emit("error", err?.message || "Task failed");
+  }
+
+  public getProvenance(): TaskInput {
     return this.config.provenance ?? {};
   }
 
-  resetInputData() {
-    // Use deep clone to avoid state leakage.
+  public resetInputData(): void {
+    // Use deep clone to avoid state leakage
     if (typeof structuredClone === "function") {
       this.runInputData = structuredClone(this.defaults);
     } else {
@@ -162,7 +172,7 @@ export abstract class TaskBase {
    * @param overrides
    * @returns
    */
-  addInputData<T extends TaskInput>(overrides: Partial<T> | undefined) {
+  public addInputData<T extends TaskInput>(overrides: Partial<T> | undefined): ITask {
     for (const input of this.inputs) {
       if (overrides?.[input.id] !== undefined) {
         let isArray = input.isArray;
@@ -174,7 +184,6 @@ export abstract class TaskBase {
         }
 
         if (isArray) {
-          // Initialize newitems as an empty array if runInputData[input.id] is not an array
           const existingItems = Array.isArray(this.runInputData[input.id])
             ? this.runInputData[input.id]
             : [];
@@ -203,7 +212,7 @@ export abstract class TaskBase {
    * @param item The item to validate
    * @returns True if the item is valid, false otherwise
    */
-  async validateItem(valueType: string, item: any) {
+  async validateItem(valueType: string, item: any): Promise<boolean> {
     switch (valueType) {
       case "any":
         return true;
@@ -227,7 +236,10 @@ export abstract class TaskBase {
    * @param inputId The id of the input to validate
    * @returns True if the input is valid, false otherwise
    */
-  async validateInputItem(input: Partial<TaskInput>, inputId: keyof TaskInput) {
+  public async validateInputItem(
+    input: Partial<TaskInput>,
+    inputId: keyof TaskInput
+  ): Promise<boolean> {
     const classRef = this.constructor as typeof TaskBase;
     const inputdef = this.inputs.find((def) => def.id === inputId);
     if (!inputdef) {
@@ -235,7 +247,6 @@ export abstract class TaskBase {
     }
     if (typeof input !== "object") return false;
     if (inputdef.defaultValue !== undefined && input[inputId] === undefined) {
-      // if there is no default value, that implies the value is required
       console.warn(
         `No default value for '${inputId}' in a ${classRef.type} so assumed required and not given (id:${this.config.id})`
       );
@@ -246,7 +257,6 @@ export abstract class TaskBase {
     if (inputdef.isArray && !Array.isArray(input[inputId])) {
       input[inputId] = [input[inputId]];
     }
-
     const inputlist: any[] = inputdef.isArray ? input[inputId] : [input[inputId]];
 
     // Rewritten using Promise.all for asynchronous validation
@@ -262,7 +272,7 @@ export abstract class TaskBase {
    * @param input The input to validate
    * @returns True if the input is valid, false otherwise
    */
-  async validateInputData(input: Partial<TaskInput>) {
+  public async validateInputData(input: Partial<TaskInput>): Promise<boolean> {
     for (const inputdef of this.inputs) {
       if ((await this.validateInputItem(input, inputdef.id)) === false) {
         return false;
@@ -271,44 +281,18 @@ export abstract class TaskBase {
     return true;
   }
 
-  /**
-   * Runs the task
-   * @returns The output of the task
-   */
-  async run(): Promise<TaskOutput> {
-    if (!(await this.validateInputData(this.runInputData))) {
-      throw new Error("Invalid input data");
-    }
-    if (this.status === TaskStatus.ABORTING) {
-      throw new Error("Task aborted by run time");
-    }
-
-    this.handleStart();
-
-    try {
-      const result = await this.runReactive();
-      this.runOutputData = result;
-
-      this.handleComplete();
-      return result;
-    } catch (err: any) {
-      this.handleError(err);
-      throw err;
-    }
-  }
+  public abstract run(): Promise<TaskOutput>;
   /**
    * Runs the task reactively
    * @returns The output of the task
    */
-  async runReactive(): Promise<TaskOutput> {
-    return this.runOutputData;
-  }
+  public abstract runReactive(): Promise<TaskOutput>;
 
   /**
    * Converts the task to a JSON format suitable for dependency tracking
    * @returns The task in JSON format
    */
-  toJSON(): JsonTaskItem {
+  public toJSON(): JsonTaskItem {
     const p = this.getProvenance();
     return {
       id: this.config.id,
@@ -329,7 +313,8 @@ export abstract class TaskBase {
    * Aborts the task
    * @returns A promise that resolves when the task is aborted
    */
-  async abort(): Promise<void> {
+  public async abort(): Promise<void> {
+    // if (this.status !== TaskStatus.PROCESSING) return;
     this.progress = 100;
     this.status = TaskStatus.ABORTING;
     this.error = "Task aborted by run time";

--- a/packages/task-graph/src/task/TaskBase.ts
+++ b/packages/task-graph/src/task/TaskBase.ts
@@ -21,6 +21,7 @@ import {
   type TaskEventListener,
   type TaskEventParameters,
   type TaskEventListeners,
+  type IConfig,
 } from "./TaskTypes";
 
 /**

--- a/packages/task-graph/src/task/TaskQueueRegistry.ts
+++ b/packages/task-graph/src/task/TaskQueueRegistry.ts
@@ -6,7 +6,7 @@
 //    *******************************************************************************
 
 import { JobQueue } from "@ellmers/job-queue";
-import { TaskInput, TaskOutput } from "./Task";
+import { TaskInput, TaskOutput } from "./TaskTypes";
 
 let taskQueueRegistry: TaskQueueRegistry<TaskInput, TaskOutput> | null = null;
 

--- a/packages/task-graph/src/task/TaskTypes.ts
+++ b/packages/task-graph/src/task/TaskTypes.ts
@@ -118,4 +118,3 @@ export type TaskIdType = TaskBase["config"]["id"];
 // ===============================================================================
 
 export type Task = SingleTask | CompoundTask;
-export type TaskStream = Task[];

--- a/packages/task-graph/src/test/genericTaskGraphJobQueueTests.ts
+++ b/packages/task-graph/src/test/genericTaskGraphJobQueueTests.ts
@@ -7,7 +7,7 @@
 
 import { expect, it, beforeEach, afterEach } from "bun:test";
 import { Job, JobQueue } from "@ellmers/job-queue";
-import { TaskInput, TaskOutput } from "../task/Task";
+import { TaskInput, TaskOutput } from "../task/TaskTypes";
 import { JobQueueTask } from "../task/JobQueueTask";
 import { getTaskQueueRegistry } from "../task/TaskQueueRegistry";
 


### PR DESCRIPTION
- Extract task type definitions into a new `TaskTypes.ts` file
- Create a new `ITask` and `ICompoundTask` interface in `ITask.ts`
- Update import statements across the project to use the new `TaskTypes` module
- Improve type safety and clarity of task-related type definitions
- Standardize task type and category static properties