### PR TITLE
feat: workflow pipe and parallel

### DIFF
--- a/examples/web/src/QueueStatus.tsx
+++ b/examples/web/src/QueueStatus.tsx
@@ -56,7 +56,7 @@ export function QueueStatus({ queueType }: { queueType: string }) {
 
   return (
     <span>
-      <span>{queue.queueName}</span>: <span title="Pending">{pending}</span> /{" "}
+      <span>{queue.queueName.split("_").pop()}</span>: <span title="Pending">{pending}</span> /{" "}
       <span title="Processing">{processing}</span> / <span title="Completed">{completed}</span> /{" "}
       <span title="Aborting">{aborting}</span> / <span title="Errors">{errors}</span> /{" "}
       <span title="Skipped">{skipped}</span>

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -6,10 +6,7 @@
 //    *******************************************************************************
 
 import { EventEmitter, uuid4 } from "@ellmers/util";
-import { TaskOutputRepository } from "../storage/TaskOutputRepository";
-import { TaskGraph } from "../task-graph/TaskGraph";
-import { CompoundMergeStrategy, NamedGraphResult } from "../task-graph/TaskGraphRunner";
-import type { IExecuteConfig, IRunConfig, ITask } from "./ITask";
+import type { IExecuteConfig, ITask } from "./ITask";
 import { TaskAbortedError, TaskError, TaskInvalidInputError } from "./TaskError";
 import {
   type TaskEventListener,


### PR DESCRIPTION
REWORK WORKFLOW

- [x] Workflow.pipe( fn1, task1, fn2 ) pipe should be able to take a task or a function, turning a function into a lambda task
- [x] Add a task state of SKIPPED that we will use for conditional execution
- [ ] Add conditional execution to task
- [ ] Add conditional execution to workflow
- [ ] Add iteration to task
- [ ] Add iteration to workflow
- [ ] Move regenerateGraph to execute and executeReactive
  - [ ] provide a createWorkflow and createTaskGraph as part of the config for execute/executeReactive so any graphs created will be attached to the current task.
  - [ ] Remove isCompound and the fixed task.subGraph. 
  - [ ] Should we have a list of subgraphs? a list of tasks (they can have subgraphs)? go back to a subgraph but with no dataflows (as some happen in execute code -- though this should be discouraged)
  - [ ] Subgraphs will still technically be immuatable, but there may be many now, and the nubmer will varry.
  - [ ] regenerateGraph() was there for so a UI could peer into what it might look like when run. We have runReactive for that, so remove it
  - [ ] rework RunOrReplicateTask and ArrayTask, hopefully they will be simpler
  - [ ] have a another look at caching decisions
- [ ] Make Workflow more like functional programming
