### PR TITLE
[feat] Add reactive execution support to AiProvider and related classes

### DIFF
--- a/packages/ai-provider/src/anthropic/AnthropicProvider.ts
+++ b/packages/ai-provider/src/anthropic/AnthropicProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { ANTHROPIC } from "./common/Anthropic_Constants";
 import type { AnthropicModelConfig } from "./common/Anthropic_ModelSchema";
 
@@ -46,8 +51,9 @@ export class AnthropicProvider extends AiProvider<AnthropicModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, AnthropicModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, AnthropicModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, AnthropicModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, AnthropicModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/google-gemini/GoogleGeminiProvider.ts
+++ b/packages/ai-provider/src/google-gemini/GoogleGeminiProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { GOOGLE_GEMINI } from "./common/Gemini_Constants";
 import type { GeminiModelConfig } from "./common/Gemini_ModelSchema";
 
@@ -44,8 +49,9 @@ export class GoogleGeminiProvider extends AiProvider<GeminiModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, GeminiModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, GeminiModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, GeminiModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, GeminiModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/hf-transformers/HuggingFaceTransformersProvider.ts
+++ b/packages/ai-provider/src/hf-transformers/HuggingFaceTransformersProvider.ts
@@ -6,6 +6,7 @@
 
 import {
   AiProvider,
+  type AiProviderReactiveRunFn,
   type AiProviderRegisterOptions,
   type AiProviderRunFn,
   type AiProviderStreamFn,
@@ -66,9 +67,10 @@ export class HuggingFaceTransformersProvider extends AiProvider<HfTransformersOn
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, HfTransformersOnnxModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, HfTransformersOnnxModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, HfTransformersOnnxModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, HfTransformersOnnxModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 
   protected override async onInitialize(options: AiProviderRegisterOptions): Promise<void> {

--- a/packages/ai-provider/src/provider-hf-inference/HfInferenceProvider.ts
+++ b/packages/ai-provider/src/provider-hf-inference/HfInferenceProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { HF_INFERENCE } from "./common/HFI_Constants";
 import type { HfInferenceModelConfig } from "./common/HFI_ModelSchema";
 
@@ -47,8 +52,9 @@ export class HfInferenceProvider extends AiProvider<HfInferenceModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, HfInferenceModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, HfInferenceModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, HfInferenceModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, HfInferenceModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/provider-llamacpp/LlamaCppProvider.ts
+++ b/packages/ai-provider/src/provider-llamacpp/LlamaCppProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { LOCAL_LLAMACPP } from "./common/LlamaCpp_Constants";
 import type { LlamaCppModelConfig } from "./common/LlamaCpp_ModelSchema";
 
@@ -48,8 +53,9 @@ export class LlamaCppProvider extends AiProvider<LlamaCppModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, LlamaCppModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, LlamaCppModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, LlamaCppModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, LlamaCppModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/provider-ollama/OllamaProvider.ts
+++ b/packages/ai-provider/src/provider-ollama/OllamaProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { OLLAMA } from "./common/Ollama_Constants";
 import type { OllamaModelConfig } from "./common/Ollama_ModelSchema";
 
@@ -46,8 +51,9 @@ export class OllamaProvider extends AiProvider<OllamaModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, OllamaModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, OllamaModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, OllamaModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, OllamaModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/provider-openai/OpenAiProvider.ts
+++ b/packages/ai-provider/src/provider-openai/OpenAiProvider.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn, type AiProviderStreamFn } from "@workglow/ai";
+import {
+  AiProvider,
+  type AiProviderReactiveRunFn,
+  type AiProviderRunFn,
+  type AiProviderStreamFn,
+} from "@workglow/ai";
 import { OPENAI } from "./common/OpenAI_Constants";
 import type { OpenAiModelConfig } from "./common/OpenAI_ModelSchema";
 
@@ -48,8 +53,9 @@ export class OpenAiProvider extends AiProvider<OpenAiModelConfig> {
 
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, OpenAiModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, OpenAiModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, OpenAiModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, OpenAiModelConfig>>
   ) {
-    super(tasks, streamTasks);
+    super(tasks, streamTasks, reactiveTasks);
   }
 }

--- a/packages/ai-provider/src/tf-mediapipe/TensorFlowMediaPipeProvider.ts
+++ b/packages/ai-provider/src/tf-mediapipe/TensorFlowMediaPipeProvider.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AiProvider, type AiProviderRunFn } from "@workglow/ai";
+import { AiProvider, type AiProviderReactiveRunFn, type AiProviderRunFn } from "@workglow/ai";
 import { TENSORFLOW_MEDIAPIPE } from "./common/TFMP_Constants";
 import type { TFMPModelConfig } from "./common/TFMP_ModelSchema";
 
@@ -54,7 +54,10 @@ export class TensorFlowMediaPipeProvider extends AiProvider<TFMPModelConfig> {
     "PoseLandmarkerTask",
   ] as const;
 
-  constructor(tasks?: Record<string, AiProviderRunFn<any, any, TFMPModelConfig>>) {
-    super(tasks);
+  constructor(
+    tasks?: Record<string, AiProviderRunFn<any, any, TFMPModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, TFMPModelConfig>>
+  ) {
+    super(tasks, undefined, reactiveTasks);
   }
 }

--- a/packages/ai/src/provider/AiProvider.ts
+++ b/packages/ai/src/provider/AiProvider.ts
@@ -9,6 +9,7 @@ import { globalServiceRegistry, WORKER_MANAGER, type WorkerServer } from "@workg
 import type { ModelConfig } from "../model/ModelSchema";
 import { createDefaultQueue } from "../queue/createDefaultQueue";
 import {
+  type AiProviderReactiveRunFn,
   type AiProviderRunFn,
   type AiProviderStreamFn,
   getAiProviderRegistry,
@@ -94,12 +95,24 @@ export abstract class AiProvider<TModelConfig extends ModelConfig = ModelConfig>
    */
   protected readonly streamTasks?: Record<string, AiProviderStreamFn<any, any, TModelConfig>>;
 
+  /**
+   * Map of task type names to their reactive run functions.
+   * Injected via constructor alongside `tasks`. Only needed for tasks that
+   * provide lightweight reactive previews via executeReactive().
+   */
+  protected readonly reactiveTasks?: Record<
+    string,
+    AiProviderReactiveRunFn<any, any, TModelConfig>
+  >;
+
   constructor(
     tasks?: Record<string, AiProviderRunFn<any, any, TModelConfig>>,
-    streamTasks?: Record<string, AiProviderStreamFn<any, any, TModelConfig>>
+    streamTasks?: Record<string, AiProviderStreamFn<any, any, TModelConfig>>,
+    reactiveTasks?: Record<string, AiProviderReactiveRunFn<any, any, TModelConfig>>
   ) {
     this.tasks = tasks;
     this.streamTasks = streamTasks;
+    this.reactiveTasks = reactiveTasks;
   }
 
   /** Get all task type names this provider supports */
@@ -127,6 +140,19 @@ export abstract class AiProvider<TModelConfig extends ModelConfig = ModelConfig>
     taskType: string
   ): AiProviderStreamFn<I, O, TModelConfig> | undefined {
     return this.streamTasks?.[taskType] as AiProviderStreamFn<I, O, TModelConfig> | undefined;
+  }
+
+  /**
+   * Get the reactive run function for a specific task type.
+   * @param taskType - The task type name (e.g., "CountTokensTask")
+   * @returns The reactive function, or undefined if not supported for this task type
+   */
+  getReactiveRunFn<I extends TaskInput = TaskInput, O extends TaskOutput = TaskOutput>(
+    taskType: string
+  ): AiProviderReactiveRunFn<I, O, TModelConfig> | undefined {
+    return this.reactiveTasks?.[taskType] as
+      | AiProviderReactiveRunFn<I, O, TModelConfig>
+      | undefined;
   }
 
   /**
@@ -178,6 +204,11 @@ export abstract class AiProvider<TModelConfig extends ModelConfig = ModelConfig>
       if (this.streamTasks) {
         for (const [taskType, fn] of Object.entries(this.streamTasks)) {
           registry.registerStreamFn(this.name, taskType, fn as AiProviderStreamFn);
+        }
+      }
+      if (this.reactiveTasks) {
+        for (const [taskType, fn] of Object.entries(this.reactiveTasks)) {
+          registry.registerReactiveRunFn(this.name, taskType, fn as AiProviderReactiveRunFn);
         }
       }
     }

--- a/packages/ai/src/provider/AiProviderRegistry.ts
+++ b/packages/ai/src/provider/AiProviderRegistry.ts
@@ -24,6 +24,17 @@ export type AiProviderRunFn<
 ) => Promise<Output>;
 
 /**
+ * Type for the reactive run function for AiTask.executeReactive().
+ * Receives the current output alongside the input so it can return a fast preview.
+ * No `signal` or `update_progress` -- reactive execution is lightweight and synchronous-ish.
+ */
+export type AiProviderReactiveRunFn<
+  Input extends TaskInput = TaskInput,
+  Output extends TaskOutput = TaskOutput,
+  Model extends ModelConfig = ModelConfig,
+> = (input: Input, output: Output, model: Model | undefined) => Promise<Output | undefined>;
+
+/**
  * Type for the streaming run function for the AiJob.
  * Returns an AsyncIterable of StreamEvents instead of a Promise.
  * No `update_progress` callback -- for streaming providers, the stream itself IS the progress signal.
@@ -46,6 +57,7 @@ export type AiProviderStreamFn<
 export class AiProviderRegistry {
   runFnRegistry: Map<string, Map<string, AiProviderRunFn<any, any>>> = new Map();
   streamFnRegistry: Map<string, Map<string, AiProviderStreamFn<any, any>>> = new Map();
+  reactiveRunFnRegistry: Map<string, Map<string, AiProviderReactiveRunFn<any, any>>> = new Map();
   private providers: Map<string, AiProvider<any>> = new Map();
 
   /**
@@ -167,6 +179,36 @@ export class AiProviderRegistry {
   ): AiProviderStreamFn<Input, Output> | undefined {
     const taskTypeMap = this.streamFnRegistry.get(taskType);
     return taskTypeMap?.get(modelProvider) as AiProviderStreamFn<Input, Output> | undefined;
+  }
+
+  /**
+   * Registers a reactive execution function for a specific task type and model provider.
+   * Called by AiTask.executeReactive() to provide a fast, lightweight preview without a network call.
+   */
+  registerReactiveRunFn<
+    Input extends TaskInput = TaskInput,
+    Output extends TaskOutput = TaskOutput,
+  >(
+    modelProvider: string,
+    taskType: string,
+    reactiveRunFn: AiProviderReactiveRunFn<Input, Output>
+  ) {
+    if (!this.reactiveRunFnRegistry.has(taskType)) {
+      this.reactiveRunFnRegistry.set(taskType, new Map());
+    }
+    this.reactiveRunFnRegistry.get(taskType)!.set(modelProvider, reactiveRunFn);
+  }
+
+  /**
+   * Retrieves the reactive execution function for a task type and model provider.
+   * Returns undefined if no reactive function is registered (fallback to default behavior).
+   */
+  getReactiveRunFn<Input extends TaskInput = TaskInput, Output extends TaskOutput = TaskOutput>(
+    modelProvider: string,
+    taskType: string
+  ): AiProviderReactiveRunFn<Input, Output> | undefined {
+    const taskTypeMap = this.reactiveRunFnRegistry.get(taskType);
+    return taskTypeMap?.get(modelProvider) as AiProviderReactiveRunFn<Input, Output> | undefined;
   }
 
   /**


### PR DESCRIPTION
- Introduced AiProviderReactiveRunFn type for lightweight reactive task execution.
- Enhanced AiProvider to support reactiveTasks, allowing for fast previews of task outputs.
- Updated AiProviderRegistry to register and retrieve reactive run functions.
- Modified AiTask to delegate to provider-registered reactive functions when available.
- Updated various provider classes to include reactiveTasks in their constructors.