### PR TITLE
Fix infinite loop in subgraph entitlement subscription

### DIFF
--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -339,6 +339,15 @@ export class GraphAsTask<
   /** Unsubscribe handle for the current subGraph entitlement subscription */
   private _entitlementUnsub: (() => void) | undefined;
 
+  /**
+   * Guards against re-entry while the synchronous initial emit of
+   * `subscribeToTaskEntitlements` is unwinding. Without this, the initial
+   * emit's callback re-reads `this.subGraph`, which would re-trigger
+   * `_syncSubGraphEntitlementSubscription` before `_entitlementUnsub` has
+   * been assigned and loop forever.
+   */
+  private _subscribingEntitlements: boolean = false;
+
   // ========================================================================
   // SubGraph entitlement subscription
   // ========================================================================
@@ -350,14 +359,22 @@ export class GraphAsTask<
    */
   private _subscribeToSubGraphEntitlements(graph: TaskGraph): void {
     this._entitlementUnsub?.();
-    this._entitlementUnsub = graph.subscribeToTaskEntitlements(() => {
-      this.emitEntitlementChange();
-    });
+    this._entitlementUnsub = undefined;
+    this._subscribingEntitlements = true;
+    try {
+      this._entitlementUnsub = graph.subscribeToTaskEntitlements(() => {
+        this.emitEntitlementChange();
+      });
+    } finally {
+      this._subscribingEntitlements = false;
+    }
   }
 
   private _syncSubGraphEntitlementSubscription(
     graph: TaskGraph | undefined = this._subGraph
   ): void {
+    if (this._subscribingEntitlements) return;
+
     if ((this._events?.listenerCount("entitlementChange") ?? 0) === 0) {
       this._entitlementUnsub?.();
       this._entitlementUnsub = undefined;


### PR DESCRIPTION
## Summary
Fixes an infinite loop that occurs during the initial subscription to task entitlements in `GraphAsTask`. The issue arises when the synchronous initial emit of `subscribeToTaskEntitlements` triggers a callback that re-reads the subgraph before the unsubscribe handle is assigned.

## Key Changes
- Added `_subscribingEntitlements` boolean guard flag to prevent re-entry during the subscription setup phase
- Wrapped the `subscribeToTaskEntitlements` call in a try-finally block to ensure the guard flag is properly reset
- Added an early return in `_syncSubGraphEntitlementSubscription` when a subscription is in progress to prevent recursive calls
- Explicitly set `_entitlementUnsub` to `undefined` before subscribing to ensure clean state

## Implementation Details
The fix uses a guard pattern to prevent `_syncSubGraphEntitlementSubscription` from being called while `_subscribeToSubGraphEntitlements` is executing. This is necessary because:
1. `subscribeToTaskEntitlements` may emit synchronously during subscription
2. The callback invokes `emitEntitlementChange()` which can trigger `_syncSubGraphEntitlementSubscription`
3. Without the guard, this would re-read `this.subGraph` and re-trigger the subscription before `_entitlementUnsub` is assigned, causing an infinite loop

The try-finally ensures the guard is always cleared, even if an error occurs during subscription.

https://claude.ai/code/session_01XVRGd1GxJ6pzZUKhQp9yva