### PR TITLE
feat(entitlements): return structured denials with reason + add can()…

### DIFF
--- a/docs/technical/14-entitlements-system.md
+++ b/docs/technical/14-entitlements-system.md
@@ -470,13 +470,22 @@ non-disabled branches are included, which is useful for runtime checks after
 conditions have been evaluated.
 
 ```ts
+import {
+  computeGraphEntitlements,
+  formatEntitlementDenial,
+  ENTITLEMENT_ENFORCER,
+} from "@workglow/task-graph";
+import { globalServiceRegistry } from "@workglow/util";
+
+const enforcer = globalServiceRegistry.get(ENTITLEMENT_ENFORCER);
+
 // Pre-execution: analyze all possible entitlements
 const allEntitlements = computeGraphEntitlements(graph, { trackOrigins: true });
 for (const e of allEntitlements.entitlements) {
   console.log(`${e.id} required by tasks: ${e.sourceTaskIds.join(", ")}`);
 }
 
-// Check against enforcer
+// Check against enforcer (requires top-level await or async context)
 const denied = await enforcer.checkAll(allEntitlements);
 if (denied.length > 0) {
   throw new Error(`Denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`);

--- a/docs/technical/14-entitlements-system.md
+++ b/docs/technical/14-entitlements-system.md
@@ -477,9 +477,9 @@ for (const e of allEntitlements.entitlements) {
 }
 
 // Check against enforcer
-const denied = enforcer.check(allEntitlements);
+const denied = await enforcer.checkAll(allEntitlements);
 if (denied.length > 0) {
-  throw new Error(`Denied entitlements: ${denied.map((e) => e.id).join(", ")}`);
+  throw new Error(`Denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`);
 }
 ```
 

--- a/docs/technical/14-entitlements-system.md
+++ b/docs/technical/14-entitlements-system.md
@@ -349,19 +349,35 @@ required entitlements are granted:
 
 ```ts
 interface IEntitlementEnforcer {
-  check(required: TaskEntitlements): readonly TaskEntitlement[];
+  checkAll(required: TaskEntitlements): Promise<readonly EntitlementDenial[]>;
+  checkTask(task: ITask): Promise<readonly EntitlementDenial[]>;
 }
 ```
 
-The `check()` method returns an array of _denied_ (non-optional) entitlements.
-An empty array means all entitlements are granted.
+`checkAll()` is the preflight check: it evaluates every required entitlement
+against the policy, resolving `"ask"` verdicts via the registered
+`IEntitlementResolver`. `checkTask()` is the runtime check for tasks with
+`hasDynamicEntitlements`. Both return an array of `EntitlementDenial` records
+(non-optional entitlements only) — an empty array means all entitlements are
+granted.
+
+Each `EntitlementDenial` is a discriminated union on `reason`:
+
+- `"policy-deny"` -- matched an explicit deny rule (`matchedRule` present)
+- `"user-deny"` -- matched an ask rule and the resolver returned `"deny"` (`matchedRule` present)
+- `"default-deny"` -- no rule covered the entitlement (`matchedRule` absent)
+
+Use `formatEntitlementDenial(denial)` to render a human-readable message.
 
 ### Built-In Enforcers
 
 **Permissive enforcer** -- grants everything, suitable for trusted environments:
 
 ```ts
-const PERMISSIVE_ENFORCER: IEntitlementEnforcer = { check: () => [] };
+const PERMISSIVE_ENFORCER: IEntitlementEnforcer = {
+  checkAll: async () => [],
+  checkTask: async () => [],
+};
 ```
 
 **Grant-list enforcer** -- checks against a list of entitlement ID strings
@@ -543,7 +559,9 @@ without needing to instantiate task classes.
 | `TrackedTaskEntitlements` | Container with `entitlements: readonly TrackedTaskEntitlement[]`            |
 | `EntitlementGrant`        | Grant declaration with `id` and optional `resources` (glob patterns)        |
 | `EntitlementProfile`      | `"browser" \| "desktop" \| "server"`                                        |
-| `IEntitlementEnforcer`    | Interface with `check(required): readonly TaskEntitlement[]`                |
+| `EntitlementDenial`       | Denied entitlement: `{ entitlement, reason, matchedRule? }` (discriminated) |
+| `EntitlementDenialReason` | `"policy-deny" \| "default-deny" \| "user-deny"`                            |
+| `IEntitlementEnforcer`    | Interface with async `checkAll(required)` and `checkTask(task)` methods     |
 
 ### Functions
 
@@ -558,6 +576,7 @@ without needing to instantiate task classes.
 | `createProfileEnforcer`    | `(profile: EntitlementProfile) => IEntitlementEnforcer`           | Create an enforcer for a standard runtime profile                   |
 | `getProfileGrants`         | `(profile: EntitlementProfile) => readonly EntitlementGrant[]`    | Get the grant list for a profile                                    |
 | `computeGraphEntitlements` | `(graph: TaskGraph, options?) => TaskEntitlements`                | Aggregate entitlements across all tasks in a graph                  |
+| `formatEntitlementDenial`  | `(denial: EntitlementDenial) => string`                           | Render a denial as a human-readable error-message fragment          |
 
 ### Constants
 

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -19,7 +19,7 @@ import {
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ConditionalTask } from "../task/ConditionalTask";
 import type { IEntitlementEnforcer } from "../task/EntitlementEnforcer";
-import { ENTITLEMENT_ENFORCER } from "../task/EntitlementEnforcer";
+import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
 import type { StreamEvent, StreamMode } from "../task/StreamTypes";
 import {
@@ -749,7 +749,7 @@ export class TaskGraphRunner {
       const denied = await this.activeEnforcer.checkTask(task);
       if (denied.length > 0) {
         throw new TaskEntitlementError(
-          `Task ${(task.constructor as typeof Task).type} denied entitlements: ${denied.map((e) => e.id).join(", ")}`
+          `Task ${(task.constructor as typeof Task).type} denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`
         );
       }
     }
@@ -1087,7 +1087,7 @@ export class TaskGraphRunner {
         const denied = await enforcer.checkAll(computeGraphEntitlements(this.graph));
         if (denied.length > 0) {
           throw new TaskEntitlementError(
-            `Denied entitlements: ${denied.map((e: { id: string }) => e.id).join(", ")}`
+            `Denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`
           );
         }
         this.activeEnforcer = enforcer;

--- a/packages/task-graph/src/task/EntitlementEnforcer.ts
+++ b/packages/task-graph/src/task/EntitlementEnforcer.ts
@@ -29,19 +29,35 @@ export type EntitlementDenialReason = "policy-deny" | "default-deny" | "user-den
  * A single denied entitlement with the reason and the matching rule (if any).
  * Returned by `IEntitlementEnforcer` to give callers enough context to build
  * actionable error messages without re-running policy evaluation.
+ *
+ * Discriminated union on `reason`:
+ * - `policy-deny`: `matchedRule` is always present (it is the deny rule that matched).
+ * - `user-deny`:   `matchedRule` is always present (it is the ask rule that matched).
+ * - `default-deny`: no rule matched at all; `matchedRule` is absent.
  */
-export interface EntitlementDenial {
-  readonly entitlement: TaskEntitlement;
-  readonly reason: EntitlementDenialReason;
-  /** The rule that produced this denial. Undefined when `reason === "default-deny"`. */
-  readonly matchedRule?: EntitlementRule;
-}
+export type EntitlementDenial =
+  | {
+      readonly entitlement: TaskEntitlement;
+      readonly reason: "policy-deny";
+      /** The deny rule that explicitly blocked this entitlement. */
+      readonly matchedRule: EntitlementRule;
+    }
+  | {
+      readonly entitlement: TaskEntitlement;
+      readonly reason: "default-deny";
+    }
+  | {
+      readonly entitlement: TaskEntitlement;
+      readonly reason: "user-deny";
+      /** The ask rule that triggered the user prompt. */
+      readonly matchedRule: EntitlementRule;
+    };
 
 /** Format a denial for inclusion in an error message. */
 export function formatEntitlementDenial(denial: EntitlementDenial): string {
   switch (denial.reason) {
     case "policy-deny":
-      return `${denial.entitlement.id} (denied by rule ${denial.matchedRule?.id ?? "?"})`;
+      return `${denial.entitlement.id} (denied by rule ${denial.matchedRule.id})`;
     case "user-deny":
       return `${denial.entitlement.id} (denied by user)`;
     case "default-deny":
@@ -106,11 +122,11 @@ export function createPolicyEnforcer(
 
     for (const result of results) {
       if (result.verdict === "denied") {
-        denied.push({
-          entitlement: result.entitlement,
-          reason: result.matchedRule ? "policy-deny" : "default-deny",
-          ...(result.matchedRule && { matchedRule: result.matchedRule }),
-        });
+        if (result.matchedRule) {
+          denied.push({ entitlement: result.entitlement, reason: "policy-deny", matchedRule: result.matchedRule });
+        } else {
+          denied.push({ entitlement: result.entitlement, reason: "default-deny" });
+        }
       } else if (result.verdict === "ask") {
         const request = {
           entitlement: result.entitlement,
@@ -124,11 +140,8 @@ export function createPolicyEnforcer(
           resolver.save(request, answer);
         }
         if (answer === "deny") {
-          denied.push({
-            entitlement: result.entitlement,
-            reason: "user-deny",
-            ...(result.matchedRule && { matchedRule: result.matchedRule }),
-          });
+          // ask verdicts always have a matchedRule (the ask rule that fired)
+          denied.push({ entitlement: result.entitlement, reason: "user-deny", matchedRule: result.matchedRule! });
         }
       }
       // "granted" — nothing to do

--- a/packages/task-graph/src/task/EntitlementEnforcer.ts
+++ b/packages/task-graph/src/task/EntitlementEnforcer.ts
@@ -141,7 +141,12 @@ export function createPolicyEnforcer(
         }
         if (answer === "deny") {
           // ask verdicts always have a matchedRule (the ask rule that fired)
-          denied.push({ entitlement: result.entitlement, reason: "user-deny", matchedRule: result.matchedRule! });
+          if (!result.matchedRule) {
+            throw new Error(
+              `Invariant violation: ask verdict for "${result.entitlement.id}" is missing matchedRule`
+            );
+          }
+          denied.push({ entitlement: result.entitlement, reason: "user-deny", matchedRule: result.matchedRule });
         }
       }
       // "granted" — nothing to do

--- a/packages/task-graph/src/task/EntitlementEnforcer.ts
+++ b/packages/task-graph/src/task/EntitlementEnforcer.ts
@@ -5,13 +5,49 @@
  */
 
 import { createServiceToken } from "@workglow/util";
-import type { EntitlementPolicy } from "./EntitlementPolicy";
+import type { EntitlementPolicy, EntitlementRule } from "./EntitlementPolicy";
 import { evaluatePolicy } from "./EntitlementPolicy";
 import type { IEntitlementResolver } from "./EntitlementResolver";
 import { PERMISSIVE_RESOLVER } from "./EntitlementResolver";
 import type { ITask } from "./ITask";
 import type { Task } from "./Task";
 import type { EntitlementGrant, TaskEntitlement, TaskEntitlements } from "./TaskEntitlements";
+
+// ========================================================================
+// Denial Type
+// ========================================================================
+
+/**
+ * Why an entitlement was denied.
+ * - `policy-deny`: matched a deny rule
+ * - `default-deny`: no rule covered the entitlement
+ * - `user-deny`: matched an ask rule and the resolver returned "deny"
+ */
+export type EntitlementDenialReason = "policy-deny" | "default-deny" | "user-deny";
+
+/**
+ * A single denied entitlement with the reason and the matching rule (if any).
+ * Returned by `IEntitlementEnforcer` to give callers enough context to build
+ * actionable error messages without re-running policy evaluation.
+ */
+export interface EntitlementDenial {
+  readonly entitlement: TaskEntitlement;
+  readonly reason: EntitlementDenialReason;
+  /** The rule that produced this denial. Undefined when `reason === "default-deny"`. */
+  readonly matchedRule?: EntitlementRule;
+}
+
+/** Format a denial for inclusion in an error message. */
+export function formatEntitlementDenial(denial: EntitlementDenial): string {
+  switch (denial.reason) {
+    case "policy-deny":
+      return `${denial.entitlement.id} (denied by rule ${denial.matchedRule?.id ?? "?"})`;
+    case "user-deny":
+      return `${denial.entitlement.id} (denied by user)`;
+    case "default-deny":
+      return `${denial.entitlement.id} (no matching grant)`;
+  }
+}
 
 // ========================================================================
 // Enforcer Interface
@@ -27,15 +63,15 @@ export interface IEntitlementEnforcer {
   /**
    * Preflight check: evaluate all required entitlements against the policy.
    * Resolves "ask" verdicts via the resolver (prompt + save).
-   * Returns the list of denied (non-optional) entitlements, or empty array if all granted.
+   * Returns the list of denials (non-optional entitlements only) — empty array when all granted.
    */
-  checkAll(required: TaskEntitlements): Promise<readonly TaskEntitlement[]>;
+  checkAll(required: TaskEntitlements): Promise<readonly EntitlementDenial[]>;
 
   /**
    * Runtime check: evaluate a single task's dynamic entitlements.
    * Called during execution for tasks with `hasDynamicEntitlements`.
    */
-  checkTask(task: ITask): Promise<readonly TaskEntitlement[]>;
+  checkTask(task: ITask): Promise<readonly EntitlementDenial[]>;
 }
 
 // ========================================================================
@@ -64,32 +100,35 @@ export function createPolicyEnforcer(
     required: TaskEntitlements,
     taskType?: string,
     taskId?: unknown
-  ): Promise<readonly TaskEntitlement[]> {
+  ): Promise<readonly EntitlementDenial[]> {
     const results = evaluatePolicy(policy, required);
-    const denied: TaskEntitlement[] = [];
+    const denied: EntitlementDenial[] = [];
 
     for (const result of results) {
       if (result.verdict === "denied") {
-        denied.push(result.entitlement);
+        denied.push({
+          entitlement: result.entitlement,
+          reason: result.matchedRule ? "policy-deny" : "default-deny",
+          ...(result.matchedRule && { matchedRule: result.matchedRule }),
+        });
       } else if (result.verdict === "ask") {
         const request = {
           entitlement: result.entitlement,
           taskType: taskType ?? "unknown",
           taskId: taskId ?? "unknown",
         };
-        // Check saved answer first
-        const saved = resolver.lookup(request);
-        if (saved !== undefined) {
-          if (saved === "deny") {
-            denied.push(result.entitlement);
-          }
-          continue;
+        // Check saved answer first; otherwise prompt and save
+        let answer = resolver.lookup(request);
+        if (answer === undefined) {
+          answer = await resolver.prompt(request);
+          resolver.save(request, answer);
         }
-        // Prompt user
-        const answer = await resolver.prompt(request);
-        resolver.save(request, answer);
         if (answer === "deny") {
-          denied.push(result.entitlement);
+          denied.push({
+            entitlement: result.entitlement,
+            reason: "user-deny",
+            ...(result.matchedRule && { matchedRule: result.matchedRule }),
+          });
         }
       }
       // "granted" — nothing to do
@@ -99,11 +138,11 @@ export function createPolicyEnforcer(
   }
 
   return {
-    async checkAll(required: TaskEntitlements): Promise<readonly TaskEntitlement[]> {
+    async checkAll(required: TaskEntitlements): Promise<readonly EntitlementDenial[]> {
       return resolveAsks(required);
     },
 
-    async checkTask(task: ITask): Promise<readonly TaskEntitlement[]> {
+    async checkTask(task: ITask): Promise<readonly EntitlementDenial[]> {
       const entitlements = task.entitlements();
       return resolveAsks(entitlements, (task.constructor as typeof Task).type, task.id);
     },

--- a/packages/task-graph/src/task/EntitlementPolicy.ts
+++ b/packages/task-graph/src/task/EntitlementPolicy.ts
@@ -128,3 +128,23 @@ export function evaluatePolicy(
 
   return results;
 }
+
+/**
+ * Pure single-entitlement check. Convenience wrapper around `evaluatePolicy`
+ * for callers that want the `can(action, resource)` style verdict in one call.
+ *
+ * Returns the per-entitlement check result with `verdict` (`"granted"`, `"denied"`,
+ * or `"ask"`) and the `matchedRule` that produced it. No side effects — no
+ * resolver is invoked even for `"ask"` verdicts; the caller decides how to
+ * handle that.
+ */
+export function can(
+  policy: EntitlementPolicy,
+  id: EntitlementId,
+  resources?: readonly string[]
+): EntitlementCheckResult {
+  const required: TaskEntitlement = resources !== undefined ? { id, resources } : { id };
+  // evaluatePolicy skips optional entitlements; we always pass a non-optional one.
+  const [result] = evaluatePolicy(policy, { entitlements: [required] });
+  return result;
+}

--- a/packages/test/src/test/task-graph/Entitlements.test.ts
+++ b/packages/test/src/test/task-graph/Entitlements.test.ts
@@ -1055,9 +1055,12 @@ describe("Entitlements", () => {
         entitlements: [{ id: "network:http" }],
       });
       expect(denied).toHaveLength(1);
-      expect(denied[0].entitlement.id).toBe("network:http");
-      expect(denied[0].reason).toBe("policy-deny");
-      expect(denied[0].matchedRule?.id).toBe("network:http");
+      const firstDenial = denied[0];
+      expect(firstDenial.entitlement.id).toBe("network:http");
+      expect(firstDenial.reason).toBe("policy-deny");
+      if (firstDenial.reason === "policy-deny") {
+        expect(firstDenial.matchedRule?.id).toBe("network:http");
+      }
     });
 
     it("ask with PERMISSIVE_RESOLVER grants", async () => {

--- a/packages/test/src/test/task-graph/Entitlements.test.ts
+++ b/packages/test/src/test/task-graph/Entitlements.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  can,
   computeGraphEntitlements,
   createGrantListEnforcer,
   createPolicyEnforcer,
@@ -485,7 +486,8 @@ describe("Entitlements", () => {
         entitlements: [{ id: "filesystem:read" }],
       });
       expect(denied).toHaveLength(1);
-      expect(denied[0].id).toBe("filesystem:read");
+      expect(denied[0].entitlement.id).toBe("filesystem:read");
+      expect(denied[0].reason).toBe("default-deny");
     });
 
     it("skips optional entitlements", async () => {
@@ -885,6 +887,157 @@ describe("Entitlements", () => {
       });
       expect(results[0].matchedRule).toBeUndefined();
     });
+
+    // ====================================================================
+    // Explicit verdict matrix — one row per (rule-source × hierarchy ×
+    // resource-scope) combination that needs to behave the same way every
+    // release. Add a row whenever a new dimension is introduced.
+    // ====================================================================
+    describe("verdict matrix", () => {
+      type MatrixRow = {
+        readonly name: string;
+        readonly policy: EntitlementPolicy;
+        readonly required: TaskEntitlements;
+        readonly expected: "granted" | "denied" | "ask";
+      };
+      const rows: readonly MatrixRow[] = [
+        {
+          name: "exact deny",
+          policy: { deny: [{ id: "network:http" }], grant: [], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "denied",
+        },
+        {
+          name: "hierarchical deny (parent covers child)",
+          policy: { deny: [{ id: "network" }], grant: [], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "denied",
+        },
+        {
+          name: "scoped deny matches resource",
+          policy: {
+            deny: [{ id: "filesystem:write", resources: ["/etc/*"] }],
+            grant: [{ id: "filesystem" }],
+            ask: [],
+          },
+          required: { entitlements: [{ id: "filesystem:write", resources: ["/etc/passwd"] }] },
+          expected: "denied",
+        },
+        {
+          name: "scoped deny misses, falls through to grant",
+          policy: {
+            deny: [{ id: "filesystem:write", resources: ["/etc/*"] }],
+            grant: [{ id: "filesystem" }],
+            ask: [],
+          },
+          required: { entitlements: [{ id: "filesystem:write", resources: ["/tmp/data"] }] },
+          expected: "granted",
+        },
+        {
+          name: "exact grant",
+          policy: { deny: [], grant: [{ id: "network:http" }], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "granted",
+        },
+        {
+          name: "hierarchical grant (parent covers child)",
+          policy: { deny: [], grant: [{ id: "network" }], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "granted",
+        },
+        {
+          name: "scoped grant matches resource pattern",
+          policy: { deny: [], grant: [{ id: "ai:model", resources: ["claude-*"] }], ask: [] },
+          required: { entitlements: [{ id: "ai:model", resources: ["claude-3-opus"] }] },
+          expected: "granted",
+        },
+        {
+          name: "scoped grant misses resource, falls through to ask",
+          policy: {
+            deny: [],
+            grant: [{ id: "ai:model", resources: ["claude-*"] }],
+            ask: [{ id: "ai:model" }],
+          },
+          required: { entitlements: [{ id: "ai:model", resources: ["gpt-4"] }] },
+          expected: "ask",
+        },
+        {
+          name: "scoped grant cannot cover broad requirement",
+          policy: { deny: [], grant: [{ id: "network", resources: ["api.example.com"] }], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "denied",
+        },
+        {
+          name: "exact ask",
+          policy: { deny: [], grant: [], ask: [{ id: "network:http" }] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "ask",
+        },
+        {
+          name: "hierarchical ask (parent covers child)",
+          policy: { deny: [], grant: [], ask: [{ id: "network" }] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "ask",
+        },
+        {
+          name: "no rule matches → default deny",
+          policy: { deny: [], grant: [], ask: [] },
+          required: { entitlements: [{ id: "network:http" }] },
+          expected: "denied",
+        },
+      ];
+
+      it.each(rows)("$name → $expected", ({ policy, required, expected }) => {
+        const results = evaluatePolicy(policy, required);
+        expect(results).toHaveLength(1);
+        expect(results[0].verdict).toBe(expected);
+      });
+
+      it("optional requirement is skipped regardless of policy", () => {
+        const results = evaluatePolicy(
+          { deny: [{ id: "network" }], grant: [], ask: [] },
+          { entitlements: [{ id: "network:http", optional: true }] }
+        );
+        expect(results).toHaveLength(0);
+      });
+    });
+  });
+
+  // ======================================================================
+  // can() helper
+  // ======================================================================
+
+  describe("can", () => {
+    const policy: EntitlementPolicy = {
+      deny: [{ id: "filesystem:write", resources: ["/etc/*"] }],
+      grant: [{ id: "network" }, { id: "filesystem" }],
+      ask: [{ id: "code-execution" }],
+    };
+
+    it("returns granted verdict for covered entitlement", () => {
+      const result = can(policy, "network:http");
+      expect(result.verdict).toBe("granted");
+      expect(result.entitlement.id).toBe("network:http");
+    });
+
+    it("returns ask verdict for ask-rule match", () => {
+      const result = can(policy, "code-execution:javascript");
+      expect(result.verdict).toBe("ask");
+    });
+
+    it("returns denied verdict for default-deny", () => {
+      const result = can(policy, "storage:read");
+      expect(result.verdict).toBe("denied");
+      expect(result.matchedRule).toBeUndefined();
+    });
+
+    it("respects resource scope when provided", () => {
+      const allowed = can(policy, "filesystem:write", ["/tmp/data"]);
+      expect(allowed.verdict).toBe("granted");
+      const blocked = can(policy, "filesystem:write", ["/etc/passwd"]);
+      expect(blocked.verdict).toBe("denied");
+      expect(blocked.matchedRule?.id).toBe("filesystem:write");
+    });
   });
 
   // ======================================================================
@@ -902,7 +1055,9 @@ describe("Entitlements", () => {
         entitlements: [{ id: "network:http" }],
       });
       expect(denied).toHaveLength(1);
-      expect(denied[0].id).toBe("network:http");
+      expect(denied[0].entitlement.id).toBe("network:http");
+      expect(denied[0].reason).toBe("policy-deny");
+      expect(denied[0].matchedRule?.id).toBe("network:http");
     });
 
     it("ask with PERMISSIVE_RESOLVER grants", async () => {


### PR DESCRIPTION
… helper

Response to entitlements system review (B/14). Three targeted changes:

1. IEntitlementEnforcer.checkAll/checkTask now return EntitlementDenial[] (with entitlement, reason, and matchedRule) instead of bare TaskEntitlement[]. Runner error messages can now distinguish policy-deny, default-deny, and user-deny via formatEntitlementDenial.

2. New pure can(policy, id, resources?) helper in EntitlementPolicy that matches the can(action, resource) shape from the review. Thin wrapper over evaluatePolicy for one-shot single-entitlement checks.

3. Added a table-driven verdict matrix test to evaluatePolicy that walks every (rule-source x hierarchy x resource-scope) row in one place, making matrix coverage legible at a glance.

https://claude.ai/code/session_018LMDXMwCyoKRkVACADwjJQ