### PR TITLE
Implement streaming task graph plan

### DIFF
--- a/docs/background/05_task_chains.md
+++ b/docs/background/05_task_chains.md
@@ -29,3 +29,10 @@ Tasks may be posted to a job queue (see `JobQueueTask`) and run by a job queue r
 ## Compound Task
 
 A compound task is `GraphAsTask` that contains a group of tasks (in DAG format) chained together to look like a single task.
+
+## Streaming Between Tasks
+
+- Tasks can stream partial results to dependants without waiting for `execute()` to finish by declaring stream-capable outputs via the static `streaming()` descriptor.
+- Ports marked with readiness `first-chunk` allow downstream tasks to begin work as soon as the first chunk is emitted. Ports with readiness `final` defer dependants until streaming completes.
+- `IExecuteContext` now exposes `pushChunk`, `closeStream`, and `attachStreamController` helpers so tasks can enqueue chunks directly or adapt custom `ReadableStream` producers.
+- Dataflows track streaming state and expose async iterables so consumers can react to chunk updates while still receiving the final aggregated output when the stream ends.

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -12,6 +12,7 @@ export * from "./task/ITask";
 export * from "./task/TaskEvents";
 export * from "./task/TaskJSON";
 export * from "./task/Task";
+export * from "./task/TaskStream";
 export * from "./task/GraphAsTask";
 export * from "./task/GraphAsTaskRunner";
 export * from "./task/TaskRegistry";

--- a/packages/task-graph/src/task-graph/DataflowEvents.ts
+++ b/packages/task-graph/src/task-graph/DataflowEvents.ts
@@ -20,6 +20,15 @@ export type DataflowEventListeners = {
   /** Fired when a source task completes successfully */
   complete: () => void;
 
+  /** Fired when a dataflow begins streaming */
+  stream_start: () => void;
+
+  /** Fired when a streaming chunk traverses the dataflow */
+  stream_chunk: (chunk: unknown, aggregate: unknown) => void;
+
+  /** Fired when streaming ends */
+  stream_end: (aggregate: unknown) => void;
+
   /** Fired when a source task is skipped */
   skipped: () => void;
 

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -27,6 +27,7 @@ import {
   type TaskInput,
   type TaskOutput,
   type TaskTypeName,
+  type TaskStreamingDescriptor,
 } from "./TaskTypes";
 
 /**
@@ -82,6 +83,14 @@ export class Task<
    */
   public static outputSchema(): DataPortSchema {
     return Type.Object({}) as DataPortSchema;
+  }
+
+  /**
+   * Streaming metadata for this task
+   * Returns descriptors for stream-capable outputs
+   */
+  public static streaming(): TaskStreamingDescriptor {
+    return { outputs: {} };
   }
 
   // ========================================================================
@@ -197,6 +206,10 @@ export class Task<
    */
   public outputSchema(): DataPortSchema {
     return (this.constructor as typeof Task).outputSchema();
+  }
+
+  public streaming(): TaskStreamingDescriptor {
+    return (this.constructor as typeof Task).streaming();
   }
 
   public get type(): TaskTypeName {

--- a/packages/task-graph/src/task/TaskEvents.ts
+++ b/packages/task-graph/src/task/TaskEvents.ts
@@ -23,6 +23,15 @@ export type TaskEventListeners = {
   /** Fired when a task completes successfully */
   complete: () => void;
 
+  /** Fired when a task begins streaming on a specific output port */
+  stream_start: (portId: string) => void;
+
+  /** Fired when a streaming chunk is produced */
+  stream_chunk: (portId: string, chunk: unknown, aggregate: unknown) => void;
+
+  /** Fired when a task finishes streaming on a specific output port */
+  stream_end: (portId: string, aggregate: unknown) => void;
+
   /** Fired when a task is aborted */
   abort: (error: TaskAbortedError) => void;
 

--- a/packages/task-graph/src/task/TaskStream.ts
+++ b/packages/task-graph/src/task/TaskStream.ts
@@ -1,0 +1,146 @@
+//    *******************************************************************************
+//    *   PODLEY.AI: Your Agentic AI library                                        *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import type { DataPortSchema } from "./TaskSchema";
+
+/**
+ * Describes a streaming-compatible value exposed by a task.
+ * Tasks may either yield values through AsyncIterables or ReadableStreams.
+ */
+export type TaskStream<TChunk = unknown> = AsyncIterable<TChunk> | ReadableStream<TChunk>;
+
+/**
+ * Defines when a downstream consumer can begin execution relative to a streaming output.
+ * - `first-chunk`: consumers may start when the first chunk is available.
+ * - `final`: consumers must wait for the stream to finish.
+ */
+export type TaskStreamReadiness = "first-chunk" | "final";
+
+/**
+ * Aggregator used to project a stream of chunks into a final output value.
+ * Implementations must be pure; they receive the current aggregate state for every chunk
+ * and are expected to return a new state instance.
+ */
+export interface TaskStreamAccumulator<Chunk, Aggregate> {
+  readonly initial: () => Aggregate;
+  readonly accumulate: (current: Aggregate, chunk: Chunk) => Aggregate;
+  readonly complete: (current: Aggregate) => Aggregate;
+}
+
+/**
+ * Metadata describing how a specific output port behaves when streaming.
+ */
+export interface TaskStreamPortDescriptor<Chunk = unknown, Aggregate = unknown> {
+  readonly chunkSchema: DataPortSchema | null;
+  readonly readiness: TaskStreamReadiness;
+  readonly accumulator: TaskStreamAccumulator<Chunk, Aggregate>;
+}
+
+/**
+ * Metadata describing all stream-capable outputs for a task.
+ */
+export interface TaskStreamingDescriptor {
+  readonly outputs: Readonly<Record<string, TaskStreamPortDescriptor<any, any>>>;
+}
+
+/**
+ * Type guard for ReadableStream values.
+ */
+export function isReadableStream<TChunk = unknown>(
+  value: unknown
+): value is ReadableStream<TChunk> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { getReader?: unknown }).getReader === "function"
+  );
+}
+
+/**
+ * Type guard for AsyncIterable values.
+ */
+export function isAsyncIterable<TChunk = unknown>(value: unknown): value is AsyncIterable<TChunk> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
+  );
+}
+
+/**
+ * Type guard that matches either ReadableStream or AsyncIterable values.
+ */
+export function isTaskStream<TChunk = unknown>(value: unknown): value is TaskStream<TChunk> {
+  return isReadableStream<TChunk>(value) || isAsyncIterable<TChunk>(value);
+}
+
+/**
+ * Converts a ReadableStream into an AsyncIterableIterator.
+ */
+export async function* readableStreamToAsyncIterable<TChunk>(
+  stream: ReadableStream<TChunk>
+): AsyncIterableIterator<TChunk> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) {
+        return;
+      }
+      yield result.value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Ensures a streaming value exposes the AsyncIterable protocol.
+ */
+export function toAsyncIterable<TChunk>(stream: TaskStream<TChunk>): AsyncIterableIterator<TChunk> {
+  if (isAsyncIterable<TChunk>(stream)) {
+    return (async function* iterate() {
+      for await (const chunk of stream) {
+        yield chunk;
+      }
+    })();
+  }
+  return readableStreamToAsyncIterable(stream);
+}
+
+/**
+ * Creates a simple accumulator that collects stream chunks into an array.
+ */
+export function createArrayAccumulator<Chunk>(): TaskStreamAccumulator<Chunk, Chunk[]> {
+  return {
+    initial: () => [],
+    accumulate: (current, chunk) => [...current, chunk],
+    complete: (current) => current,
+  };
+}
+
+/**
+ * Creates an accumulator that concatenates string chunks.
+ */
+export function createStringAccumulator(): TaskStreamAccumulator<string, string> {
+  return {
+    initial: () => "",
+    accumulate: (current, chunk) => `${current}${chunk}`,
+    complete: (current) => current,
+  };
+}
+
+/**
+ * Creates an accumulator that always retains the most recent chunk.
+ */
+export function createLatestValueAccumulator<Chunk>(): TaskStreamAccumulator<Chunk, Chunk | null> {
+  return {
+    initial: () => null,
+    accumulate: (_, chunk) => chunk,
+    complete: (current) => current,
+  };
+}

--- a/packages/task-graph/src/task/TaskTypes.ts
+++ b/packages/task-graph/src/task/TaskTypes.ts
@@ -7,6 +7,13 @@
 
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { Task } from "./Task";
+export type {
+  TaskStream,
+  TaskStreamAccumulator,
+  TaskStreamPortDescriptor,
+  TaskStreamReadiness,
+  TaskStreamingDescriptor,
+} from "./TaskStream";
 
 /**
  * Enum representing the possible states of a task
@@ -24,6 +31,8 @@ export enum TaskStatus {
   SKIPPED = "SKIPPED",
   /** Task is currently running */
   PROCESSING = "PROCESSING",
+  /** Task is emitting streaming output */
+  STREAMING = "STREAMING",
   /** Task has completed successfully */
   COMPLETED = "COMPLETED",
   /** Task is in the process of being aborted */

--- a/packages/test/src/test/task-graph/StreamingTaskGraph.test.ts
+++ b/packages/test/src/test/task-graph/StreamingTaskGraph.test.ts
@@ -1,0 +1,201 @@
+//    *******************************************************************************
+//    *   PODLEY.AI: Your Agentic AI library                                        *
+//    *                                                                             *
+//    *   Copyright Steven Roussey <sroussey@gmail.com>                             *
+//    *   Licensed under the Apache License, Version 2.0 (the "License");           *
+//    *******************************************************************************
+
+import { describe, expect, it } from "bun:test";
+import {
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+  Dataflow,
+  type IExecuteContext,
+  type TaskConfig,
+  type TaskStreamingDescriptor,
+  type DataPortSchema,
+  createStringAccumulator,
+} from "@podley/task-graph";
+import { Type, type TObject } from "@sinclair/typebox";
+import { sleep } from "@podley/util";
+
+type ProducerInput = {
+  chunks: string[];
+  delay: number;
+};
+
+type ProducerOutput = {
+  output: string;
+};
+
+abstract class BaseStreamingProducer extends Task<ProducerInput, ProducerOutput> {
+  static readiness: "first-chunk" | "final" = "first-chunk";
+  protected readonly events: string[];
+
+  constructor(events: string[], input: ProducerInput, config?: TaskConfig) {
+    super(input, config);
+    this.events = events;
+  }
+
+  static inputSchema(): TObject {
+    return Type.Object({
+      chunks: Type.Array(
+        Type.String({
+          description: "Chunk to emit",
+        })
+      ),
+      delay: Type.Number({
+        description: "Delay between chunks (ms)",
+        default: 0,
+      }),
+    });
+  }
+
+  static outputSchema(): TObject {
+    return Type.Object({
+      output: Type.String({
+        description: "Concatenated result",
+      }),
+    });
+  }
+
+  static streaming(): TaskStreamingDescriptor {
+    return {
+      outputs: {
+        output: {
+          chunkSchema: Type.String({
+            description: "Streamed chunk",
+          }) as DataPortSchema,
+          readiness: this.readiness,
+          accumulator: createStringAccumulator(),
+        },
+      },
+    };
+  }
+
+  async execute(input: ProducerInput, context: IExecuteContext): Promise<ProducerOutput> {
+    let final = "";
+    for (const chunk of input.chunks) {
+      this.events.push(`chunk:${chunk}`);
+      await context.pushChunk("output", chunk);
+      final += chunk;
+      if (input.delay > 0) {
+        await sleep(input.delay);
+      }
+    }
+    await context.closeStream("output");
+    this.events.push("producer-complete");
+    return { output: final };
+  }
+}
+
+describe("Streaming task orchestration", () => {
+  it("allows dependants to start once the first chunk arrives", async () => {
+    class FirstChunkProducer extends BaseStreamingProducer {
+      static override readiness: "first-chunk" | "final" = "first-chunk";
+    }
+
+    class RecordingConsumer extends Task<{ input: string }, { length: number }> {
+      static readonly type = "RecordingConsumer";
+      private readonly events: string[];
+
+      constructor(events: string[], config?: TaskConfig) {
+        super({}, config);
+        this.events = events;
+      }
+
+      static inputSchema(): TObject {
+        return Type.Object({
+          input: Type.String({
+            description: "Aggregated streaming input",
+            default: "",
+          }),
+        });
+      }
+
+      static outputSchema(): TObject {
+        return Type.Object({
+          length: Type.Number({ description: "Length of received string" }),
+        });
+      }
+
+      async execute(input: { input: string }): Promise<{ length: number }> {
+        this.events.push("consumer-start");
+        return { length: input.input.length };
+      }
+    }
+
+    const events: string[] = [];
+    const graph = new TaskGraph();
+    const producer = new FirstChunkProducer(events, { chunks: ["A", "B", "C"], delay: 20 }, { id: "producer" });
+    const consumer = new RecordingConsumer(events, { id: "consumer" });
+
+    graph.addTasks([producer, consumer]);
+    graph.addDataflow(new Dataflow("producer", "output", "consumer", "input"));
+
+    const runner = new TaskGraphRunner(graph);
+    const results = await runner.runGraph();
+
+    expect(events.indexOf("consumer-start")).toBeGreaterThan(events.indexOf("chunk:A"));
+    expect(events.indexOf("consumer-start")).toBeLessThan(events.indexOf("producer-complete"));
+
+    const producerResult = results.find((entry) => entry.id === "producer");
+    expect(producerResult?.data.output).toBe("ABC");
+
+    const consumerResult = results.find((entry) => entry.id === "consumer");
+    expect(consumerResult?.data.length).toBe(3);
+  });
+
+  it("waits for stream completion when readiness is final", async () => {
+    class FinalProducer extends BaseStreamingProducer {
+      static override readiness: "first-chunk" | "final" = "final";
+    }
+
+    class CapturingConsumer extends Task<{ input: string }, { seen: string }> {
+      static readonly type = "CapturingConsumer";
+      private readonly events: string[];
+
+      constructor(events: string[], config?: TaskConfig) {
+        super({}, config);
+        this.events = events;
+      }
+
+      static inputSchema(): TObject {
+        return Type.Object({
+          input: Type.String({
+            description: "Aggregated streaming input",
+            default: "",
+          }),
+        });
+      }
+
+      static outputSchema(): TObject {
+        return Type.Object({
+          seen: Type.String({ description: "Observed string" }),
+        });
+      }
+
+      async execute(input: { input: string }): Promise<{ seen: string }> {
+        this.events.push("consumer-start");
+        return { seen: input.input };
+      }
+    }
+
+    const events: string[] = [];
+    const graph = new TaskGraph();
+    const producer = new FinalProducer(events, { chunks: ["X", "Y"], delay: 20 }, { id: "producer" });
+    const consumer = new CapturingConsumer(events, { id: "consumer" });
+
+    graph.addTasks([producer, consumer]);
+    graph.addDataflow(new Dataflow("producer", "output", "consumer", "input"));
+
+    const runner = new TaskGraphRunner(graph);
+    const results = await runner.runGraph();
+
+    expect(events.indexOf("consumer-start")).toBeGreaterThan(events.indexOf("producer-complete"));
+
+    const consumerResult = results.find((entry) => entry.id === "consumer");
+    expect(consumerResult?.data.seen).toBe("XY");
+  });
+});


### PR DESCRIPTION
Implements streaming outputs for tasks, allowing partial results to be propagated and consumed by downstream tasks with configurable readiness.

This introduces a new `STREAMING` status for tasks and extends the `TaskRunner`, `Dataflow`, and `TaskGraphRunner` to manage stream lifecycle, chunk propagation, and readiness signaling. The `DependencyBasedScheduler` is updated to respect `first-chunk` or `final` readiness, enabling more efficient execution of task graphs by reducing idle time. New `IExecuteContext` helpers (`pushChunk`, `closeStream`, `attachStreamController`) facilitate stream production, and schema annotations (`x-stream`) allow tasks to declare streaming capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-96014899-56e7-4508-89c0-22d27143b3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96014899-56e7-4508-89c0-22d27143b3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

