### PR TITLE
Add streaming backpressure tests and document streaming primitives

### DIFF
--- a/docs/technical/04-dataflow-and-streaming.md
+++ b/docs/technical/04-dataflow-and-streaming.md
@@ -258,8 +258,8 @@ No streaming. The task returns its output as a complete `Promise<Output>` from `
 // No x-stream annotation: standard execution
 properties: {
   result: {
-    type: "string";
-  }
+    type: "string",
+  },
 }
 ```
 
@@ -575,7 +575,7 @@ Each `TaskRunner` owns an `AbortController`, created in `handleStart()` and wire
 1. **Either poll `context.signal.aborted`** at safe loop boundaries, **or forward `context.signal`** to any I/O it performs (fetch, SDK client, subprocess, child task).
 2. **Stop producing output promptly.** A streaming task's generator must return (or throw) on the next `yield` point after abort, not continue producing events.
 3. **Release resources.** Close readers, cancel timers, unregister listeners. A `try { ... } finally { ... }` block in an `async *executeStream()` generator is the idiomatic cleanup hook -- `finally` runs when the consumer stops iterating (including on abort).
-4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires (`TaskRunner.ts:487-489`).
+4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires, via the post-stream abort check in `TaskRunner.executeStreamingTask`.
 
 Tasks **do not** need to manually set the task status -- the runner's `handleAbort()` transitions the task to `ABORTING` (the terminal aborted state) and attaches a `TaskAbortedError`.
 

--- a/docs/technical/04-dataflow-and-streaming.md
+++ b/docs/technical/04-dataflow-and-streaming.md
@@ -27,10 +27,10 @@ A `Dataflow` represents a single directed edge from one task's output port to an
 
 ```typescript
 const dataflow = new Dataflow(
-  sourceTaskId,      // ID of the source task
-  sourceTaskPortId,  // Name of the output port on the source task
-  targetTaskId,      // ID of the target task
-  targetTaskPortId   // Name of the input port on the target task
+  sourceTaskId, // ID of the source task
+  sourceTaskPortId, // Name of the output port on the source task
+  targetTaskId, // ID of the target task
+  targetTaskPortId // Name of the input port on the target task
 );
 ```
 
@@ -46,12 +46,12 @@ For example: `"task-abc[result] ==> task-def[value]"`.
 
 Each dataflow maintains its own lifecycle state, mirroring the task lifecycle:
 
-| Property  | Type         | Description                                        |
-|-----------|--------------|----------------------------------------------------|
-| `value`   | `any`        | The materialized data carried by the dataflow      |
-| `status`  | `TaskStatus`  | Current lifecycle status                          |
-| `error`   | `TaskError`   | Error object if the dataflow failed               |
-| `stream`  | `ReadableStream<StreamEvent>` | Active stream for streaming tasks  |
+| Property | Type                          | Description                                   |
+| -------- | ----------------------------- | --------------------------------------------- |
+| `value`  | `any`                         | The materialized data carried by the dataflow |
+| `status` | `TaskStatus`                  | Current lifecycle status                      |
+| `error`  | `TaskError`                   | Error object if the dataflow failed           |
+| `stream` | `ReadableStream<StreamEvent>` | Active stream for streaming tasks             |
 
 The dataflow status transitions mirror the source task's execution:
 
@@ -70,7 +70,7 @@ When the TaskGraphRunner pushes output from a completed task onto outgoing dataf
 dataflow.value = entireDataBlock[sourceTaskPortId];
 
 // If sourceTaskPortId is "*" (DATAFLOW_ALL_PORTS):
-dataflow.value = entireDataBlock;  // Entire output object
+dataflow.value = entireDataBlock; // Entire output object
 
 // If sourceTaskPortId is "[error]" (DATAFLOW_ERROR_PORT):
 dataflow.error = entireDataBlock;
@@ -83,7 +83,7 @@ When the runner copies input from dataflows into a target task, it calls `getPor
 return { [targetTaskPortId]: dataflow.value };
 
 // If targetTaskPortId is "*" (DATAFLOW_ALL_PORTS):
-return dataflow.value;  // Entire value object
+return dataflow.value; // Entire value object
 
 // If targetTaskPortId is "[error]" (DATAFLOW_ERROR_PORT):
 return { "[error]": dataflow.error };
@@ -91,10 +91,10 @@ return { "[error]": dataflow.error };
 
 ### Special Port Identifiers
 
-| Constant             | Value       | Description                                              |
-|----------------------|-------------|----------------------------------------------------------|
-| `DATAFLOW_ALL_PORTS` | `"*"`       | Pass the entire output/input object, not a single port   |
-| `DATAFLOW_ERROR_PORT`| `"[error]"` | Route error objects between tasks for error handling      |
+| Constant              | Value       | Description                                            |
+| --------------------- | ----------- | ------------------------------------------------------ |
+| `DATAFLOW_ALL_PORTS`  | `"*"`       | Pass the entire output/input object, not a single port |
+| `DATAFLOW_ERROR_PORT` | `"[error]"` | Route error objects between tasks for error handling   |
 
 The wildcard port `"*"` is used when a task should receive the complete output object from its upstream dependency, rather than a single named property.
 
@@ -107,11 +107,11 @@ dataflow.semanticallyCompatible(graph, dataflow);
 // Returns: "static" | "runtime" | "incompatible"
 ```
 
-| Result          | Meaning                                                    |
-|-----------------|------------------------------------------------------------|
-| `"static"`      | Types are statically compatible                            |
-| `"runtime"`     | Compatibility can only be determined at runtime            |
-| `"incompatible"`| Types are known to be incompatible                         |
+| Result           | Meaning                                         |
+| ---------------- | ----------------------------------------------- |
+| `"static"`       | Types are statically compatible                 |
+| `"runtime"`      | Compatibility can only be determined at runtime |
+| `"incompatible"` | Types are known to be incompatible              |
 
 Compatibility results are cached for tasks with stable schemas. Tasks with `hasDynamicSchemas = true` bypass the cache because their schemas may change between checks.
 
@@ -154,15 +154,91 @@ This task has two output ports: `text` (string) and `confidence` (number).
 
 Ports support several custom annotations beyond standard JSON Schema:
 
-| Annotation              | Type      | Description                                              |
-|-------------------------|-----------|----------------------------------------------------------|
-| `x-stream`              | `string`  | Streaming mode: `"append"`, `"replace"`, or `"object"`  |
-| `x-ui-hidden`           | `boolean` | Hide from UI display                                    |
-| `x-ui-iteration`        | `boolean` | Iteration context port (hidden from parent display)     |
-| `x-ui-manual`           | `boolean` | User-added port (dynamic)                               |
-| `x-auto-generated`      | `boolean` | Auto-generated primary key                              |
-| `x-structured-output`   | `boolean` | Port schema used for structured AI output               |
-| `format`                | `string`  | Semantic type hint (e.g., `"model"`, `"storage:tabular"`, `"knowledge-base"`) |
+| Annotation            | Type      | Description                                                                   |
+| --------------------- | --------- | ----------------------------------------------------------------------------- |
+| `x-stream`            | `string`  | Streaming mode: `"append"`, `"replace"`, or `"object"`                        |
+| `x-ui-hidden`         | `boolean` | Hide from UI display                                                          |
+| `x-ui-iteration`      | `boolean` | Iteration context port (hidden from parent display)                           |
+| `x-ui-manual`         | `boolean` | User-added port (dynamic)                                                     |
+| `x-auto-generated`    | `boolean` | Auto-generated primary key                                                    |
+| `x-structured-output` | `boolean` | Port schema used for structured AI output                                     |
+| `format`              | `string`  | Semantic type hint (e.g., `"model"`, `"storage:tabular"`, `"knowledge-base"`) |
+
+---
+
+## Streaming Primitive Contract
+
+Workglow's streaming layer uses three primitives that serve distinct, non-overlapping roles. Authors only ever write one of them. The other two are engine internals.
+
+### The Three Primitives
+
+| Primitive                     | Role                | Where it appears                                       | Who writes it                     |
+| ----------------------------- | ------------------- | ------------------------------------------------------ | --------------------------------- |
+| `AsyncIterable<StreamEvent>`  | Authoring           | `Task.executeStream()`, `AiProviderStreamFn`           | Task / provider authors           |
+| `ReadableStream<StreamEvent>` | Engine-internal tee | `Dataflow.stream`, `TaskGraphRunner` fan-out           | Engine only (do not use in tasks) |
+| `EventEmitter` (task events)  | Observation only    | `stream_start`, `stream_chunk`, `stream_end` on `Task` | Engine emits; consumers subscribe |
+
+### Authoring Rule: AsyncIterable
+
+**All streaming tasks and providers MUST return `AsyncIterable<StreamEvent>` -- typically as an `async function*` generator.**
+
+```typescript
+// Task: use `async *executeStream()`
+async *executeStream(input, context): AsyncIterable<StreamEvent> {
+  yield { type: "text-delta", port: "text", textDelta: "Hello" };
+  yield { type: "finish", data: {} as Output };
+}
+
+// Provider: the `AiProviderStreamFn` signature IS an AsyncIterable-returning function
+export const MyProvider_Stream: AiProviderStreamFn = async function* (input, model, signal) {
+  for await (const delta of underlyingSdk.stream(input, { signal })) {
+    yield { type: "text-delta", port: "text", textDelta: delta };
+  }
+  yield { type: "finish", data: {} };
+};
+```
+
+Why AsyncIterable for authoring:
+
+- **Pull-based backpressure is inherent.** When the consumer is slow, `yield` suspends the generator. No buffer bloat without writing any extra code.
+- **Cancel cleanup is natural.** A `try { ... } finally { ... }` in the generator runs when the consumer stops iterating -- including on `AbortSignal` firing.
+- **Trivial to write.** One `async function*`; no manual controller plumbing.
+
+### Engine-Internal: ReadableStream
+
+`ReadableStream<StreamEvent>` exists in exactly two engine-internal places:
+
+- `Dataflow.stream` -- the edge-level stream attached to dataflows that carry streaming data between tasks.
+- `TaskGraphRunner` fan-out -- when one upstream streaming task feeds multiple downstream consumers, the engine uses `ReadableStream.tee()` to split the stream cleanly.
+
+Why ReadableStream is the right tool here:
+
+- `tee()` is the correct fan-out primitive -- splitting an `AsyncIterable` to N consumers would require building (and maintaining) a custom broadcaster.
+- `cancel()` back-propagates to the producer, matching the existing abort plumbing.
+- It is a Web-platform standard available uniformly in browsers, workers, Node, and Bun.
+
+**Authors do not write `ReadableStream` directly.** The engine wraps task-authored `AsyncIterable`s into `ReadableStream`s at the dataflow edge. If you find yourself reaching for `new ReadableStream(...)` in a task, you are on the wrong layer.
+
+One exception lives in `HFT_Pipeline.ts`: that code wraps an HTTP `Response.body` (already a `ReadableStream<Uint8Array>`) into an abort-aware, pull-based `ReadableStream<Uint8Array>` for multi-GB model downloads. That wrapping is below the task layer -- it is shaping an external I/O primitive, not authoring a task stream.
+
+### Observation-Only: EventEmitter
+
+Tasks emit `stream_start`, `stream_chunk`, and `stream_end` via `EventEmitter` for UI and telemetry observers. These events:
+
+- **MUST NOT** be used for data transfer between tasks. Data transfer goes through dataflows (AsyncIterable -> engine tee -> downstream consumer).
+- Carry no backpressure. A slow listener cannot slow a producer. This is intentional -- observers must never be able to stall the pipeline.
+- Are safe to subscribe to from any number of listeners.
+
+### Which Primitive Do I Use?
+
+| Task                                            | Answer                                                 |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| Writing a new task that streams output          | `async *executeStream()` returning `AsyncIterable`     |
+| Writing a new AI provider stream function       | `AiProviderStreamFn` (async generator)                 |
+| Passing streaming data between two tasks        | Don't -- the engine handles this via dataflows         |
+| Forking one stream to multiple downstream tasks | Don't -- the engine tees via `ReadableStream.tee()`    |
+| Subscribing to streaming progress from the UI   | `graph.subscribeToTaskStreaming({...})` (EventEmitter) |
+| Logging or telemetry on streaming lifecycle     | `task.on("stream_chunk", ...)` (EventEmitter)          |
 
 ---
 
@@ -181,7 +257,9 @@ No streaming. The task returns its output as a complete `Promise<Output>` from `
 ```typescript
 // No x-stream annotation: standard execution
 properties: {
-  result: { type: "string" }
+  result: {
+    type: "string";
+  }
 }
 ```
 
@@ -281,8 +359,8 @@ type StreamEvent<Output = Record<string, any>> =
 ```typescript
 interface StreamTextDelta {
   type: "text-delta";
-  port: string;       // Output port name
-  textDelta: string;  // Incremental text fragment
+  port: string; // Output port name
+  textDelta: string; // Incremental text fragment
 }
 ```
 
@@ -293,7 +371,7 @@ Used with `x-stream: "append"`. Each event carries a fragment of text that shoul
 ```typescript
 interface StreamObjectDelta {
   type: "object-delta";
-  port: string;                                    // Output port name
+  port: string; // Output port name
   objectDelta: Record<string, unknown> | unknown[]; // Progressive partial object
 }
 ```
@@ -305,7 +383,7 @@ Used with `x-stream: "object"`. Each event carries a progressively more complete
 ```typescript
 interface StreamSnapshot<Output = Record<string, any>> {
   type: "snapshot";
-  data: Output;  // Complete snapshot of current output state
+  data: Output; // Complete snapshot of current output state
 }
 ```
 
@@ -316,7 +394,7 @@ Used with `x-stream: "replace"`. Each event carries a full snapshot of the outpu
 ```typescript
 interface StreamFinish<Output = Record<string, any>> {
   type: "finish";
-  data: Output;  // Final output data
+  data: Output; // Final output data
 }
 ```
 
@@ -329,7 +407,7 @@ Signals that the stream has ended. In append mode, the TaskRunner enriches this 
 ```typescript
 interface StreamError {
   type: "error";
-  error: Error;  // The error that occurred
+  error: Error; // The error that occurred
 }
 ```
 
@@ -450,6 +528,7 @@ await dataflow.awaitStreamValue();
 ```
 
 The method prioritizes events:
+
 1. `snapshot` events: Use the last snapshot data
 2. `finish` events: Use the finish data (which may include accumulated text from the source)
 3. `text-delta` / `object-delta`: Ignored here (source task handles accumulation)
@@ -459,10 +538,7 @@ The method prioritizes events:
 The `edgeNeedsAccumulation()` function determines whether a specific dataflow edge needs its source's stream to be accumulated:
 
 ```typescript
-function edgeNeedsAccumulation(
-  sourceSchema, sourcePort,
-  targetSchema, targetPort
-): boolean {
+function edgeNeedsAccumulation(sourceSchema, sourcePort, targetSchema, targetPort): boolean {
   const sourceMode = getPortStreamMode(sourceSchema, sourcePort);
   if (sourceMode === "none") return false;
   const targetMode = getPortStreamMode(targetSchema, targetPort);
@@ -474,20 +550,103 @@ If the source port streams in "append" mode but the target port does not declare
 
 ---
 
+## Cancel Semantics
+
+Every task execution carries an `AbortSignal`. What happens when it fires, and what each task is responsible for, is defined here.
+
+### Signal Origin and Propagation
+
+Each `TaskRunner` owns an `AbortController`, created in `handleStart()` and wired into the task via `IExecuteContext.signal`:
+
+```
+┌─────────────────┐  AbortSignal   ┌──────────────────────────┐
+│ TaskRunner      │ ─────────────> │ task.execute(input, ctx) │
+│  AbortController│                │ task.executeStream(...)  │
+└─────────────────┘                │    ctx.signal ───────────┼──> provider / fetch / SDK
+                                   └──────────────────────────┘
+```
+
+- `taskRunner.abort()` calls `AbortController.abort()` on its own controller, and recursively aborts any owned subgraph (`task.subGraph.abort()`).
+- Graph-level `graph.abort()` aborts every active task runner in the graph.
+- Aborting an upstream task causes its dataflows to transition to `ABORTING` (the terminal aborted state); downstream tasks that have not yet started will never start.
+
+### What Every Task MUST Do on Abort
+
+1. **Either poll `context.signal.aborted`** at safe loop boundaries, **or forward `context.signal`** to any I/O it performs (fetch, SDK client, subprocess, child task).
+2. **Stop producing output promptly.** A streaming task's generator must return (or throw) on the next `yield` point after abort, not continue producing events.
+3. **Release resources.** Close readers, cancel timers, unregister listeners. A `try { ... } finally { ... }` block in an `async *executeStream()` generator is the idiomatic cleanup hook -- `finally` runs when the consumer stops iterating (including on abort).
+4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires (`TaskRunner.ts:487-489`).
+
+Tasks **do not** need to manually set the task status -- the runner's `handleAbort()` transitions the task to `ABORTING` (the terminal aborted state) and attaches a `TaskAbortedError`.
+
+### Partial-Result Contract
+
+When a streaming task is aborted mid-stream:
+
+- `task.runOutputData` **may contain partially accumulated data** (whatever text deltas or object deltas were received before the abort).
+- `task.status` transitions to `ABORTING` (the terminal aborted state -- there is no separate `ABORTED` value).
+- `task.error` is set to a `TaskAbortedError`.
+- Downstream consumers **MUST treat `ABORTING` status as a failure**, not as a valid result, even if `runOutputData` looks superficially complete.
+
+If you need guaranteed-complete results for a downstream computation, check `task.status === COMPLETED` before reading `runOutputData`.
+
+### Downstream Propagation
+
+When an upstream task aborts, the graph runner's behavior depends on the downstream task's current state:
+
+| Downstream state | What happens                                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `PENDING`        | Task is never started. Its dataflows transition to `ABORTING`.                                                    |
+| `PROCESSING`     | Receives abort via its own `AbortSignal` (which was derived from the graph). Task follows the normal cancel path. |
+| `STREAMING`      | Receives an `error` `StreamEvent` on its input stream; runner throws `TaskAbortedError`.                          |
+| `COMPLETED`      | No effect -- completed tasks are immutable.                                                                       |
+
+### Per-Task JSDoc Convention
+
+Any task overriding `executeStream()` (or `execute()` with non-trivial cancel behavior) **SHOULD** document its cancel contract in a `@cancel` JSDoc tag on the class or method. Minimum contents:
+
+- What I/O or resources are opened during execution.
+- What happens to partial state on abort (discarded, flushed, etc.).
+- Whether side effects are reversible.
+
+Example:
+
+```typescript
+/**
+ * Streams text from an HTTP endpoint.
+ *
+ * @cancel Forwards `context.signal` to the underlying `fetch`. On abort:
+ * the HTTP connection is torn down by the browser/runtime, the reader is
+ * released in the generator's `finally` block, and any partial text
+ * accumulated on the task is discarded (status becomes `ABORTING`).
+ * No side effects to clean up.
+ */
+async *executeStream(input, context): AsyncIterable<StreamEvent> { ... }
+```
+
+For provider stream functions (`AiProviderStreamFn`), the equivalent contract is documented on the function type itself -- signal forwarding to the underlying SDK is mandatory.
+
+### Known Gaps
+
+- **Per-provider cancel forwarding audit** -- most providers (Anthropic, OpenAI, Gemini, Ollama, llamacpp) rely on their SDK's handling of `AbortSignal`. A systematic audit confirming each SDK promptly stops yielding after abort is still open.
+- **Bounded tee buffer** -- `ReadableStream.tee()` buffers for the slowest consumer with no cap. A `maxBufferedEvents` safety limit is a possible future hardening.
+
+---
+
 ## Dataflow Event System
 
 Dataflows emit events for lifecycle changes:
 
-| Event       | Parameters   | Description                          |
-|-------------|--------------|--------------------------------------|
-| `start`     | --           | Dataflow status set to PROCESSING    |
-| `streaming` | --           | Dataflow status set to STREAMING     |
-| `complete`  | --           | Dataflow status set to COMPLETED     |
-| `error`     | `TaskError`  | Dataflow status set to FAILED        |
-| `abort`     | --           | Dataflow status set to ABORTING      |
-| `disabled`  | --           | Dataflow status set to DISABLED      |
-| `reset`     | --           | Dataflow reset to initial state      |
-| `status`    | `TaskStatus` | Any status change                    |
+| Event       | Parameters   | Description                       |
+| ----------- | ------------ | --------------------------------- |
+| `start`     | --           | Dataflow status set to PROCESSING |
+| `streaming` | --           | Dataflow status set to STREAMING  |
+| `complete`  | --           | Dataflow status set to COMPLETED  |
+| `error`     | `TaskError`  | Dataflow status set to FAILED     |
+| `abort`     | --           | Dataflow status set to ABORTING   |
+| `disabled`  | --           | Dataflow status set to DISABLED   |
+| `reset`     | --           | Dataflow reset to initial state   |
+| `status`    | `TaskStatus` | Any status change                 |
 
 ### Subscribing to Dataflow Events
 
@@ -597,9 +756,7 @@ function getAppendPortId(schema: DataPortSchema): string | undefined;
 function getObjectPortId(schema: DataPortSchema): string | undefined;
 
 // Check if a dataflow edge needs value accumulation
-function edgeNeedsAccumulation(
-  sourceSchema, sourcePort, targetSchema, targetPort
-): boolean;
+function edgeNeedsAccumulation(sourceSchema, sourcePort, targetSchema, targetPort): boolean;
 
 // Get schemas for structured output ports
 function getStructuredOutputSchemas(schema: DataPortSchema): Map<string, JsonSchema>;
@@ -640,7 +797,7 @@ class StreamingTextTask extends Task<{ prompt: string }, { text: string }> {
       properties: {
         text: {
           type: "string",
-          "x-stream": "append",  // Enable append-mode streaming
+          "x-stream": "append", // Enable append-mode streaming
         },
       },
     } as const satisfies DataPortSchema;
@@ -707,10 +864,14 @@ unsub();
 // Pass entire output object as input using DATAFLOW_ALL_PORTS
 import { DATAFLOW_ALL_PORTS } from "@workglow/task-graph";
 
-graph.addDataflow(new Dataflow(
-  "producer", DATAFLOW_ALL_PORTS,   // All output properties
-  "consumer", DATAFLOW_ALL_PORTS    // Spread into all input properties
-));
+graph.addDataflow(
+  new Dataflow(
+    "producer",
+    DATAFLOW_ALL_PORTS, // All output properties
+    "consumer",
+    DATAFLOW_ALL_PORTS // Spread into all input properties
+  )
+);
 ```
 
 ### Checking Port Compatibility

--- a/packages/ai/src/provider/AiProviderRegistry.ts
+++ b/packages/ai/src/provider/AiProviderRegistry.ts
@@ -48,6 +48,22 @@ export type AiProviderReactiveRunFn<
  * Returns an AsyncIterable of StreamEvents instead of a Promise.
  * No `update_progress` callback -- for streaming providers, the stream itself IS the progress signal.
  * The optional `outputSchema` is provided for structured output tasks.
+ *
+ * Streaming primitive: this is the canonical authoring surface for provider streams.
+ * Implementations MUST be `async function*` generators returning `AsyncIterable`.
+ * Do not return a `ReadableStream` -- `ReadableStream` is an engine-internal primitive
+ * used only at the dataflow edge for fan-out via `tee()`.
+ *
+ * Finish convention: yield `{ type: "finish", data: {} as Output }` at the end.
+ * Do not accumulate deltas into the finish payload -- the `StreamingAiTask` / `TaskRunner`
+ * consumer handles accumulation.
+ *
+ * @cancel The provided `signal` MUST be forwarded to the underlying SDK or fetch.
+ * Generators MUST stop yielding promptly after `signal.aborted` becomes true -- either
+ * because the underlying SDK tears down the connection, or because the generator checks
+ * `signal.aborted` at loop boundaries. Use `try { ... } finally { ... }` to release any
+ * resources (readers, timers) -- `finally` runs when the consumer stops iterating on abort.
+ * On abort, the consumer will throw `TaskAbortedError`; do not swallow abort errors.
  */
 export type AiProviderStreamFn<
   Input extends TaskInput = TaskInput,

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -32,6 +32,15 @@ import type { ModelConfig } from "../../model/ModelSchema";
  * Port annotation: providers yield raw events without a `port` field.
  * This class wraps text-delta events with the correct port from the task's
  * output schema before they reach the TaskRunner.
+ *
+ * @cancel The `context.signal` is forwarded to the resolved execution strategy
+ * (direct or queued), which in turn forwards it to the provider stream function.
+ * When the signal fires, the underlying provider SDK tears down its connection
+ * and the inner `for await` exits; this generator then returns. Any partial
+ * accumulated text / object state on the task is discarded -- downstream
+ * consumers see status `ABORTING` and MUST NOT treat `runOutputData` as valid.
+ * Subclasses overriding `executeStream()` MUST preserve this contract: forward
+ * `context.signal`, and either return or throw promptly after abort.
  */
 export class StreamingAiTask<
   Input extends AiTaskInput = AiTaskInput,

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -36,9 +36,10 @@ import type { ModelConfig } from "../../model/ModelSchema";
  * @cancel The `context.signal` is forwarded to the resolved execution strategy
  * (direct or queued), which in turn forwards it to the provider stream function.
  * When the signal fires, the underlying provider SDK tears down its connection
- * and the inner `for await` exits; this generator then returns. Any partial
- * accumulated text / object state on the task is discarded -- downstream
- * consumers see status `ABORTING` and MUST NOT treat `runOutputData` as valid.
+ * and the inner `for await` exits; this generator then returns or throws
+ * promptly. Partial accumulated text / object state may still remain in task
+ * or runner state after abort (the runner does not clear `runOutputData`) and
+ * MUST be treated as invalid unless the final run status is `COMPLETED`.
  * Subclasses overriding `executeStream()` MUST preserve this contract: forward
  * `context.signal`, and either return or throw promptly after abort.
  */

--- a/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
+++ b/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
@@ -84,7 +84,7 @@ class HighRateProducer extends Task<PromptInput, TextOutput> {
       for (let i = 0; i < this.totalEvents; i++) {
         if (context.signal.aborted) return;
         this.yieldCount++;
-        yield { type: "text-delta", port: "text", textDelta: "x" };
+        yield { type: "text-delta", port: "text", textDelta: `${i}|` };
       }
       yield { type: "finish", data: {} as TextOutput };
     } finally {
@@ -94,8 +94,14 @@ class HighRateProducer extends Task<PromptInput, TextOutput> {
   }
 
   override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
-    return { text: "x".repeat(this.totalEvents) };
+    return { text: expectedAccumulatedText(this.totalEvents) };
   }
+}
+
+function expectedAccumulatedText(totalEvents: number): string {
+  let out = "";
+  for (let i = 0; i < totalEvents; i++) out += `${i}|`;
+  return out;
 }
 
 /**
@@ -206,10 +212,14 @@ describe("Streaming backpressure and stress", () => {
       expect(deltaEvents.length).toBe(totalEvents);
       expect(finishEvents.length).toBe(1);
 
+      // Deltas arrived in strict index order (order-sensitive payloads).
+      const expectedDeltas = Array.from({ length: totalEvents }, (_, i) => `${i}|`);
+      const observedDeltas = deltaEvents.map((e) => (e as { textDelta: string }).textDelta);
+      expect(observedDeltas).toEqual(expectedDeltas);
+
       // Accumulated text materialised correctly for the downstream consumer.
       const consumerOutput = consumer.runOutputData as TextOutput;
-      expect(consumerOutput.text.length).toBe(totalEvents);
-      expect(consumerOutput.text).toBe("x".repeat(totalEvents));
+      expect(consumerOutput.text).toBe(expectedDeltas.join(""));
     });
   });
 
@@ -224,18 +234,34 @@ describe("Streaming backpressure and stress", () => {
       graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
 
       const runner = new TaskGraphRunner(graph);
-      const runPromise = runner.runGraph({ prompt: "" });
 
-      // Abort as soon as the producer has started streaming.
-      await new Promise<void>((resolve) => {
+      // Attach the status listener BEFORE starting the run so we cannot
+      // miss the PROCESSING/STREAMING transition. Short-circuit if the
+      // producer has already reached STREAMING, and time out defensively.
+      const streamingPromise = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          producer.off("status", onStatus);
+          reject(new Error("Timed out waiting for producer to reach STREAMING"));
+        }, 5_000);
+
         const onStatus = (s: TaskStatus) => {
           if (s === TaskStatus.STREAMING) {
+            clearTimeout(timeout);
             producer.off("status", onStatus);
             resolve();
           }
         };
         producer.on("status", onStatus);
+
+        if (producer.status === TaskStatus.STREAMING) {
+          clearTimeout(timeout);
+          producer.off("status", onStatus);
+          resolve();
+        }
       });
+
+      const runPromise = runner.runGraph({ prompt: "" });
+      await streamingPromise;
 
       const yieldCountAtAbort = producer.yieldCount;
       runner.abort();
@@ -278,11 +304,12 @@ describe("Streaming backpressure and stress", () => {
       const runner = new TaskGraphRunner(graph);
       await runner.runGraph({ prompt: "" });
 
+      // Every consumer sees the identical, order-sensitive sequence.
+      const expected = expectedAccumulatedText(totalEvents);
       for (const consumer of [consumerA, consumerB, consumerC]) {
         expect(consumer.status).toBe(TaskStatus.COMPLETED);
         const output = consumer.runOutputData as TextOutput;
-        expect(output.text.length).toBe(totalEvents);
-        expect(output.text).toBe("x".repeat(totalEvents));
+        expect(output.text).toBe(expected);
       }
     });
   });

--- a/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
+++ b/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
@@ -1,0 +1,317 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stress tests for the streaming layer covering high event rates, abort
+ * responsiveness, fan-out, and error propagation.
+ *
+ * These tests exercise behaviour that is difficult to observe in ordinary
+ * streaming tests:
+ *   - A producer generator that yields thousands of events in a tight loop
+ *     must deliver every event without dropping or reordering.
+ *   - AsyncIterable is pull-based, so an abort signal must stop the producer
+ *     promptly rather than after the generator has drained on its own.
+ *   - Fan-out via engine-internal ReadableStream.tee() must deliver identical
+ *     event sequences to every downstream consumer.
+ *   - A StreamError event mid-stream must fail the source task and prevent
+ *     downstream tasks from starting.
+ */
+
+import {
+  Dataflow,
+  IExecuteContext,
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskStatus,
+} from "@workglow/task-graph";
+import type { StreamEvent } from "@workglow/task-graph";
+import { setLogger } from "@workglow/util";
+import { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+import { getTestingLogger } from "../../binding/TestingLogger";
+
+setLogger(getTestingLogger());
+
+// ============================================================================
+// Test tasks
+// ============================================================================
+
+type PromptInput = { prompt: string };
+type TextOutput = { text: string };
+
+/**
+ * Streaming producer that yields `totalEvents` text-delta events in a tight
+ * async generator loop, then a finish event. Exposes `yieldCount` so tests
+ * can observe how far the generator progressed before abort.
+ */
+class HighRateProducer extends Task<PromptInput, TextOutput> {
+  public static override type = "StreamingBackpressure_HighRateProducer";
+  public static override cacheable = false;
+
+  public totalEvents: number;
+  public yieldCount = 0;
+
+  constructor(config: { id: string; totalEvents: number }) {
+    super({ id: config.id, defaults: { prompt: "" } });
+    this.totalEvents = config.totalEvents;
+  }
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: PromptInput,
+    context: IExecuteContext
+  ): AsyncIterable<StreamEvent<TextOutput>> {
+    try {
+      for (let i = 0; i < this.totalEvents; i++) {
+        if (context.signal.aborted) return;
+        this.yieldCount++;
+        yield { type: "text-delta", port: "text", textDelta: "x" };
+      }
+      yield { type: "finish", data: {} as TextOutput };
+    } finally {
+      // `finally` runs when the consumer stops iterating (abort, throw, return)
+      // so resource cleanup in real tasks is guaranteed.
+    }
+  }
+
+  override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
+    return { text: "x".repeat(this.totalEvents) };
+  }
+}
+
+/**
+ * Non-streaming downstream consumer: receives fully-materialised text from
+ * an upstream streaming producer and returns it unchanged.
+ */
+class MaterialisedConsumer extends Task<{ text: string }, TextOutput> {
+  public static override type = "StreamingBackpressure_MaterialisedConsumer";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: { text: string }): Promise<TextOutput | undefined> {
+    return { text: input.text ?? "" };
+  }
+}
+
+/**
+ * Producer that yields `preErrorEvents` text-deltas and then a StreamError.
+ */
+class ErroringProducer extends Task<PromptInput, TextOutput> {
+  public static override type = "StreamingBackpressure_ErroringProducer";
+  public static override cacheable = false;
+
+  public preErrorEvents: number;
+  public readonly errorMessage = "producer failed mid-stream";
+
+  constructor(config: { id: string; preErrorEvents: number }) {
+    super({ id: config.id, defaults: { prompt: "" } });
+    this.preErrorEvents = config.preErrorEvents;
+  }
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: PromptInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<TextOutput>> {
+    for (let i = 0; i < this.preErrorEvents; i++) {
+      yield { type: "text-delta", port: "text", textDelta: "x" };
+    }
+    yield { type: "error", error: new Error(this.errorMessage) };
+  }
+
+  override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
+    throw new Error(this.errorMessage);
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Streaming backpressure and stress", () => {
+  describe("High-rate event delivery", () => {
+    it("delivers 10,000 text-delta events in order with no drops", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 10_000;
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const chunkEvents: StreamEvent[] = [];
+      producer.on("stream_chunk", (event: StreamEvent) => chunkEvents.push(event));
+
+      const runner = new TaskGraphRunner(graph);
+      await runner.runGraph({ prompt: "" });
+
+      expect(producer.status).toBe(TaskStatus.COMPLETED);
+      expect(consumer.status).toBe(TaskStatus.COMPLETED);
+
+      // Producer yielded exactly `totalEvents` deltas.
+      expect(producer.yieldCount).toBe(totalEvents);
+
+      // Every delta plus one finish were observed by the task.
+      const deltaEvents = chunkEvents.filter((e) => e.type === "text-delta");
+      const finishEvents = chunkEvents.filter((e) => e.type === "finish");
+      expect(deltaEvents.length).toBe(totalEvents);
+      expect(finishEvents.length).toBe(1);
+
+      // Accumulated text materialised correctly for the downstream consumer.
+      const consumerOutput = consumer.runOutputData as TextOutput;
+      expect(consumerOutput.text.length).toBe(totalEvents);
+      expect(consumerOutput.text).toBe("x".repeat(totalEvents));
+    });
+  });
+
+  describe("Abort responsiveness", () => {
+    it("stops the producer generator promptly when the runner is aborted", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 100_000; // deliberately huge so abort must short-circuit
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+      const runPromise = runner.runGraph({ prompt: "" });
+
+      // Abort as soon as the producer has started streaming.
+      await new Promise<void>((resolve) => {
+        const onStatus = (s: TaskStatus) => {
+          if (s === TaskStatus.STREAMING) {
+            producer.off("status", onStatus);
+            resolve();
+          }
+        };
+        producer.on("status", onStatus);
+      });
+
+      const yieldCountAtAbort = producer.yieldCount;
+      runner.abort();
+
+      try {
+        await runPromise;
+      } catch {
+        // Abort errors are expected.
+      }
+
+      // The producer generator halted instead of draining to `totalEvents`.
+      expect(producer.yieldCount).toBeLessThan(totalEvents);
+
+      // At most a small number of additional events slipped through between
+      // the abort call and the next signal check in the generator.
+      expect(producer.yieldCount - yieldCountAtAbort).toBeLessThan(1_000);
+
+      // Producer ends up in an abort-adjacent state, not COMPLETED.
+      expect([TaskStatus.ABORTING, TaskStatus.FAILED]).toContain(producer.status);
+
+      // Downstream consumer never reaches COMPLETED for a valid result.
+      expect(consumer.status).not.toBe(TaskStatus.COMPLETED);
+    });
+  });
+
+  describe("Fan-out", () => {
+    it("delivers identical event sequences to every downstream consumer", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 1_000;
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumerA = new MaterialisedConsumer({ id: "consumerA" });
+      const consumerB = new MaterialisedConsumer({ id: "consumerB" });
+      const consumerC = new MaterialisedConsumer({ id: "consumerC" });
+
+      graph.addTasks([producer, consumerA, consumerB, consumerC]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumerA", "text"));
+      graph.addDataflow(new Dataflow("producer", "text", "consumerB", "text"));
+      graph.addDataflow(new Dataflow("producer", "text", "consumerC", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+      await runner.runGraph({ prompt: "" });
+
+      for (const consumer of [consumerA, consumerB, consumerC]) {
+        expect(consumer.status).toBe(TaskStatus.COMPLETED);
+        const output = consumer.runOutputData as TextOutput;
+        expect(output.text.length).toBe(totalEvents);
+        expect(output.text).toBe("x".repeat(totalEvents));
+      }
+    });
+  });
+
+  describe("StreamError propagation", () => {
+    it("fails the source task on a StreamError event and keeps downstream from completing", async () => {
+      const graph = new TaskGraph();
+      const producer = new ErroringProducer({ id: "producer", preErrorEvents: 500 });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+
+      let caught: unknown;
+      try {
+        await runner.runGraph({ prompt: "" });
+      } catch (err) {
+        caught = err;
+      }
+
+      // Either the graph throws, or the producer records the error on itself.
+      const producerFailed = producer.status === TaskStatus.FAILED;
+      const graphRejected = caught !== undefined;
+      expect(producerFailed || graphRejected).toBe(true);
+
+      // Downstream consumer must not claim a completed, valid result.
+      expect(consumer.status).not.toBe(TaskStatus.COMPLETED);
+    });
+  });
+});

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -58,6 +58,17 @@ const PROVIDER_LLAMACPP_FILES = [
   "LlamaCpp_NativeToolCalling",
 ];
 
+/** node-llama-cpp/ipull downloads use shared ./models paths; parallel test files corrupt the same .gguf.ipull partial. */
+function isLlamaCppProviderIntegrationFile(filePath: string): boolean {
+  const base = filePath.split("/").pop() ?? filePath;
+  return (PROVIDER_LLAMACPP_FILES as readonly string[]).some((stem) => base.startsWith(`${stem}.`));
+}
+
+function shouldRunLlamaCppIntegrationFilesSequentially(files: string[]): boolean {
+  const n = files.filter(isLlamaCppProviderIntegrationFile).length;
+  return n > 1;
+}
+
 const SECTION_DIRS: Record<Section, string[]> = {
   graph: [
     join(TEST_BASE, "task-graph"),
@@ -155,8 +166,12 @@ function collectFiles(
 }
 
 async function runBunTest(files: string[]): Promise<number> {
+  const parallelFlag =
+    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
+      ? "--parallel=1"
+      : "--parallel";
   const proc = Bun.spawn(
-    files.length > 0 ? ["bun", "test", "--parallel", ...files] : ["bun", "test", "--parallel"],
+    files.length > 0 ? ["bun", "test", parallelFlag, ...files] : ["bun", "test", parallelFlag],
     {
       cwd: ROOT,
       stdio: ["inherit", "inherit", "inherit"],
@@ -173,6 +188,9 @@ async function runVitest(files: string[]): Promise<number> {
   // When no file filter: run all. Otherwise pass relative paths as name filters.
   const relFiles = files.length > 0 ? files.map((f) => relative(ROOT, f)) : [];
   const args = ["npx", "vitest", "run", ...relFiles];
+  if (files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)) {
+    args.push("--no-file-parallelism");
+  }
   if (process.env.CI) {
     args.push("--coverage");
   }


### PR DESCRIPTION
## Summary

This PR adds comprehensive stress tests for the streaming layer and documents the three-primitive streaming contract that governs how tasks, the engine, and observers interact with streaming data.

## Key Changes

### New Test Suite: `StreamingBackpressure.test.ts`
- **High-rate event delivery**: Validates that 10,000 text-delta events are delivered in order with no drops
- **Abort responsiveness**: Confirms that aborting the runner stops a high-volume producer generator promptly (within ~1,000 events of the abort signal, not after draining all 100,000)
- **Fan-out correctness**: Verifies that three downstream consumers receive identical event sequences when fed from a single streaming producer via `ReadableStream.tee()`
- **Error propagation**: Ensures that a `StreamError` event mid-stream fails the source task and prevents downstream consumers from completing

Includes three custom task implementations:
- `HighRateProducer`: Yields thousands of events in a tight loop; exposes `yieldCount` for observing abort behavior
- `MaterialisedConsumer`: Non-streaming downstream consumer that receives fully-accumulated text
- `ErroringProducer`: Yields events then a `StreamError` to test error handling

### Documentation: Streaming Primitive Contract
Added a new "Streaming Primitive Contract" section to `04-dataflow-and-streaming.md` that clarifies the three non-overlapping roles:

1. **`AsyncIterable<StreamEvent>` (Authoring)**: What task authors and provider authors write
   - Pull-based backpressure is inherent
   - Cancel cleanup via `try { ... } finally { ... }` in generators
   - Trivial to write as `async function*`

2. **`ReadableStream<StreamEvent>` (Engine-internal)**: Used only by the engine for dataflow edges and fan-out via `tee()`
   - Authors do NOT write this directly
   - Exception: `HFT_Pipeline.ts` wraps HTTP `Response.body` for multi-GB downloads (below task layer)

3. **`EventEmitter` (Observation-only)**: For UI and telemetry observers
   - NOT for data transfer between tasks
   - Carries no backpressure (intentional)

### Cancel Semantics Documentation
Added comprehensive "Cancel Semantics" section covering:
- Signal origin and propagation through `TaskRunner.AbortController`
- What every task MUST do on abort (poll signal, stop promptly, release resources, throw `TaskAbortedError`)
- Partial-result contract: `ABORTING` status means failure even if `runOutputData` looks complete
- Downstream propagation rules for `PENDING`, `PROCESSING`, `STREAMING`, and `COMPLETED` states
- Per-task JSDoc convention with `@cancel` tag
- Known gaps (per-provider audit, bounded tee buffer)

### Updated JSDoc Comments
- `AiProviderStreamFn`: Added streaming primitive guidance, finish convention, and `@cancel` contract
- `StreamingAiTask.executeStream()`: Added `@cancel` documentation for signal forwarding and partial state handling

### Documentation Formatting
- Normalized markdown table formatting for consistency across the document
- Improved code block formatting and alignment

## Notable Implementation Details

- The abort responsiveness test deliberately uses 100,000 events to force the abort to short-circuit the generator; without prompt abort handling, the test would timeout
- Fan-out test confirms that `ReadableStream.tee()` delivers identical sequences to all three consumers, validating the engine's use of this primitive
- Error propagation test verifies that downstream tasks do not claim `COMPLETED` status when an upstream error occurs
- Documentation explicitly forbids authors from writing `ReadableStream` directly, with one documented exception for HTTP response wrapping

https://claude.ai/code/session_01D8adpHTkTdEGvVpZpzckcD