### PR TITLE
[feat] Implement checkpointing mechanism for task execution

### DIFF
--- a/packages/task-graph/src/checkpoint/CheckpointSaver.ts
+++ b/packages/task-graph/src/checkpoint/CheckpointSaver.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createServiceToken } from "@workglow/util";
+import type { CheckpointData, CheckpointId, ThreadId } from "./CheckpointTypes";
+
+/**
+ * Service token for CheckpointSaver
+ */
+export const CHECKPOINT_SAVER = createServiceToken<CheckpointSaver>("taskgraph.checkpointSaver");
+
+/**
+ * Abstract class for saving and retrieving execution checkpoints.
+ * Implementations provide persistence for checkpoint data to enable
+ * resume-from-failure and execution history features.
+ */
+export abstract class CheckpointSaver {
+  abstract saveCheckpoint(data: CheckpointData): Promise<void>;
+  abstract getCheckpoint(checkpointId: CheckpointId): Promise<CheckpointData | undefined>;
+  abstract getLatestCheckpoint(threadId: ThreadId): Promise<CheckpointData | undefined>;
+  abstract getCheckpointHistory(threadId: ThreadId): Promise<CheckpointData[]>;
+  abstract getCheckpointsForIteration(
+    threadId: ThreadId,
+    iterationParentTaskId: unknown
+  ): Promise<CheckpointData[]>;
+  abstract deleteCheckpoints(threadId: ThreadId): Promise<void>;
+}

--- a/packages/task-graph/src/checkpoint/CheckpointTypes.ts
+++ b/packages/task-graph/src/checkpoint/CheckpointTypes.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskGraphJson } from "../task/TaskJSON";
+import type { TaskInput, TaskOutput, TaskStatus } from "../task/TaskTypes";
+
+export type CheckpointId = string;
+export type ThreadId = string;
+
+export type CheckpointGranularity = "every-task" | "top-level-only" | "none";
+
+export interface TaskCheckpointState {
+  taskId: unknown;
+  taskType: string;
+  status: TaskStatus;
+  inputData: TaskInput;
+  outputData: TaskOutput;
+  progress: number;
+  error?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface DataflowCheckpointState {
+  id: string;
+  sourceTaskId: unknown;
+  targetTaskId: unknown;
+  status: TaskStatus;
+  portData?: TaskOutput;
+}
+
+export interface CheckpointData {
+  checkpointId: CheckpointId;
+  threadId: ThreadId;
+  parentCheckpointId?: CheckpointId;
+  graphJson: TaskGraphJson;
+  taskStates: TaskCheckpointState[];
+  dataflowStates: DataflowCheckpointState[];
+  metadata: {
+    createdAt: string;
+    triggerTaskId?: unknown;
+    iterationIndex?: number;
+    iterationParentTaskId?: unknown;
+  };
+}

--- a/packages/task-graph/src/checkpoint/InMemoryCheckpointSaver.ts
+++ b/packages/task-graph/src/checkpoint/InMemoryCheckpointSaver.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CheckpointSaver } from "./CheckpointSaver";
+import type { CheckpointData, CheckpointId, ThreadId } from "./CheckpointTypes";
+
+/**
+ * In-memory implementation of CheckpointSaver.
+ * Uses a Map with a secondary index on threadId for efficient lookups.
+ */
+export class InMemoryCheckpointSaver extends CheckpointSaver {
+  private checkpoints: Map<CheckpointId, CheckpointData> = new Map();
+  private threadIndex: Map<ThreadId, CheckpointId[]> = new Map();
+
+  async saveCheckpoint(data: CheckpointData): Promise<void> {
+    this.checkpoints.set(data.checkpointId, data);
+
+    const threadCheckpoints = this.threadIndex.get(data.threadId) ?? [];
+    threadCheckpoints.push(data.checkpointId);
+    this.threadIndex.set(data.threadId, threadCheckpoints);
+  }
+
+  async getCheckpoint(checkpointId: CheckpointId): Promise<CheckpointData | undefined> {
+    return this.checkpoints.get(checkpointId);
+  }
+
+  async getLatestCheckpoint(threadId: ThreadId): Promise<CheckpointData | undefined> {
+    const ids = this.threadIndex.get(threadId);
+    if (!ids || ids.length === 0) return undefined;
+    return this.checkpoints.get(ids[ids.length - 1]);
+  }
+
+  async getCheckpointHistory(threadId: ThreadId): Promise<CheckpointData[]> {
+    const ids = this.threadIndex.get(threadId);
+    if (!ids) return [];
+    return ids
+      .map((id) => this.checkpoints.get(id))
+      .filter((cp): cp is CheckpointData => cp !== undefined);
+  }
+
+  async getCheckpointsForIteration(
+    threadId: ThreadId,
+    iterationParentTaskId: unknown
+  ): Promise<CheckpointData[]> {
+    const history = await this.getCheckpointHistory(threadId);
+    return history.filter((cp) => cp.metadata.iterationParentTaskId === iterationParentTaskId);
+  }
+
+  async deleteCheckpoints(threadId: ThreadId): Promise<void> {
+    const ids = this.threadIndex.get(threadId);
+    if (ids) {
+      for (const id of ids) {
+        this.checkpoints.delete(id);
+      }
+      this.threadIndex.delete(threadId);
+    }
+  }
+}

--- a/packages/task-graph/src/checkpoint/TabularCheckpointSaver.ts
+++ b/packages/task-graph/src/checkpoint/TabularCheckpointSaver.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BaseTabularStorage } from "@workglow/storage";
+import { compress, DataPortSchemaObject, decompress } from "@workglow/util";
+import { CheckpointSaver } from "./CheckpointSaver";
+import type { CheckpointData, CheckpointId, ThreadId } from "./CheckpointTypes";
+
+export const CheckpointSchema = {
+  type: "object",
+  properties: {
+    checkpoint_id: { type: "string" },
+    thread_id: { type: "string" },
+    parent_checkpoint_id: { type: "string" },
+    graph_json: { type: "string", contentEncoding: "blob" },
+    task_states: { type: "string", contentEncoding: "blob" },
+    dataflow_states: { type: "string", contentEncoding: "blob" },
+    metadata: { type: "string" },
+    created_at: { type: "string", format: "date-time" },
+  },
+  additionalProperties: false,
+} satisfies DataPortSchemaObject;
+
+export const CheckpointPrimaryKeyNames = ["checkpoint_id"] as const;
+
+export type CheckpointStorage = BaseTabularStorage<
+  typeof CheckpointSchema,
+  typeof CheckpointPrimaryKeyNames
+>;
+
+export type TabularCheckpointSaverOptions = {
+  tabularRepository: CheckpointStorage;
+  compression?: boolean;
+};
+
+/**
+ * Tabular storage implementation of CheckpointSaver.
+ * Uses the existing ITabularStorage interface for persistence,
+ * giving access to SQLite, Postgres, IndexedDB, Supabase, and
+ * file-backed checkpoint storage via existing backends.
+ */
+export class TabularCheckpointSaver extends CheckpointSaver {
+  tabularRepository: CheckpointStorage;
+  compression: boolean;
+
+  constructor({ tabularRepository, compression = true }: TabularCheckpointSaverOptions) {
+    super();
+    this.tabularRepository = tabularRepository;
+    this.compression = compression;
+  }
+
+  async setupDatabase(): Promise<void> {
+    await this.tabularRepository.setupDatabase?.();
+  }
+
+  private async compressJson(value: string): Promise<unknown> {
+    if (this.compression) {
+      return (await compress(value)) as unknown;
+    }
+    return Buffer.from(value) as unknown;
+  }
+
+  private async decompressJson(raw: unknown): Promise<string> {
+    if (this.compression) {
+      const bytes: Uint8Array =
+        raw instanceof Uint8Array
+          ? raw
+          : Array.isArray(raw)
+            ? new Uint8Array(raw as number[])
+            : raw && typeof raw === "object"
+              ? new Uint8Array(
+                  Object.keys(raw as Record<string, number>)
+                    .filter((k) => /^\d+$/.test(k))
+                    .sort((a, b) => Number(a) - Number(b))
+                    .map((k) => (raw as Record<string, number>)[k])
+                )
+              : new Uint8Array();
+      return await decompress(bytes);
+    }
+    return (raw as Buffer).toString();
+  }
+
+  async saveCheckpoint(data: CheckpointData): Promise<void> {
+    await this.tabularRepository.put({
+      checkpoint_id: data.checkpointId,
+      thread_id: data.threadId,
+      parent_checkpoint_id: data.parentCheckpointId ?? "",
+      graph_json: (await this.compressJson(JSON.stringify(data.graphJson))) as string,
+      task_states: (await this.compressJson(JSON.stringify(data.taskStates))) as string,
+      dataflow_states: (await this.compressJson(JSON.stringify(data.dataflowStates))) as string,
+      metadata: JSON.stringify(data.metadata),
+      created_at: data.metadata.createdAt,
+    });
+  }
+
+  async getCheckpoint(checkpointId: CheckpointId): Promise<CheckpointData | undefined> {
+    const row = await this.tabularRepository.get({ checkpoint_id: checkpointId });
+    if (!row) return undefined;
+    return this.rowToCheckpointData(row);
+  }
+
+  async getLatestCheckpoint(threadId: ThreadId): Promise<CheckpointData | undefined> {
+    const rows = await this.tabularRepository.search({ thread_id: threadId });
+    if (!rows || rows.length === 0) return undefined;
+
+    // Sort by created_at descending and return the latest
+    rows.sort((a, b) => {
+      const aTime = a.created_at ?? "";
+      const bTime = b.created_at ?? "";
+      return bTime.localeCompare(aTime);
+    });
+
+    return this.rowToCheckpointData(rows[0]);
+  }
+
+  async getCheckpointHistory(threadId: ThreadId): Promise<CheckpointData[]> {
+    const rows = await this.tabularRepository.search({ thread_id: threadId });
+    if (!rows || rows.length === 0) return [];
+
+    // Sort by created_at ascending
+    rows.sort((a, b) => {
+      const aTime = a.created_at ?? "";
+      const bTime = b.created_at ?? "";
+      return aTime.localeCompare(bTime);
+    });
+
+    const results: CheckpointData[] = [];
+    for (const row of rows) {
+      results.push(await this.rowToCheckpointData(row));
+    }
+    return results;
+  }
+
+  async getCheckpointsForIteration(
+    threadId: ThreadId,
+    iterationParentTaskId: unknown
+  ): Promise<CheckpointData[]> {
+    const history = await this.getCheckpointHistory(threadId);
+    return history.filter((cp) => cp.metadata.iterationParentTaskId === iterationParentTaskId);
+  }
+
+  async deleteCheckpoints(threadId: ThreadId): Promise<void> {
+    await this.tabularRepository.deleteSearch({ thread_id: threadId });
+  }
+
+  private async rowToCheckpointData(row: Record<string, unknown>): Promise<CheckpointData> {
+    const graphJson = JSON.parse(await this.decompressJson(row.graph_json));
+    const taskStates = JSON.parse(await this.decompressJson(row.task_states));
+    const dataflowStates = JSON.parse(await this.decompressJson(row.dataflow_states));
+    const metadata = JSON.parse(row.metadata as string);
+
+    return {
+      checkpointId: row.checkpoint_id as string,
+      threadId: row.thread_id as string,
+      parentCheckpointId: (row.parent_checkpoint_id as string) || undefined,
+      graphJson,
+      taskStates,
+      dataflowStates,
+      metadata,
+    };
+  }
+}

--- a/packages/task-graph/src/checkpoint/index.ts
+++ b/packages/task-graph/src/checkpoint/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./CheckpointSaver";
+export * from "./CheckpointTypes";
+export * from "./InMemoryCheckpointSaver";
+export * from "./TabularCheckpointSaver";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -22,3 +22,5 @@ export * from "./storage/TaskGraphRepository";
 export * from "./storage/TaskGraphTabularRepository";
 export * from "./storage/TaskOutputRepository";
 export * from "./storage/TaskOutputTabularRepository";
+
+export * from "./checkpoint";

--- a/packages/task-graph/src/task-graph/TaskGraphEvents.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphEvents.ts
@@ -5,6 +5,7 @@
  */
 
 import { EventParameters } from "@workglow/util";
+import type { CheckpointData } from "../checkpoint/CheckpointTypes";
 import { TaskIdType } from "../task/TaskTypes";
 import { DataflowIdType } from "./Dataflow";
 
@@ -19,6 +20,7 @@ export type TaskGraphStatusListeners = {
   error: (error: Error) => void;
   abort: () => void;
   disabled: () => void;
+  checkpoint: (data: CheckpointData) => void;
 };
 export type TaskGraphStatusEvents = keyof TaskGraphStatusListeners;
 export type TaskGraphStatusListener<Event extends TaskGraphStatusEvents> =

--- a/packages/task-graph/src/task/GraphAsTaskRunner.ts
+++ b/packages/task-graph/src/task/GraphAsTaskRunner.ts
@@ -29,6 +29,8 @@ export class GraphAsTaskRunner<
     const results = await this.task.subGraph!.run<Output>(input, {
       parentSignal: this.abortController?.signal,
       outputCache: this.outputCache,
+      checkpointSaver: this.checkpointSaver,
+      threadId: this.threadId,
     });
     unsubscribe();
     return results;

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -5,6 +5,8 @@
  */
 
 import type { DataPortSchema, EventEmitter, ServiceRegistry } from "@workglow/util";
+import type { CheckpointSaver } from "../checkpoint/CheckpointSaver";
+import type { ThreadId } from "../checkpoint/CheckpointTypes";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ITaskGraph } from "../task-graph/ITaskGraph";
 import { IWorkflow } from "../task-graph/IWorkflow";
@@ -29,6 +31,10 @@ export interface IExecuteContext {
   updateProgress: (progress: number, message?: string, ...args: any[]) => Promise<void>;
   own: <T extends ITask | ITaskGraph | IWorkflow>(i: T) => T;
   registry: ServiceRegistry;
+  /** Optional checkpoint saver for iteration-level checkpoints */
+  checkpointSaver?: CheckpointSaver;
+  /** Thread ID for checkpoint isolation */
+  threadId?: ThreadId;
 }
 
 export type IExecuteReactiveContext = Pick<IExecuteContext, "own">;
@@ -45,6 +51,10 @@ export interface IRunConfig {
     ...args: any[]
   ) => Promise<void>;
   registry?: ServiceRegistry;
+  /** Optional checkpoint saver for persisting execution state */
+  checkpointSaver?: CheckpointSaver;
+  /** Thread ID for checkpoint isolation */
+  threadId?: ThreadId;
 }
 
 /**

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -5,6 +5,8 @@
  */
 
 import { globalServiceRegistry, ServiceRegistry } from "@workglow/util";
+import type { CheckpointSaver } from "../checkpoint/CheckpointSaver";
+import type { ThreadId } from "../checkpoint/CheckpointTypes";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ensureTask, type Taskish } from "../task-graph/Conversions";
 import { resolveSchemaInputs } from "./InputResolver";
@@ -48,6 +50,16 @@ export class TaskRunner<
    * The service registry for the task
    */
   protected registry: ServiceRegistry = globalServiceRegistry;
+
+  /**
+   * Checkpoint saver propagated from graph runner
+   */
+  protected checkpointSaver?: CheckpointSaver;
+
+  /**
+   * Thread ID for checkpoint isolation
+   */
+  protected threadId?: ThreadId;
 
   /**
    * Constructor for TaskRunner
@@ -189,6 +201,8 @@ export class TaskRunner<
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
+      checkpointSaver: this.checkpointSaver,
+      threadId: this.threadId,
     });
     return await this.executeTaskReactive(input, result || ({} as Output));
   }
@@ -238,6 +252,13 @@ export class TaskRunner<
 
     if (config.registry) {
       this.registry = config.registry;
+    }
+
+    if (config.checkpointSaver) {
+      this.checkpointSaver = config.checkpointSaver;
+    }
+    if (config.threadId) {
+      this.threadId = config.threadId;
     }
 
     this.task.emit("start");

--- a/packages/task-graph/src/task/WhileTaskRunner.ts
+++ b/packages/task-graph/src/task/WhileTaskRunner.ts
@@ -33,6 +33,8 @@ export class WhileTaskRunner<
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
+      checkpointSaver: this.checkpointSaver,
+      threadId: this.threadId,
     });
 
     return result;

--- a/packages/test/src/test/task/Checkpoint.test.ts
+++ b/packages/test/src/test/task/Checkpoint.test.ts
@@ -1,0 +1,461 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CheckpointData, Dataflow, InMemoryCheckpointSaver, TaskGraph } from "@workglow/task-graph";
+import { beforeEach, describe, expect, it } from "vitest";
+import { FailingTask, NumberTask, TestSimpleTask } from "./TestTasks";
+
+describe("Checkpoint", () => {
+  let saver: InMemoryCheckpointSaver;
+
+  beforeEach(() => {
+    saver = new InMemoryCheckpointSaver();
+  });
+
+  describe("InMemoryCheckpointSaver", () => {
+    it("should save and retrieve a checkpoint", async () => {
+      const data: CheckpointData = {
+        checkpointId: "cp-1",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: new Date().toISOString() },
+      };
+
+      await saver.saveCheckpoint(data);
+      const retrieved = await saver.getCheckpoint("cp-1");
+      expect(retrieved).toEqual(data);
+    });
+
+    it("should return undefined for non-existent checkpoint", async () => {
+      const retrieved = await saver.getCheckpoint("non-existent");
+      expect(retrieved).toBeUndefined();
+    });
+
+    it("should get latest checkpoint for thread", async () => {
+      const data1: CheckpointData = {
+        checkpointId: "cp-1",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:00:00Z" },
+      };
+      const data2: CheckpointData = {
+        checkpointId: "cp-2",
+        threadId: "thread-1",
+        parentCheckpointId: "cp-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:01:00Z" },
+      };
+
+      await saver.saveCheckpoint(data1);
+      await saver.saveCheckpoint(data2);
+
+      const latest = await saver.getLatestCheckpoint("thread-1");
+      expect(latest?.checkpointId).toBe("cp-2");
+    });
+
+    it("should get checkpoint history for thread", async () => {
+      await saver.saveCheckpoint({
+        checkpointId: "cp-1",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:00:00Z" },
+      });
+      await saver.saveCheckpoint({
+        checkpointId: "cp-2",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:01:00Z" },
+      });
+      await saver.saveCheckpoint({
+        checkpointId: "cp-3",
+        threadId: "thread-2",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:02:00Z" },
+      });
+
+      const history = await saver.getCheckpointHistory("thread-1");
+      expect(history).toHaveLength(2);
+    });
+
+    it("should get checkpoints for iteration", async () => {
+      await saver.saveCheckpoint({
+        checkpointId: "cp-1",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: {
+          createdAt: "2025-01-01T00:00:00Z",
+          iterationParentTaskId: "while-1",
+          iterationIndex: 0,
+        },
+      });
+      await saver.saveCheckpoint({
+        checkpointId: "cp-2",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: {
+          createdAt: "2025-01-01T00:01:00Z",
+          iterationParentTaskId: "while-1",
+          iterationIndex: 1,
+        },
+      });
+      await saver.saveCheckpoint({
+        checkpointId: "cp-3",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: {
+          createdAt: "2025-01-01T00:02:00Z",
+          triggerTaskId: "other-task",
+        },
+      });
+
+      const iterCheckpoints = await saver.getCheckpointsForIteration("thread-1", "while-1");
+      expect(iterCheckpoints).toHaveLength(2);
+    });
+
+    it("should delete checkpoints for thread", async () => {
+      await saver.saveCheckpoint({
+        checkpointId: "cp-1",
+        threadId: "thread-1",
+        graphJson: { tasks: [], dataflows: [] },
+        taskStates: [],
+        dataflowStates: [],
+        metadata: { createdAt: "2025-01-01T00:00:00Z" },
+      });
+
+      await saver.deleteCheckpoints("thread-1");
+
+      const history = await saver.getCheckpointHistory("thread-1");
+      expect(history).toHaveLength(0);
+    });
+  });
+
+  describe("Checkpoint save during graph execution", () => {
+    it("should capture checkpoints after each task completion", async () => {
+      const graph = new TaskGraph();
+      const task1 = new TestSimpleTask({ input: "hello" }, { id: "task-1" });
+      const task2 = new TestSimpleTask({ input: "world" }, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      const checkpoints: CheckpointData[] = [];
+      graph.on("checkpoint", (data) => {
+        checkpoints.push(data);
+      });
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "test-thread",
+          checkpointGranularity: "every-task",
+        }
+      );
+
+      // Should have checkpoints for each task completion
+      expect(checkpoints.length).toBeGreaterThanOrEqual(1);
+
+      // Verify checkpoint data structure
+      const lastCheckpoint = checkpoints[checkpoints.length - 1];
+      expect(lastCheckpoint.threadId).toBe("test-thread");
+      expect(lastCheckpoint.taskStates.length).toBe(2);
+      expect(lastCheckpoint.dataflowStates.length).toBe(1);
+    });
+
+    it("should not capture checkpoints when granularity is none", async () => {
+      const graph = new TaskGraph();
+      const task1 = new TestSimpleTask({ input: "hello" }, { id: "task-1" });
+
+      graph.addTask(task1);
+
+      const checkpoints: CheckpointData[] = [];
+      graph.on("checkpoint", (data) => {
+        checkpoints.push(data);
+      });
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          checkpointGranularity: "none",
+        }
+      );
+
+      expect(checkpoints).toHaveLength(0);
+    });
+
+    it("should capture single checkpoint for top-level-only granularity", async () => {
+      const graph = new TaskGraph();
+      const task1 = new TestSimpleTask({ input: "hello" }, { id: "task-1" });
+      const task2 = new TestSimpleTask({ input: "world" }, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      const checkpoints: CheckpointData[] = [];
+      graph.on("checkpoint", (data) => {
+        checkpoints.push(data);
+      });
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "test-thread",
+          checkpointGranularity: "top-level-only",
+        }
+      );
+
+      // Should have exactly one checkpoint at the end
+      expect(checkpoints).toHaveLength(1);
+
+      // All tasks should be completed in the checkpoint
+      const cp = checkpoints[0];
+      expect(cp.taskStates.every((ts) => ts.status === "COMPLETED")).toBe(true);
+    });
+
+    it("should persist checkpoints in the saver", async () => {
+      const graph = new TaskGraph();
+      const task1 = new NumberTask({ input: 42 }, { id: "task-1" });
+
+      graph.addTask(task1);
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "persist-thread",
+        }
+      );
+
+      const history = await saver.getCheckpointHistory("persist-thread");
+      expect(history.length).toBeGreaterThanOrEqual(1);
+
+      const latest = await saver.getLatestCheckpoint("persist-thread");
+      expect(latest).toBeDefined();
+      expect(latest!.threadId).toBe("persist-thread");
+    });
+
+    it("should chain parent checkpoint IDs", async () => {
+      const graph = new TaskGraph();
+      const task1 = new TestSimpleTask({ input: "a" }, { id: "task-1" });
+      const task2 = new TestSimpleTask({ input: "b" }, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "chain-thread",
+        }
+      );
+
+      const history = await saver.getCheckpointHistory("chain-thread");
+      if (history.length >= 2) {
+        expect(history[1].parentCheckpointId).toBe(history[0].checkpointId);
+      }
+    });
+  });
+
+  describe("Resume from checkpoint", () => {
+    it("should resume from a checkpoint, skipping completed tasks", async () => {
+      // First run: execute a graph and save checkpoints
+      const graph = new TaskGraph();
+      const task1 = new TestSimpleTask({ input: "first" }, { id: "task-1" });
+      const task2 = new TestSimpleTask({ input: "second" }, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "resume-thread",
+        }
+      );
+
+      // Get the checkpoint after task-1 completed (first checkpoint)
+      const history = await saver.getCheckpointHistory("resume-thread");
+      expect(history.length).toBeGreaterThanOrEqual(1);
+
+      // Now create a new graph with the same structure and resume
+      const graph2 = new TaskGraph();
+      const task1b = new TestSimpleTask({ input: "first" }, { id: "task-1" });
+      const task2b = new TestSimpleTask({ input: "second" }, { id: "task-2" });
+
+      graph2.addTask(task1b);
+      graph2.addTask(task2b);
+      graph2.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      // Resume from the last checkpoint (all tasks completed)
+      const lastCheckpoint = history[history.length - 1];
+      const results = await graph2.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "resume-thread-2",
+          resumeFromCheckpoint: lastCheckpoint.checkpointId,
+        }
+      );
+
+      // Should complete successfully
+      expect(results.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should re-run failed tasks when resuming from checkpoint before failure", async () => {
+      // Create a graph where task-2 fails
+      const graph = new TaskGraph();
+      const task1 = new NumberTask({ input: 42 }, { id: "task-1" });
+      const task2 = new FailingTask({}, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "in"));
+
+      try {
+        await graph.run(
+          {},
+          {
+            checkpointSaver: saver,
+            threadId: "fail-thread",
+          }
+        );
+      } catch {
+        // Expected failure
+      }
+
+      // Should have captured at least a checkpoint after task-1
+      const history = await saver.getCheckpointHistory("fail-thread");
+      expect(history.length).toBeGreaterThanOrEqual(1);
+
+      // Find the checkpoint where task-1 is completed but task-2 hasn't run yet
+      const resumeCheckpoint = history.find((cp) =>
+        cp.taskStates.some((ts) => ts.taskId === "task-1" && ts.status === "COMPLETED")
+      );
+      expect(resumeCheckpoint).toBeDefined();
+    });
+  });
+
+  describe("Checkpoint data correctness", () => {
+    it("should capture task input and output data", async () => {
+      const graph = new TaskGraph();
+      const task = new NumberTask({ input: 42 }, { id: "task-1" });
+
+      graph.addTask(task);
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "data-thread",
+        }
+      );
+
+      const latest = await saver.getLatestCheckpoint("data-thread");
+      expect(latest).toBeDefined();
+
+      const taskState = latest!.taskStates.find((ts) => ts.taskId === "task-1");
+      expect(taskState).toBeDefined();
+      expect(taskState!.status).toBe("COMPLETED");
+      expect(taskState!.outputData).toBeDefined();
+      expect(taskState!.outputData.output).toBe(42);
+    });
+
+    it("should capture dataflow state", async () => {
+      const graph = new TaskGraph();
+      const task1 = new NumberTask({ input: 10 }, { id: "task-1" });
+      const task2 = new NumberTask({}, { id: "task-2" });
+
+      graph.addTask(task1);
+      graph.addTask(task2);
+      graph.addDataflow(new Dataflow("task-1", "output", "task-2", "input"));
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "df-thread",
+        }
+      );
+
+      const latest = await saver.getLatestCheckpoint("df-thread");
+      expect(latest).toBeDefined();
+      expect(latest!.dataflowStates.length).toBe(1);
+
+      const dfState = latest!.dataflowStates[0];
+      expect(dfState.sourceTaskId).toBe("task-1");
+      expect(dfState.targetTaskId).toBe("task-2");
+      expect(dfState.status).toBe("COMPLETED");
+    });
+
+    it("should include graph JSON in checkpoint", async () => {
+      const graph = new TaskGraph();
+      const task = new TestSimpleTask({ input: "test" }, { id: "task-1" });
+      graph.addTask(task);
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+          threadId: "json-thread",
+        }
+      );
+
+      const latest = await saver.getLatestCheckpoint("json-thread");
+      expect(latest).toBeDefined();
+      expect(latest!.graphJson).toBeDefined();
+      expect(latest!.graphJson.tasks.length).toBe(1);
+    });
+
+    it("should auto-generate threadId when not provided", async () => {
+      const graph = new TaskGraph();
+      const task = new TestSimpleTask({ input: "test" }, { id: "task-1" });
+      graph.addTask(task);
+
+      const checkpoints: CheckpointData[] = [];
+      graph.on("checkpoint", (data) => {
+        checkpoints.push(data);
+      });
+
+      await graph.run(
+        {},
+        {
+          checkpointSaver: saver,
+        }
+      );
+
+      expect(checkpoints.length).toBeGreaterThanOrEqual(1);
+      // Thread ID should be auto-generated (non-empty UUID)
+      expect(checkpoints[0].threadId).toBeTruthy();
+      expect(checkpoints[0].threadId.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
- Introduced CheckpointSaver interface and its implementations (InMemoryCheckpointSaver, TabularCheckpointSaver) for persisting execution state.
- Enhanced task runners (GraphAsTaskRunner, IteratorTaskRunner, TaskRunner, WhileTaskRunner) to support checkpointing, allowing for state recovery and iteration-level checkpoints.
- Updated TaskGraph to manage checkpointing configuration and resume execution from checkpoints.
- Added tests to validate checkpoint saving and retrieval functionality, ensuring robust handling of task execution states.

Plan:
---
name: Checkpointing & Retry
overview: Add execution checkpointing to @workglow/task-graph that saves graph state (task statuses, outputs, dataflow data) after each task completion, with configurable granularity. Build InMemory and Tabular checkpoint savers, add thread_id isolation, enable resume-from-checkpoint. On the builder side, wire checkpoint data into activities and build iteration time-travel UI (builder not a part) todos:
  - id: checkpoint-types content: Create checkpoint data model types (CheckpointData, TaskCheckpointState, etc.) in packages/task-graph/src/checkpoint/ status: pending
  - id: checkpoint-saver-interface content: Create abstract CheckpointSaver class with save/get/getLatest/getHistory/delete methods status: pending
  - id: inmemory-saver content: Implement InMemoryCheckpointSaver using Map with threadId index status: pending
  - id: tabular-saver content: Implement TabularCheckpointSaver using existing ITabularStorage interface status: pending
  - id: runner-checkpoint-hooks content: Add captureCheckpoint() to TaskGraphRunner, call after each task completion with configurable granularity status: pending
  - id: runner-restore content: Add restoreFromCheckpoint() to TaskGraphRunner for resume-on-failure status: pending
  - id: config-extensions content: Extend TaskGraphRunConfig, IRunConfig, and IExecuteContext with checkpointSaver/threadId/granularity status: pending
  - id: iteration-checkpoints content: Add iteration checkpointing to WhileTask and IteratorTaskRunner after each subgraph run status: pending
  - id: checkpoint-events content: Add 'checkpoint' event to TaskGraphEvents and emit from runner status: pending
  - id: exports content: Export all checkpoint types/classes from common.ts and add checkpoint/index.ts status: pending
  - id: tests content: Write tests for checkpoint save/restore, resume-from-failure, and iteration checkpoints status: pending isProject: false
---

# Checkpointing & Retry

## Architecture Overview

```mermaid
flowchart TD
    subgraph taskGraph ["@workglow/task-graph"]
        CheckpointSaver["CheckpointSaver (abstract)"]
        InMemory["InMemoryCheckpointSaver"]
        Tabular["TabularCheckpointSaver"]
        CheckpointData["CheckpointData"]
        TaskGraphRunner_CP["TaskGraphRunner (checkpoint hooks)"]
        WhileTask_CP["WhileTask / IteratorTask (iteration checkpoints)"]
    end

    subgraph builder ["Builder (frontend)"]
        ActivityRepo["ActivityRepository + checkpoint_id refs"]
        ActivityViewer["ActivityViewer (per-task drill-in)"]
        TimeTravelUI["Iteration Time Travel UI"]
    end

    TaskGraphRunner_CP -->|"after each task"| CheckpointSaver
    WhileTask_CP -->|"after each iteration"| CheckpointSaver
    CheckpointSaver --> InMemory
    CheckpointSaver --> Tabular
    ActivityRepo -->|"reads"| CheckpointSaver
    ActivityViewer -->|"reads"| ActivityRepo
    TimeTravelUI -->|"navigates"| ActivityViewer
```

## Part 1: Checkpoint Data Model & Saver Interface

**New directory:** `packages/task-graph/src/checkpoint/`

### 1a. Checkpoint Types (`CheckpointTypes.ts`)

Define the core data structures:

```typescript
export type CheckpointId = string;
export type ThreadId = string;

export interface TaskCheckpointState {
  taskId: unknown;
  taskType: string;
  status: TaskStatus;
  inputData: TaskInput;
  outputData: TaskOutput;
  progress: number;
  error?: string;
  startedAt?: string;
  completedAt?: string;
}

export interface DataflowCheckpointState {
  id: string;
  sourceTaskId: unknown;
  targetTaskId: unknown;
  status: TaskStatus;
  portData?: TaskOutput;
}

export interface CheckpointData {
  checkpointId: CheckpointId;
  threadId: ThreadId;
  parentCheckpointId?: CheckpointId;
  graphJson: TaskGraphJson; // structural definition
  taskStates: TaskCheckpointState[]; // runtime state per task
  dataflowStates: DataflowCheckpointState[];
  metadata: {
    createdAt: string;
    triggerTaskId?: unknown; // task that just completed
    iterationIndex?: number; // for while/map loops
    iterationParentTaskId?: unknown; // which iterator task owns this
  };
}
```

### 1b. CheckpointSaver Interface (`CheckpointSaver.ts`)

```typescript
export abstract class CheckpointSaver {
  abstract saveCheckpoint(data: CheckpointData): Promise<void>;
  abstract getCheckpoint(checkpointId: CheckpointId): Promise<CheckpointData | undefined>;
  abstract getLatestCheckpoint(threadId: ThreadId): Promise<CheckpointData | undefined>;
  abstract getCheckpointHistory(threadId: ThreadId): Promise<CheckpointData[]>;
  abstract getCheckpointsForIteration(
    threadId: ThreadId,
    iterationParentTaskId: unknown
  ): Promise<CheckpointData[]>;
  abstract deleteCheckpoints(threadId: ThreadId): Promise<void>;
}
```

Modeled after the existing `TaskOutputRepository` pattern with `EventEmitter` support and a service token (`CHECKPOINT_SAVER`).

### 1c. InMemoryCheckpointSaver (`InMemoryCheckpointSaver.ts`)

Simple `Map<CheckpointId, CheckpointData>` with a secondary index on `threadId`. Follows the same pattern as existing in-memory storage implementations.

### 1d. TabularCheckpointSaver (`TabularCheckpointSaver.ts`)

Uses the existing `ITabularStorage` interface (same as `TaskOutputTabularRepository`). Schema:

- Primary key: `checkpoint_id`
- Columns: `thread_id`, `parent_checkpoint_id`, `graph_json` (compressed JSON), `task_states` (compressed JSON), `dataflow_states` (compressed JSON), `metadata` (JSON), `created_at`
- Searchable by: `thread_id`

This automatically gives us SQLite, Postgres, IndexedDB, Supabase, and File-backed checkpoint storage via the existing tabular storage backends.

### 1e. Exports

Add all checkpoint exports to `[packages/task-graph/src/common.ts](packages/task-graph/src/common.ts)`:

```typescript
export * from "./checkpoint/CheckpointTypes";
export * from "./checkpoint/CheckpointSaver";
export * from "./checkpoint/InMemoryCheckpointSaver";
export * from "./checkpoint/TabularCheckpointSaver";
```

## Part 2: Integrate Checkpointing into Execution

### 2a. Add `CheckpointSaver` to `TaskGraphRunConfig`

In `[packages/task-graph/src/task-graph/TaskGraph.ts](packages/task-graph/src/task-graph/TaskGraph.ts)`, extend `TaskGraphRunConfig`:

```typescript
export interface TaskGraphRunConfig {
  outputCache?: TaskOutputRepository | boolean;
  parentSignal?: AbortSignal;
  registry?: ServiceRegistry;
  checkpointSaver?: CheckpointSaver; // NEW
  threadId?: string; // NEW
  resumeFromCheckpoint?: CheckpointId; // NEW
  checkpointGranularity?: "every-task" | "top-level-only" | "none"; // NEW, default 'every-task'
}
```

### 2b. Checkpoint Hook in `TaskGraphRunner`

In `[packages/task-graph/src/task-graph/TaskGraphRunner.ts](packages/task-graph/src/task-graph/TaskGraphRunner.ts)`:

1. Store `checkpointSaver`, `threadId`, and `checkpointGranularity` as instance properties (set in `handleStart`).
2. Add a `captureCheckpoint(triggerTaskId)` method that snapshots the full graph state (iterating `graph.getTasks()` and `graph.getDataflows()` to build `TaskCheckpointState[]` and `DataflowCheckpointState[]`).
3. Call `captureCheckpoint` in `runGraph()` after each task completes (inside the `runAsync` function, after `pushOutputFromNodeToEdges` and `pushStatusFromNodeToEdges`), respecting `checkpointGranularity`.
4. Emit a new `checkpoint` event on the graph: `this.graph.emit("checkpoint", checkpointData)`.

### 2c. Resume from Checkpoint

Add a `restoreFromCheckpoint(checkpointData: CheckpointData)` method to `TaskGraphRunner` that:

1. For each task in `checkpointData.taskStates` with status `COMPLETED` or `DISABLED`, restore the task's `status`, `runOutputData`, `progress`, `error`.
2. For each dataflow, restore `portData` and `status`.
3. Configure the `DependencyBasedScheduler` to skip already-completed tasks by calling `onTaskCompleted` for each.
4. The subsequent `runGraph` call then only processes `PENDING` tasks.

In `TaskGraph.run()`, if `config.resumeFromCheckpoint` is provided, call `restoreFromCheckpoint` instead of `resetGraph` in `handleStart`.

### 2d. Iteration Checkpoints in `WhileTask` and `IteratorTaskRunner`

In `[packages/task-graph/src/task/WhileTask.ts](packages/task-graph/src/task/WhileTask.ts)` (line ~380, inside the while loop):

- After each iteration's `subGraph.run()` completes, if the execution context has a checkpoint saver, capture a checkpoint with `iterationIndex` and `iterationParentTaskId` metadata.

In `[packages/task-graph/src/task/IteratorTaskRunner.ts](packages/task-graph/src/task/IteratorTaskRunner.ts)` (inside `executeSubgraphIteration`):

- Same pattern: after each subgraph run, capture an iteration checkpoint.

This requires threading the `checkpointSaver` and `threadId` through the execution context (`IExecuteContext` or `IRunConfig`). The cleanest approach is to add optional `checkpointSaver` and `threadId` to the `IRunConfig` interface in `[packages/task-graph/src/task/ITask.ts](packages/task-graph/src/task/ITask.ts)`.

### 2e. Thread ID Concept

The `threadId` serves as the isolation key for checkpoint namespacing. When running a graph:

- If no `threadId` is provided, generate one via `uuid4()`.
- The `threadId` is stored on the runner and propagated to all child graph runs.
- Maps directly to `activity_id` in the builder.

## Part 3: Builder - Checkpoint Data in Activities

### 3a. Wire CheckpointSaver into `runWorkflow`

In `[builder/src/lib/run-workflow.ts](builder/src/lib/run-workflow.ts)`:

1. Create/get a `CheckpointSaver` (TabularCheckpointSaver backed by the same storage infrastructure used by `ActivityRepository`).
2. Pass it to `taskGraph.run()` via the config: `{ checkpointSaver, threadId: actId }`.
3. On failure, the checkpoint is already saved. The existing `activity_id` serves as the `threadId`.
4. Add a `resumeFromCheckpoint` option to `RunWorkflowOptions` that, when set, passes `resumeFromCheckpoint` to the graph config to skip completed tasks.

### 3b. Checkpoint Repository for the Builder

Create `builder/src/components/activities/CheckpointRepository.ts`:

- Wraps a `TabularCheckpointSaver` (or an `InMemoryCheckpointSaver` for browser-only mode).
- Provides queries: `getCheckpointsForActivity(activityId)`, `getIterationCheckpoints(activityId, taskId)`.
- Registered alongside `ActivityRepository` in the builder's storage setup.

### 3c. Activity Detail: Per-Task Run Data

Enhance `[builder/src/components/activities/ActivityViewer.tsx](builder/src/components/activities/ActivityViewer.tsx)`:

- Fetch checkpoints for the current activity using `CheckpointRepository`.
- Display a timeline of task completions derived from checkpoint `metadata.triggerTaskId` and `metadata.createdAt`.
- For each task in the graph, show its state (status, inputs, outputs, timing) by reading from the relevant checkpoint's `taskStates`.
- For iterative tasks (WhileTask, MapTask), show an expandable list of iteration checkpoints.

## File Summary

| Area | Files                                                           | Action                                |
| ---- | --------------------------------------------------------------- | ------------------------------------- |
| libs | `packages/task-graph/src/checkpoint/CheckpointTypes.ts`         | New                                   |
| libs | `packages/task-graph/src/checkpoint/CheckpointSaver.ts`         | New                                   |
| libs | `packages/task-graph/src/checkpoint/InMemoryCheckpointSaver.ts` | New                                   |
| libs | `packages/task-graph/src/checkpoint/TabularCheckpointSaver.ts`  | New                                   |
| libs | `packages/task-graph/src/checkpoint/index.ts`                   | New                                   |
| libs | `packages/task-graph/src/common.ts`                             | Modify (add checkpoint exports)       |
| libs | `packages/task-graph/src/task-graph/TaskGraph.ts`               | Modify (extend config)                |
| libs | `packages/task-graph/src/task-graph/TaskGraphRunner.ts`         | Modify (checkpoint hooks, restore)    |
| libs | `packages/task-graph/src/task-graph/TaskGraphEvents.ts`         | Modify (add checkpoint event)         |
| libs | `packages/task-graph/src/task/ITask.ts`                         | Modify (add checkpoint to IRunConfig) |
| libs | `packages/task-graph/src/task/TaskRunner.ts`                    | Modify (propagate checkpoint config)  |
| libs | `packages/task-graph/src/task/WhileTask.ts`                     | Modify (iteration checkpoints)        |
| libs | `packages/task-graph/src/task/IteratorTaskRunner.ts`            | Modify (iteration checkpoints)        |

## Testing

Tests should be added in `packages/test/src/test/task/`:

- `Checkpoint.test.ts` - Test checkpoint save/restore cycle for a simple graph
- `CheckpointResume.test.ts` - Test resume from checkpoint after simulated failure
- `CheckpointIteration.test.ts` - Test iteration checkpoints for WhileTask and MapTask