### PR TITLE
Add structured ILogger interface with DI-based registry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -338,6 +338,7 @@
         "@workglow/task-graph": "workspace:*",
         "@workglow/tasks": "workspace:*",
         "@workglow/util": "workspace:*",
+        "tslog": "^4.9.3",
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "catalog:",
@@ -2082,6 +2083,8 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tslog": ["tslog@4.10.2", "", {}, "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -6,6 +6,7 @@
 
 export * from "./di";
 export * from "./events/EventEmitter";
+export * from "./logging";
 export * from "./graph";
 export * from "./json-schema/DataPortSchema";
 export * from "./json-schema/FromSchema";

--- a/packages/util/src/logging/ConsoleLogger.ts
+++ b/packages/util/src/logging/ConsoleLogger.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ILogger } from "./ILogger";
+
+/**
+ * Default logger that delegates to the global `console` object.
+ * When created via {@link child}, accumulated bindings are passed
+ * as a second argument to every console call.
+ */
+export class ConsoleLogger implements ILogger {
+  private readonly bindings: Record<string, unknown>;
+
+  constructor(bindings: Record<string, unknown> = {}) {
+    this.bindings = bindings;
+  }
+
+  info(message: string, meta?: Record<string, unknown>): void {
+    const merged = this.merge(meta);
+    if (merged) {
+      console.info(message, merged);
+    } else {
+      console.info(message);
+    }
+  }
+
+  error(message: string, meta?: Record<string, unknown>): void {
+    const merged = this.merge(meta);
+    if (merged) {
+      console.error(message, merged);
+    } else {
+      console.error(message);
+    }
+  }
+
+  debug(message: string, meta?: Record<string, unknown>): void {
+    const merged = this.merge(meta);
+    if (merged) {
+      console.debug(message, merged);
+    } else {
+      console.debug(message);
+    }
+  }
+
+  fatal(err: Error, message: string, meta?: Record<string, unknown>): void {
+    const merged = this.merge(meta);
+    if (merged) {
+      console.error(message, { ...merged, error: err });
+    } else {
+      console.error(message, { error: err });
+    }
+  }
+
+  child(bindings: Record<string, unknown>): ILogger {
+    return new ConsoleLogger({ ...this.bindings, ...bindings });
+  }
+
+  private merge(meta: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+    const hasBindings = Object.keys(this.bindings).length > 0;
+    if (!hasBindings && !meta) return undefined;
+    if (!hasBindings) return meta;
+    if (!meta) return this.bindings;
+    return { ...this.bindings, ...meta };
+  }
+}

--- a/packages/util/src/logging/ILogger.ts
+++ b/packages/util/src/logging/ILogger.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Structured logger interface for use across all workglow packages.
+ * Implementations are swapped via DI ({@link LoggerRegistry}).
+ */
+export interface ILogger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+  debug(message: string, meta?: Record<string, unknown>): void;
+  fatal(err: Error, message: string, meta?: Record<string, unknown>): void;
+  child(bindings: Record<string, unknown>): ILogger;
+}

--- a/packages/util/src/logging/LoggerRegistry.ts
+++ b/packages/util/src/logging/LoggerRegistry.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createServiceToken, globalServiceRegistry } from "../di/ServiceRegistry";
+import { ConsoleLogger } from "./ConsoleLogger";
+import type { ILogger } from "./ILogger";
+
+/**
+ * Service token for the global logger instance.
+ */
+export const LOGGER = createServiceToken<ILogger>("logger");
+
+// Register default ConsoleLogger if nothing else has been registered yet.
+if (!globalServiceRegistry.has(LOGGER)) {
+  globalServiceRegistry.register(LOGGER, (): ILogger => new ConsoleLogger(), true);
+}
+
+/**
+ * Returns the current global logger.
+ */
+export function getLogger(): ILogger {
+  return globalServiceRegistry.get(LOGGER);
+}
+
+/**
+ * Replaces the global logger instance.
+ */
+export function setLogger(logger: ILogger): void {
+  globalServiceRegistry.registerInstance(LOGGER, logger);
+}

--- a/packages/util/src/logging/NullLogger.ts
+++ b/packages/util/src/logging/NullLogger.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ILogger } from "./ILogger";
+
+/**
+ * Silent logger that discards all output.
+ * Useful for suppressing log noise in tests.
+ */
+export class NullLogger implements ILogger {
+  info(_message: string, _meta?: Record<string, unknown>): void {}
+  error(_message: string, _meta?: Record<string, unknown>): void {}
+  debug(_message: string, _meta?: Record<string, unknown>): void {}
+  fatal(_err: Error, _message: string, _meta?: Record<string, unknown>): void {}
+  child(_bindings: Record<string, unknown>): ILogger {
+    return this;
+  }
+}

--- a/packages/util/src/logging/index.ts
+++ b/packages/util/src/logging/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./ILogger";
+export * from "./ConsoleLogger";
+export * from "./NullLogger";
+export * from "./LoggerRegistry";

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -79,7 +79,8 @@
     "@workglow/storage": "workspace:*",
     "@workglow/task-graph": "workspace:*",
     "@workglow/tasks": "workspace:*",
-    "@workglow/util": "workspace:*"
+    "@workglow/util": "workspace:*",
+    "tslog": "^4.9.3"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "catalog:",

--- a/packages/workglow/src/common.ts
+++ b/packages/workglow/src/common.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "./logging";
+
 export * from "@workglow/ai";
 export * from "@workglow/ai-provider";
 export * from "@workglow/dataset";

--- a/packages/workglow/src/logging.ts
+++ b/packages/workglow/src/logging.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from "tslog";
+import { setLogger } from "@workglow/util";
+import type { ILogger } from "@workglow/util";
+
+/**
+ * {@link ILogger} adapter backed by tslog.
+ * Registered as the global logger when the `workglow` meta-package is imported.
+ */
+export class TsLogLogger implements ILogger {
+  private readonly logger: Logger<unknown>;
+
+  constructor(logger?: Logger<unknown>) {
+    this.logger = logger ?? new Logger({ name: "workglow" });
+  }
+
+  info(message: string, meta?: Record<string, unknown>): void {
+    if (meta) {
+      this.logger.info(message, meta);
+    } else {
+      this.logger.info(message);
+    }
+  }
+
+  error(message: string, meta?: Record<string, unknown>): void {
+    if (meta) {
+      this.logger.error(message, meta);
+    } else {
+      this.logger.error(message);
+    }
+  }
+
+  debug(message: string, meta?: Record<string, unknown>): void {
+    if (meta) {
+      this.logger.debug(message, meta);
+    } else {
+      this.logger.debug(message);
+    }
+  }
+
+  fatal(err: Error, message: string, meta?: Record<string, unknown>): void {
+    if (meta) {
+      this.logger.fatal(message, err, meta);
+    } else {
+      this.logger.fatal(message, err);
+    }
+  }
+
+  child(bindings: Record<string, unknown>): ILogger {
+    return new TsLogLogger(this.logger.getSubLogger({}, bindings));
+  }
+}
+
+// Override the default ConsoleLogger with tslog.
+setLogger(new TsLogLogger());


### PR DESCRIPTION
Introduce a centralized logging system across the monorepo:
- ILogger interface (info, error, debug, fatal, child) in @workglow/util
- ConsoleLogger as the default implementation wrapping console.xxx
- NullLogger for silencing output in tests
- LoggerRegistry using ServiceRegistry DI (getLogger/setLogger)
- TsLogLogger adapter in the workglow meta-package binding tslog

https://claude.ai/code/session_01E1f9mQCDaigp27YH9or4pi