### PR TITLE
refactor: Simplify task execution and reactive methods

### DIFF
--- a/docs/developers/01_getting_started.md
+++ b/docs/developers/01_getting_started.md
@@ -11,7 +11,6 @@
 - [Tasks](#tasks)
 - [TaskGraph](#taskgraph)
 - [Dataflows](#dataflows)
-- [TaskGraphRunner](#taskgraphrunner)
 - [Source](#source)
   - [`docs/`](#docs)
   - [`packages/storage`](#packagesstorage)
@@ -80,7 +79,6 @@ import {
   DebugLog,
   Dataflow,
   TaskGraph,
-  TaskGraphRunner,
 } from "@ellmers/task-graph";
 import { registerHuggingfaceLocalTasksInMemory } from "@ellmers/test";
 
@@ -119,8 +117,7 @@ graph.addDataflow(
   })
 );
 
-const runner = new TaskGraphRunner(graph);
-await runner.run();
+await graph.run();
 ```
 
 ## Using Task and TaskGraph directly (no config helper)
@@ -132,7 +129,6 @@ import {
   DebugLog,
   Dataflow,
   TaskGraph,
-  TaskGraphRunner,
   ConcurrencyLimiter,
   TaskInput,
   TaskOutput,
@@ -219,8 +215,7 @@ graph.addDataflow(
   })
 );
 
-const runner = new TaskGraphRunner(graph);
-runner.run();
+await graph.run();
 ```
 
 You can use as much or as little "magic" as you want. The config helpers are there to make it easier to get started, but eventually you will want to do it yourself.
@@ -434,15 +429,6 @@ graph.addDataflow(
 ```
 
 This links the output of the TextRewriterCompoundTask (id 1) to the input of the DebugLogTask (id 2). The output of the TextRewriterCompoundTask is the `text` field, and the input of the DebugLogTask is the `message` field.
-
-## TaskGraphRunner
-
-The TaskGraphRunner is used to run the graph. It understands that some tasks depend on others, and will run them in the correct order. It also handles compound tasks which have sub graphs.
-
-```ts
-const runner = new TaskGraphRunner(graph);
-runner.run();
-```
 
 # Appendix
 

--- a/docs/developers/02_architecture.md
+++ b/docs/developers/02_architecture.md
@@ -197,8 +197,8 @@ classDiagram
   style DebugLogTask type:output,stroke-width:1px
 
   class LambdaTask{
-    Function runFull
-    Function runReactive
+    Function execute
+    Function executeReactive
     TaskInput input
     run() output
   }

--- a/docs/developers/03_extending.md
+++ b/docs/developers/03_extending.md
@@ -19,8 +19,8 @@ To write a new Task, you need to create a new class that extends the `Task` clas
 Here we will write an example of a simple Task that prints a message to the console. Below if the starting code for the Task:
 
 ```ts
-export class SimpleDebugLogTask extends SimpleTask {
-  runFull() {
+export class SimpleDebugLogTask extends Task {
+  execute() {
     console.dir(<something>, { depth: null });
   }
 }
@@ -40,7 +40,7 @@ Here is the code for the `SimpleDebugLogTask` with the inputs defined:
 type SimpleDebugLogTaskInputs = {
   message: any;
 };
-export class SimpleDebugLogTask extends SimpleTask {
+export class SimpleDebugLogTask extends Task<SimpleDebugLogTaskInputs> {
   public static inputs: TaskInputDefinition[] = [
     {
       id: "message",
@@ -48,9 +48,7 @@ export class SimpleDebugLogTask extends SimpleTask {
       valueType: "any",
     },
   ] as const;
-  declare defaults: Partial<SimpleDebugLogTaskInputs>;
-  declare runInputData: SimpleDebugLogTaskInputs;
-  runFull() {
+  execute() {
     console.dir(this.runInputData.message, { depth: null });
   }
 }
@@ -73,7 +71,7 @@ type SimpleDebugLogTaskInputs = {
 type SimpleDebugLogTaskOutputs = {
   output: any;
 };
-export class SimpleDebugLogTask extends SimpleTask {
+export class SimpleDebugLogTask extends Task<SimpleDebugLogTaskInputs, SimpleDebugLogTaskOutputs> {
   public static sideeffects = true;
   public static inputs: TaskInputDefinition[] = [
     {
@@ -82,8 +80,6 @@ export class SimpleDebugLogTask extends SimpleTask {
       valueType: "any",
     },
   ] as const;
-  declare defaults: Partial<SimpleDebugLogTaskInputs>;
-  declare runInputData: SimpleDebugLogTaskInputs;
   public static outputs: TaskOutputDefinition[] = [
     {
       id: "output",
@@ -91,8 +87,7 @@ export class SimpleDebugLogTask extends SimpleTask {
       valueType: "any",
     },
   ] as const;
-  declare runOutputData: SimpleDebugLogTaskOutputs;
-  runFull() {
+  execute() {
     console.dir(this.runInputData.message, { depth: null });
     this.runOutputData.output = this.runInputData.message;
     return this.runOutputData;
@@ -116,7 +111,7 @@ To use the Task in Workflow, there are a few steps:
 
 ```ts
 export const SimpleDebug = (input: DebugLogTaskInput) => {
-  return new SimpleDebugTask({ input }).run();
+  return new SimpleDebugTask(input).run();
 };
 
 declare module "./base/Workflow" {

--- a/examples/cli/src/TaskGraphToUI.ts
+++ b/examples/cli/src/TaskGraphToUI.ts
@@ -11,12 +11,11 @@ import { render } from "tuir";
 import App from "./components/App";
 import { sleep } from "@ellmers/util";
 
-export async function runTask(dag: TaskGraph) {
-  const runner = new TaskGraphRunner(dag);
+export async function runTask(graph: TaskGraph) {
   if (process.stdout.isTTY) {
-    await runTaskToInk(runner);
+    await runTaskToInk(graph.runner);
   } else {
-    const result = await runner.runGraph();
+    const result = await graph.run();
     console.log(JSON.stringify(result, null, 2));
   }
 }

--- a/packages/ai/src/task/DocumentSplitterTask.ts
+++ b/packages/ai/src/task/DocumentSplitterTask.ts
@@ -71,7 +71,7 @@ export class DocumentSplitterTask extends Task<
     }
   }
 
-  async runReactive(): Promise<DocumentSplitterTaskOutput> {
+  async executeReactive(): Promise<DocumentSplitterTaskOutput> {
     return { texts: this.flattenFragmentsToTexts(this.runInputData.file) };
   }
 }

--- a/packages/ai/src/task/DownloadModelTask.ts
+++ b/packages/ai/src/task/DownloadModelTask.ts
@@ -146,7 +146,7 @@ export class DownloadModelTask<
     super.handleStart();
   }
 
-  async runReactive(): Promise<Output> {
+  async executeReactive(): Promise<Output> {
     const model = await getGlobalModelRepository().findByName(this.runInputData.model);
     if (model) {
       const tasks = (await getGlobalModelRepository().findTasksByModel(model.name)) || [];

--- a/packages/ai/src/task/SimilarityTask.ts
+++ b/packages/ai/src/task/SimilarityTask.ts
@@ -136,7 +136,7 @@ export class SimilarityTask<
     }
   }
 
-  async runReactive() {
+  async executeReactive() {
     const query = this.runInputData.query as ElVector<Float32Array>;
     let similarities = [];
     const fns = { cosine_similarity };

--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -20,7 +20,7 @@ bun add @ellmers/task-graph
 ## Basic Usage
 
 ```typescript
-import { TaskGraph, Dataflow, TaskGraphRunner } from "@ellmers/task-graph";
+import { TaskGraph, Dataflow } from "@ellmers/task-graph";
 
 // Define tasks
 class DataLoader extends Task {
@@ -37,8 +37,7 @@ const graph = new TaskGraph()
   .addDataflow(new Dataflow("loader", "data", "model", "input"));
 
 // Execute graph
-const runner = new TaskGraphRunner(graph);
-await runner.run(graph);
+await graph.run();
 ```
 
 ## Core Concepts

--- a/packages/task-graph/src/task-graph/README.md
+++ b/packages/task-graph/src/task-graph/README.md
@@ -56,10 +56,7 @@ graph.addDataflow(new Dataflow("task1", "output", "task2", "input"));
 ### Executing Tasks
 
 ```typescript
-import { TaskGraphRunner } from "@ellmers/task-graph";
-
-const runner = new TaskGraphRunner(graph);
-const results = await runner.runGraph();
+const results = await graph.run();
 ```
 
 ### Workflow API

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -252,7 +252,11 @@ export class Workflow {
     this._abortController = new AbortController();
 
     try {
-      const output = await this._runner.runGraph({}, this._abortController.signal);
+      const output = await this._runner.runGraph({
+        parentSignal: this._abortController.signal,
+        parentProvenance: {},
+        outputCache: this._repository,
+      });
       this.events.emit("complete");
       return output;
     } catch (error) {

--- a/packages/task-graph/src/task-graph/test/TaskGraphRunner.test.ts
+++ b/packages/task-graph/src/task-graph/test/TaskGraphRunner.test.ts
@@ -59,14 +59,11 @@ describe("TaskGraphRunner", () => {
       graph.addDataflow(new Dataflow("task1", "output", "task3", "a"));
       graph.addDataflow(new Dataflow("task2", "output", "task3", "b"));
 
-      const nodeRunSpy = spyOn(task3, "runReactive");
-
       const results = await runner.runGraph();
 
       expect(nodes[1].runOutputData.output).toEqual(25);
       expect(nodes[2].runOutputData.output).toEqual(10);
       expect(results?.find((r) => r.id === "task3")?.data.output).toEqual(35);
-      expect(nodeRunSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -83,7 +80,8 @@ describe("TaskGraphRunner", () => {
 
       // Create a task that will throw an error
       errorTask = new FailingTask({}, { id: "error-source" });
-      errorTask.runReactive = async () => {
+      // @ts-expect-error ts(2445)
+      errorTask.executeReactive = async () => {
         throw new Error("Test error");
       };
 
@@ -142,8 +140,9 @@ describe("TaskGraphRunner", () => {
       graph = new TaskGraph();
       const longRunningTask = new LongRunningTask({}, { id: "long-running" });
 
-      // Override the runReactive method to be long-running and check for abort signal
-      longRunningTask.runReactive = async () => {
+      // Override the executeReactive method to be long-running and check for abort signal
+      // @ts-expect-error ts(2445)
+      longRunningTask.executeReactive = async () => {
         try {
           await new Promise((resolve, reject) => {
             const timeout = setTimeout(resolve, 1000);

--- a/packages/task-graph/src/task/README.md
+++ b/packages/task-graph/src/task/README.md
@@ -44,14 +44,12 @@ class MyTask extends Task {
   static outputs = [{ id: "result", valueType: "number" }];
   static isCompound = false;
 
-  async runFull() {
+  async execute() {
     // Do something with the input that takes a long time
     await sleep(1000);
-    // Return the reactive result
-    return this.runReactive();
   }
-  async runReactive() {
-    return { result: this.runInputData.input * 2 };
+  async executeReactive(input: MyTaskInput) {
+    return { result: input.input * 2 };
   }
 }
 ```
@@ -81,8 +79,8 @@ class MyJobTask extends JobQueueTask {
 
 - **Statuses**: `Pending` → `Processing` → (`Completed`|`Failed`|`Aborted`)
 - **Methods**:
-  - `run()`: Full execution with caching
-  - `runReactive()`: Lightweight execution for UI updates
+  - `run()`: Full execution with caching, calls the subclass `execute` method
+  - `runReactive()`: Lightweight execution for UI updates, calls the subclass `executeReactive` method
   - `abort()`: Cancel running task
 
 ## Event Handling

--- a/packages/task-graph/src/task/TaskTypes.ts
+++ b/packages/task-graph/src/task/TaskTypes.ts
@@ -5,7 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import type { TaskGraph } from "../task-graph/TaskGraph";
+import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
 import type { Task } from "./Task";
 
 /**
@@ -74,6 +74,9 @@ export interface IConfig {
 
   /** Optional ID of the runner to use for this task */
   runnerId?: string;
+
+  /** Optional output cache to use for this task */
+  outputCache?: TaskOutputRepository;
 }
 
 /**

--- a/packages/task-graph/src/task/test/ArrayTask.test.ts
+++ b/packages/task-graph/src/task/test/ArrayTask.test.ts
@@ -11,10 +11,16 @@ import { TaskGraphRunner } from "../../task-graph/TaskGraphRunner";
 import { ITask } from "../ITask";
 import { TaskError } from "../TaskError";
 import { TaskStatus } from "../TaskTypes";
-import { TestSquareMultiInputTask, TestErrorMultiInputTask } from "./TestTasks";
+import {
+  TestSquareMultiInputTask,
+  TestErrorMultiInputTask,
+  TestSquareNonReactiveMultiInputTask,
+  TestSquareNonReactiveTask,
+  TestSquareTaskOutput,
+} from "./TestTasks";
 
 describe("ArrayTask", () => {
-  test("in task mode", async () => {
+  test("in task mode reactive run", async () => {
     const task = new TestSquareMultiInputTask(
       {
         input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -25,6 +31,57 @@ describe("ArrayTask", () => {
     );
     const results = await task.run();
     expect(results).toEqual({ output: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  });
+
+  test("in task mode reactive runReactive", async () => {
+    const task = new TestSquareMultiInputTask(
+      {
+        input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      },
+      {
+        id: "task1",
+      }
+    );
+    const results = await task.runReactive();
+    expect(results).toEqual({ output: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  });
+
+  test("in task mode reactive run with single", async () => {
+    const task = new TestSquareNonReactiveTask({ input: 5 });
+    const results = await task.run();
+    expect(results).toEqual({ output: 25 });
+  });
+
+  test("in task mode reactive runReactive single", async () => {
+    const task = new TestSquareNonReactiveTask({ input: 5 });
+    const results = await task.runReactive();
+    expect(results).toEqual({} as TestSquareTaskOutput);
+  });
+
+  test("in task mode non-reactive run", async () => {
+    const task = new TestSquareNonReactiveMultiInputTask(
+      {
+        input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      },
+      {
+        id: "task1",
+      }
+    );
+    const results = await task.run();
+    expect(results).toEqual({ output: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  });
+
+  test("in task mode non-reactive runReactive", async () => {
+    const task = new TestSquareNonReactiveMultiInputTask(
+      {
+        input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      },
+      {
+        id: "task1",
+      }
+    );
+    const results = await task.runReactive();
+    expect(results).toEqual({} as any);
   });
 
   test("in task graph mode", async () => {
@@ -39,8 +96,7 @@ describe("ArrayTask", () => {
         }
       )
     );
-    const runner = new TaskGraphRunner(graph);
-    const results = await runner.runGraph();
+    const results = await graph.run();
     expect(results![0].data).toEqual({ output: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 121] });
   });
 
@@ -158,7 +214,9 @@ describe("ArrayTask", () => {
 
     // Manually trigger progress events on child tasks
     task.subGraph!.getNodes().forEach((childTask: ITask) => {
+      // @ts-expect-error - we are testing the protected method
       childTask.handleStart();
+      // @ts-expect-error - we are testing the protected method
       childTask.handleProgress(0.5);
     });
 

--- a/packages/tasks/src/task/DebugLogTask.ts
+++ b/packages/tasks/src/task/DebugLogTask.ts
@@ -70,15 +70,15 @@ export class DebugLogTask<
     },
   ] as const;
 
-  async runReactive() {
-    const { log_level = DEFAULT_LOG_LEVEL, console: messages } = this.runInputData;
+  async executeReactive(input: Input, output: Output) {
+    const { log_level = DEFAULT_LOG_LEVEL, console: messages } = input;
     if (log_level == "dir") {
       console.dir(messages, { depth: null });
     } else {
       console[log_level](messages);
     }
-    this.runOutputData.console = messages;
-    return this.runOutputData;
+    output.console = input.console;
+    return output;
   }
 
   async validateItem(valueType: string, item: any) {

--- a/packages/tasks/src/task/FetchTask.ts
+++ b/packages/tasks/src/task/FetchTask.ts
@@ -169,7 +169,7 @@ export class FetchTask<
     this.jobClass = FetchJob;
   }
 
-  async runReactive(): Promise<Output> {
+  async executeReactive(): Promise<Output> {
     return this.runOutputData ?? { body: null };
   }
 

--- a/packages/tasks/src/task/JavaScriptTask.ts
+++ b/packages/tasks/src/task/JavaScriptTask.ts
@@ -49,7 +49,7 @@ export class JavaScriptTask extends Task<JavaScriptTaskInput, JavaScriptTaskOutp
   constructor(config: TaskConfig & { input?: JavaScriptTaskInput } = {}) {
     super(config);
   }
-  async runReactive() {
+  async executeReactive() {
     if (this.runInputData.code) {
       try {
         const myInterpreter = new Interpreter(this.runInputData.code);

--- a/packages/tasks/src/test/DelayTask.test.ts
+++ b/packages/tasks/src/test/DelayTask.test.ts
@@ -23,7 +23,7 @@ describe("DelayTask", () => {
 
     // Verify the task completed successfully
     expect(task.status).toBe(TaskStatus.COMPLETED);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({});
   });
 
   it("should pass through input to output", async () => {

--- a/packages/tasks/src/test/LambdaTask.test.ts
+++ b/packages/tasks/src/test/LambdaTask.test.ts
@@ -8,15 +8,14 @@
 import { describe, test, expect } from "bun:test";
 import { Lambda, LambdaTask } from "../task/LambdaTask";
 import { TaskGraph } from "@ellmers/task-graph";
-import { TaskGraphRunner } from "@ellmers/task-graph";
 import { Workflow } from "@ellmers/task-graph";
 
 describe("LambdaTask", () => {
   test("in command mode", async () => {
     const results = await Lambda(
-      {},
+      { data: null },
       {
-        runFull: async () => {
+        execute: async () => {
           return { output: "Hello, world!" };
         },
       }
@@ -31,7 +30,7 @@ describe("LambdaTask", () => {
         b: 2,
       },
       {
-        runReactive: async (input) => {
+        executeReactive: async (input) => {
           return { output: input.a + input.b };
         },
       }
@@ -43,7 +42,7 @@ describe("LambdaTask", () => {
     const task = new LambdaTask(
       {},
       {
-        runReactive: async () => {
+        executeReactive: async () => {
           return { output: "Hello, world!" };
         },
       }
@@ -59,14 +58,13 @@ describe("LambdaTask", () => {
         {},
         {
           id: "lambdaReactiveTest",
-          runReactive: async () => {
+          executeReactive: async () => {
             return { output: "Hello, world!" };
           },
         }
       )
     );
-    const runner = new TaskGraphRunner(graph);
-    const results = await runner.runGraph();
+    const results = await graph.run();
     expect(results[0]).toEqual({
       id: "lambdaReactiveTest",
       type: "LambdaTask",
@@ -79,7 +77,7 @@ describe("LambdaTask", () => {
     workflow.Lambda(
       {},
       {
-        runFull: async () => {
+        execute: async () => {
           return { output: "Hello, world!" };
         },
       }
@@ -90,7 +88,7 @@ describe("LambdaTask", () => {
     });
   });
 
-  test("in task workflow mode with input runFull", async () => {
+  test("in task workflow mode with input execute", async () => {
     const workflow = new Workflow();
     workflow.Lambda(
       {
@@ -98,7 +96,7 @@ describe("LambdaTask", () => {
         b: 2,
       },
       {
-        runFull: async (input) => {
+        execute: async (input) => {
           return { output: input.a + input.b };
         },
       }
@@ -107,7 +105,7 @@ describe("LambdaTask", () => {
     expect(results[0].data).toEqual({ output: 3 });
   });
 
-  test("in task workflow mode with input runReactive", async () => {
+  test("in task workflow mode with input executeReactive", async () => {
     const workflow = new Workflow();
     workflow.Lambda(
       {
@@ -115,7 +113,7 @@ describe("LambdaTask", () => {
         b: 2,
       },
       {
-        runReactive: async (input) => {
+        executeReactive: async (input) => {
           return { output: input.a + input.b };
         },
       }
@@ -129,19 +127,18 @@ describe("LambdaTask", () => {
     const task = new LambdaTask(
       {},
       {
-        runFull: async (input, updateProgress) => {
+        execute: async (input, { updateProgress }) => {
           updateProgress(0.5, "Halfway there");
           return { output: "Hello, world!" };
         },
       }
     );
     graph.addTask(task);
-    const runner = new TaskGraphRunner(graph);
     let progressCounter = 0;
     task.on("progress", (progress: number) => {
       progressCounter++;
     });
-    const results = await runner.runGraph();
+    const results = await graph.run();
     expect(results[0].data).toEqual({ output: "Hello, world!" });
     expect(progressCounter).toEqual(1);
   });


### PR DESCRIPTION
- Rename `runFull` and `runReactive` to `execute` and `executeReactive`
- Update task execution flow to use new method names
- Improve input handling and default value management
- Simplify task lifecycle methods
- Remove redundant task execution logic
- Update task interfaces and type definitions
- Enhance task graph and runner to support new execution model