### PR TITLE
Refactor ModelRepository validation to support schema extension

### DIFF
--- a/packages/ai/src/model/ModelRepository.ts
+++ b/packages/ai/src/model/ModelRepository.ts
@@ -132,7 +132,7 @@ export class ModelRepository {
 
   /**
    * Adds a new model to the repository.
-   * Validates against ModelRecordSchema and rejects duplicates.
+   * Validates against the schema returned by {@link getValidationSchema} and rejects duplicates.
    * @param model - The model instance to add
    * @throws if the model fails schema validation or a model with the same model_id already exists
    */
@@ -151,7 +151,7 @@ export class ModelRepository {
 
   /**
    * Updates an existing model in the repository.
-   * Validates against ModelRecordSchema and requires the model to already exist.
+   * Validates against the schema returned by {@link getValidationSchema} and requires the model to already exist.
    * @param model - The model instance with updated fields
    * @throws if the model fails schema validation or the model_id does not exist
    */

--- a/packages/ai/src/model/ModelRepository.ts
+++ b/packages/ai/src/model/ModelRepository.ts
@@ -7,29 +7,9 @@
 import { ITabularStorage } from "@workglow/storage";
 import { EventEmitter, EventParameters } from "@workglow/util";
 import { compileSchema } from "@workglow/util/schema";
-import type { SchemaNode } from "@workglow/util/schema";
+import type { DataPortSchemaObject, SchemaNode } from "@workglow/util/schema";
 
 import { ModelPrimaryKeyNames, ModelRecord, ModelRecordSchema } from "./ModelSchema";
-
-let compiledModelRecordSchema: SchemaNode | undefined;
-function getModelRecordSchemaNode(): SchemaNode {
-  if (!compiledModelRecordSchema) {
-    compiledModelRecordSchema = compileSchema(ModelRecordSchema);
-  }
-  return compiledModelRecordSchema;
-}
-
-function validateModelRecord(model: ModelRecord): void {
-  const schemaNode = getModelRecordSchemaNode();
-  const result = schemaNode.validate(model);
-  if (!result.valid) {
-    const errorMessages = result.errors.map((e) => {
-      const path = e.data?.pointer || "";
-      return `${e.message}${path ? ` (${path})` : ""}`;
-    });
-    throw new Error(`Invalid model record: ${errorMessages.join(", ")}`);
-  }
-}
 
 /**
  * Events that can be emitted by the ModelRepository
@@ -75,6 +55,36 @@ export class ModelRepository {
 
   /** Event emitter for repository events */
   protected events = new EventEmitter<ModelEventListeners>();
+
+  /** Cached compiled validation schema, lazily built on first validate call */
+  private compiledValidationSchema: SchemaNode | undefined;
+
+  /**
+   * Returns the JSON schema used to validate model records before persistence.
+   * Subclasses can override this to accept additional properties (for example,
+   * owner/project IDs in repositories scoped to a user's workspace).
+   */
+  protected getValidationSchema(): DataPortSchemaObject {
+    return ModelRecordSchema;
+  }
+
+  /**
+   * Validates a model record against {@link getValidationSchema}.
+   * @throws if the record fails schema validation
+   */
+  protected validateModelRecord(model: ModelRecord): void {
+    if (!this.compiledValidationSchema) {
+      this.compiledValidationSchema = compileSchema(this.getValidationSchema());
+    }
+    const result = this.compiledValidationSchema.validate(model);
+    if (!result.valid) {
+      const errorMessages = result.errors.map((e) => {
+        const path = e.data?.pointer || "";
+        return `${e.message}${path ? ` (${path})` : ""}`;
+      });
+      throw new Error(`Invalid model record: ${errorMessages.join(", ")}`);
+    }
+  }
 
   /**
    * Sets up the database for the repository.
@@ -127,7 +137,7 @@ export class ModelRepository {
    * @throws if the model fails schema validation or a model with the same model_id already exists
    */
   async addModel(model: ModelRecord): Promise<ModelRecord> {
-    validateModelRecord(model);
+    this.validateModelRecord(model);
 
     const existing = await this.modelTabularRepository.get({ model_id: model.model_id });
     if (existing) {
@@ -146,7 +156,7 @@ export class ModelRepository {
    * @throws if the model fails schema validation or the model_id does not exist
    */
   async updateModel(model: ModelRecord): Promise<ModelRecord> {
-    validateModelRecord(model);
+    this.validateModelRecord(model);
 
     const existing = await this.modelTabularRepository.get({ model_id: model.model_id });
     if (!existing) {


### PR DESCRIPTION
## Summary
Refactored the model record validation logic in `ModelRepository` to support schema customization by subclasses. The validation is now an instance method that can be overridden, enabling repositories to extend the base schema with additional properties (e.g., owner/project IDs).

## Key Changes
- Moved `validateModelRecord()` and `getModelRecordSchemaNode()` from module-level functions to protected instance methods in `ModelRepository`
- Added `getValidationSchema()` protected method that returns the schema used for validation, allowing subclasses to override and extend it
- Converted `compiledModelRecordSchema` from a module-level cache to an instance property `compiledValidationSchema`
- Updated all calls to `validateModelRecord()` to use `this.validateModelRecord()` within the class
- Added `DataPortSchemaObject` to the imports to support the new method signature

## Implementation Details
- The validation schema is still lazily compiled on first use and cached as an instance property for performance
- The `getValidationSchema()` method provides a clear extension point for subclasses to customize validation rules
- Error handling and validation logic remain unchanged, ensuring backward compatibility

https://claude.ai/code/session_01HDd9z3mV1HnFPy2xTyAxUG