### PR TITLE
refactor: migrate to TypeBox for tabular schema definitions

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -11,8 +11,8 @@
     "build-example": "bun run build-clean && concurrently -c 'auto' -n 'js,js-worker,js-worker-hft,lib' 'bun run build-js' 'bun run build-js-worker' 'bun run build-js-worker-hft' 'bun run build-lib'",
     "build-clean": "rm -fr dist/*",
     "build-js": "bun build --target=bun --packages=external --outdir ./dist ./src/ellmers.ts",
-    "build-js-worker": "bun build --target=node --outdir ./dist ./src/ellmers_worker.ts",
-    "build-js-worker-hft": "bun build --target=node --outdir ./dist ./src/worker_hft.ts",
+    "build-js-worker": "bun build --target=bun --outdir ./dist ./src/ellmers_worker.ts",
+    "build-js-worker-hft": "bun build --target=bun --outdir ./dist ./src/worker_hft.ts",
     "build-lib": "bun build --target=bun --packages=external --outdir ./dist ./src/lib.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/ai/src/model/ModelRepository.ts
+++ b/packages/ai/src/model/ModelRepository.ts
@@ -8,6 +8,7 @@
 import { EventEmitter, EventParameters } from "@ellmers/util";
 import { type TabularRepository } from "@ellmers/storage";
 import { Model } from "./Model";
+import { Type, TObject, Static } from "@sinclair/typebox";
 
 /**
  * Events that can be emitted by the ModelRepository
@@ -30,19 +31,19 @@ export type ModelEventParameters<Event extends ModelEvents> = EventParameters<
   Event
 >;
 
-export const ModelSchema = {
-  name: "string",
-  details: "json",
-} as const;
+export const ModelSchema = Type.Object({
+  name: Type.String(),
+  details: Type.String()
+});
 export const ModelPrimaryKeyNames = ["name"] as const;
 
 /**
  * Represents the structure for mapping tasks to models
  */
-export const Task2ModelSchema = {
-  task: "string",
-  model: "string",
-} as const;
+export const Task2ModelSchema = Type.Object({
+  task: Type.String(),
+  model: Type.String()
+});
 export const Task2ModelPrimaryKeyNames = ["task", "model"] as const;
 
 /**

--- a/packages/ai/src/task/DownloadModelTask.ts
+++ b/packages/ai/src/task/DownloadModelTask.ts
@@ -32,7 +32,6 @@ export type DownloadModelTaskExecuteInput = {
 export type DownloadModelTaskExecuteOutput = {
   model: string;
 };
-
 /**
  * Download a model from a remote source and cache it locally.
  *

--- a/packages/ai/src/task/base/TaskIOSchemas.ts
+++ b/packages/ai/src/task/base/TaskIOSchemas.ts
@@ -1,0 +1,68 @@
+//    *******************************************************************************
+//    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import { Static, TSchema, Type, TypeRegistry } from "@sinclair/typebox";
+import { getGlobalModelRepository } from "../../model/ModelRegistry";
+
+export const TypeVector = (annotations: Record<string, unknown> = {}) =>
+  Type.Union(
+    [
+      Type.Array(Type.Number()),
+      Type.Unsafe<Float64Array>({ type: "Float64Array" }),
+      Type.Unsafe<Float32Array>({ type: "Float32Array" }),
+      Type.Unsafe<Int32Array>({ type: "Int32Array" }),
+      Type.Unsafe<Int16Array>({ type: "Int16Array" }),
+      Type.Unsafe<Int8Array>({ type: "Int8Array" }),
+      Type.Unsafe<Uint8Array>({ type: "Uint8Array" }),
+      Type.Unsafe<Uint16Array>({ type: "Uint16Array" }),
+      Type.Unsafe<Uint32Array>({ type: "Uint32Array" }),
+      Type.Unsafe<Uint8ClampedArray>({ type: "Uint8ClampedArray" }),
+      Type.Unsafe<BigInt64Array>({ type: "BigInt64Array" }),
+      Type.Unsafe<BigUint64Array>({ type: "BigUint64Array" }),
+    ],
+    {
+      ...annotations,
+      $id: "TypeVector",
+    }
+  );
+
+export type TypeVector = Static<ReturnType<typeof TypeVector>>;
+TypeRegistry.Set("TypeVector", (schema: TSchema, value: unknown) => {
+  return typeof value === "object" && value !== null && schema.$id === "TypeVector";
+});
+
+export const TypeModel = (annotations: Record<"task" | string, unknown> = {}) =>
+  Type.String({
+    title: "Model",
+    description: `The model ${annotations.task ? `for ${annotations.task} ` : "to use"}`,
+    ...annotations,
+    $id: "TypeModel",
+  });
+
+export const TypeLanguage = (annotations: Record<string, unknown> = {}) =>
+  Type.String({
+    title: "Language",
+    description: "The language to use",
+    maxLength: 2,
+    minLength: 2,
+    ...annotations,
+    $id: "TypeLanguage",
+  });
+
+TypeRegistry.Set("TypeModel", (schema: TSchema, modelName: unknown) => {
+  if (schema.$id === "TypeModel" && typeof modelName === "string") {
+    const repository = getGlobalModelRepository();
+    const model = repository.models.get(modelName);
+    if (!model) return false;
+    if (schema.task) {
+      const taskModels = repository.taskModels.get(schema.task);
+      if (!taskModels) return false;
+    }
+    return true;
+  }
+  return false;
+});

--- a/packages/storage/src/kv/FsFolderJsonKvRepository.ts
+++ b/packages/storage/src/kv/FsFolderJsonKvRepository.ts
@@ -8,14 +8,12 @@
 import {
   JSONValue,
   ValueOptionType,
-  KeyOptionType,
-  KeyOption,
-  ValueOption,
 } from "../tabular/ITabularRepository";
 import { KvViaTabularRepository } from "./KvViaTabularRepository";
 import { FsFolderTabularRepository } from "../tabular/FsFolderTabularRepository";
 import { DefaultKeyValueKey, DefaultKeyValueSchema, IKvRepository } from "./IKvRepository";
 import { createServiceToken } from "@ellmers/util";
+import { Type, TSchema } from "@sinclair/typebox";
 
 export const FS_FOLDER_JSON_KV_REPOSITORY = createServiceToken<IKvRepository<string, any, any>>(
   "storage.kvRepository.fsFolderJson"
@@ -30,7 +28,7 @@ export const FS_FOLDER_JSON_KV_REPOSITORY = createServiceToken<IKvRepository<str
  * @template Combined - Combined type of Key & Value
  */
 export class FsFolderJsonKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > extends KvViaTabularRepository<Key, Value, Combined> {
@@ -44,10 +42,10 @@ export class FsFolderJsonKvRepository<
    */
   constructor(
     public folderPath: string,
-    primaryKeyType: KeyOption,
-    valueType: ValueOption
+    keySchema: TSchema = Type.String(),
+    valueSchema: TSchema = Type.Any()
   ) {
-    super(primaryKeyType, valueType);
+    super(keySchema, valueSchema);
     this.tabularRepository = new FsFolderTabularRepository(
       folderPath,
       DefaultKeyValueSchema,

--- a/packages/storage/src/kv/IKvRepository.ts
+++ b/packages/storage/src/kv/IKvRepository.ts
@@ -6,20 +6,19 @@
 //    *******************************************************************************
 
 import { EventParameters } from "@ellmers/util";
+import { Type } from "@sinclair/typebox";
 import {
   JSONValue,
-  KeyOptionType,
-  ValueSchema,
-  ValueOptionType,
+  ValueOptionType
 } from "../tabular/ITabularRepository";
 
 /**
  * Default schema types for simple string row data
  */
-export const DefaultKeyValueSchema: ValueSchema = {
-  key: "string",
-  value: "json",
-} as const;
+export const DefaultKeyValueSchema = Type.Object({
+  key: Type.String(),
+  value: Type.Any()
+});
 export const DefaultKeyValueKey = ["key"] as const;
 export type DefaultKvPkType = string;
 export type DefaultKvPk = { key: DefaultKvPkType };
@@ -59,7 +58,7 @@ export type KvEventParameters<Event extends KvEventName, Key, Value, Combined> =
  * @typeParam Combined - Combined type of Key & Value
  */
 export interface IKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > {

--- a/packages/storage/src/kv/InMemoryKvRepository.ts
+++ b/packages/storage/src/kv/InMemoryKvRepository.ts
@@ -7,11 +7,9 @@
 
 import {
   JSONValue,
-  KeyOptionType,
   ValueOptionType,
-  KeyOption,
-  ValueOption,
 } from "../tabular/ITabularRepository";
+import { Type, TSchema } from "@sinclair/typebox";
 import { KvViaTabularRepository } from "./KvViaTabularRepository";
 import { InMemoryTabularRepository } from "../tabular/InMemoryTabularRepository";
 import { DefaultKeyValueKey, DefaultKeyValueSchema, IKvRepository } from "./IKvRepository";
@@ -30,7 +28,7 @@ export const MEMORY_KV_REPOSITORY = createServiceToken<IKvRepository<string, any
  * @template Combined - Combined type of Key & Value
  */
 export class InMemoryKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > extends KvViaTabularRepository<Key, Value, Combined> {
@@ -42,8 +40,8 @@ export class InMemoryKvRepository<
   /**
    * Creates a new KvRepository instance
    */
-  constructor(primaryKeyType: KeyOption, valueType: ValueOption) {
-    super(primaryKeyType, valueType);
+  constructor(keySchema: TSchema = Type.String(), valueSchema: TSchema = Type.Any()) {
+    super(keySchema, valueSchema);
     this.tabularRepository = new InMemoryTabularRepository(
       DefaultKeyValueSchema,
       DefaultKeyValueKey

--- a/packages/storage/src/kv/IndexedDbKvRepository.ts
+++ b/packages/storage/src/kv/IndexedDbKvRepository.ts
@@ -8,10 +8,8 @@
 import {
   JSONValue,
   ValueOptionType,
-  KeyOptionType,
-  KeyOption,
-  ValueOption,
 } from "../tabular/ITabularRepository";
+import { Type, TSchema } from "@sinclair/typebox";
 import { KvViaTabularRepository } from "./KvViaTabularRepository";
 import { IndexedDbTabularRepository } from "../tabular/IndexedDbTabularRepository";
 import { DefaultKeyValueKey, DefaultKeyValueSchema, IKvRepository } from "./IKvRepository";
@@ -30,7 +28,7 @@ export const IDB_KV_REPOSITORY = createServiceToken<IKvRepository<string, any, a
  * @template Combined - Combined type of Key & Value
  */
 export class IndexedDbKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > extends KvViaTabularRepository<Key, Value, Combined> {
@@ -44,10 +42,10 @@ export class IndexedDbKvRepository<
    */
   constructor(
     public dbName: string,
-    primaryKeyType: KeyOption,
-    valueType: ValueOption
+    keySchema: TSchema = Type.String(),
+    valueSchema: TSchema = Type.Any()
   ) {
-    super(primaryKeyType, valueType);
+    super(keySchema, valueSchema);
     this.tabularRepository = new IndexedDbTabularRepository(
       dbName,
       DefaultKeyValueSchema,

--- a/packages/storage/src/kv/KvRepository.ts
+++ b/packages/storage/src/kv/KvRepository.ts
@@ -6,11 +6,9 @@
 //    *******************************************************************************
 
 import { createServiceToken, EventEmitter, makeFingerprint } from "@ellmers/util";
+import { TSchema, Static } from "@sinclair/typebox";
 import {
   JSONValue,
-  KeyOption,
-  KeyOptionType,
-  ValueOption,
   ValueOptionType,
 } from "../tabular/ITabularRepository";
 import {
@@ -33,7 +31,7 @@ export const KV_REPOSITORY =
  * @template Combined - Combined type of Key & Value
  */
 export abstract class KvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key extends any = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > implements IKvRepository<Key, Value, Combined>
@@ -45,8 +43,8 @@ export abstract class KvRepository<
    * Creates a new KvRepository instance
    */
   constructor(
-    public primaryKeyType: KeyOption,
-    public valueType: ValueOption
+    public keySchema: TSchema,
+    public valueSchema: TSchema
   ) {}
 
   /**

--- a/packages/storage/src/kv/PostgresKvRepository.ts
+++ b/packages/storage/src/kv/PostgresKvRepository.ts
@@ -9,11 +9,9 @@ import { PostgresTabularRepository } from "../tabular/PostgresTabularRepository"
 import { DefaultKeyValueKey, DefaultKeyValueSchema, IKvRepository } from "./IKvRepository";
 import {
   JSONValue,
-  KeyOptionType,
   ValueOptionType,
-  KeyOption,
-  ValueOption,
 } from "../tabular/ITabularRepository";
+import { Type, TSchema } from "@sinclair/typebox";
 import { KvViaTabularRepository } from "./KvViaTabularRepository";
 import { createServiceToken } from "@ellmers/util";
 
@@ -30,7 +28,7 @@ export const POSTGRES_KV_REPOSITORY = createServiceToken<IKvRepository<string, a
  * @template Combined - Combined type of Key & Value
  */
 export class PostgresKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > extends KvViaTabularRepository<Key, Value, Combined> {
@@ -45,10 +43,10 @@ export class PostgresKvRepository<
   constructor(
     public db: any,
     public dbName: string,
-    primaryKeyType: KeyOption,
-    valueType: ValueOption
+    keySchema: TSchema = Type.String(),
+    valueSchema: TSchema = Type.Any()
   ) {
-    super(primaryKeyType, valueType);
+    super(keySchema, valueSchema);
     this.tabularRepository = new PostgresTabularRepository(
       db,
       dbName,

--- a/packages/storage/src/kv/SqliteKvRepository.ts
+++ b/packages/storage/src/kv/SqliteKvRepository.ts
@@ -7,11 +7,9 @@
 
 import {
   JSONValue,
-  KeyOptionType,
   ValueOptionType,
-  KeyOption,
-  ValueOption,
 } from "../tabular/ITabularRepository";
+import { Type, TSchema } from "@sinclair/typebox";
 import { KvViaTabularRepository } from "./KvViaTabularRepository";
 import { SqliteTabularRepository } from "../tabular/SqliteTabularRepository";
 import { DefaultKeyValueKey, DefaultKeyValueSchema, IKvRepository } from "./IKvRepository";
@@ -30,7 +28,7 @@ export const SQLITE_KV_REPOSITORY = createServiceToken<IKvRepository<string, any
  * @template Combined - Combined type of Key & Value
  */
 export class SqliteKvRepository<
-  Key extends KeyOptionType = KeyOptionType,
+  Key = string,
   Value extends ValueOptionType = JSONValue,
   Combined = { key: Key; value: Value },
 > extends KvViaTabularRepository<Key, Value, Combined> {
@@ -45,10 +43,10 @@ export class SqliteKvRepository<
   constructor(
     public db: any,
     public dbName: string,
-    primaryKeyType: KeyOption,
-    valueType: ValueOption
+    keySchema: TSchema = Type.String(),
+    valueSchema: TSchema = Type.Any()
   ) {
-    super(primaryKeyType, valueType);
+    super(keySchema, valueSchema);
     this.tabularRepository = new SqliteTabularRepository(
       db,
       dbName,

--- a/packages/storage/src/tabular/FsFolderTabularRepository.ts
+++ b/packages/storage/src/tabular/FsFolderTabularRepository.ts
@@ -9,11 +9,10 @@ import path from "node:path";
 import { readFile, writeFile, rm, readdir } from "node:fs/promises";
 import { mkdirSync } from "node:fs";
 import { glob } from "glob";
+import { TObject, Static } from "@sinclair/typebox";
 import {
-  ValueSchema,
   ExtractPrimaryKey,
   ExtractValue,
-  SchemaToType,
   ITabularRepository,
   ValueOptionType,
 } from "./ITabularRepository";
@@ -33,11 +32,11 @@ export const FS_FOLDER_TABULAR_REPOSITORY = createServiceToken<ITabularRepositor
  * @template PrimaryKeyNames - Array of property names that form the primary key
  */
 export class FsFolderTabularRepository<
-  Schema extends ValueSchema,
-  PrimaryKeyNames extends ReadonlyArray<keyof Schema>,
+  Schema extends TObject,
+  PrimaryKeyNames extends ReadonlyArray<keyof Static<Schema>>,
   // computed types
   PrimaryKey = ExtractPrimaryKey<Schema, PrimaryKeyNames>,
-  Entity = SchemaToType<Schema>,
+  Entity = Static<Schema>,
   Value = ExtractValue<Schema, PrimaryKeyNames>,
 > extends TabularRepository<Schema, PrimaryKeyNames, PrimaryKey, Entity, Value> {
   private folderPath: string;

--- a/packages/storage/src/tabular/ITabularRepository.ts
+++ b/packages/storage/src/tabular/ITabularRepository.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, EventParameters } from "@ellmers/util";
+import { TObject, TProperties, Static, Type } from "@sinclair/typebox";
 
 //    *******************************************************************************
 //    *   ELLMERS: Embedding Large Language Model Experiential Retrieval Service    *
@@ -31,9 +32,6 @@ export type TabularEventParameters<
   Entity,
 > = EventParameters<TabularEventListeners<PrimaryKey, Entity>, Event>;
 
-// Helper type to map schema types to their actual types
-export type MapSchemaTypes<T extends keyof SchemaTypeMap> = SchemaTypeMap[T];
-
 // Type definitions for specialized string types
 export type uuid4 = string;
 export type JSONValue =
@@ -44,61 +42,38 @@ export type JSONValue =
   | JSONValue[]
   | { [key: string]: JSONValue };
 
-// Type mapping from schema type strings to actual types
-export type SchemaTypeMap = {
-  uuid4: uuid4;
-  string: string;
-  number: number;
-  bigint: bigint;
-  boolean: boolean;
-  null: null;
-  json: JSONValue;
-  date: Date;
-  blob: Uint8Array;
-};
-
-export type KeyOption = "string" | "number" | "bigint" | "uuid4" | "date";
-export type KeySchema = Record<string, KeyOption>;
-export type KeyOptionType = MapSchemaTypes<KeyOption>;
-export type ExcludeDateKeyOptionType = Exclude<KeyOptionType, Date>;
-
-export type ValueOption = KeyOption | "boolean" | "null" | "json" | "blob";
-export type ValueSchema = Record<string, ValueOption>;
-export type ValueOptionType = MapSchemaTypes<ValueOption>;
-export type ExcludeDateValueOptionType = Exclude<ValueOptionType, Date>;
-// Type to map schema to TypeScript types
-export type SchemaToType<T extends Record<string, keyof SchemaTypeMap>> = {
-  [K in keyof T]: MapSchemaTypes<T[K]>;
-};
-
-// Extract primary key type
+// Extract primary key type from TypeBox schema
 export type ExtractPrimaryKey<
-  T extends Record<string, keyof SchemaTypeMap>,
-  K extends ReadonlyArray<keyof T>,
+  T extends TObject,
+  K extends ReadonlyArray<keyof Static<T>>,
 > = {
-  [P in K[number]]: MapSchemaTypes<T[P]>;
+  [P in K[number]]: Static<T>[P];
 };
 
-// Extract value type (everything except the primary key)
+// Extract value type from TypeBox schema (everything except the primary key)
 export type ExtractValue<
-  T extends Record<string, keyof SchemaTypeMap>,
-  K extends ReadonlyArray<keyof T>,
-> = Omit<SchemaToType<T>, K[number]>;
+  T extends TObject,
+  K extends ReadonlyArray<keyof Static<T>>,
+> = Omit<Static<T>, K[number]>;
+
+// Generic type for possible value types in the repository
+export type ValueOptionType = string | number | bigint | boolean | null | JSONValue | Date | Uint8Array;
+export type ExcludeDateValueOptionType = Exclude<ValueOptionType, Date>;
 
 /**
  * Interface defining the contract for tabular storage repositories.
  * Provides a flexible interface for storing and retrieving data with typed
  * primary keys and values, and supports compound keys and partial key lookup.
  *
- * @typeParam Schema - The schema definition for the entity
+ * @typeParam Schema - The schema definition for the entity using TypeBox
  * @typeParam PrimaryKeyNames - Array of property names that form the primary key
  */
 export interface ITabularRepository<
-  Schema extends ValueSchema,
-  PrimaryKeyNames extends ReadonlyArray<keyof Schema> = ReadonlyArray<keyof Schema>,
+  Schema extends TObject,
+  PrimaryKeyNames extends ReadonlyArray<keyof Static<Schema>> = ReadonlyArray<keyof Static<Schema>>,
   // computed types
   PrimaryKey = ExtractPrimaryKey<Schema, PrimaryKeyNames>,
-  Entity = SchemaToType<Schema>,
+  Entity = Static<Schema>,
 > {
   // Core methods
   put(value: Entity): Promise<void>;

--- a/packages/storage/src/tabular/InMemoryTabularRepository.ts
+++ b/packages/storage/src/tabular/InMemoryTabularRepository.ts
@@ -6,11 +6,10 @@
 //    *******************************************************************************
 
 import { makeFingerprint } from "@ellmers/util";
+import { TObject, Static } from "@sinclair/typebox";
 import {
-  ValueSchema,
   ExtractPrimaryKey,
   ExtractValue,
-  SchemaToType,
   ITabularRepository,
   ValueOptionType,
 } from "./ITabularRepository";
@@ -25,15 +24,15 @@ export const MEMORY_TABULAR_REPOSITORY = createServiceToken<ITabularRepository<a
  * A generic in-memory key-value repository implementation.
  * Provides a simple, non-persistent storage solution suitable for testing and caching scenarios.
  *
- * @template Schema - The schema definition for the entity
+ * @template Schema - The schema definition for the entity using TypeBox
  * @template PrimaryKeyNames - Array of property names that form the primary key
  */
 export class InMemoryTabularRepository<
-  Schema extends ValueSchema,
-  PrimaryKeyNames extends ReadonlyArray<keyof Schema>,
+  Schema extends TObject,
+  PrimaryKeyNames extends ReadonlyArray<keyof Static<Schema>>,
   // computed types
   PrimaryKey = ExtractPrimaryKey<Schema, PrimaryKeyNames>,
-  Entity = SchemaToType<Schema>,
+  Entity = Static<Schema>,
   Value = ExtractValue<Schema, PrimaryKeyNames>,
 > extends TabularRepository<Schema, PrimaryKeyNames, PrimaryKey, Entity, Value> {
   /** Internal storage using a Map with fingerprint strings as keys */

--- a/packages/storage/src/tabular/IndexedDbTabularRepository.ts
+++ b/packages/storage/src/tabular/IndexedDbTabularRepository.ts
@@ -6,11 +6,10 @@
 //    *******************************************************************************
 
 import { ensureIndexedDbTable, ExpectedIndexDefinition } from "../util/IndexedDbTable";
+import { TObject, Static } from "@sinclair/typebox";
 import {
-  ValueSchema,
   ExtractPrimaryKey,
   ExtractValue,
-  SchemaToType,
   ITabularRepository,
   ValueOptionType,
 } from "./ITabularRepository";
@@ -28,11 +27,11 @@ export const IDB_TABULAR_REPOSITORY = createServiceToken<ITabularRepository<any>
  * @template PrimaryKeyNames - Array of property names that form the primary key
  */
 export class IndexedDbTabularRepository<
-  Schema extends ValueSchema,
-  PrimaryKeyNames extends ReadonlyArray<keyof Schema>,
+  Schema extends TObject,
+  PrimaryKeyNames extends ReadonlyArray<keyof Static<Schema>>,
   // computed types
   PrimaryKey = ExtractPrimaryKey<Schema, PrimaryKeyNames>,
-  Entity = SchemaToType<Schema>,
+  Entity = Static<Schema>,
   Value = ExtractValue<Schema, PrimaryKeyNames>,
 > extends TabularRepository<Schema, PrimaryKeyNames, PrimaryKey, Entity, Value> {
   /** Promise that resolves to the IndexedDB database instance */

--- a/packages/storage/src/tabular/TabularRepository.ts
+++ b/packages/storage/src/tabular/TabularRepository.ts
@@ -7,19 +7,15 @@
 
 import { createServiceToken, EventEmitter } from "@ellmers/util";
 import { makeFingerprint } from "@ellmers/util";
+import { TObject, Static, Type } from "@sinclair/typebox";
 import {
   TabularEventName,
   TabularEventListener,
   TabularEventListeners,
   TabularEventParameters,
   ITabularRepository,
-  ValueSchema,
-  KeyOptionType,
-  SchemaToType,
   ExtractPrimaryKey,
   ExtractValue,
-  KeyOption,
-  KeySchema,
   ValueOptionType,
 } from "./ITabularRepository";
 
@@ -33,15 +29,15 @@ export const TABULAR_REPOSITORY = createServiceToken<ITabularRepository<any>>(
  * primary keys and values, and supports compound keys and partial key lookup.
  * Has a basic event emitter for listening to repository events.
  *
- * @template Schema - The schema definition for the entity
+ * @template Schema - The schema definition for the entity using TypeBox
  * @template PrimaryKeyNames - Array of property names that form the primary key
  */
 export abstract class TabularRepository<
-  Schema extends ValueSchema,
-  PrimaryKeyNames extends ReadonlyArray<keyof Schema>,
+  Schema extends TObject,
+  PrimaryKeyNames extends ReadonlyArray<keyof Static<Schema>>,
   // computed types
   PrimaryKey = ExtractPrimaryKey<Schema, PrimaryKeyNames>,
-  Entity = SchemaToType<Schema>,
+  Entity = Static<Schema>,
   Value = ExtractValue<Schema, PrimaryKeyNames>,
 > implements ITabularRepository<Schema, PrimaryKeyNames, PrimaryKey, Entity>
 {
@@ -49,8 +45,8 @@ export abstract class TabularRepository<
   protected events = new EventEmitter<TabularEventListeners<PrimaryKey, Entity>>();
 
   protected indexes: Array<keyof Entity>[];
-  protected primaryKeySchema: KeySchema;
-  protected valueSchema: ValueSchema;
+  protected primaryKeySchema: TObject;
+  protected valueSchema: TObject;
 
   /**
    * Creates a new TabularRepository instance
@@ -64,19 +60,21 @@ export abstract class TabularRepository<
     protected primaryKeyNames: PrimaryKeyNames,
     indexes: Array<keyof Entity | Array<keyof Entity>> = []
   ) {
-    this.primaryKeySchema = {};
+    const primaryKeyProps: Record<string, any> = {};
+    const valueProps: Record<string, any> = {};
     const primaryKeySet = new Set(primaryKeyNames);
-    for (const [key, type] of Object.entries(schema)) {
-      if (primaryKeySet.has(key as keyof Schema)) {
-        this.primaryKeySchema[key] = type as KeyOption;
+    
+    // Split the schema properties into primary key and value properties
+    for (const key in schema.properties) {
+      if (primaryKeySet.has(key as keyof Static<Schema>)) {
+        primaryKeyProps[key] = schema.properties[key];
+      } else {
+        valueProps[key] = schema.properties[key];
       }
     }
-    this.valueSchema = {};
-    for (const [key, type] of Object.entries(schema)) {
-      if (!primaryKeySet.has(key as keyof Schema)) {
-        this.valueSchema[key] = type;
-      }
-    }
+
+    this.primaryKeySchema = Type.Object(primaryKeyProps);
+    this.valueSchema = Type.Object(valueProps);
 
     // validate all combined columns names are "identifier" names
     const combinedColumns = [...this.primaryKeyColumns(), ...this.valueColumns()];
@@ -96,7 +94,7 @@ export abstract class TabularRepository<
       Array<keyof Entity>
     >;
 
-    // searchable is an arrya of compound keys, which are arrays of columns
+    // searchable is an array of compound keys, which are arrays of columns
     // clean up searchable array by removing any compoundkeys that are a prefix of another compoundkey
     // or a prefix of the primary key
     this.indexes = this.filterCompoundKeys(
@@ -107,7 +105,7 @@ export abstract class TabularRepository<
     // Validate searchable columns
     for (const compoundIndex of this.indexes) {
       for (const column of compoundIndex) {
-        if (!(column in this.primaryKeySchema) && !(column in this.valueSchema)) {
+        if (!(column in this.primaryKeySchema.properties) && !(column in this.valueSchema.properties)) {
           throw new Error(
             `Searchable column ${String(column)} is not in the primary key schema or value schema`
           );
@@ -239,16 +237,16 @@ export abstract class TabularRepository<
 
   protected primaryKeyColumns(): Array<keyof PrimaryKey> {
     const columns: Array<keyof PrimaryKey> = [];
-    for (const [k, type] of Object.entries(this.primaryKeySchema)) {
-      columns.push(k as keyof PrimaryKey);
+    for (const key in this.primaryKeySchema.properties) {
+      columns.push(key as keyof PrimaryKey);
     }
     return columns;
   }
 
   protected valueColumns(): Array<keyof Value> {
     const columns: Array<keyof Value> = [];
-    for (const [k, type] of Object.entries(this.valueSchema)) {
-      columns.push(k as keyof Value);
+    for (const key in this.valueSchema.properties) {
+      columns.push(key as keyof Value);
     }
     return columns;
   }
@@ -298,10 +296,10 @@ export abstract class TabularRepository<
    * @param key - The primary key object to convert
    * @returns Array of key values ordered according to the schema
    */
-  protected getPrimaryKeyAsOrderedArray(key: PrimaryKey): KeyOptionType[] {
-    const orderedParams: KeyOptionType[] = [];
-    const keyObj = key as Record<string, KeyOptionType>;
-    for (const [k, type] of Object.entries(this.primaryKeySchema)) {
+  protected getPrimaryKeyAsOrderedArray(key: PrimaryKey): ValueOptionType[] {
+    const orderedParams: ValueOptionType[] = [];
+    const keyObj = key as Record<string, ValueOptionType>;
+    for (const k in this.primaryKeySchema.properties) {
       if (k in keyObj) {
         orderedParams.push(keyObj[k]);
       } else {

--- a/packages/task-graph/src/storage/TaskGraphTabularRepository.ts
+++ b/packages/task-graph/src/storage/TaskGraphTabularRepository.ts
@@ -6,14 +6,15 @@
 //    *******************************************************************************
 
 import type { TabularRepository } from "@ellmers/storage";
+import { Type } from "@sinclair/typebox";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { createGraphFromGraphJSON } from "../task/TaskJSON";
 import { TaskGraphRepository } from "./TaskGraphRepository";
 
-export const TaskGraphSchema = {
-  key: "string",
-  value: "string",
-} as const;
+export const TaskGraphSchema = Type.Object({
+  key: Type.String(),
+  value: Type.String()
+});
 
 export const TaskGraphPrimaryKeyNames = ["key"] as const;
 

--- a/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
@@ -7,6 +7,7 @@
 
 import { type TabularRepository } from "@ellmers/storage";
 import { compress, decompress, makeFingerprint } from "@ellmers/util";
+import { Type } from "@sinclair/typebox";
 import { TaskInput, TaskOutput } from "../task/TaskTypes";
 import { TaskOutputRepository } from "./TaskOutputRepository";
 
@@ -15,12 +16,12 @@ export type TaskOutputPrimaryKey = {
   taskType: string;
 };
 
-export const TaskOutputSchema = {
-  key: "string",
-  taskType: "string",
-  value: "blob",
-  createdAt: "date",
-} as const;
+export const TaskOutputSchema = Type.Object({
+  key: Type.String(),
+  taskType: Type.String(),
+  value: Type.Any(), // For binary data
+  createdAt: Type.Any() // For Date objects
+});
 
 export const TaskOutputPrimaryKeyNames = ["key", "taskType"] as const;
 

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -19,6 +19,8 @@ import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
 import { IWorkflow } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
 import { CompoundMergeStrategy } from "./TaskGraphRunner";
+import { getLastTask, parallel, pipe, PipeFunction, Taskish } from "./Conversions";
+import { simplifySchema } from "../task/TaskSchema";
 
 // Type definitions for the workflow
 export type CreateWorkflow<I extends TaskIO, O extends TaskIO, C extends TaskConfig> = (

--- a/packages/task-graph/src/task/ArrayTask.ts
+++ b/packages/task-graph/src/task/ArrayTask.ts
@@ -10,6 +10,7 @@ import { JsonTaskItem, TaskGraphItemJson } from "../node";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { TaskConfig, TaskInput, TaskOutput } from "./TaskTypes";
 import { GraphAsTask } from "./GraphAsTask";
+import { simplifySchema } from "./TaskSchema";
 
 /**
  * ArrayTask is a compound task that either:

--- a/packages/test/src/test/storage-tabular/genericTabularRepositoryTests.test.ts
+++ b/packages/test/src/test/storage-tabular/genericTabularRepositoryTests.test.ts
@@ -6,25 +6,26 @@
 //    *******************************************************************************
 
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
-import { ValueSchema, ITabularRepository } from "@ellmers/storage";
+import { ITabularRepository } from "@ellmers/storage";
+import { Type } from "@sinclair/typebox";
 
 export const CompoundPrimaryKeyNames = ["name", "type"] as const;
-export const CompoundSchema: ValueSchema = {
-  name: "string",
-  type: "string",
-  option: "string",
-  success: "boolean",
-} as const;
+export const CompoundSchema = Type.Object({
+  name: Type.String(),
+  type: Type.String(),
+  option: Type.String(),
+  success: Type.Boolean(),
+});
 
 export const SearchPrimaryKeyNames = ["id"] as const;
-export const SearchSchema: ValueSchema = {
-  id: "string",
-  category: "string",
-  subcategory: "string",
-  value: "number",
-  createdAt: "date",
-  updatedAt: "date",
-} as const;
+export const SearchSchema = Type.Object({
+  id: Type.String(),
+  category: Type.String(),
+  subcategory: Type.String(),
+  value: Type.Number(),
+  createdAt: Type.Any(), // Use Type.Any() for Date objects
+  updatedAt: Type.Any(), // Use Type.Any() for Date objects
+});
 
 export function runGenericTabularRepositoryTests(
   createCompoundPkRepository: () => Promise<


### PR DESCRIPTION
- Replaced existing schema definitions with TypeBox for improved type safety and validation across various repositories and models.
- Updated ModelRepository, KvRepository implementations, and related classes to utilize TypeBox for defining key and value schemas.
- Enhanced handling of JSON and binary data types in storage repositories to align with new schema definitions.
- Refactored tabular repository classes to support TypeBox schemas, ensuring consistency and better type inference throughout the codebase.