### PR TITLE
Improve security and error handling in editor invocation and AI content

### DIFF
--- a/examples/cli/src/editInEditor.ts
+++ b/examples/cli/src/editInEditor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import process from "node:process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -24,6 +24,42 @@ export function getEditorCommand(): string {
 }
 
 /**
+ * Minimal POSIX shell-word splitter. Handles unquoted whitespace separators
+ * plus matched single/double quotes. Intentionally does NOT interpret shell
+ * metacharacters — an editor env var like `vim; rm -rf ~` splits into
+ * `["vim;", "rm", "-rf", "~"]` and is passed to execFileSync with shell:false,
+ * so the literal string `vim;` is treated as a binary name (which won't exist)
+ * rather than being interpreted by a shell.
+ */
+function splitEditorCommand(cmd: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (/\s/.test(ch) && !inSingle && !inDouble) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) args.push(current);
+  return args;
+}
+
+/**
  * Writes `initialContent` to a temp file, launches the user's editor, then reads the file back.
  * Same idea as `git commit`: unchanged buffer ⇒ cancel; non-zero editor exit ⇒ error.
  */
@@ -35,10 +71,14 @@ export function editStringInExternalEditor(
   const file = join(dir, tempBasename);
   writeFileSync(file, initialContent, "utf-8");
 
-  const shell = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "/bin/sh";
   try {
-    const cmd = `${getEditorCommand()} ${JSON.stringify(file)}`;
-    execSync(cmd, { stdio: "inherit", shell });
+    const parts = splitEditorCommand(getEditorCommand());
+    if (parts.length === 0) {
+      throw new Error("No editor configured (GIT_EDITOR/VISUAL/EDITOR is empty)");
+    }
+    const [editorBin, ...editorArgs] = parts;
+    editorArgs.push(file);
+    execFileSync(editorBin, editorArgs, { stdio: "inherit" });
   } catch (e) {
     try {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/ai-provider/src/provider-hf-transformers/common/HFT_Chat.ts
+++ b/packages/ai-provider/src/provider-hf-transformers/common/HFT_Chat.ts
@@ -186,6 +186,10 @@ export const HFT_Chat_Stream: AiProviderStreamFn<
   const queue: string[] = [];
   let done = false;
   let resolver: (() => void) | undefined;
+  // Capture errors from the background generation task so they propagate
+  // through the generator even if the consumer drops the iterator before
+  // we reach `await task` in the normal path.
+  let genError: unknown = undefined;
 
   const task = (async () => {
     try {
@@ -193,6 +197,8 @@ export const HFT_Chat_Stream: AiProviderStreamFn<
         queue.push(piece);
         resolver?.();
       });
+    } catch (err) {
+      genError = err;
     } finally {
       done = true;
       resolver?.();
@@ -208,6 +214,12 @@ export const HFT_Chat_Stream: AiProviderStreamFn<
       yield { type: "text-delta", port: "text", textDelta: queue.shift()! };
     }
   }
+  // Ensure the background task settles before we decide whether to finish
+  // or surface an error. The task never rejects (errors are captured in
+  // genError above) so this just awaits the microtask chain.
   await task;
+  if (genError) {
+    throw genError;
+  }
   yield { type: "finish", data: {} as AiChatProviderOutput };
 };

--- a/packages/ai-provider/src/provider-llamacpp/common/LlamaCpp_Chat.ts
+++ b/packages/ai-provider/src/provider-llamacpp/common/LlamaCpp_Chat.ts
@@ -141,6 +141,10 @@ export const LlamaCpp_Chat_Stream: AiProviderStreamFn<
   const queue: string[] = [];
   let done = false;
   let resolver: (() => void) | undefined;
+  // Capture errors from the background prompt so they propagate through the
+  // generator even if the consumer drops the iterator before we reach
+  // `await promptPromise` on the normal completion path.
+  let genError: unknown = undefined;
 
   const promptPromise = session
     .prompt(userText, {
@@ -152,6 +156,9 @@ export const LlamaCpp_Chat_Stream: AiProviderStreamFn<
         queue.push(chunk);
         resolver?.();
       },
+    })
+    .catch((err: unknown) => {
+      genError = err;
     })
     .finally(() => {
       done = true;
@@ -175,6 +182,10 @@ export const LlamaCpp_Chat_Stream: AiProviderStreamFn<
       yield { type: "text-delta", port: "text", textDelta: queue.shift()! };
     }
   }
+  // Await the settled promise (never rejects — errors land in genError).
   await promptPromise;
+  if (genError) {
+    throw genError;
+  }
   yield { type: "finish", data: {} as AiChatProviderOutput };
 };

--- a/packages/ai/src/task/ChatMessage.ts
+++ b/packages/ai/src/task/ChatMessage.ts
@@ -7,6 +7,31 @@
 import type { DataPortSchema } from "@workglow/util/schema";
 
 // ========================================================================
+// Image content constraints (shared by schema + runtime guard)
+// ========================================================================
+
+/**
+ * MIME types accepted for image content blocks. Matches the set supported
+ * by the major provider APIs (Anthropic, Gemini, OpenAI).
+ */
+export const ALLOWED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export type ImageMimeType = (typeof ALLOWED_IMAGE_MIME_TYPES)[number];
+
+/**
+ * Maximum base64 length for image data. 20 MiB of base64 encodes ~15 MiB
+ * of binary — a reasonable upper bound for provider APIs, and a hard guard
+ * against unbounded memory use when ContentBlockImage originates from an
+ * untrusted caller.
+ */
+export const MAX_IMAGE_DATA_LENGTH = 20_971_520;
+
+// ========================================================================
 // Canonical ContentBlock union
 // ========================================================================
 
@@ -17,7 +42,7 @@ export type ContentBlockText = {
 
 export type ContentBlockImage = {
   readonly type: "image";
-  readonly mimeType: string;
+  readonly mimeType: ImageMimeType;
   readonly data: string;
 };
 
@@ -70,8 +95,8 @@ const ContentBlockImageSchema = {
   type: "object",
   properties: {
     type: { type: "string", enum: ["image"] },
-    mimeType: { type: "string" },
-    data: { type: "string" },
+    mimeType: { type: "string", enum: ALLOWED_IMAGE_MIME_TYPES },
+    data: { type: "string", maxLength: MAX_IMAGE_DATA_LENGTH },
   },
   required: ["type", "mimeType", "data"],
   additionalProperties: false,
@@ -155,7 +180,12 @@ export function isContentBlock(value: unknown): value is ContentBlock {
     case "text":
       return typeof v.text === "string";
     case "image":
-      return typeof v.mimeType === "string" && typeof v.data === "string";
+      return (
+        typeof v.mimeType === "string" &&
+        (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(v.mimeType) &&
+        typeof v.data === "string" &&
+        v.data.length <= MAX_IMAGE_DATA_LENGTH
+      );
     case "tool_use":
       return (
         typeof v.id === "string" &&


### PR DESCRIPTION
## Summary
This PR addresses security vulnerabilities and improves error handling across three main areas: editor command execution, image content validation, and async error propagation in AI providers.

## Key Changes

### Editor Command Execution Security (examples/cli/src/editInEditor.ts)
- **Replaced `execSync` with `execFileSync`**: Prevents shell injection attacks by avoiding shell interpretation of editor commands
- **Added `splitEditorCommand()` function**: Implements a minimal POSIX shell-word splitter that safely parses editor commands with quote handling, while intentionally NOT interpreting shell metacharacters
- **Removed shell parameter**: Commands are now executed directly without shell interpretation, so malicious characters like `;` are treated as literal binary names rather than shell operators
- **Added validation**: Checks that editor command is not empty before execution

### Image Content Validation (packages/ai/src/task/ChatMessage.ts)
- **Defined `ALLOWED_IMAGE_MIME_TYPES`**: Explicit whitelist of supported image MIME types (jpeg, png, gif, webp) matching major provider APIs
- **Added `MAX_IMAGE_DATA_LENGTH` constant**: 20 MiB upper bound on base64-encoded image data to prevent unbounded memory use from untrusted sources
- **Updated `ContentBlockImage` type**: Changed `mimeType` from generic `string` to typed `ImageMimeType`
- **Enhanced schema validation**: Added enum constraint for MIME types and maxLength constraint for data in JSON schema
- **Strengthened runtime guard**: `isContentBlock()` now validates MIME type against whitelist and enforces data length limit

### Async Error Propagation (AI Providers)
- **HFT_Chat.ts**: Captures errors from background generation task in `genError` variable and re-throws after awaiting task completion, ensuring errors propagate even if consumer abandons iterator early
- **LlamaCpp_Chat.ts**: Similar pattern—captures errors from prompt promise via `.catch()` handler and re-throws after awaiting, preventing silent failures when iterator is dropped

## Notable Implementation Details
- The shell-word splitter handles both single and double quotes correctly while maintaining security by not interpreting any shell metacharacters
- Error capture in async generators uses a closure variable pattern to ensure errors aren't lost when the consumer stops iterating before natural completion
- Image validation is enforced at both schema (JSON validation) and runtime (type guard) levels for defense-in-depth

https://claude.ai/code/session_01CDFtYNDLFYgxJQFQ8UNp9B