### PR TITLE
Add image codec security limits and validation helpers

### DIFF
--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -30,6 +30,7 @@ export * from "./task/image/ImageGrayscaleTask";
 export * from "./task/image/ImageInvertTask";
 export * from "./task/image/ImagePixelateTask";
 export * from "./task/image/ImagePosterizeTask";
+export * from "./task/image/imageCodecLimits";
 export * from "./task/image/imageRasterCodecRegistry";
 export * from "./task/image/ImageResizeTask";
 export * from "./task/image/ImageRotateTask";

--- a/packages/tasks/src/task/image/imageCodecLimits.ts
+++ b/packages/tasks/src/task/image/imageCodecLimits.ts
@@ -83,6 +83,31 @@ export function assertWithinByteBudget(byteLength: number, limit: number): void 
 }
 
 /**
+ * Returns a safe preview of `value` for error messages.
+ *
+ * - Non-strings are coerced with `String()`.
+ * - `data:` URIs have everything after the first comma replaced with
+ *   `[REDACTED]` so that base64-encoded image bytes are never written to
+ *   logs or telemetry.
+ * - All other strings are truncated to 80 characters.
+ */
+function formatDataUriErrorPreview(value: unknown): string {
+  if (typeof value !== "string") {
+    return String(value);
+  }
+
+  if (value.startsWith("data:")) {
+    const commaIndex = value.indexOf(",");
+    if (commaIndex >= 0) {
+      return `${value.slice(0, commaIndex)},[REDACTED]`;
+    }
+    return `${value.slice(0, 80)}${value.length > 80 ? "…" : ""}`;
+  }
+
+  return `${value.slice(0, 80)}${value.length > 80 ? "…" : ""}`;
+}
+
+/**
  * Throws unless `value` is a string that starts with `data:`. Defense in depth
  * at the codec boundary — prevents the browser codec's `fetch(value)` from ever
  * reaching the network (`http:`, `file:`, etc.) even if an upstream validator
@@ -90,10 +115,8 @@ export function assertWithinByteBudget(byteLength: number, limit: number): void 
  */
 export function assertIsDataUri(value: string): void {
   if (typeof value !== "string" || !value.startsWith("data:")) {
-    const preview = typeof value === "string" ? value.slice(0, 80) : String(value);
-    throw new Error(
-      `Image raster codec: expected a data: URI but received "${preview}${preview.length >= 80 ? "…" : ""}"`
-    );
+    const preview = formatDataUriErrorPreview(value);
+    throw new Error(`Image raster codec: expected a data: URI but received "${preview}"`);
   }
 }
 

--- a/packages/tasks/src/task/image/imageCodecLimits.ts
+++ b/packages/tasks/src/task/image/imageCodecLimits.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Maximum number of decoded pixels (width * height) accepted by the image raster codec.
+ *
+ * Caps worst-case RGBA allocation at ~400 MiB (100 MP * 4 bytes/pixel). Legitimate
+ * photographic content rarely exceeds ~50 MP; synthetic pipelines that need more
+ * should bypass the codec and operate on ImageBinary directly.
+ *
+ * Defends against header-declared pixel bombs where a small compressed payload
+ * claims billions of pixels to force a downstream OOM.
+ */
+export const MAX_DECODED_PIXELS = 100_000_000;
+
+/**
+ * Maximum raw (base64-decoded) byte size of an incoming data URI on the Node codec.
+ *
+ * This is a coarse pre-filter before format-specific decoding. The Node codec
+ * additionally enforces {@link MAX_DECODED_PIXELS} via sharp's header-level
+ * `limitInputPixels`, so 64 MiB is a comfortable ceiling on the server side.
+ */
+export const MAX_INPUT_BYTES_NODE = 64 * 1024 * 1024;
+
+/**
+ * Maximum raw byte size of an incoming data URI on the browser codec.
+ *
+ * The browser codec uses a stricter ceiling than {@link MAX_INPUT_BYTES_NODE}
+ * because `createImageBitmap` eagerly decompresses before we can observe the
+ * bitmap's dimensions. Bounding the compressed input is the primary defense;
+ * the post-bitmap `assertWithinPixelBudget` check only avoids the subsequent
+ * canvas + ImageData allocations.
+ */
+export const MAX_INPUT_BYTES_BROWSER = 8 * 1024 * 1024;
+
+/**
+ * Mime types rejected at decode time because rasterization would silently lose
+ * information (vector data, animation frames). Callers that need these formats
+ * must convert to PNG/JPEG/WebP externally before invoking the codec.
+ *
+ * Known limitations:
+ * - APNG declared as `image/png` cannot be distinguished by mime type alone;
+ *   sharp will decode only the first frame. True APNG rejection requires
+ *   post-decode metadata inspection (`pages > 1`).
+ * - Animated WebP declared as `image/webp` has the same limitation.
+ */
+export const REJECTED_DECODE_MIME_TYPES: ReadonlySet<string> = new Set([
+  "image/svg+xml",
+  "image/svg",
+  "image/gif",
+  "image/apng",
+]);
+
+/** Output formats the codec is willing to produce. Everything else throws at encode. */
+export const SUPPORTED_OUTPUT_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+export type SupportedOutputMimeType = (typeof SUPPORTED_OUTPUT_MIME_TYPES)[number];
+
+/**
+ * Throws if the decoded image would exceed {@link MAX_DECODED_PIXELS}, or if
+ * the dimensions are non-finite or non-positive.
+ */
+export function assertWithinPixelBudget(width: number, height: number): void {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    throw new Error(`Image raster codec: invalid dimensions ${width}x${height}`);
+  }
+  const pixels = width * height;
+  if (pixels > MAX_DECODED_PIXELS) {
+    throw new Error(
+      `Image raster codec: decoded image exceeds pixel budget ` +
+        `(${width}x${height} = ${pixels} > ${MAX_DECODED_PIXELS})`
+    );
+  }
+}
+
+/** Throws if `byteLength` exceeds `limit`. */
+export function assertWithinByteBudget(byteLength: number, limit: number): void {
+  if (byteLength > limit) {
+    throw new Error(`Image raster codec: input exceeds byte budget (${byteLength} > ${limit})`);
+  }
+}
+
+/**
+ * Throws unless `value` is a string that starts with `data:`. Defense in depth
+ * at the codec boundary — prevents the browser codec's `fetch(value)` from ever
+ * reaching the network (`http:`, `file:`, etc.) even if an upstream validator
+ * is removed or bypassed.
+ */
+export function assertIsDataUri(value: string): void {
+  if (typeof value !== "string" || !value.startsWith("data:")) {
+    const preview = typeof value === "string" ? value.slice(0, 80) : String(value);
+    throw new Error(
+      `Image raster codec: expected a data: URI but received "${preview}${preview.length >= 80 ? "…" : ""}"`
+    );
+  }
+}
+
+/**
+ * Extracts the mime type from a data URI for pre-decode validation. Returns
+ * the lowercased mime type, or `undefined` if not parseable.
+ *
+ * Intentionally looser than `parseDataUri` in `@workglow/util/media`: this lets
+ * us report "unsupported svg+xml" before failing on an otherwise-malformed data
+ * URI, so the caller gets the most actionable error.
+ */
+export function extractDataUriMimeType(dataUri: string): string | undefined {
+  const match = dataUri.match(/^data:([^;,]+)/);
+  return match?.[1]?.trim().toLowerCase();
+}
+
+/**
+ * Normalizes and validates an output mime type. Throws for unsupported or
+ * lossy types (e.g. `image/svg+xml`, `image/gif`) instead of silently falling
+ * through to PNG. Replaces the per-file `normalizeMimeType` helpers that used
+ * to mask format mismatches.
+ */
+export function normalizeOutputMimeType(mimeType: string): SupportedOutputMimeType {
+  const m = mimeType.toLowerCase().trim();
+  if (m === "image/jpeg" || m === "image/jpg") {
+    return "image/jpeg";
+  }
+  if (m === "image/png") {
+    return "image/png";
+  }
+  if (m === "image/webp") {
+    return "image/webp";
+  }
+  throw new Error(
+    `Image raster codec: unsupported output mime type "${mimeType}". ` +
+      `Supported: ${SUPPORTED_OUTPUT_MIME_TYPES.join(", ")}.`
+  );
+}

--- a/packages/tasks/src/task/image/imageRasterCodecBrowser.ts
+++ b/packages/tasks/src/task/image/imageRasterCodecBrowser.ts
@@ -6,18 +6,16 @@
 
 import type { ImageBinary } from "@workglow/util/media";
 
+import {
+  MAX_INPUT_BYTES_BROWSER,
+  REJECTED_DECODE_MIME_TYPES,
+  assertIsDataUri,
+  assertWithinByteBudget,
+  assertWithinPixelBudget,
+  extractDataUriMimeType,
+  normalizeOutputMimeType,
+} from "./imageCodecLimits";
 import type { ImageRasterCodec } from "./imageRasterCodecRegistry";
-
-function normalizeMimeType(mimeType: string): "image/jpeg" | "image/png" | "image/webp" {
-  const m = mimeType.toLowerCase();
-  if (m.includes("jpeg") || m.includes("jpg")) {
-    return "image/jpeg";
-  }
-  if (m.includes("webp")) {
-    return "image/webp";
-  }
-  return "image/png";
-}
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
@@ -87,23 +85,50 @@ function get2dContext(
 }
 
 async function decodeDataUri(dataUri: string): Promise<ImageBinary> {
+  // Defense in depth: without this assertion, `fetch(dataUri)` below would
+  // happily reach the network for `http:`, `file:`, etc. — turning any future
+  // upstream-validation removal into SSRF.
+  assertIsDataUri(dataUri);
+
+  const declaredMime = extractDataUriMimeType(dataUri);
+  if (declaredMime && REJECTED_DECODE_MIME_TYPES.has(declaredMime)) {
+    throw new Error(
+      `Image raster codec: refusing to rasterize "${declaredMime}". ` +
+        `Vector and animated formats lose information when converted to pixels. ` +
+        `Convert to PNG, JPEG, or WebP before passing to the codec.`
+    );
+  }
+
   const response = await fetch(dataUri);
   const blob = await response.blob();
+  // Compressed-size pre-check is the primary browser defense against decoder
+  // bombs: `createImageBitmap` decompresses eagerly, so by the time we can
+  // read `bmp.width`/`bmp.height` the expensive allocation has already
+  // happened. The subsequent pixel-budget check only avoids the canvas +
+  // ImageData allocations (another ~2 * w*h*4 bytes).
+  assertWithinByteBudget(blob.size, MAX_INPUT_BYTES_BROWSER);
+
   const bmp = await createImageBitmap(blob);
-  const { ctx } = get2dContext(bmp.width, bmp.height);
-  ctx.drawImage(bmp, 0, 0);
-  const id = ctx.getImageData(0, 0, bmp.width, bmp.height);
-  bmp.close();
-  return {
-    data: new Uint8ClampedArray(id.data),
-    width: id.width,
-    height: id.height,
-    channels: 4,
-  };
+  try {
+    assertWithinPixelBudget(bmp.width, bmp.height);
+    const { ctx } = get2dContext(bmp.width, bmp.height);
+    ctx.drawImage(bmp, 0, 0);
+    const id = ctx.getImageData(0, 0, bmp.width, bmp.height);
+    return {
+      data: new Uint8ClampedArray(id.data),
+      width: id.width,
+      height: id.height,
+      channels: 4,
+    };
+  } finally {
+    // Always close the bitmap, even on rejection, to avoid leaking a
+    // decompressed allocation on every oversized input.
+    bmp.close();
+  }
 }
 
 async function encodeDataUri(image: ImageBinary, mimeType: string): Promise<string> {
-  const fmt = normalizeMimeType(mimeType);
+  const fmt = normalizeOutputMimeType(mimeType);
   const { canvas, ctx } = get2dContext(image.width, image.height);
   ctx.putImageData(rasterToImageData(image), 0, 0);
 

--- a/packages/tasks/src/task/image/imageRasterCodecNode.ts
+++ b/packages/tasks/src/task/image/imageRasterCodecNode.ts
@@ -7,18 +7,17 @@
 import type { ImageBinary, ImageChannels } from "@workglow/util/media";
 import { parseDataUri } from "@workglow/util/media";
 
+import {
+  MAX_DECODED_PIXELS,
+  MAX_INPUT_BYTES_NODE,
+  REJECTED_DECODE_MIME_TYPES,
+  assertIsDataUri,
+  assertWithinByteBudget,
+  assertWithinPixelBudget,
+  extractDataUriMimeType,
+  normalizeOutputMimeType,
+} from "./imageCodecLimits";
 import type { ImageRasterCodec } from "./imageRasterCodecRegistry";
-
-function normalizeMimeType(mimeType: string): "image/jpeg" | "image/png" | "image/webp" {
-  const m = mimeType.toLowerCase();
-  if (m.includes("jpeg") || m.includes("jpg")) {
-    return "image/jpeg";
-  }
-  if (m.includes("webp")) {
-    return "image/webp";
-  }
-  return "image/png";
-}
 
 function expandGrayAlphaToRgba(src: Buffer, width: number, height: number): Uint8ClampedArray {
   const n = width * height;
@@ -51,13 +50,41 @@ async function getSharp() {
 }
 
 async function decodeDataUri(dataUri: string): Promise<ImageBinary> {
+  // Defense in depth: the codec must not trust its caller. An accidental
+  // `fetch`/`Buffer.from` path is not reachable here today, but refusing
+  // anything that is not a data URI keeps that door shut.
+  assertIsDataUri(dataUri);
+
+  const declaredMime = extractDataUriMimeType(dataUri);
+  if (declaredMime && REJECTED_DECODE_MIME_TYPES.has(declaredMime)) {
+    throw new Error(
+      `Image raster codec: refusing to rasterize "${declaredMime}". ` +
+        `Vector and animated formats lose information when converted to pixels. ` +
+        `Convert to PNG, JPEG, or WebP before passing to the codec.`
+    );
+  }
+
   const sharp = await getSharp();
   const { base64 } = parseDataUri(dataUri);
   const buffer = Buffer.from(base64, "base64");
-  const { data, info } = await sharp(buffer).raw().toBuffer({ resolveWithObject: true });
+  assertWithinByteBudget(buffer.byteLength, MAX_INPUT_BYTES_NODE);
+
+  // `limitInputPixels` rejects header-declared pixel bombs before decompression.
+  // `sequentialRead` lowers peak memory for large inputs.
+  const { data, info } = await sharp(buffer, {
+    limitInputPixels: MAX_DECODED_PIXELS,
+    sequentialRead: true,
+  })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
   const width = info.width;
   const height = info.height;
   const ch = info.channels;
+
+  // Belt-and-suspenders: sharp should have rejected already, but assert on the
+  // post-decode dimensions too so any future sharp option change cannot
+  // silently disable the pixel budget.
+  assertWithinPixelBudget(width, height);
 
   if (ch === 2) {
     return {
@@ -68,8 +95,14 @@ async function decodeDataUri(dataUri: string): Promise<ImageBinary> {
     };
   }
   if (ch === 1 || ch === 3 || ch === 4) {
+    // IMPORTANT: copy, do not alias. Node Buffers up to ~4 KiB are sliced out
+    // of a shared pool (`Buffer.poolSize / 2`), so aliasing `data.buffer`
+    // would expose unrelated pool memory through the Uint8ClampedArray view,
+    // and downstream pixel mutations would corrupt sibling allocations. The
+    // `TypedArray(typedArray)` constructor allocates a fresh ArrayBuffer and
+    // element-wise copies — matching the pattern in `expandGrayAlphaToRgba`.
     return {
-      data: new Uint8ClampedArray(data.buffer, data.byteOffset, data.byteLength),
+      data: new Uint8ClampedArray(data),
       width,
       height,
       channels: ch as ImageChannels,
@@ -81,7 +114,7 @@ async function decodeDataUri(dataUri: string): Promise<ImageBinary> {
 async function encodeDataUri(image: ImageBinary, mimeType: string): Promise<string> {
   const sharp = await getSharp();
   const { data, width, height, channels } = image;
-  const fmt = normalizeMimeType(mimeType);
+  const fmt = normalizeOutputMimeType(mimeType);
   const base = sharp(Buffer.from(data), { raw: { width, height, channels } });
 
   const out =

--- a/packages/tasks/src/task/image/imageRasterCodecNode.ts
+++ b/packages/tasks/src/task/image/imageRasterCodecNode.ts
@@ -66,8 +66,15 @@ async function decodeDataUri(dataUri: string): Promise<ImageBinary> {
 
   const sharp = await getSharp();
   const { base64 } = parseDataUri(dataUri);
+
+  // Estimate decoded byte count from the base64 string length *before*
+  // allocating the buffer. Each 4 base64 characters decode to 3 bytes;
+  // ceiling gives a slight over-estimate (≥ real size), so oversized inputs
+  // are rejected without touching Buffer.from().
+  const estimatedBytes = Math.ceil(base64.length * 3 / 4);
+  assertWithinByteBudget(estimatedBytes, MAX_INPUT_BYTES_NODE);
+
   const buffer = Buffer.from(base64, "base64");
-  assertWithinByteBudget(buffer.byteLength, MAX_INPUT_BYTES_NODE);
 
   // `limitInputPixels` rejects header-declared pixel bombs before decompression.
   // `sequentialRead` lowers peak memory for large inputs.

--- a/packages/test/src/test/task/ImageCodec.test.ts
+++ b/packages/test/src/test/task/ImageCodec.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  MAX_DECODED_PIXELS,
+  MAX_INPUT_BYTES_BROWSER,
+  MAX_INPUT_BYTES_NODE,
+  REJECTED_DECODE_MIME_TYPES,
+  assertIsDataUri,
+  assertWithinByteBudget,
+  assertWithinPixelBudget,
+  extractDataUriMimeType,
+  getImageRasterCodec,
+  normalizeOutputMimeType,
+} from "@workglow/tasks";
+import type { ImageBinary } from "@workglow/util/media";
+import { describe, expect, test } from "vitest";
+
+/** Minimal valid 1×1 RGB PNG (shared with ImageTask.test.ts). */
+const PNG_1X1_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADElEQVR4nGPgEpEDAABoAD1UCKP3AAAAAElFTkSuQmCC";
+
+/** Minimal valid 1×1 GIF89a data URI. Used to confirm GIF is rejected outright. */
+const GIF_1X1_DATA_URI = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=";
+
+/** Minimal valid 1×1 SVG data URI. Used to confirm SVG is rejected outright. */
+const SVG_1X1_DATA_URI =
+  "data:image/svg+xml;base64," +
+  Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>', "utf8").toString(
+    "base64"
+  );
+
+describe("imageCodecLimits helpers", () => {
+  describe("assertWithinPixelBudget", () => {
+    test("accepts small positive dimensions", () => {
+      expect(() => assertWithinPixelBudget(1, 1)).not.toThrow();
+      expect(() => assertWithinPixelBudget(1920, 1080)).not.toThrow();
+    });
+
+    test("accepts a square exactly at the budget", () => {
+      const side = Math.floor(Math.sqrt(MAX_DECODED_PIXELS));
+      expect(() => assertWithinPixelBudget(side, side)).not.toThrow();
+    });
+
+    test("rejects dimensions exceeding the budget", () => {
+      expect(() => assertWithinPixelBudget(20_000, 20_000)).toThrow(/pixel budget/);
+    });
+
+    test("rejects non-finite or non-positive dimensions", () => {
+      expect(() => assertWithinPixelBudget(0, 1)).toThrow(/invalid dimensions/);
+      expect(() => assertWithinPixelBudget(-1, 1)).toThrow(/invalid dimensions/);
+      expect(() => assertWithinPixelBudget(Number.POSITIVE_INFINITY, 1)).toThrow(
+        /invalid dimensions/
+      );
+      expect(() => assertWithinPixelBudget(Number.NaN, 1)).toThrow(/invalid dimensions/);
+    });
+  });
+
+  describe("assertWithinByteBudget", () => {
+    test("accepts lengths at or below the limit", () => {
+      expect(() => assertWithinByteBudget(0, 100)).not.toThrow();
+      expect(() => assertWithinByteBudget(100, 100)).not.toThrow();
+    });
+
+    test("rejects lengths above the limit", () => {
+      expect(() => assertWithinByteBudget(101, 100)).toThrow(/byte budget/);
+      expect(() => assertWithinByteBudget(MAX_INPUT_BYTES_NODE + 1, MAX_INPUT_BYTES_NODE)).toThrow(
+        /byte budget/
+      );
+      expect(() =>
+        assertWithinByteBudget(MAX_INPUT_BYTES_BROWSER + 1, MAX_INPUT_BYTES_BROWSER)
+      ).toThrow(/byte budget/);
+    });
+  });
+
+  describe("assertIsDataUri", () => {
+    test("accepts data URIs", () => {
+      expect(() => assertIsDataUri(PNG_1X1_DATA_URI)).not.toThrow();
+      expect(() => assertIsDataUri("data:image/png;base64,xxx")).not.toThrow();
+    });
+
+    test("rejects http(s) and file URLs", () => {
+      expect(() => assertIsDataUri("http://evil.example/x.png")).toThrow(/expected a data: URI/);
+      expect(() => assertIsDataUri("https://evil.example/x.png")).toThrow(/expected a data: URI/);
+      expect(() => assertIsDataUri("file:///etc/passwd")).toThrow(/expected a data: URI/);
+    });
+
+    test("rejects empty and non-data strings", () => {
+      expect(() => assertIsDataUri("")).toThrow(/expected a data: URI/);
+      expect(() => assertIsDataUri("not a uri")).toThrow(/expected a data: URI/);
+    });
+  });
+
+  describe("extractDataUriMimeType", () => {
+    test("extracts and lowercases the mime type", () => {
+      expect(extractDataUriMimeType("data:image/png;base64,xxx")).toBe("image/png");
+      expect(extractDataUriMimeType("data:image/JPEG;base64,xxx")).toBe("image/jpeg");
+      expect(extractDataUriMimeType("data:image/SVG+XML;base64,xxx")).toBe("image/svg+xml");
+    });
+
+    test("returns undefined for non-data strings", () => {
+      expect(extractDataUriMimeType("not a uri")).toBeUndefined();
+      expect(extractDataUriMimeType("")).toBeUndefined();
+    });
+  });
+
+  describe("normalizeOutputMimeType", () => {
+    test("maps supported types to canonical form", () => {
+      expect(normalizeOutputMimeType("image/jpeg")).toBe("image/jpeg");
+      expect(normalizeOutputMimeType("image/JPG")).toBe("image/jpeg");
+      expect(normalizeOutputMimeType("image/png")).toBe("image/png");
+      expect(normalizeOutputMimeType("image/webp")).toBe("image/webp");
+      expect(normalizeOutputMimeType("  image/PNG  ")).toBe("image/png");
+    });
+
+    test("throws for vector/animated types instead of silently falling back to PNG", () => {
+      // This is the critical regression test for the silent-PNG re-encode bug.
+      expect(() => normalizeOutputMimeType("image/svg+xml")).toThrow(/unsupported output/);
+      expect(() => normalizeOutputMimeType("image/gif")).toThrow(/unsupported output/);
+      expect(() => normalizeOutputMimeType("image/apng")).toThrow(/unsupported output/);
+    });
+
+    test("throws for arbitrary non-image types", () => {
+      expect(() => normalizeOutputMimeType("application/json")).toThrow(/unsupported output/);
+      expect(() => normalizeOutputMimeType("")).toThrow(/unsupported output/);
+    });
+  });
+
+  describe("REJECTED_DECODE_MIME_TYPES", () => {
+    test("covers known lossy formats", () => {
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/svg+xml")).toBe(true);
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/svg")).toBe(true);
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/gif")).toBe(true);
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/apng")).toBe(true);
+    });
+
+    test("does not reject the supported raster formats", () => {
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/png")).toBe(false);
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/jpeg")).toBe(false);
+      expect(REJECTED_DECODE_MIME_TYPES.has("image/webp")).toBe(false);
+    });
+  });
+});
+
+describe("Image raster codec security", () => {
+  const codec = getImageRasterCodec();
+
+  test("decodeDataUri rejects non-data URIs (SSRF guard)", async () => {
+    await expect(codec.decodeDataUri("http://evil.example/x.png")).rejects.toThrow(
+      /expected a data: URI/
+    );
+    await expect(codec.decodeDataUri("file:///etc/passwd")).rejects.toThrow(/expected a data: URI/);
+  });
+
+  test("decodeDataUri rejects SVG to prevent silent rasterization", async () => {
+    await expect(codec.decodeDataUri(SVG_1X1_DATA_URI)).rejects.toThrow(/refusing to rasterize/);
+  });
+
+  test("decodeDataUri rejects GIF to prevent animation-frame loss", async () => {
+    await expect(codec.decodeDataUri(GIF_1X1_DATA_URI)).rejects.toThrow(/refusing to rasterize/);
+  });
+
+  test("encodeDataUri rejects unsupported output types (no silent PNG fallback)", async () => {
+    const image: ImageBinary = {
+      data: new Uint8ClampedArray([255, 128, 0]),
+      width: 1,
+      height: 1,
+      channels: 3,
+    };
+    await expect(codec.encodeDataUri(image, "image/svg+xml")).rejects.toThrow(/unsupported output/);
+    await expect(codec.encodeDataUri(image, "image/gif")).rejects.toThrow(/unsupported output/);
+  });
+
+  test("decodeDataUri happy path on a 1×1 PNG is unchanged", async () => {
+    const result = await codec.decodeDataUri(PNG_1X1_DATA_URI);
+    expect(result.width).toBe(1);
+    expect(result.height).toBe(1);
+    expect([1, 3, 4]).toContain(result.channels);
+    expect(result.data.length).toBe(result.width * result.height * result.channels);
+  });
+
+  test("decoded ImageBinary does not alias sharp's pooled Buffer", async () => {
+    // Node Buffers up to ~4 KiB are sliced from a shared 8 KiB pool. If the
+    // codec returned `new Uint8ClampedArray(data.buffer, data.byteOffset, ...)`,
+    // the view's ArrayBuffer would be the full pool slab (≥ 4 KiB) while the
+    // view itself covers only a few bytes. A fresh copy allocates an
+    // ArrayBuffer sized exactly to the view. This is a direct, deterministic
+    // observation of the fix (see imageRasterCodecNode.ts: `new Uint8ClampedArray(data)`).
+    const result = await codec.decodeDataUri(PNG_1X1_DATA_URI);
+    expect(result.data.buffer.byteLength).toBe(result.data.byteLength);
+    expect(result.data.byteOffset).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Introduces centralized security validation for the image raster codec, extracting common limit checks and mime-type validation into a dedicated module. This prevents silent format conversions, defends against decoder bombs, and enforces consistent byte/pixel budgets across browser and Node implementations.

## Key Changes

- **New module `imageCodecLimits.ts`**: Centralizes security constants and validation functions:
  - `MAX_DECODED_PIXELS` (100 MP): Caps worst-case RGBA allocation at ~400 MiB
  - `MAX_INPUT_BYTES_NODE` (64 MiB) and `MAX_INPUT_BYTES_BROWSER` (8 MiB): Pre-decode size limits
  - `REJECTED_DECODE_MIME_TYPES`: Set of vector/animated formats (SVG, GIF, APNG) that lose information when rasterized
  - Validation functions: `assertWithinPixelBudget()`, `assertWithinByteBudget()`, `assertIsDataUri()`, `extractDataUriMimeType()`, `normalizeOutputMimeType()`

- **Browser codec (`imageRasterCodecBrowser.ts`)**:
  - Adds SSRF defense: `assertIsDataUri()` prevents `fetch()` from reaching network URLs
  - Rejects vector/animated formats before decompression
  - Enforces compressed-size pre-check (primary defense against decoder bombs)
  - Replaces loose `normalizeMimeType()` with strict `normalizeOutputMimeType()` that throws on unsupported types instead of silently falling back to PNG
  - Ensures `ImageBitmap` is always closed, even on rejection

- **Node codec (`imageRasterCodecNode.ts`)**:
  - Adds data-URI validation for defense in depth
  - Rejects vector/animated formats before decompression
  - Enforces byte budget pre-check
  - Passes `limitInputPixels` and `sequentialRead` options to sharp for header-level bomb detection and lower peak memory
  - **Critical fix**: Changes `new Uint8ClampedArray(data.buffer, data.byteOffset, data.byteLength)` to `new Uint8ClampedArray(data)` to avoid aliasing Node's shared Buffer pool (≤4 KiB buffers are sliced from an 8 KiB pool), which would expose unrelated pool memory and corrupt sibling allocations on pixel mutations

- **Comprehensive test suite (`ImageCodec.test.ts`)**:
  - Tests all validation helpers with edge cases (non-finite dimensions, oversized inputs, malformed URIs)
  - Verifies SSRF, rasterization, and silent-fallback regressions are blocked
  - Confirms Buffer pool aliasing fix via `byteLength === buffer.byteLength` assertion

## Notable Implementation Details

- `normalizeOutputMimeType()` throws for unsupported types (e.g., `image/svg+xml`, `image/gif`) instead of masking format mismatches with silent PNG fallback
- Browser codec's byte-budget check is the primary defense against decoder bombs because `createImageBitmap` decompresses eagerly
- Node codec uses both sharp's `limitInputPixels` (header-level) and post-decode `assertWithinPixelBudget()` (belt-and-suspenders)
- APNG and animated WebP declared as `image/png`/`image/webp` cannot be rejected by mime type alone; sharp will decode only the first frame

https://claude.ai/code/session_01PPrUZTgbxoQW72ri2F1Bex