### PR TITLE
refactor: Introduce RunOrReplicateTask for flexible task execution

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -1,0 +1,6 @@
+---
+description: Import
+globs: *.ts, *.tsx, *.js, *.jsx
+alwaysApply: false
+---
+Do not import from files with the name: index, node, bun, browser

--- a/.cursor/rules/react-rules.mdc
+++ b/.cursor/rules/react-rules.mdc
@@ -1,4 +1,0 @@
----
-description: 
-globs: 
----

--- a/examples/web/src/TurboNode.tsx
+++ b/examples/web/src/TurboNode.tsx
@@ -67,12 +67,12 @@ export const CompoundNode = ({ data }: NodeProps<Node<TurboNodeData>>) => {
           <Handle type="target" position={Position.Left} />
           <Handle type="source" position={Position.Right} />
           <div className="progress">
-            {data.progressItems?.map((item) => (
+            {/* {data.progressItems?.map((item) => (
               <React.Fragment key={item.id}>
                 <div className="bar" style={{ width: `${item.progress}%` }} />
                 <div className="subline">{item.text}</div>
               </React.Fragment>
-            ))}
+            ))} */}
           </div>
         </div>
       </div>

--- a/examples/web/src/main.tsx
+++ b/examples/web/src/main.tsx
@@ -45,13 +45,12 @@ console.log(
 console.log(
   `  %cworkflow.%creset%c();
 
-
-  workflow.%cDownloadModel%c({ %cmodel%c: [%c'ONNX Xenova/LaMini-Flan-T5-783M q8']%c });
+  workflow.%cDownloadModel%c({ %cmodel%c: [%c'onnx:Xenova/LaMini-Flan-T5-783M:q8']%c });
   workflow.%cTextRewriter%c({ %ctext%c: %c'The quick brown fox jumps over the lazy dog.'%c, %cprompt%c: [%c'Rewrite the following text in reverse:'%c, %c'Rewrite this to sound like a pirate:'%c] });
   workflow.%crename%c(%c'*'%c, %c'console'%c);
   workflow.%cDebugLog%c({ %clevel%c: %c'info'%c });
   
-  console.log(JSON.stringify(workflow.toJSON(),null,2));
+  console.log(JSON.stringify(workflow.toDependencyJSON(),null,2));
   `,
   `color: ${grey}; font-weight: normal;`,
   `color: ${yellow}; font-weight: normal;`,

--- a/packages/ai-provider/src/hf-transformers/provider/HuggingFaceLocal_TaskRun.ts
+++ b/packages/ai-provider/src/hf-transformers/provider/HuggingFaceLocal_TaskRun.ts
@@ -136,12 +136,12 @@ function generateProgressCallback(job: AiJob) {
 
 export async function HuggingFaceLocal_DownloadRun(
   job: AiJob,
-  runInputData: DownloadModelTaskInput,
+  input: DownloadModelTaskInput,
   signal?: AbortSignal
 ) {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   await getPipeline(job, model, { abort_signal: signal });
   return {
@@ -158,12 +158,12 @@ export async function HuggingFaceLocal_DownloadRun(
  */
 export async function HuggingFaceLocal_EmbeddingRun(
   job: AiJob,
-  runInputData: TextEmbeddingTaskInput,
+  input: TextEmbeddingTaskInput,
   signal?: AbortSignal
 ): Promise<TextEmbeddingTaskOutput> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Embedding run aborted");
@@ -174,7 +174,7 @@ export async function HuggingFaceLocal_EmbeddingRun(
   if (signal?.aborted) {
     throw new PermanentJobError("Embedding run aborted");
   }
-  const hfVector = await generateEmbedding(runInputData.text, {
+  const hfVector = await generateEmbedding(input.text, {
     pooling: "mean",
     normalize: model.normalize,
     ...(signal ? { abort_signal: signal } : {}),
@@ -183,7 +183,7 @@ export async function HuggingFaceLocal_EmbeddingRun(
   if (hfVector.size !== model.nativeDimensions) {
     console.warn(
       `HuggingFaceLocal Embedding vector length does not match model dimensions v${hfVector.size} != m${model.nativeDimensions}`,
-      runInputData,
+      input,
       hfVector
     );
     throw `HuggingFaceLocal Embedding vector length does not match model dimensions v${hfVector.size} != m${model.nativeDimensions}`;
@@ -199,12 +199,12 @@ export async function HuggingFaceLocal_EmbeddingRun(
  */
 export async function HuggingFaceLocal_TextGenerationRun(
   job: AiJob,
-  runInputData: TextGenerationTaskInput,
+  input: TextGenerationTaskInput,
   signal?: AbortSignal
 ): Promise<TextGenerationTaskOutput> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Text generation run aborted");
@@ -222,7 +222,7 @@ export async function HuggingFaceLocal_TextGenerationRun(
     ...(signal ? { abort_signal: signal } : {}),
   });
 
-  let results = await generateText(runInputData.prompt, {
+  let results = await generateText(input.prompt, {
     streamer,
   } as any);
   if (!Array.isArray(results)) {
@@ -246,12 +246,12 @@ export async function HuggingFaceLocal_TextGenerationRun(
  */
 export async function HuggingFaceLocal_TextTranslationRun(
   job: AiJob,
-  runInputData: TextTranslationTaskInput,
+  input: TextTranslationTaskInput,
   signal?: AbortSignal
 ): Promise<Partial<TextTranslationTaskOutput>> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Text translation run aborted");
@@ -269,9 +269,9 @@ export async function HuggingFaceLocal_TextTranslationRun(
     ...(signal ? { abort_signal: signal } : {}),
   });
 
-  let results = await translate(runInputData.text, {
-    src_lang: runInputData.source_lang,
-    tgt_lang: runInputData.target_lang,
+  let results = await translate(input.text, {
+    src_lang: input.source_lang,
+    tgt_lang: input.target_lang,
     streamer,
   } as any);
   if (!Array.isArray(results)) {
@@ -289,12 +289,12 @@ export async function HuggingFaceLocal_TextTranslationRun(
  */
 export async function HuggingFaceLocal_TextRewriterRun(
   job: AiJob,
-  runInputData: TextRewriterTaskInput,
+  input: TextRewriterTaskInput,
   signal?: AbortSignal
 ): Promise<TextRewriterTaskOutput> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Text rewriter run aborted");
@@ -313,7 +313,7 @@ export async function HuggingFaceLocal_TextRewriterRun(
   });
 
   // This lib doesn't support this kind of rewriting with a separate prompt vs text
-  const promptedtext = (runInputData.prompt ? runInputData.prompt + "\n" : "") + runInputData.text;
+  const promptedtext = (input.prompt ? input.prompt + "\n" : "") + input.text;
   let results = await generateText(promptedtext, {
     streamer,
     ...(signal ? { abort_signal: signal } : {}),
@@ -341,12 +341,12 @@ export async function HuggingFaceLocal_TextRewriterRun(
 
 export async function HuggingFaceLocal_TextSummaryRun(
   job: AiJob,
-  runInputData: TextSummaryTaskInput,
+  input: TextSummaryTaskInput,
   signal?: AbortSignal
 ): Promise<TextSummaryTaskOutput> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Text summary run aborted");
@@ -364,7 +364,7 @@ export async function HuggingFaceLocal_TextSummaryRun(
     ...(signal ? { abort_signal: signal } : {}),
   });
 
-  let results = await generateSummary(runInputData.text, {
+  let results = await generateSummary(input.text, {
     streamer,
   } as any);
   if (!Array.isArray(results)) {
@@ -382,12 +382,12 @@ export async function HuggingFaceLocal_TextSummaryRun(
  */
 export async function HuggingFaceLocal_TextQuestionAnswerRun(
   job: AiJob,
-  runInputData: TextQuestionAnswerTaskInput,
+  input: TextQuestionAnswerTaskInput,
   signal?: AbortSignal
 ): Promise<TextQuestionAnswerTaskOutput> {
-  const model = await getGlobalModelRepository().findByName(runInputData.model);
+  const model = await getGlobalModelRepository().findByName(input.model);
   if (!model) {
-    throw `Model ${runInputData.model} not found`;
+    throw `Model ${input.model} not found`;
   }
   if (signal?.aborted) {
     throw new PermanentJobError("Text question answer run aborted");
@@ -405,7 +405,7 @@ export async function HuggingFaceLocal_TextQuestionAnswerRun(
     ...(signal ? { abort_signal: signal } : {}),
   });
 
-  let results = await generateAnswer(runInputData.question, runInputData.context, {
+  let results = await generateAnswer(input.question, input.context, {
     streamer,
   } as any);
   if (!Array.isArray(results)) {

--- a/packages/ai-provider/src/tf-mediapipe/provider/MediaPipeLocalTaskRun.ts
+++ b/packages/ai-provider/src/tf-mediapipe/provider/MediaPipeLocalTaskRun.ts
@@ -19,15 +19,15 @@ import {
  */
 export async function MediaPipeTfJsLocal_Download(
   job: AiJob,
-  runInputData: DownloadModelTaskInput,
+  input: DownloadModelTaskInput,
   signal?: AbortSignal
 ) {
   const textFiles = await FilesetResolver.forTextTasks(
     "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-text@latest/wasm"
   );
-  const model = (await getGlobalModelRepository().findByName(runInputData.model))!;
+  const model = (await getGlobalModelRepository().findByName(input.model))!;
   if (!model) {
-    throw `MediaPipeTfJsLocal_Download: Model ${runInputData.model} not found`;
+    throw `MediaPipeTfJsLocal_Download: Model ${input.model} not found`;
   }
   const results = await TextEmbedder.createFromOptions(textFiles, {
     baseOptions: {
@@ -45,15 +45,15 @@ export async function MediaPipeTfJsLocal_Download(
  */
 export async function MediaPipeTfJsLocal_Embedding(
   job: AiJob,
-  runInputData: TextEmbeddingTaskInput,
+  input: TextEmbeddingTaskInput,
   signal?: AbortSignal
 ) {
   const textFiles = await FilesetResolver.forTextTasks(
     "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-text@latest/wasm"
   );
-  const model = (await getGlobalModelRepository().findByName(runInputData.model))!;
+  const model = (await getGlobalModelRepository().findByName(input.model))!;
   if (!model) {
-    throw `MediaPipeTfJsLocal_Embedding: Model ${runInputData.model} not found`;
+    throw `MediaPipeTfJsLocal_Embedding: Model ${input.model} not found`;
   }
   const textEmbedder = await TextEmbedder.createFromOptions(textFiles, {
     baseOptions: {
@@ -62,7 +62,7 @@ export async function MediaPipeTfJsLocal_Embedding(
     quantize: true,
   });
 
-  const output = textEmbedder.embed(runInputData.text);
+  const output = textEmbedder.embed(input.text);
   const vector = output.embeddings[0].floatEmbedding;
 
   if (vector?.length !== model.nativeDimensions) {

--- a/packages/task-graph/src/index.ts
+++ b/packages/task-graph/src/index.ts
@@ -19,6 +19,7 @@ export * from "./task-graph/Workflow";
 export * from "./task/ArrayTask";
 export * from "./task/JobQueueTask";
 export * from "./task/TaskQueueRegistry";
+export * from "./task/RunOrReplicateTask";
 
 export * from "./storage/taskoutput/TaskOutputRepository";
 export * from "./storage/taskgraph/TaskGraphRepository";

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -12,7 +12,6 @@ import { Dataflow, DataflowIdType } from "./Dataflow";
 import { ITask } from "../task/ITask";
 import { TaskGraphRunner } from "./TaskGraphRunner";
 import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
-import { IRunConfig } from "../task/ITask";
 
 /**
  * Configuration for running a task graph

--- a/packages/task-graph/src/task/ArrayTask.ts
+++ b/packages/task-graph/src/task/ArrayTask.ts
@@ -5,6 +5,7 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
+import { collectPropertyValues, Writeable } from "@ellmers/util";
 import { TaskOutputRepository } from "../storage/taskoutput/TaskOutputRepository";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { ITaskConstructor, IRunConfig, IExecuteConfig } from "./ITask";
@@ -21,53 +22,6 @@ import {
 } from "./TaskTypes";
 import { JsonTaskItem, TaskGraphItemJson } from "./TaskJSON";
 import { Task } from "./Task";
-import { TaskGraphRunner } from "../task-graph/TaskGraphRunner";
-
-// Type utilities for array transformations
-// Makes specified properties optional arrays
-export type ConvertSomeToOptionalArray<T, K extends keyof T> = {
-  [P in keyof T]: P extends K ? Array<T[P]> | T[P] : T[P];
-};
-
-// Makes all properties optional arrays
-export type ConvertAllToOptionalArray<T> = {
-  [P in keyof T]: Array<T[P]> | T[P];
-};
-
-// Makes specified properties required arrays
-export type ConvertSomeToArray<T, K extends keyof T> = {
-  [P in keyof T]: P extends K ? Array<T[P]> : T[P];
-};
-
-// Makes all properties required arrays
-export type ConvertAllToArrays<T> = {
-  [P in keyof T]: Array<T[P]>;
-};
-
-// Removes readonly modifiers from object properties
-type Writeable<T> = { -readonly [P in keyof T]: T[P] };
-
-/**
- * Takes an array of objects and collects values for each property into arrays
- * @param input Array of objects to process
- * @returns Object with arrays of values for each property
- */
-function collectPropertyValues<Input>(input: Input[]): { [K in keyof Input]: Input[K][] } {
-  const output = {} as { [K in keyof Input]: Input[K][] };
-
-  (input || []).forEach((item) => {
-    Object.keys(item as object).forEach((key) => {
-      const value = item[key as keyof Input];
-      if (output[key as keyof Input]) {
-        output[key as keyof Input].push(value);
-      } else {
-        output[key as keyof Input] = [value];
-      }
-    });
-  });
-
-  return output;
-}
 
 /**
  * Converts specified IO definitions to array type

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -90,6 +90,7 @@ export interface ITaskCompound {
   get isCompound(): boolean; // this gets local access for static isCompound property
   subGraph: TaskGraph | null;
   regenerateGraph(): void;
+  hasChildren(): boolean;
 }
 
 /**

--- a/packages/task-graph/src/task/JobQueueTask.ts
+++ b/packages/task-graph/src/task/JobQueueTask.ts
@@ -5,14 +5,14 @@
 //    *   Licensed under the Apache License, Version 2.0 (the "License");           *
 //    *******************************************************************************
 
-import { getTaskQueueRegistry } from "./TaskQueueRegistry";
-import { TaskConfig, TaskOutput, TaskInput } from "./TaskTypes";
-import { TaskEventListeners } from "./TaskEvents";
-import { EventEmitter } from "@ellmers/util";
 import { Job } from "@ellmers/job-queue";
-import { TaskConfigurationError } from "./TaskError";
-import { Task } from "./Task";
+import { EventEmitter } from "@ellmers/util";
 import { IExecuteConfig } from "./ITask";
+import { RunOrReplicateTask } from "./RunOrReplicateTask";
+import { TaskConfigurationError } from "./TaskError";
+import { TaskEventListeners } from "./TaskEvents";
+import { getTaskQueueRegistry } from "./TaskQueueRegistry";
+import { TaskConfig, TaskInput, TaskOutput } from "./TaskTypes";
 
 /**
  * Configuration interface for JobQueueTask.
@@ -45,7 +45,7 @@ export abstract class JobQueueTask<
   Input extends TaskInput = TaskInput,
   Output extends TaskOutput = TaskOutput,
   Config extends JobQueueTaskConfig = JobQueueTaskConfig,
-> extends Task<Input, Output, Config> {
+> extends RunOrReplicateTask<Input, Output, Config> {
   static readonly type: string = "JobQueueTask";
   static canRunDirectly = true;
 
@@ -84,7 +84,7 @@ export abstract class JobQueueTask<
       } else {
         const jobId = await queue.add(job);
         this.config.currentJobId = jobId;
-        // this.config.runnerId = job.jobRunId; // ??
+        this.config.runnerId = job.jobRunId; // TODO: think about this more
 
         cleanup = queue.onJobProgress(jobId, (progress, message, details) => {
           this.handleProgress(progress, message, details);

--- a/packages/task-graph/src/task/README.md
+++ b/packages/task-graph/src/task/README.md
@@ -21,7 +21,8 @@ This module provides a flexible task processing system with support for various 
 ### Core Classes
 
 - `Task`: Base class implementing core task functionality
-- `ArrayTask`: Processes arrays of inputs using parallel subtasks
+- `RunOrReplicateTask`: Executes a task or a task with multiple inputs in parallel with a subGraph
+- `ArrayTask`: Processes arrays of inputs using parallel subtasks (deprecated)
 - `JobQueueTask`: Integrates with job queue system for distributed processing
 
 ## Task Types
@@ -59,6 +60,12 @@ class MyTask extends Task {
 - Compound tasks are tasks that contain other tasks. They are represented as an internal TaskGraph.
 - Compound tasks can regenerate its own subtasks based on changes to its inputs.
 - An ArrayTask is a regenerative task based on a single task that processes an array of inputs in parallel by creating a new subtask for each input, and then combining the results into a single array output.
+
+### RunOrReplicateTask
+
+- RunOrReplicateTask is a task that can run a task as normal, or if the inputs are an arryay and the input definition has isArray="replicate", then the task will run parallel copies with a subGraph.
+- The subGraph is a TaskGraph that is created from the inputs of the task.
+- The results of the subGraph are combined such that the outputs are turned into arrays.
 
 ### Job Queue Tasks
 

--- a/packages/task-graph/src/task/RunOrReplicateTask.ts
+++ b/packages/task-graph/src/task/RunOrReplicateTask.ts
@@ -1,0 +1,253 @@
+//    *******************************************************************************
+//    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import { nanoid } from "nanoid";
+import { TaskGraph } from "../task-graph/TaskGraph";
+import { Task } from "./Task";
+import { IExecuteConfig } from "./ITask";
+import {
+  TaskConfig,
+  TaskInput,
+  TaskInputDefinition,
+  TaskOutput,
+  TaskOutputDefinition,
+} from "./TaskTypes";
+import { GraphResult } from "../task-graph/TaskGraphRunner";
+import { TaskGraphItemJson } from "../node";
+import { JsonTaskItem } from "../node";
+import { collectPropertyValues } from "@ellmers/util";
+
+/**
+ * RunOrReplicate is a compound task that either:
+ * 1. Executes directly if all inputs are non-arrays
+ * 2. Creates a subGraph with one task instance per array element if any input is an array
+ * 3. Creates all combinations if multiple inputs are arrays
+ */
+export class RunOrReplicateTask<
+  Input extends TaskInput = TaskInput,
+  Output extends TaskOutput = TaskOutput,
+  Config extends TaskConfig = TaskConfig,
+> extends Task<Input, Output, Config> {
+  /**
+   * The type identifier for this task class
+   */
+  public static type = "RunOrReplicate";
+
+  /**
+   * Whether this task has side effects
+   */
+  public static sideeffects = false;
+
+  /**
+   * Whether this task is a compound task (contains subtasks)
+   */
+  public static readonly isCompound = true;
+
+  /**
+   * Input definitions for this task
+   * Note: Subclasses should override this with their own specific inputs
+   */
+  public static inputs: TaskInputDefinition[] = [];
+
+  /**
+   * Output definitions for this task
+   * Note: Subclasses should override this with their own specific outputs
+   */
+  public static outputs: TaskOutputDefinition[] = [];
+
+  constructor(defaultInputs?: Partial<Input>, config?: Config) {
+    super(defaultInputs, config);
+    if (this.execute === RunOrReplicateTask.prototype.execute) {
+      // @ts-ignore
+      this.execute = (input: Input, config: IExecuteConfig) => undefined;
+    } else {
+      // @ts-ignore
+      this.executeDirectly = this.execute;
+      // @ts-ignore
+      this.execute = RunOrReplicateTask.prototype.execute;
+    }
+    if (this.executeReactive === RunOrReplicateTask.prototype.executeReactive) {
+      // @ts-ignore
+      this.executeReactive = (input: Input, output: Output) => output;
+    } else {
+      // @ts-ignore
+      this.executeReactiveDirectly = this.executeReactive;
+      // @ts-ignore
+      this.executeReactive = RunOrReplicateTask.prototype.executeReactive;
+    }
+  }
+
+  /**
+   * Regenerates the task subgraph based on input arrays
+   */
+  public regenerateGraph(): void {
+    // Check if any inputs are arrays
+    const arrayInputs = new Map<string, any[]>();
+    let hasArrayInputs = false;
+    for (const inputDef of this.inputs) {
+      const inputId = inputDef.id;
+      const inputValue = this.runInputData[inputId];
+
+      if (inputDef.isArray === "replicate" && Array.isArray(inputValue) && inputValue.length > 0) {
+        arrayInputs.set(inputId, inputValue);
+        hasArrayInputs = true;
+      }
+    }
+
+    // If no array inputs, no need to create a subgraph
+    if (!hasArrayInputs) return;
+
+    // Clear the existing subgraph
+    this.subGraph = new TaskGraph();
+
+    // Create all combinations of inputs
+    const combinations = this.generateCombinations(arrayInputs);
+
+    // Create task instances for each combination
+    const tasks = combinations.map((combination) => {
+      // Create a new instance of this same class
+      const { id, name, ...rest } = this.config;
+      const task = new (this.constructor as any)(
+        { ...this.defaults, ...combination },
+        { ...rest, id: `${id}_${nanoid(8)}` }
+      );
+      return task;
+    });
+
+    // Add tasks to subgraph
+    this.subGraph.addTasks(tasks);
+
+    // Emit regenerate event
+    super.regenerateGraph();
+  }
+
+  /**
+   * Generate all combinations of array inputs
+   */
+  private generateCombinations(arrayInputs: Map<string, any[]>): Input[] {
+    // Start with an empty object
+    const combinations: Input[] = [{ ...this.runInputData }];
+
+    // For each array input, generate all combinations
+    for (const [inputId, values] of arrayInputs.entries()) {
+      const newCombinations: Input[] = [];
+
+      // For each existing combination
+      for (const combination of combinations) {
+        // For each value in the array
+        for (const value of values) {
+          // Create a new combination with this value
+          newCombinations.push({
+            ...combination,
+            [inputId]: value,
+          } as Input);
+        }
+      }
+
+      // Replace combinations with new ones
+      combinations.length = 0;
+      combinations.push(...newCombinations);
+    }
+
+    return combinations;
+  }
+
+  private fixInput(input: Input): Input {
+    // inputs has turned each property into an array, so we need to flatten the input
+    const flattenedInput = Object.entries(input).reduce((acc, [key, value]) => {
+      if (Array.isArray(value)) {
+        return { ...acc, [key]: value[0] };
+      }
+      return { ...acc, [key]: value };
+    }, {});
+    return flattenedInput as Input;
+  }
+
+  private fixOutput(results: GraphResult): Output {
+    let fixedOutput = {} as Output;
+    const outputs = results.map((result: any) => result.data);
+    if (outputs.length > 0) {
+      const collected = collectPropertyValues<Output>(outputs as Output[]);
+      if (Object.keys(collected).length > 0) {
+        fixedOutput = collected as unknown as Output;
+      }
+    }
+    return fixedOutput;
+  }
+
+  private async executeLocally(input: Input, config: IExecuteConfig): Promise<Output | undefined> {
+    // @ts-ignore
+    if (this.executeDirectly) {
+      // @ts-ignore
+      const result = await this.executeDirectly(this.runInputData, config);
+      this.runOutputData = result;
+    }
+    // @ts-ignore
+    if (this.executeReactiveDirectly) {
+      // @ts-ignore
+      return this.executeReactiveDirectly(this.runInputData, config);
+    } else {
+      return this.runOutputData;
+    }
+  }
+
+  private async executeGraph(input: Input, config: IExecuteConfig): Promise<Output | undefined> {
+    // Run subgraph
+    const results = await this.subGraph!.run({
+      parentProvenance: config.nodeProvenance || {},
+      parentSignal: config.signal,
+      outputCache: this.outputCache,
+    });
+    this.runOutputData = this.fixOutput(results);
+    return this.runOutputData as unknown as Output;
+  }
+
+  /**
+   * Execute the task
+   */
+  protected async execute(input: Input, config: IExecuteConfig): Promise<Output | undefined> {
+    const hasArrayInputs = this.hasChildren();
+    if (!hasArrayInputs) {
+      this.runInputData = this.fixInput(input);
+      return this.executeLocally(this.runInputData, config);
+    }
+    return this.executeGraph(input, config);
+  }
+
+  /**
+   * Execute the task reactively
+   */
+  protected async executeReactive(input: Input, output: Output): Promise<Output | undefined> {
+    const hasArrayInputs = this.hasChildren();
+    // If no array inputs, execute directly
+    if (!hasArrayInputs) {
+      this.runInputData = this.fixInput(input);
+      // @ts-ignore
+      if (this.executeReactiveDirectly) {
+        // @ts-ignore
+        return this.executeReactiveDirectly(this.runInputData, output);
+      } else {
+        return output;
+      }
+    }
+
+    // Run subgraph
+    const results = await this.subGraph!.runReactive();
+    this.runOutputData = this.fixOutput(results);
+    return this.runOutputData as unknown as Output;
+  }
+
+  toJSON(): JsonTaskItem {
+    const { subgraph, ...result } = super.toJSON() as TaskGraphItemJson;
+    return result;
+  }
+
+  toDependencyJSON(): JsonTaskItem {
+    const { subtasks, ...result } = super.toDependencyJSON() as JsonTaskItem;
+    return result;
+  }
+}

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -72,7 +72,7 @@ export class Task<
   /**
    * Whether this task is a compound task (contains subtasks)
    */
-  public static readonly isCompound: boolean = false;
+  public static isCompound: boolean = false;
 
   // ========================================================================
   // Methods to be overridden by subclasses
@@ -86,7 +86,7 @@ export class Task<
    * @returns The output of the task or undefined if no changes
    */
   protected async execute(input: Input, config: IExecuteConfig): Promise<Output | undefined> {
-    if (this.isCompound) {
+    if (this.hasChildren()) {
       const results = await this.subGraph!.run({
         parentProvenance: config.nodeProvenance || {},
         parentSignal: config.signal || undefined,
@@ -110,8 +110,12 @@ export class Task<
    */
   protected async executeReactive(input: Input, output: Output): Promise<Output | undefined> {
     if (this.isCompound) {
-      const results = await this.subGraph!.runReactive();
-      return { outputs: results } as unknown as Output;
+      if (this.hasChildren()) {
+        const results = await this.subGraph!.runReactive();
+        return { outputs: results || [] } as unknown as Output;
+      } else {
+        return { outputs: [] } as unknown as Output;
+      }
     } else {
       return output;
     }
@@ -237,6 +241,10 @@ export class Task<
 
   public get category(): string {
     return (this.constructor as typeof Task).category;
+  }
+
+  public hasChildren(): boolean {
+    return this.isCompound && this.subGraph !== null && this.subGraph.getNodes().length > 0;
   }
 
   // ========================================================================
@@ -381,7 +389,7 @@ export class Task<
     } catch (err) {
       this.runInputData = JSON.parse(JSON.stringify(this.defaults)) as Input;
     }
-    if (this.isCompound) {
+    if (this.hasChildren()) {
       this.subGraph!.getNodes().forEach((node) => {
         node.resetInputData();
       });
@@ -520,7 +528,6 @@ export class Task<
     this.abortController = undefined;
     // this.outputCache = this.config.outputCache;
     this.nodeProvenance = {};
-
     this.events.emit("error", this.error);
   }
 
@@ -659,11 +666,12 @@ export class Task<
       }
     }
 
-    if (inputdef.isArray && !Array.isArray(input[inputId])) {
+    if (inputdef.isArray === true && !Array.isArray(input[inputId])) {
       input[inputId] = [input[inputId]] as any;
     }
 
-    const inputlist: any[] = inputdef.isArray ? (input[inputId] as any[]) : [input[inputId]];
+    const inputlist: any[] =
+      inputdef.isArray === true ? (input[inputId] as any[]) : [input[inputId]];
 
     const validationPromises = inputlist.map((item) =>
       this.validateItem(inputdef.valueType as string, item)
@@ -712,10 +720,10 @@ export class Task<
       input: this.defaults,
       ...(Object.keys(provenance).length ? { provenance } : {}),
     };
-    if (!this.isCompound) {
-      return json;
+    if (this.hasChildren()) {
+      return { ...json, subgraph: this.subGraph!.toJSON() };
     }
-    return { ...json, subgraph: this.subGraph!.toJSON() };
+    return json;
   }
 
   /**
@@ -725,7 +733,7 @@ export class Task<
   public toDependencyJSON(): JsonTaskItem {
     // this.resetInputData();
     const json = this.toJSON();
-    if (this.isCompound) {
+    if (this.hasChildren()) {
       return { ...json, subtasks: this.subGraph!.toDependencyJSON() };
     }
     return json;

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -47,27 +47,27 @@ export class Task<
   /**
    * The type identifier for this task class
    */
-  public static readonly type: TaskTypeName = "Task";
+  public static type: TaskTypeName = "Task";
 
   /**
    * The category this task belongs to
    */
-  public static readonly category: string = "Hidden";
+  public static category: string = "Hidden";
 
   /**
    * Whether this task has side effects
    */
-  public static readonly sideeffects: boolean = false;
+  public static sideeffects: boolean = false;
 
   /**
    * Input definitions for this task
    */
-  public static readonly inputs: readonly TaskInputDefinition[] = [];
+  public static inputs: readonly TaskInputDefinition[] = [];
 
   /**
    * Output definitions for this task
    */
-  public static readonly outputs: readonly TaskOutputDefinition[] = [];
+  public static outputs: readonly TaskOutputDefinition[] = [];
 
   /**
    * Whether this task is a compound task (contains subtasks)

--- a/packages/task-graph/src/task/TaskTypes.ts
+++ b/packages/task-graph/src/task/TaskTypes.ts
@@ -93,7 +93,7 @@ export type TaskInputDefinition = {
   readonly valueType: string;
 
   /** Whether this input accepts an array of values */
-  readonly isArray?: boolean;
+  readonly isArray?: boolean | "replicate";
 
   /** Default value for this input */
   readonly defaultValue?: any;
@@ -116,7 +116,7 @@ export type TaskOutputDefinition = {
   readonly valueType: string;
 
   /** Whether this output produces an array of values */
-  readonly isArray?: boolean;
+  readonly isArray?: boolean | "replicate";
 };
 
 /** Type for task ID */

--- a/packages/task-graph/src/task/test/ArrayTask.test.ts
+++ b/packages/task-graph/src/task/test/ArrayTask.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, expect, test } from "bun:test";
 import { TaskGraph } from "../../task-graph/TaskGraph";
-import { TaskGraphRunner } from "../../task-graph/TaskGraphRunner";
 import { ITask } from "../ITask";
 import { TaskError } from "../TaskError";
 import { TaskStatus } from "../TaskTypes";

--- a/packages/task-graph/src/task/test/RunOrReplicate.test.ts
+++ b/packages/task-graph/src/task/test/RunOrReplicate.test.ts
@@ -16,34 +16,40 @@ import {
 } from "../TaskTypes";
 import { describe, expect, spyOn, test } from "bun:test";
 import { TaskGraph } from "../../task-graph/TaskGraph";
+import { ConvertAllToOptionalArray } from "@ellmers/util";
 
 // Define our input and output types
 interface MultiplyInput extends TaskInput {
-  a: number | number[];
-  b: number | number[];
+  a: number;
+  b: number;
 }
 
 interface MultiplyOutput extends TaskOutput {
-  result: number | number[];
+  result: number;
 }
 
 /**
  * Create a task that multiplies two numbers
  * This is a direct subclass of RunOrReplicate
  */
-class MultiplyRunTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> {
+class MultiplyRunTask extends RunOrReplicateTask<
+  ConvertAllToOptionalArray<MultiplyInput>,
+  ConvertAllToOptionalArray<MultiplyOutput>
+> {
   public static readonly inputs: readonly TaskInputDefinition[] = [
     {
       id: "a",
       name: "First Number",
       valueType: "number",
       isArray: "replicate", // This can be a single number or an array of numbers
+      defaultValue: 0,
     },
     {
       id: "b",
       name: "Second Number",
       valueType: "number",
       isArray: "replicate", // This can be a single number or an array of numbers
+      defaultValue: 0,
     },
   ];
   public static readonly outputs: readonly TaskOutputDefinition[] = [
@@ -57,7 +63,7 @@ class MultiplyRunTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> 
   protected async execute(input: MultiplyInput, config: IExecuteConfig): Promise<MultiplyOutput> {
     // Simple multiplication - at this point, we know the inputs are not arrays
     return {
-      result: (input.a as number) * (input.b as number),
+      result: input.a * input.b,
     };
   }
 }
@@ -65,19 +71,24 @@ class MultiplyRunTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> 
  * Create a task that multiplies two numbers
  * This is a direct subclass of RunOrReplicate
  */
-class MultiplyRunReactiveTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> {
+class MultiplyRunReactiveTask extends RunOrReplicateTask<
+  ConvertAllToOptionalArray<MultiplyInput>,
+  ConvertAllToOptionalArray<MultiplyOutput>
+> {
   public static readonly inputs: readonly TaskInputDefinition[] = [
     {
       id: "a",
       name: "First Number",
       valueType: "number",
       isArray: "replicate", // This can be a single number or an array of numbers
+      defaultValue: 0,
     },
     {
       id: "b",
       name: "Second Number",
       valueType: "number",
       isArray: "replicate", // This can be a single number or an array of numbers
+      defaultValue: 0,
     },
   ];
   public static readonly outputs: readonly TaskOutputDefinition[] = [
@@ -94,22 +105,25 @@ class MultiplyRunReactiveTask extends RunOrReplicateTask<MultiplyInput, Multiply
   ): Promise<MultiplyOutput> {
     // Simple multiplication - at this point, we know the inputs are not arrays
     return {
-      result: (input.a as number) * (input.b as number),
+      result: input.a * input.b,
     };
   }
 }
 
 interface SquareInput extends TaskInput {
-  a: number | number[];
+  a: number;
 }
 interface SquareOutput extends TaskOutput {
-  result: number | number[];
+  result: number;
 }
 /**
  * Create a task that squares a number
  * This is a direct subclass of RunOrReplicate
  */
-class SquareRunTask extends RunOrReplicateTask<SquareInput, SquareOutput> {
+class SquareRunTask extends RunOrReplicateTask<
+  ConvertAllToOptionalArray<SquareInput>,
+  ConvertAllToOptionalArray<SquareOutput>
+> {
   public static readonly inputs: readonly TaskInputDefinition[] = [
     {
       id: "a",
@@ -129,13 +143,16 @@ class SquareRunTask extends RunOrReplicateTask<SquareInput, SquareOutput> {
   ];
 
   protected async execute(input: SquareInput, config: IExecuteConfig): Promise<SquareOutput> {
-    // Simple multiplication - at this point, we know the inputs are not arrays
+    // Simple square - at this point, we know the inputs are not arrays
     return {
-      result: (input.a as number) * (input.a as number),
+      result: input.a * input.a,
     };
   }
 }
-class SquareRunReactiveTask extends RunOrReplicateTask<SquareInput, SquareOutput> {
+class SquareRunReactiveTask extends RunOrReplicateTask<
+  ConvertAllToOptionalArray<SquareInput>,
+  ConvertAllToOptionalArray<SquareOutput>
+> {
   public static readonly inputs: readonly TaskInputDefinition[] = [
     {
       id: "a",
@@ -155,15 +172,15 @@ class SquareRunReactiveTask extends RunOrReplicateTask<SquareInput, SquareOutput
   ];
 
   protected async executeReactive(input: SquareInput, output: SquareOutput): Promise<SquareOutput> {
-    // Simple multiplication - at this point, we know the inputs are not arrays
+    // Simple square - at this point, we know the inputs are not arrays
     return {
-      result: (input.a as number) * (input.a as number),
+      result: input.a * input.a,
     };
   }
 }
 
 describe("RunOrReplicate", () => {
-  test.only("in task mode run plain", async () => {
+  test("MultiplyRunTask in task mode run plain", async () => {
     const task = new MultiplyRunTask({
       a: 4,
       b: 5,
@@ -175,7 +192,7 @@ describe("RunOrReplicate", () => {
     expect(executeGraphSpy).not.toHaveBeenCalled();
   });
 
-  test("in task mode run array", async () => {
+  test("MultiplyRunTask in task mode run array", async () => {
     const task = new MultiplyRunTask({
       a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       b: 1,
@@ -186,7 +203,7 @@ describe("RunOrReplicate", () => {
     expect(results).toEqual({ result: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
     expect(executeGraphSpy).toHaveBeenCalled();
   });
-  test("in task mode run array x array", async () => {
+  test("MultiplyRunTask in task mode run array x array", async () => {
     const task = new MultiplyRunTask({
       a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       b: [1, 2],
@@ -196,7 +213,7 @@ describe("RunOrReplicate", () => {
       result: [0, 0, 1, 2, 2, 4, 3, 6, 4, 8, 5, 10, 6, 12, 7, 14, 8, 16, 9, 18, 10, 20],
     });
   });
-  test("in task mode reactive run", async () => {
+  test("MultiplyRunTask in task mode reactive run", async () => {
     const task = new MultiplyRunTask({
       a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       b: 10,
@@ -212,7 +229,35 @@ describe("RunOrReplicate", () => {
     }
   });
 
-  test("in task mode reactive runReactive", async () => {
+  test("MultiplyRunReactiveTask in task mode reactive run", async () => {
+    const task = new MultiplyRunReactiveTask({
+      a: 2,
+      b: 10,
+    });
+    debugger;
+    const results = await task.run();
+    expect(results).toEqual({ result: 20 });
+  });
+
+  test("MultiplyRunReactiveTask in task mode reactive runReactive", async () => {
+    const task = new MultiplyRunReactiveTask({
+      a: 2,
+      b: 10,
+    });
+    const results = await task.runReactive();
+    expect(results).toEqual({ result: 20 });
+  });
+
+  test("MultiplyRunReactiveTask in task mode reactive runReactive array", async () => {
+    const task = new MultiplyRunReactiveTask({
+      a: [2],
+      b: [10],
+    });
+    const results = await task.runReactive();
+    expect(results).toEqual({ result: [20] });
+  });
+
+  test("MultiplyRunReactiveTask in task mode reactive runReactive", async () => {
     const task = new MultiplyRunReactiveTask({
       a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       b: 10,
@@ -221,30 +266,37 @@ describe("RunOrReplicate", () => {
     expect(results).toEqual({ result: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] });
   });
 
-  // test("in task mode reactive run with single", async () => {
-  //   const task = new TestSquareNonReactiveTask({ input: 5 });
-  //   const results = await task.run();
-  //   expect(results).toEqual({ output: 25 });
-  // });
+  test("SquareRunTask in task mode run with single", async () => {
+    const task = new SquareRunTask({ a: 5 });
+    const results = await task.run();
+    expect(results).toEqual({ result: 25 });
+  });
 
-  // test("in task mode reactive runReactive single", async () => {
-  //   const task = new TestSquareNonReactiveTask({ input: 5 });
-  //   const results = await task.runReactive();
-  //   expect(results).toEqual({} as TestSquareTaskOutput);
-  // });
+  test("SquareRunTask in task mode reactive run with single", async () => {
+    const task = new SquareRunTask({ a: 5 });
+    const results = await task.runReactive();
+    expect(results).toEqual({} as SquareOutput);
+  });
 
-  // test("in task mode non-reactive run", async () => {
-  //   const task = new TestSquareNonReactiveMultiInputTask(
-  //     {
-  //       input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-  //     },
-  //     {
-  //       id: "task1",
-  //     }
-  //   );
-  //   const results = await task.run();
-  //   expect(results).toEqual({ result: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
-  // });
+  test("SquareRunReactiveTask in task mode run with single", async () => {
+    const task = new SquareRunReactiveTask({ a: 5 });
+    const results = await task.run();
+    expect(results).toEqual({ result: 25 });
+  });
+
+  test("SquareRunReactiveTask in task mode reactive run with single", async () => {
+    const task = new SquareRunReactiveTask({ a: 5 });
+    const results = await task.runReactive();
+    expect(results).toEqual({ result: 25 } as SquareOutput);
+  });
+
+  test("in task mode non-reactive run", async () => {
+    const task = new SquareRunTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    const results = await task.run();
+    expect(results).toEqual({ result: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  });
 
   test("in task mode non-reactive runReactive", async () => {
     const task = new SquareRunReactiveTask({

--- a/packages/task-graph/src/task/test/RunOrReplicate.test.ts
+++ b/packages/task-graph/src/task/test/RunOrReplicate.test.ts
@@ -1,0 +1,459 @@
+//    *******************************************************************************
+//    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import { RunOrReplicateTask } from "../RunOrReplicateTask";
+import { IExecuteConfig, ITask } from "../ITask";
+import {
+  TaskInput,
+  TaskInputDefinition,
+  TaskOutput,
+  TaskOutputDefinition,
+  TaskStatus,
+} from "../TaskTypes";
+import { describe, expect, spyOn, test } from "bun:test";
+import { TaskGraph } from "../../task-graph/TaskGraph";
+
+// Define our input and output types
+interface MultiplyInput extends TaskInput {
+  a: number | number[];
+  b: number | number[];
+}
+
+interface MultiplyOutput extends TaskOutput {
+  result: number | number[];
+}
+
+/**
+ * Create a task that multiplies two numbers
+ * This is a direct subclass of RunOrReplicate
+ */
+class MultiplyRunTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> {
+  public static readonly inputs: readonly TaskInputDefinition[] = [
+    {
+      id: "a",
+      name: "First Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+    {
+      id: "b",
+      name: "Second Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+  ];
+  public static readonly outputs: readonly TaskOutputDefinition[] = [
+    {
+      id: "result",
+      name: "Result",
+      valueType: "number",
+      isArray: "replicate", // The result can be a single number or an array
+    },
+  ];
+  protected async execute(input: MultiplyInput, config: IExecuteConfig): Promise<MultiplyOutput> {
+    // Simple multiplication - at this point, we know the inputs are not arrays
+    return {
+      result: (input.a as number) * (input.b as number),
+    };
+  }
+}
+/**
+ * Create a task that multiplies two numbers
+ * This is a direct subclass of RunOrReplicate
+ */
+class MultiplyRunReactiveTask extends RunOrReplicateTask<MultiplyInput, MultiplyOutput> {
+  public static readonly inputs: readonly TaskInputDefinition[] = [
+    {
+      id: "a",
+      name: "First Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+    {
+      id: "b",
+      name: "Second Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+  ];
+  public static readonly outputs: readonly TaskOutputDefinition[] = [
+    {
+      id: "result",
+      name: "Result",
+      valueType: "number",
+      isArray: "replicate", // The result can be a single number or an array
+    },
+  ];
+  protected async executeReactive(
+    input: MultiplyInput,
+    output: MultiplyOutput
+  ): Promise<MultiplyOutput> {
+    // Simple multiplication - at this point, we know the inputs are not arrays
+    return {
+      result: (input.a as number) * (input.b as number),
+    };
+  }
+}
+
+interface SquareInput extends TaskInput {
+  a: number | number[];
+}
+interface SquareOutput extends TaskOutput {
+  result: number | number[];
+}
+/**
+ * Create a task that squares a number
+ * This is a direct subclass of RunOrReplicate
+ */
+class SquareRunTask extends RunOrReplicateTask<SquareInput, SquareOutput> {
+  public static readonly inputs: readonly TaskInputDefinition[] = [
+    {
+      id: "a",
+      name: "First Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+  ];
+
+  public static readonly outputs: readonly TaskOutputDefinition[] = [
+    {
+      id: "result",
+      name: "Result",
+      valueType: "number",
+      isArray: "replicate", // The result can be a single number or an array
+    },
+  ];
+
+  protected async execute(input: SquareInput, config: IExecuteConfig): Promise<SquareOutput> {
+    // Simple multiplication - at this point, we know the inputs are not arrays
+    return {
+      result: (input.a as number) * (input.a as number),
+    };
+  }
+}
+class SquareRunReactiveTask extends RunOrReplicateTask<SquareInput, SquareOutput> {
+  public static readonly inputs: readonly TaskInputDefinition[] = [
+    {
+      id: "a",
+      name: "First Number",
+      valueType: "number",
+      isArray: "replicate", // This can be a single number or an array of numbers
+    },
+  ];
+
+  public static readonly outputs: readonly TaskOutputDefinition[] = [
+    {
+      id: "result",
+      name: "Result",
+      valueType: "number",
+      isArray: "replicate", // The result can be a single number or an array
+    },
+  ];
+
+  protected async executeReactive(input: SquareInput, output: SquareOutput): Promise<SquareOutput> {
+    // Simple multiplication - at this point, we know the inputs are not arrays
+    return {
+      result: (input.a as number) * (input.a as number),
+    };
+  }
+}
+
+describe("RunOrReplicate", () => {
+  test.only("in task mode run plain", async () => {
+    const task = new MultiplyRunTask({
+      a: 4,
+      b: 5,
+    });
+    // @ts-expect-error - we are testing the protected method
+    const executeGraphSpy = spyOn(task, "executeGraph");
+    const results = await task.run();
+    expect(results).toEqual({ result: 20 });
+    expect(executeGraphSpy).not.toHaveBeenCalled();
+  });
+
+  test("in task mode run array", async () => {
+    const task = new MultiplyRunTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: 1,
+    });
+    // @ts-expect-error - we are testing the protected method
+    const executeGraphSpy = spyOn(task, "executeGraph");
+    const results = await task.run();
+    expect(results).toEqual({ result: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    expect(executeGraphSpy).toHaveBeenCalled();
+  });
+  test("in task mode run array x array", async () => {
+    const task = new MultiplyRunTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: [1, 2],
+    });
+    const results = await task.run();
+    expect(results).toEqual({
+      result: [0, 0, 1, 2, 2, 4, 3, 6, 4, 8, 5, 10, 6, 12, 7, 14, 8, 16, 9, 18, 10, 20],
+    });
+  });
+  test("in task mode reactive run", async () => {
+    const task = new MultiplyRunTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: 10,
+    });
+    {
+      const results = await task.runReactive();
+      expect(results).toEqual({} as any);
+    }
+    {
+      await task.run();
+      const results = await task.runReactive();
+      expect(results).toEqual({ result: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] });
+    }
+  });
+
+  test("in task mode reactive runReactive", async () => {
+    const task = new MultiplyRunReactiveTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: 10,
+    });
+    const results = await task.runReactive();
+    expect(results).toEqual({ result: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] });
+  });
+
+  // test("in task mode reactive run with single", async () => {
+  //   const task = new TestSquareNonReactiveTask({ input: 5 });
+  //   const results = await task.run();
+  //   expect(results).toEqual({ output: 25 });
+  // });
+
+  // test("in task mode reactive runReactive single", async () => {
+  //   const task = new TestSquareNonReactiveTask({ input: 5 });
+  //   const results = await task.runReactive();
+  //   expect(results).toEqual({} as TestSquareTaskOutput);
+  // });
+
+  // test("in task mode non-reactive run", async () => {
+  //   const task = new TestSquareNonReactiveMultiInputTask(
+  //     {
+  //       input: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  //     },
+  //     {
+  //       id: "task1",
+  //     }
+  //   );
+  //   const results = await task.run();
+  //   expect(results).toEqual({ result: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  // });
+
+  test("in task mode non-reactive runReactive", async () => {
+    const task = new SquareRunReactiveTask({
+      a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    });
+    const results = await task.runReactive();
+    expect(results).toEqual({ result: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81, 100] });
+  });
+
+  test("in task graph mode", async () => {
+    const graph = new TaskGraph();
+    graph.addTask(
+      new MultiplyRunTask({
+        a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        b: 11,
+      })
+    );
+    const results = await graph.run();
+    expect(results![0].data).toEqual({ result: [0, 11, 22, 33, 44, 55, 66, 77, 88, 99, 110] });
+  });
+
+  test("emits events correctly", async () => {
+    // Create a task with a smaller array for testing events
+    const task = new SquareRunTask({
+      a: [1, 2, 3],
+    });
+
+    // Create event tracking variables
+    const events: Record<string, number> = {
+      start: 0,
+      progress: 0,
+      complete: 0,
+    };
+
+    // Set up event listeners
+    task.on("start", () => {
+      events.start++;
+      expect(task.status).toBe(TaskStatus.PROCESSING);
+    });
+
+    task.on("progress", (progress: number) => {
+      events.progress++;
+      expect(progress).toBeGreaterThanOrEqual(0);
+      expect(progress).toBeLessThanOrEqual(1);
+    });
+
+    task.on("complete", () => {
+      events.complete++;
+      expect(task.status).toBe(TaskStatus.COMPLETED);
+      expect(task.completedAt).toBeDefined();
+    });
+
+    // Manually trigger a progress event before running the task
+    // @ts-expect-error - we are testing the protected method
+    task.handleStart();
+    // @ts-expect-error - we are testing the protected method
+    task.handleProgress(0.5);
+
+    // Run the task
+    const results = await task.run();
+
+    // Verify events were emitted
+    expect(events.start).toBeGreaterThanOrEqual(1);
+    expect(events.progress).toBeGreaterThanOrEqual(1);
+    expect(events.complete).toBe(1);
+
+    // Verify the task completed successfully
+    expect(results).toEqual({ result: [1, 4, 9] });
+    expect(task.runOutputData).toEqual({ result: [1, 4, 9] });
+  });
+
+  test("child tasks emit events that bubble up to parent", async () => {
+    // Create a task with a smaller array for testing events
+    const task = new SquareRunTask({
+      a: [1, 2],
+    });
+
+    // Create event tracking variables for parent and children
+    const parentEvents: Record<string, number> = {
+      start: 0,
+      progress: 0,
+      complete: 0,
+    };
+
+    const childEvents: Record<string, number> = {
+      start: 0,
+      progress: 0,
+      complete: 0,
+    };
+
+    // Set up event listeners on parent task
+    task.on("start", () => {
+      parentEvents.start++;
+    });
+
+    task.on("progress", () => {
+      parentEvents.progress++;
+    });
+
+    task.on("complete", () => {
+      parentEvents.complete++;
+    });
+
+    // After task is created, we can access its subGraph and child tasks
+    task.regenerateGraph();
+
+    // Set up event listeners on child tasks
+    task.subGraph!.getNodes().forEach((childTask: ITask) => {
+      childTask.on("start", () => {
+        childEvents.start++;
+      });
+
+      childTask.on("progress", () => {
+        childEvents.progress++;
+      });
+
+      childTask.on("complete", () => {
+        childEvents.complete++;
+      });
+    });
+
+    // Manually trigger progress events
+    // @ts-expect-error - we are testing the protected method
+    task.handleStart();
+    // @ts-expect-error - we are testing the protected method
+    task.handleProgress(0.5);
+
+    // Manually trigger progress events on child tasks
+    task.subGraph!.getNodes().forEach((childTask: ITask) => {
+      // @ts-expect-error - we are testing the protected method
+      childTask.handleStart();
+      // @ts-expect-error - we are testing the protected method
+      childTask.handleProgress(0.5);
+    });
+
+    // Run the task
+    await task.run();
+
+    // Verify parent events were emitted
+    expect(parentEvents.start).toBeGreaterThanOrEqual(1);
+    expect(parentEvents.progress).toBeGreaterThanOrEqual(1);
+    expect(parentEvents.complete).toBe(1);
+
+    // Verify child events were emitted
+    expect(childEvents.start).toBeGreaterThanOrEqual(2); // At least one for each child task
+    expect(childEvents.progress).toBeGreaterThanOrEqual(2); // At least one for each child task
+    expect(childEvents.complete).toBe(2); // One for each child task
+  });
+
+  // test("handles errors correctly", async () => {
+  //   // Create a task with inputs that will cause an error
+  //   const task = new TestErrorMultiInputTask(
+  //     {
+  //       input: [1, 2, 3], // The value 2 will cause an error
+  //     },
+  //     {
+  //       id: "error-test-task",
+  //     }
+  //   );
+
+  //   // Create event tracking variables
+  //   const events: Record<string, number> = {
+  //     start: 0,
+  //     progress: 0,
+  //     error: 0,
+  //     complete: 0,
+  //   };
+
+  //   // Set up event listeners
+  //   task.on("start", () => {
+  //     events.start++;
+  //   });
+
+  //   task.on("progress", () => {
+  //     events.progress++;
+  //   });
+
+  //   task.on("error", (error: TaskError) => {
+  //     events.error++;
+  //     expect(error).toBeDefined();
+  //     expect(error.message).toContain("Test error");
+  //   });
+
+  //   task.on("complete", () => {
+  //     events.complete++;
+  //   });
+
+  //   // Manually trigger a progress event
+  //   task.handleStart();
+  //   task.handleProgress(0.5);
+
+  //   // Run the task and catch the error
+  //   try {
+  //     await task.run();
+  //   } catch (error) {
+  //     // Expected error
+  //     expect(error).toBeDefined();
+  //   }
+
+  //   // Verify events were emitted
+  //   expect(events.start).toBeGreaterThanOrEqual(1);
+  //   expect(events.progress).toBeGreaterThanOrEqual(1);
+  //   expect(events.error).toBeGreaterThanOrEqual(1);
+
+  //   // The complete event should not be emitted when there's an error
+  //   expect(events.complete).toBe(0);
+
+  //   // Verify the task status is ERROR
+  //   expect(task.status).toBe(TaskStatus.FAILED);
+  //   expect(task.error).toBeDefined();
+  // });
+});

--- a/packages/task-graph/src/task/test/TestTasks.ts
+++ b/packages/task-graph/src/task/test/TestTasks.ts
@@ -13,9 +13,9 @@ import { TaskInput } from "../TaskTypes";
  */
 
 import { TaskOutputRepository, CreateWorkflow, IExecuteConfig } from "@ellmers/task-graph";
-import { sleep } from "@ellmers/util";
+import { ConvertAllToArrays, ConvertSomeToOptionalArray, sleep } from "@ellmers/util";
 import { Workflow } from "../../browser";
-import { arrayTaskFactory, ConvertSomeToOptionalArray, ConvertAllToArrays } from "../ArrayTask";
+import { arrayTaskFactory } from "../ArrayTask";
 import { JobQueueTaskConfig } from "../JobQueueTask";
 import { Task } from "../Task";
 import { TaskAbortedError, TaskError, TaskFailedError } from "../TaskError";

--- a/packages/util/src/browser.ts
+++ b/packages/util/src/browser.ts
@@ -1,3 +1,4 @@
 export * from "./utilities/Misc";
 export * from "./utilities/EventEmitter";
 export * from "./utilities/Crypto.browser";
+export * from "./utilities/TypeUtilities";

--- a/packages/util/src/bun.ts
+++ b/packages/util/src/bun.ts
@@ -1,4 +1,5 @@
 export * from "./utilities/Misc";
 export * from "./utilities/EventEmitter";
 export * from "./utilities/Crypto.bun";
+export * from "./utilities/TypeUtilities";
 export * as Sqlite from "bun:sqlite";

--- a/packages/util/src/node.ts
+++ b/packages/util/src/node.ts
@@ -1,6 +1,7 @@
 export * from "./utilities/Misc";
 export * from "./utilities/EventEmitter";
 export * from "./utilities/Crypto.node";
+export * from "./utilities/TypeUtilities";
 import bettersqlite from "better-sqlite3";
 
 export const Sqlite: { Database: typeof bettersqlite } = {

--- a/packages/util/src/utilities/Misc.ts
+++ b/packages/util/src/utilities/Misc.ts
@@ -14,6 +14,28 @@ export async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Takes an array of objects and collects values for each property into arrays
+ * @param input Array of objects to process
+ * @returns Object with arrays of values for each property
+ */
+export function collectPropertyValues<Input>(input: Input[]): { [K in keyof Input]: Input[K][] } {
+  const output = {} as { [K in keyof Input]: Input[K][] };
+
+  (input || []).forEach((item) => {
+    Object.keys(item as object).forEach((key) => {
+      const value = item[key as keyof Input];
+      if (output[key as keyof Input]) {
+        output[key as keyof Input].push(value);
+      } else {
+        output[key as keyof Input] = [value];
+      }
+    });
+  });
+
+  return output;
+}
+
 export function toSQLiteTimestamp(date: Date | null | undefined) {
   if (!date) return null;
   const pad = (number: number) => (number < 10 ? "0" + number : number);

--- a/packages/util/src/utilities/TypeUtilities.ts
+++ b/packages/util/src/utilities/TypeUtilities.ts
@@ -1,0 +1,30 @@
+//    *******************************************************************************
+//    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+// Type utilities for array transformations
+// Makes specified properties optional arrays
+export type ConvertSomeToOptionalArray<T, K extends keyof T> = {
+  [P in keyof T]: P extends K ? Array<T[P]> | T[P] : T[P];
+};
+
+// Makes all properties optional arrays
+export type ConvertAllToOptionalArray<T> = {
+  [P in keyof T]: Array<T[P]> | T[P];
+};
+
+// Makes specified properties required arrays
+export type ConvertSomeToArray<T, K extends keyof T> = {
+  [P in keyof T]: P extends K ? Array<T[P]> : T[P];
+};
+
+// Makes all properties required arrays
+export type ConvertAllToArrays<T> = {
+  [P in keyof T]: Array<T[P]>;
+};
+
+// Removes readonly modifiers from object properties
+export type Writeable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
- Add new RunOrReplicateTask to support dynamic task replication
- Implement task execution with array inputs using subgraph
- Update task type definitions to support "replicate" input/output mode
- Move type utility functions to separate module
- Simplify task execution logic across AI and task-graph packages
- Enhance task input handling and type conversion