### PR TITLE
Support multi-wildcard glob patterns in resource entitlements

### DIFF
--- a/docs/technical/14-entitlements-system.md
+++ b/docs/technical/14-entitlements-system.md
@@ -170,8 +170,10 @@ entitlement, enabling targeted approval or task removal.
 
 ## Resource Scoping with Glob Patterns
 
-Entitlement grants support resource-level scoping using single-`*` glob
-patterns. The `resourcePatternMatches()` function implements pattern matching:
+Entitlement grants support resource-level scoping using glob patterns with any
+number of `*` wildcards. Each `*` matches zero or more characters of any kind,
+including path separators like `/`. The `resourcePatternMatches()` function
+implements pattern matching:
 
 ```ts
 function resourcePatternMatches(grantPattern: string, requiredResource: string): boolean;
@@ -184,18 +186,23 @@ Matching rules:
 - `"*.example.com"` matches anything ending with `".example.com"`.
 - `"pre*suf"` matches strings with the given prefix and suffix, with any content
   in between.
+- `"a*b*c"` matches strings containing `"a"`, then `"b"`, then `"c"` in order.
+- `"https://localhost:*/*"` matches any URL on localhost with a path segment.
 
 Examples:
 
-| Grant Pattern       | Required Resource       | Match?  |
-| ------------------- | ----------------------- | ------- |
-| `"/tmp/*"`          | `"/tmp/data.json"`      | Yes     |
-| `"/tmp/*"`          | `"/tmp/sub/file.txt"`   | Yes     |
-| `"claude-*"`        | `"claude-3-opus"`       | Yes     |
-| `"claude-*"`        | `"gpt-4o"`             | No      |
-| `"*.example.com"`   | `"api.example.com"`     | Yes     |
-| `"gpt-4o"`          | `"gpt-4o"`             | Yes     |
-| `"gpt-4o"`          | `"gpt-4o-mini"`        | No      |
+| Grant Pattern             | Required Resource              | Match? |
+| ------------------------- | ------------------------------ | ------ |
+| `"/tmp/*"`                | `"/tmp/data.json"`             | Yes    |
+| `"/tmp/*"`                | `"/tmp/sub/file.txt"`          | Yes    |
+| `"claude-*"`              | `"claude-3-opus"`              | Yes    |
+| `"claude-*"`              | `"gpt-4o"`                     | No     |
+| `"*.example.com"`         | `"api.example.com"`            | Yes    |
+| `"gpt-4o"`                | `"gpt-4o"`                     | Yes    |
+| `"gpt-4o"`                | `"gpt-4o-mini"`                | No     |
+| `"https://localhost:*/*"` | `"https://localhost:3000/foo"` | Yes    |
+| `"https://localhost:*/*"` | `"https://localhost:3000"`     | No     |
+| `"a*b*c"`                 | `"aXXbYYc"`                    | Yes    |
 
 ### Grant-to-Requirement Matching
 

--- a/packages/task-graph/src/task/TaskEntitlements.ts
+++ b/packages/task-graph/src/task/TaskEntitlements.ts
@@ -135,34 +135,51 @@ export interface EntitlementGrant {
    * - undefined → broad grant, covers all resources for this entitlement
    * - string[] → scoped grant, only covers requirements whose resources are a subset
    *
-   * Supports glob-style trailing wildcards:
+   * Supports glob-style patterns with any number of `*` wildcards.
+   * Each `*` matches zero or more characters of any kind, including `/`.
    * - "/tmp/*" covers "/tmp/data.json" and "/tmp/subdir/file.txt"
-   * - "claude-*" covers "claude-3-opus", "claude-3-sonnet"
    * - "*.example.com" covers "api.example.com"
+   * - "file-*-v*.json" covers "file-data-v2.json"
    */
   readonly resources?: readonly string[];
 }
 
 /**
  * Check if a single grant resource pattern matches a single required resource.
- * Supports single-`*` glob matching:
+ * Supports glob-style patterns with any number of `*` wildcards; each `*`
+ * matches zero or more characters of any kind (including `/`).
  * - "prefix*" matches anything starting with "prefix"
  * - "*.example.com" matches anything ending with ".example.com"
- * - "pre*suf" matches anything with both the given prefix and suffix
+ * - "pre*suf" matches anything with the given prefix and suffix
+ * - "a*b*c" matches anything containing "a", then "b", then "c" in order
  * Without `*`, requires exact match.
  */
 export function resourcePatternMatches(grantPattern: string, requiredResource: string): boolean {
   if (grantPattern === requiredResource) return true;
-  const starIdx = grantPattern.indexOf("*");
-  if (starIdx === -1) return false;
+  if (!grantPattern.includes("*")) return false;
 
-  const prefix = grantPattern.slice(0, starIdx);
-  const suffix = grantPattern.slice(starIdx + 1);
+  const parts = grantPattern.split("*");
+  const first = parts[0];
+  const last = parts[parts.length - 1];
 
-  if (!requiredResource.startsWith(prefix)) return false;
-  if (!requiredResource.endsWith(suffix)) return false;
+  if (!requiredResource.startsWith(first)) return false;
+  if (!requiredResource.endsWith(last)) return false;
 
-  return requiredResource.length >= prefix.length + suffix.length;
+  let fixedLength = 0;
+  for (const p of parts) fixedLength += p.length;
+  if (requiredResource.length < fixedLength) return false;
+
+  let searchStart = first.length;
+  const searchEnd = requiredResource.length - last.length;
+  for (let i = 1; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (part.length === 0) continue; // consecutive wildcards collapse
+    const idx = requiredResource.indexOf(part, searchStart);
+    if (idx === -1 || idx + part.length > searchEnd) return false;
+    searchStart = idx + part.length;
+  }
+
+  return true;
 }
 
 /**

--- a/packages/test/src/test/task-graph/Entitlements.test.ts
+++ b/packages/test/src/test/task-graph/Entitlements.test.ts
@@ -255,6 +255,42 @@ describe("Entitlements", () => {
     it("bare wildcard matches empty string", () => {
       expect(resourcePatternMatches("*", "")).toBe(true);
     });
+
+    it("multi-wildcard URL pattern matches", () => {
+      expect(
+        resourcePatternMatches("https://localhost:*/*", "https://localhost:3000/foo")
+      ).toBe(true);
+    });
+
+    it("multi-wildcard URL pattern requires each wildcard segment", () => {
+      expect(resourcePatternMatches("https://localhost:*/*", "https://localhost:3000")).toBe(
+        false
+      );
+    });
+
+    it("multi-wildcard pattern matches with zero-length wildcards", () => {
+      expect(resourcePatternMatches("a*b*c", "abc")).toBe(true);
+    });
+
+    it("multi-wildcard pattern matches with content between segments", () => {
+      expect(resourcePatternMatches("a*b*c", "aXXbYYc")).toBe(true);
+    });
+
+    it("multi-wildcard pattern rejects out-of-order segments", () => {
+      expect(resourcePatternMatches("a*b*c", "acb")).toBe(false);
+    });
+
+    it("wrapped wildcards match single character", () => {
+      expect(resourcePatternMatches("*a*", "a")).toBe(true);
+    });
+
+    it("wrapped wildcards do not match when required segment is missing", () => {
+      expect(resourcePatternMatches("*a*", "")).toBe(false);
+    });
+
+    it("consecutive wildcards collapse", () => {
+      expect(resourcePatternMatches("**", "anything")).toBe(true);
+    });
   });
 
   // ======================================================================
@@ -309,6 +345,15 @@ describe("Entitlements", () => {
           { id: "ai:model", resources: ["claude-3-opus", "gpt-4o"] }
         )
       ).toBe(false);
+    });
+
+    it("multi-wildcard URL grant covers localhost request", () => {
+      expect(
+        grantCoversResources(
+          { id: "network:http", resources: ["https://localhost:*/*"] },
+          { id: "network:http", resources: ["https://localhost:3000/foo"] }
+        )
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
Enhanced the resource pattern matching system to support glob patterns with multiple `*` wildcards, allowing more flexible and expressive resource scoping in entitlement grants.

## Key Changes
- **Updated `resourcePatternMatches()` function** to handle patterns with any number of `*` wildcards instead of just a single wildcard
  - Each `*` now matches zero or more characters of any kind, including path separators like `/`
  - Consecutive wildcards collapse into a single match operation
  - Validates that all non-wildcard segments appear in order within the required resource

- **Expanded test coverage** with 8 new test cases covering:
  - Multi-wildcard URL patterns (e.g., `https://localhost:*/*`)
  - Zero-length wildcard matches
  - Content between wildcard segments
  - Out-of-order segment rejection
  - Wrapped wildcards
  - Consecutive wildcard collapsing

- **Updated documentation** to reflect the new multi-wildcard capability with additional examples and a more comprehensive matching rules table

## Implementation Details
The new implementation splits the grant pattern by `*` delimiters and validates that:
1. The required resource starts with the first segment
2. The required resource ends with the last segment
3. All middle segments appear in order within the resource
4. The total length of all non-wildcard segments doesn't exceed the required resource length

This approach maintains backward compatibility with single-wildcard patterns while enabling more sophisticated matching scenarios like URL path patterns and multi-part version strings.

https://claude.ai/code/session_01SJBaTsRk9N7ruKHJkH7XHw