### PR TITLE
docs: finish --force cleanup and tighten credential-management notes

### DIFF
--- a/docs/technical/15-credential-management.md
+++ b/docs/technical/15-credential-management.md
@@ -374,10 +374,16 @@ the `onExpiry` callback is invoked -- typically used to lock a
   Browser applications should use `InMemoryCredentialStore` or
   `EncryptedKvCredentialStore` backed by `IndexedDbKvStorage`.
 - The Web Crypto API (`crypto.subtle`) is available natively -- no polyfills needed.
-- Provider clients (Anthropic, OpenAI) set `dangerouslyAllowBrowser: true` when
-  they detect a browser context. This is safe in Workglow because credentials
-  flow through the credential store rather than being hardcoded, and the application
-  controls which credentials are available in the browser context.
+- Provider clients (Anthropic, OpenAI) set `dangerouslyAllowBrowser: true`
+  when they detect a browser or web worker context (see
+  `packages/ai-provider/src/provider-anthropic/common/Anthropic_Client.ts:48`
+  and `packages/ai-provider/src/provider-openai/common/OpenAI_Client.ts:49`).
+  This is **not** automatically safe: any API key loaded into a browser
+  context — even one decrypted from `EncryptedKvCredentialStore` at runtime —
+  is reachable from the page and should be treated as exposed to the end user.
+  Use browser-side provider calls only with short-lived, user-scoped keys, a
+  proxy that injects credentials server-side, or local providers (Ollama,
+  Transformers.js, MediaPipe) that do not require a secret at all.
 - Web Workers receive credentials via structured cloning, same as Node/Bun workers.
 
 ---
@@ -393,7 +399,11 @@ import { EncryptedKvCredentialStore, SqliteKvStorage } from "@workglow/storage";
 
 // 1. Create the encrypted backend
 const kv = new SqliteKvStorage("credentials.db");
-const encrypted = new EncryptedKvCredentialStore(kv, process.env.CREDENTIAL_PASSPHRASE!);
+const passphrase = process.env.CREDENTIAL_PASSPHRASE;
+if (!passphrase) {
+  throw new Error("CREDENTIAL_PASSPHRASE environment variable is required");
+}
+const encrypted = new EncryptedKvCredentialStore(kv, passphrase);
 
 // 2. Chain with environment fallback
 const store = new ChainedCredentialStore([

--- a/docs/technical/19-build-system.md
+++ b/docs/technical/19-build-system.md
@@ -485,7 +485,8 @@ examples.
 | `bun run build:js` | Build JavaScript only (no type declarations) |
 | `bun run build:types` | Build type declarations only |
 | `bun run build:examples` | Build examples only (requires packages built first) |
-| `bun run build:release` | Build packages without `--force` (uses Turbo cache) |
+| `bun run build:release` | Build packages only (release build; same task graph as `build:packages`) |
+| `bun run rebuild` | Force rebuild everything, bypassing Turbo cache (`turbo run build-package build-example --force`) |
 | `bun run watch` | Full watch mode (builds once, then watches with concurrency 15) |
 | `bun run watch:js` | Watch JavaScript only (stream UI) |
 | `bun run watch-types` | Watch type declarations only |
@@ -530,12 +531,15 @@ Commonly used flags when running Turbo commands directly:
 
 | Flag | Purpose |
 |------|---------|
-| `--force` | Bypass cache, rebuild everything |
 | `--filter=<package>` | Run only for a specific package and its dependencies |
 | `--concurrency N` | Limit parallel task execution |
 | `--ui=stream` | Use streaming output (useful for watch mode) |
 | `--dry-run` | Show what would run without executing |
 | `--graph` | Generate a visual dependency graph |
+
+To bypass Turbo's cache and rebuild everything from scratch, use `bun run rebuild`
+rather than passing `--force` directly — it runs the full package and example
+task graph with caching disabled.
 
 Example: rebuild only `@workglow/task-graph` and its dependencies:
 


### PR DESCRIPTION
- 19-build-system.md: drop --force from the Turbo Flags table, add bun run rebuild to the root command reference, rephrase the stale "without --force" framing on build:release, and point readers at bun run rebuild as the cache-bypass escape hatch.
- 15-credential-management.md: replace the misleading "safe in Workglow" dangerouslyAllowBrowser claim with a clear warning that any API key loaded into a browser context is reachable from the page, and swap the CREDENTIAL_PASSPHRASE non-null assertion in the production setup example for an explicit guard.

https://claude.ai/code/session_01QKYUMPh6xzz4sszuEMMAQA