### PR TITLE
Refine CI workflow: limit push triggers and gate coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,7 +406,7 @@ jobs:
           path: coverage
           retention-days: 1
       - name: Report Coverage
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: davelosert/vitest-coverage-report-action@v2
       - name: Delete Vitest coverage fragments
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -404,6 +406,7 @@ jobs:
           path: coverage
           retention-days: 1
       - name: Report Coverage
+        if: github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@v2
       - name: Delete Vitest coverage fragments
         if: always()


### PR DESCRIPTION
## Summary
Updated the GitHub Actions test workflow to be more selective about when it runs and when coverage reports are generated, reducing unnecessary CI executions and focusing coverage reporting on pull requests.

## Key Changes
- **Push trigger filtering**: Added `branches: [main]` filter to push events, ensuring the workflow only runs on pushes to the main branch rather than all branches
- **Pull request trigger**: Added explicit `pull_request` event trigger to the workflow
- **Coverage report gating**: Added conditional check (`if: github.event_name == 'pull_request'`) to the coverage report step, ensuring the davelosert/vitest-coverage-report-action only runs for pull requests

## Implementation Details
These changes optimize CI resource usage by:
1. Preventing redundant test runs on every branch push
2. Ensuring coverage reports are only generated and posted for pull requests where they're most useful for code review
3. Maintaining test execution on pull requests to catch issues before merge

https://claude.ai/code/session_01CdFiP2pGNPRgAYcBhrGttD