### PR TITLE
Make maxIterations required for loop tasks; add ForEachTask and ConditionalBuilder

### DIFF
--- a/docs/technical/03-control-flow-tasks.md
+++ b/docs/technical/03-control-flow-tasks.md
@@ -208,7 +208,7 @@ interface MapTaskConfig extends IteratorTaskConfig {
   flatten?: boolean;           // Flatten nested arrays in results (default: false)
   concurrencyLimit?: number;   // Max concurrent iterations
   batchSize?: number;          // Items per batch
-  maxIterations?: number;      // Safety cap on iteration count
+  maxIterations: IterationBound; // REQUIRED — positive integer or "unbounded"
 }
 ```
 
@@ -216,7 +216,7 @@ interface MapTaskConfig extends IteratorTaskConfig {
 
 ```typescript
 const workflow = new Workflow()
-  .map()                                  // Start map loop
+  .map({ maxIterations: "unbounded" })    // Start map loop (required: bound)
     .addTask(new FetchUrlTask())
     .pipe(new ExtractTextTask())
   .endMap();                              // Close map loop
@@ -232,7 +232,7 @@ const results = await workflow.run({
 
 ```typescript
 const workflow = new Workflow()
-  .map({ concurrencyLimit: 3 })           // Max 3 concurrent iterations
+  .map({ concurrencyLimit: 3, maxIterations: "unbounded" }) // 3 concurrent + explicit unbounded
     .addTask(new TranslateTask())
   .endMap();
 
@@ -275,7 +275,8 @@ await workflow.run({ text: [] });
 
 ```typescript
 interface ReduceTaskConfig extends IteratorTaskConfig {
-  initialValue?: unknown;   // Starting value for the accumulator
+  initialValue?: unknown;          // Starting value for the accumulator
+  maxIterations: IterationBound;   // REQUIRED — inherited from IteratorTaskConfig
 }
 ```
 
@@ -287,7 +288,7 @@ Unlike MapTask, ReduceTask does **not** wrap output properties in arrays. The ou
 
 ```typescript
 const workflow = new Workflow()
-  .reduce({ initialValue: { total: 0 } })
+  .reduce({ initialValue: { total: 0 }, maxIterations: "unbounded" })
     .addTask(new SumTask())
   .endReduce();
 
@@ -301,7 +302,7 @@ await workflow.run({
 
 ```typescript
 const workflow = new Workflow()
-  .reduce({ initialValue: { summary: "" } })
+  .reduce({ initialValue: { summary: "" }, maxIterations: "unbounded" })
     .addTask(new AppendSummaryTask())
   .endReduce();
 
@@ -364,11 +365,11 @@ WhileTask injects an `_iterationIndex` property into each iteration's input. Unl
 ```typescript
 interface WhileTaskConfig extends GraphAsTaskConfig {
   condition?: (output: Output, iteration: number) => boolean;
-  maxIterations?: number;      // Safety limit (default: 100)
-  chainIterations?: boolean;   // Pass output as next input (default: true)
-  conditionField?: string;     // Serializable: field to check
-  conditionOperator?: string;  // Serializable: comparison operator
-  conditionValue?: string;     // Serializable: value to compare against
+  maxIterations: IterationBound; // REQUIRED — positive integer or "unbounded"
+  chainIterations?: boolean;     // Pass output as next input (default: true)
+  conditionField?: string;       // Serializable: field to check
+  conditionOperator?: string;    // Serializable: comparison operator
+  conditionValue?: string;       // Serializable: value to compare against
 }
 ```
 
@@ -575,7 +576,7 @@ const workflow = new Workflow()
     condition: (output) => output.needsMoreData,
     maxIterations: 5,
   })
-    .map({ concurrencyLimit: 3 })
+    .map({ concurrencyLimit: 3, maxIterations: "unbounded" })
       .addTask(new FetchTask())
     .endMap()
     .addTask(new AggregateTask())
@@ -587,7 +588,7 @@ const workflow = new Workflow()
 
 ```typescript
 const workflow = new Workflow()
-  .map()
+  .map({ maxIterations: "unbounded" })
     .addTask(new ClassifyTask())
     .pipe(new ConditionalTask({
       branches: [
@@ -692,7 +693,7 @@ class WhileTask<Input, Output, Config> extends GraphAsTask<Input, Output, Config
   static category: "Flow Control";
 
   condition?: WhileConditionFn<Output>;             // Loop condition
-  maxIterations: number;                            // Default: 100
+  maxIterations: IterationBound;                    // REQUIRED — number | "unbounded"
   chainIterations: boolean;                         // Default: true
   currentIteration: number;                         // Read-only counter
 

--- a/docs/technical/04-dataflow-and-streaming.md
+++ b/docs/technical/04-dataflow-and-streaming.md
@@ -258,8 +258,8 @@ No streaming. The task returns its output as a complete `Promise<Output>` from `
 // No x-stream annotation: standard execution
 properties: {
   result: {
-    type: "string";
-  }
+    type: "string",
+  },
 }
 ```
 
@@ -575,7 +575,7 @@ Each `TaskRunner` owns an `AbortController`, created in `handleStart()` and wire
 1. **Either poll `context.signal.aborted`** at safe loop boundaries, **or forward `context.signal`** to any I/O it performs (fetch, SDK client, subprocess, child task).
 2. **Stop producing output promptly.** A streaming task's generator must return (or throw) on the next `yield` point after abort, not continue producing events.
 3. **Release resources.** Close readers, cancel timers, unregister listeners. A `try { ... } finally { ... }` block in an `async *executeStream()` generator is the idiomatic cleanup hook -- `finally` runs when the consumer stops iterating (including on abort).
-4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires (`TaskRunner.ts:487-489`).
+4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires, via the post-stream abort check in `TaskRunner.executeStreamingTask`.
 
 Tasks **do not** need to manually set the task status -- the runner's `handleAbort()` transitions the task to `ABORTING` (the terminal aborted state) and attaches a `TaskAbortedError`.
 

--- a/docs/technical/04-dataflow-and-streaming.md
+++ b/docs/technical/04-dataflow-and-streaming.md
@@ -27,10 +27,10 @@ A `Dataflow` represents a single directed edge from one task's output port to an
 
 ```typescript
 const dataflow = new Dataflow(
-  sourceTaskId,      // ID of the source task
-  sourceTaskPortId,  // Name of the output port on the source task
-  targetTaskId,      // ID of the target task
-  targetTaskPortId   // Name of the input port on the target task
+  sourceTaskId, // ID of the source task
+  sourceTaskPortId, // Name of the output port on the source task
+  targetTaskId, // ID of the target task
+  targetTaskPortId // Name of the input port on the target task
 );
 ```
 
@@ -46,12 +46,12 @@ For example: `"task-abc[result] ==> task-def[value]"`.
 
 Each dataflow maintains its own lifecycle state, mirroring the task lifecycle:
 
-| Property  | Type         | Description                                        |
-|-----------|--------------|----------------------------------------------------|
-| `value`   | `any`        | The materialized data carried by the dataflow      |
-| `status`  | `TaskStatus`  | Current lifecycle status                          |
-| `error`   | `TaskError`   | Error object if the dataflow failed               |
-| `stream`  | `ReadableStream<StreamEvent>` | Active stream for streaming tasks  |
+| Property | Type                          | Description                                   |
+| -------- | ----------------------------- | --------------------------------------------- |
+| `value`  | `any`                         | The materialized data carried by the dataflow |
+| `status` | `TaskStatus`                  | Current lifecycle status                      |
+| `error`  | `TaskError`                   | Error object if the dataflow failed           |
+| `stream` | `ReadableStream<StreamEvent>` | Active stream for streaming tasks             |
 
 The dataflow status transitions mirror the source task's execution:
 
@@ -70,7 +70,7 @@ When the TaskGraphRunner pushes output from a completed task onto outgoing dataf
 dataflow.value = entireDataBlock[sourceTaskPortId];
 
 // If sourceTaskPortId is "*" (DATAFLOW_ALL_PORTS):
-dataflow.value = entireDataBlock;  // Entire output object
+dataflow.value = entireDataBlock; // Entire output object
 
 // If sourceTaskPortId is "[error]" (DATAFLOW_ERROR_PORT):
 dataflow.error = entireDataBlock;
@@ -83,7 +83,7 @@ When the runner copies input from dataflows into a target task, it calls `getPor
 return { [targetTaskPortId]: dataflow.value };
 
 // If targetTaskPortId is "*" (DATAFLOW_ALL_PORTS):
-return dataflow.value;  // Entire value object
+return dataflow.value; // Entire value object
 
 // If targetTaskPortId is "[error]" (DATAFLOW_ERROR_PORT):
 return { "[error]": dataflow.error };
@@ -91,10 +91,10 @@ return { "[error]": dataflow.error };
 
 ### Special Port Identifiers
 
-| Constant             | Value       | Description                                              |
-|----------------------|-------------|----------------------------------------------------------|
-| `DATAFLOW_ALL_PORTS` | `"*"`       | Pass the entire output/input object, not a single port   |
-| `DATAFLOW_ERROR_PORT`| `"[error]"` | Route error objects between tasks for error handling      |
+| Constant              | Value       | Description                                            |
+| --------------------- | ----------- | ------------------------------------------------------ |
+| `DATAFLOW_ALL_PORTS`  | `"*"`       | Pass the entire output/input object, not a single port |
+| `DATAFLOW_ERROR_PORT` | `"[error]"` | Route error objects between tasks for error handling   |
 
 The wildcard port `"*"` is used when a task should receive the complete output object from its upstream dependency, rather than a single named property.
 
@@ -107,11 +107,11 @@ dataflow.semanticallyCompatible(graph, dataflow);
 // Returns: "static" | "runtime" | "incompatible"
 ```
 
-| Result          | Meaning                                                    |
-|-----------------|------------------------------------------------------------|
-| `"static"`      | Types are statically compatible                            |
-| `"runtime"`     | Compatibility can only be determined at runtime            |
-| `"incompatible"`| Types are known to be incompatible                         |
+| Result           | Meaning                                         |
+| ---------------- | ----------------------------------------------- |
+| `"static"`       | Types are statically compatible                 |
+| `"runtime"`      | Compatibility can only be determined at runtime |
+| `"incompatible"` | Types are known to be incompatible              |
 
 Compatibility results are cached for tasks with stable schemas. Tasks with `hasDynamicSchemas = true` bypass the cache because their schemas may change between checks.
 
@@ -154,15 +154,91 @@ This task has two output ports: `text` (string) and `confidence` (number).
 
 Ports support several custom annotations beyond standard JSON Schema:
 
-| Annotation              | Type      | Description                                              |
-|-------------------------|-----------|----------------------------------------------------------|
-| `x-stream`              | `string`  | Streaming mode: `"append"`, `"replace"`, or `"object"`  |
-| `x-ui-hidden`           | `boolean` | Hide from UI display                                    |
-| `x-ui-iteration`        | `boolean` | Iteration context port (hidden from parent display)     |
-| `x-ui-manual`           | `boolean` | User-added port (dynamic)                               |
-| `x-auto-generated`      | `boolean` | Auto-generated primary key                              |
-| `x-structured-output`   | `boolean` | Port schema used for structured AI output               |
-| `format`                | `string`  | Semantic type hint (e.g., `"model"`, `"storage:tabular"`, `"knowledge-base"`) |
+| Annotation            | Type      | Description                                                                   |
+| --------------------- | --------- | ----------------------------------------------------------------------------- |
+| `x-stream`            | `string`  | Streaming mode: `"append"`, `"replace"`, or `"object"`                        |
+| `x-ui-hidden`         | `boolean` | Hide from UI display                                                          |
+| `x-ui-iteration`      | `boolean` | Iteration context port (hidden from parent display)                           |
+| `x-ui-manual`         | `boolean` | User-added port (dynamic)                                                     |
+| `x-auto-generated`    | `boolean` | Auto-generated primary key                                                    |
+| `x-structured-output` | `boolean` | Port schema used for structured AI output                                     |
+| `format`              | `string`  | Semantic type hint (e.g., `"model"`, `"storage:tabular"`, `"knowledge-base"`) |
+
+---
+
+## Streaming Primitive Contract
+
+Workglow's streaming layer uses three primitives that serve distinct, non-overlapping roles. Authors only ever write one of them. The other two are engine internals.
+
+### The Three Primitives
+
+| Primitive                     | Role                | Where it appears                                       | Who writes it                     |
+| ----------------------------- | ------------------- | ------------------------------------------------------ | --------------------------------- |
+| `AsyncIterable<StreamEvent>`  | Authoring           | `Task.executeStream()`, `AiProviderStreamFn`           | Task / provider authors           |
+| `ReadableStream<StreamEvent>` | Engine-internal tee | `Dataflow.stream`, `TaskGraphRunner` fan-out           | Engine only (do not use in tasks) |
+| `EventEmitter` (task events)  | Observation only    | `stream_start`, `stream_chunk`, `stream_end` on `Task` | Engine emits; consumers subscribe |
+
+### Authoring Rule: AsyncIterable
+
+**All streaming tasks and providers MUST return `AsyncIterable<StreamEvent>` -- typically as an `async function*` generator.**
+
+```typescript
+// Task: use `async *executeStream()`
+async *executeStream(input, context): AsyncIterable<StreamEvent> {
+  yield { type: "text-delta", port: "text", textDelta: "Hello" };
+  yield { type: "finish", data: {} as Output };
+}
+
+// Provider: the `AiProviderStreamFn` signature IS an AsyncIterable-returning function
+export const MyProvider_Stream: AiProviderStreamFn = async function* (input, model, signal) {
+  for await (const delta of underlyingSdk.stream(input, { signal })) {
+    yield { type: "text-delta", port: "text", textDelta: delta };
+  }
+  yield { type: "finish", data: {} };
+};
+```
+
+Why AsyncIterable for authoring:
+
+- **Pull-based backpressure is inherent.** When the consumer is slow, `yield` suspends the generator. No buffer bloat without writing any extra code.
+- **Cancel cleanup is natural.** A `try { ... } finally { ... }` in the generator runs when the consumer stops iterating -- including on `AbortSignal` firing.
+- **Trivial to write.** One `async function*`; no manual controller plumbing.
+
+### Engine-Internal: ReadableStream
+
+`ReadableStream<StreamEvent>` exists in exactly two engine-internal places:
+
+- `Dataflow.stream` -- the edge-level stream attached to dataflows that carry streaming data between tasks.
+- `TaskGraphRunner` fan-out -- when one upstream streaming task feeds multiple downstream consumers, the engine uses `ReadableStream.tee()` to split the stream cleanly.
+
+Why ReadableStream is the right tool here:
+
+- `tee()` is the correct fan-out primitive -- splitting an `AsyncIterable` to N consumers would require building (and maintaining) a custom broadcaster.
+- `cancel()` back-propagates to the producer, matching the existing abort plumbing.
+- It is a Web-platform standard available uniformly in browsers, workers, Node, and Bun.
+
+**Authors do not write `ReadableStream` directly.** The engine wraps task-authored `AsyncIterable`s into `ReadableStream`s at the dataflow edge. If you find yourself reaching for `new ReadableStream(...)` in a task, you are on the wrong layer.
+
+One exception lives in `HFT_Pipeline.ts`: that code wraps an HTTP `Response.body` (already a `ReadableStream<Uint8Array>`) into an abort-aware, pull-based `ReadableStream<Uint8Array>` for multi-GB model downloads. That wrapping is below the task layer -- it is shaping an external I/O primitive, not authoring a task stream.
+
+### Observation-Only: EventEmitter
+
+Tasks emit `stream_start`, `stream_chunk`, and `stream_end` via `EventEmitter` for UI and telemetry observers. These events:
+
+- **MUST NOT** be used for data transfer between tasks. Data transfer goes through dataflows (AsyncIterable -> engine tee -> downstream consumer).
+- Carry no backpressure. A slow listener cannot slow a producer. This is intentional -- observers must never be able to stall the pipeline.
+- Are safe to subscribe to from any number of listeners.
+
+### Which Primitive Do I Use?
+
+| Task                                            | Answer                                                 |
+| ----------------------------------------------- | ------------------------------------------------------ |
+| Writing a new task that streams output          | `async *executeStream()` returning `AsyncIterable`     |
+| Writing a new AI provider stream function       | `AiProviderStreamFn` (async generator)                 |
+| Passing streaming data between two tasks        | Don't -- the engine handles this via dataflows         |
+| Forking one stream to multiple downstream tasks | Don't -- the engine tees via `ReadableStream.tee()`    |
+| Subscribing to streaming progress from the UI   | `graph.subscribeToTaskStreaming({...})` (EventEmitter) |
+| Logging or telemetry on streaming lifecycle     | `task.on("stream_chunk", ...)` (EventEmitter)          |
 
 ---
 
@@ -181,7 +257,9 @@ No streaming. The task returns its output as a complete `Promise<Output>` from `
 ```typescript
 // No x-stream annotation: standard execution
 properties: {
-  result: { type: "string" }
+  result: {
+    type: "string";
+  }
 }
 ```
 
@@ -281,8 +359,8 @@ type StreamEvent<Output = Record<string, any>> =
 ```typescript
 interface StreamTextDelta {
   type: "text-delta";
-  port: string;       // Output port name
-  textDelta: string;  // Incremental text fragment
+  port: string; // Output port name
+  textDelta: string; // Incremental text fragment
 }
 ```
 
@@ -293,7 +371,7 @@ Used with `x-stream: "append"`. Each event carries a fragment of text that shoul
 ```typescript
 interface StreamObjectDelta {
   type: "object-delta";
-  port: string;                                    // Output port name
+  port: string; // Output port name
   objectDelta: Record<string, unknown> | unknown[]; // Progressive partial object
 }
 ```
@@ -305,7 +383,7 @@ Used with `x-stream: "object"`. Each event carries a progressively more complete
 ```typescript
 interface StreamSnapshot<Output = Record<string, any>> {
   type: "snapshot";
-  data: Output;  // Complete snapshot of current output state
+  data: Output; // Complete snapshot of current output state
 }
 ```
 
@@ -316,7 +394,7 @@ Used with `x-stream: "replace"`. Each event carries a full snapshot of the outpu
 ```typescript
 interface StreamFinish<Output = Record<string, any>> {
   type: "finish";
-  data: Output;  // Final output data
+  data: Output; // Final output data
 }
 ```
 
@@ -329,7 +407,7 @@ Signals that the stream has ended. In append mode, the TaskRunner enriches this 
 ```typescript
 interface StreamError {
   type: "error";
-  error: Error;  // The error that occurred
+  error: Error; // The error that occurred
 }
 ```
 
@@ -450,6 +528,7 @@ await dataflow.awaitStreamValue();
 ```
 
 The method prioritizes events:
+
 1. `snapshot` events: Use the last snapshot data
 2. `finish` events: Use the finish data (which may include accumulated text from the source)
 3. `text-delta` / `object-delta`: Ignored here (source task handles accumulation)
@@ -459,10 +538,7 @@ The method prioritizes events:
 The `edgeNeedsAccumulation()` function determines whether a specific dataflow edge needs its source's stream to be accumulated:
 
 ```typescript
-function edgeNeedsAccumulation(
-  sourceSchema, sourcePort,
-  targetSchema, targetPort
-): boolean {
+function edgeNeedsAccumulation(sourceSchema, sourcePort, targetSchema, targetPort): boolean {
   const sourceMode = getPortStreamMode(sourceSchema, sourcePort);
   if (sourceMode === "none") return false;
   const targetMode = getPortStreamMode(targetSchema, targetPort);
@@ -474,20 +550,103 @@ If the source port streams in "append" mode but the target port does not declare
 
 ---
 
+## Cancel Semantics
+
+Every task execution carries an `AbortSignal`. What happens when it fires, and what each task is responsible for, is defined here.
+
+### Signal Origin and Propagation
+
+Each `TaskRunner` owns an `AbortController`, created in `handleStart()` and wired into the task via `IExecuteContext.signal`:
+
+```
+┌─────────────────┐  AbortSignal   ┌──────────────────────────┐
+│ TaskRunner      │ ─────────────> │ task.execute(input, ctx) │
+│  AbortController│                │ task.executeStream(...)  │
+└─────────────────┘                │    ctx.signal ───────────┼──> provider / fetch / SDK
+                                   └──────────────────────────┘
+```
+
+- `taskRunner.abort()` calls `AbortController.abort()` on its own controller, and recursively aborts any owned subgraph (`task.subGraph.abort()`).
+- Graph-level `graph.abort()` aborts every active task runner in the graph.
+- Aborting an upstream task causes its dataflows to transition to `ABORTING` (the terminal aborted state); downstream tasks that have not yet started will never start.
+
+### What Every Task MUST Do on Abort
+
+1. **Either poll `context.signal.aborted`** at safe loop boundaries, **or forward `context.signal`** to any I/O it performs (fetch, SDK client, subprocess, child task).
+2. **Stop producing output promptly.** A streaming task's generator must return (or throw) on the next `yield` point after abort, not continue producing events.
+3. **Release resources.** Close readers, cancel timers, unregister listeners. A `try { ... } finally { ... }` block in an `async *executeStream()` generator is the idiomatic cleanup hook -- `finally` runs when the consumer stops iterating (including on abort).
+4. **Throw `TaskAbortedError`** if the abort is detected inside `execute()` / `executeStream()`. The TaskRunner also detects abort on its own and converts it to a `TaskAbortedError` when the generator finishes after the signal fires (`TaskRunner.ts:487-489`).
+
+Tasks **do not** need to manually set the task status -- the runner's `handleAbort()` transitions the task to `ABORTING` (the terminal aborted state) and attaches a `TaskAbortedError`.
+
+### Partial-Result Contract
+
+When a streaming task is aborted mid-stream:
+
+- `task.runOutputData` **may contain partially accumulated data** (whatever text deltas or object deltas were received before the abort).
+- `task.status` transitions to `ABORTING` (the terminal aborted state -- there is no separate `ABORTED` value).
+- `task.error` is set to a `TaskAbortedError`.
+- Downstream consumers **MUST treat `ABORTING` status as a failure**, not as a valid result, even if `runOutputData` looks superficially complete.
+
+If you need guaranteed-complete results for a downstream computation, check `task.status === COMPLETED` before reading `runOutputData`.
+
+### Downstream Propagation
+
+When an upstream task aborts, the graph runner's behavior depends on the downstream task's current state:
+
+| Downstream state | What happens                                                                                                      |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `PENDING`        | Task is never started. Its dataflows transition to `ABORTING`.                                                    |
+| `PROCESSING`     | Receives abort via its own `AbortSignal` (which was derived from the graph). Task follows the normal cancel path. |
+| `STREAMING`      | Receives an `error` `StreamEvent` on its input stream; runner throws `TaskAbortedError`.                          |
+| `COMPLETED`      | No effect -- completed tasks are immutable.                                                                       |
+
+### Per-Task JSDoc Convention
+
+Any task overriding `executeStream()` (or `execute()` with non-trivial cancel behavior) **SHOULD** document its cancel contract in a `@cancel` JSDoc tag on the class or method. Minimum contents:
+
+- What I/O or resources are opened during execution.
+- What happens to partial state on abort (discarded, flushed, etc.).
+- Whether side effects are reversible.
+
+Example:
+
+```typescript
+/**
+ * Streams text from an HTTP endpoint.
+ *
+ * @cancel Forwards `context.signal` to the underlying `fetch`. On abort:
+ * the HTTP connection is torn down by the browser/runtime, the reader is
+ * released in the generator's `finally` block, and any partial text
+ * accumulated on the task is discarded (status becomes `ABORTING`).
+ * No side effects to clean up.
+ */
+async *executeStream(input, context): AsyncIterable<StreamEvent> { ... }
+```
+
+For provider stream functions (`AiProviderStreamFn`), the equivalent contract is documented on the function type itself -- signal forwarding to the underlying SDK is mandatory.
+
+### Known Gaps
+
+- **Per-provider cancel forwarding audit** -- most providers (Anthropic, OpenAI, Gemini, Ollama, llamacpp) rely on their SDK's handling of `AbortSignal`. A systematic audit confirming each SDK promptly stops yielding after abort is still open.
+- **Bounded tee buffer** -- `ReadableStream.tee()` buffers for the slowest consumer with no cap. A `maxBufferedEvents` safety limit is a possible future hardening.
+
+---
+
 ## Dataflow Event System
 
 Dataflows emit events for lifecycle changes:
 
-| Event       | Parameters   | Description                          |
-|-------------|--------------|--------------------------------------|
-| `start`     | --           | Dataflow status set to PROCESSING    |
-| `streaming` | --           | Dataflow status set to STREAMING     |
-| `complete`  | --           | Dataflow status set to COMPLETED     |
-| `error`     | `TaskError`  | Dataflow status set to FAILED        |
-| `abort`     | --           | Dataflow status set to ABORTING      |
-| `disabled`  | --           | Dataflow status set to DISABLED      |
-| `reset`     | --           | Dataflow reset to initial state      |
-| `status`    | `TaskStatus` | Any status change                    |
+| Event       | Parameters   | Description                       |
+| ----------- | ------------ | --------------------------------- |
+| `start`     | --           | Dataflow status set to PROCESSING |
+| `streaming` | --           | Dataflow status set to STREAMING  |
+| `complete`  | --           | Dataflow status set to COMPLETED  |
+| `error`     | `TaskError`  | Dataflow status set to FAILED     |
+| `abort`     | --           | Dataflow status set to ABORTING   |
+| `disabled`  | --           | Dataflow status set to DISABLED   |
+| `reset`     | --           | Dataflow reset to initial state   |
+| `status`    | `TaskStatus` | Any status change                 |
 
 ### Subscribing to Dataflow Events
 
@@ -597,9 +756,7 @@ function getAppendPortId(schema: DataPortSchema): string | undefined;
 function getObjectPortId(schema: DataPortSchema): string | undefined;
 
 // Check if a dataflow edge needs value accumulation
-function edgeNeedsAccumulation(
-  sourceSchema, sourcePort, targetSchema, targetPort
-): boolean;
+function edgeNeedsAccumulation(sourceSchema, sourcePort, targetSchema, targetPort): boolean;
 
 // Get schemas for structured output ports
 function getStructuredOutputSchemas(schema: DataPortSchema): Map<string, JsonSchema>;
@@ -640,7 +797,7 @@ class StreamingTextTask extends Task<{ prompt: string }, { text: string }> {
       properties: {
         text: {
           type: "string",
-          "x-stream": "append",  // Enable append-mode streaming
+          "x-stream": "append", // Enable append-mode streaming
         },
       },
     } as const satisfies DataPortSchema;
@@ -707,10 +864,14 @@ unsub();
 // Pass entire output object as input using DATAFLOW_ALL_PORTS
 import { DATAFLOW_ALL_PORTS } from "@workglow/task-graph";
 
-graph.addDataflow(new Dataflow(
-  "producer", DATAFLOW_ALL_PORTS,   // All output properties
-  "consumer", DATAFLOW_ALL_PORTS    // Spread into all input properties
-));
+graph.addDataflow(
+  new Dataflow(
+    "producer",
+    DATAFLOW_ALL_PORTS, // All output properties
+    "consumer",
+    DATAFLOW_ALL_PORTS // Spread into all input properties
+  )
+);
 ```
 
 ### Checking Port Compatibility

--- a/packages/ai/src/provider/AiProviderRegistry.ts
+++ b/packages/ai/src/provider/AiProviderRegistry.ts
@@ -48,6 +48,22 @@ export type AiProviderReactiveRunFn<
  * Returns an AsyncIterable of StreamEvents instead of a Promise.
  * No `update_progress` callback -- for streaming providers, the stream itself IS the progress signal.
  * The optional `outputSchema` is provided for structured output tasks.
+ *
+ * Streaming primitive: this is the canonical authoring surface for provider streams.
+ * Implementations MUST be `async function*` generators returning `AsyncIterable`.
+ * Do not return a `ReadableStream` -- `ReadableStream` is an engine-internal primitive
+ * used only at the dataflow edge for fan-out via `tee()`.
+ *
+ * Finish convention: yield `{ type: "finish", data: {} as Output }` at the end.
+ * Do not accumulate deltas into the finish payload -- the `StreamingAiTask` / `TaskRunner`
+ * consumer handles accumulation.
+ *
+ * @cancel The provided `signal` MUST be forwarded to the underlying SDK or fetch.
+ * Generators MUST stop yielding promptly after `signal.aborted` becomes true -- either
+ * because the underlying SDK tears down the connection, or because the generator checks
+ * `signal.aborted` at loop boundaries. Use `try { ... } finally { ... }` to release any
+ * resources (readers, timers) -- `finally` runs when the consumer stops iterating on abort.
+ * On abort, the consumer will throw `TaskAbortedError`; do not swallow abort errors.
  */
 export type AiProviderStreamFn<
   Input extends TaskInput = TaskInput,

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -32,6 +32,15 @@ import type { ModelConfig } from "../../model/ModelSchema";
  * Port annotation: providers yield raw events without a `port` field.
  * This class wraps text-delta events with the correct port from the task's
  * output schema before they reach the TaskRunner.
+ *
+ * @cancel The `context.signal` is forwarded to the resolved execution strategy
+ * (direct or queued), which in turn forwards it to the provider stream function.
+ * When the signal fires, the underlying provider SDK tears down its connection
+ * and the inner `for await` exits; this generator then returns. Any partial
+ * accumulated text / object state on the task is discarded -- downstream
+ * consumers see status `ABORTING` and MUST NOT treat `runOutputData` as valid.
+ * Subclasses overriding `executeStream()` MUST preserve this contract: forward
+ * `context.signal`, and either return or throw promptly after abort.
  */
 export class StreamingAiTask<
   Input extends AiTaskInput = AiTaskInput,

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -36,9 +36,10 @@ import type { ModelConfig } from "../../model/ModelSchema";
  * @cancel The `context.signal` is forwarded to the resolved execution strategy
  * (direct or queued), which in turn forwards it to the provider stream function.
  * When the signal fires, the underlying provider SDK tears down its connection
- * and the inner `for await` exits; this generator then returns. Any partial
- * accumulated text / object state on the task is discarded -- downstream
- * consumers see status `ABORTING` and MUST NOT treat `runOutputData` as valid.
+ * and the inner `for await` exits; this generator then returns or throws
+ * promptly. Partial accumulated text / object state may still remain in task
+ * or runner state after abort (the runner does not clear `runOutputData`) and
+ * MUST be treated as invalid unless the final run status is `COMPLETED`.
  * Subclasses overriding `executeStream()` MUST preserve this contract: forward
  * `context.signal`, and either return or throw promptly after abort.
  */

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -288,6 +288,12 @@ This ensures:
 
 ## Key Invariants
 
+### 0. Cycle Guarantees
+
+- `TaskGraph` is a `DirectedAcyclicGraph`. The underlying `TaskGraphDAG` extends `DirectedAcyclicGraph` from `@workglow/util/graph`.
+- `TaskGraph.addDataflow` throws `CycleError` **synchronously** whenever the new edge would close a cycle. Detection runs inside `DirectedAcyclicGraph.addEdge` via `wouldAddingEdgeCreateCycle`, so no graph can ever reach a cyclic state — cycles are rejected at the construction call, not at run time.
+- Loop tasks (`WhileTask`, `IteratorTask`, `MapTask`, `ReduceTask`) achieve repetition by re-running an internally-acyclic subgraph once per iteration, never by adding back-edges. Each subgraph is its own `TaskGraph` and inherits the same invariant. `GraphAsTask.validateAcyclic()` re-asserts the invariant when the subgraph is finalized, so any direct `_dag` manipulation is caught before execution.
+
 ### 1. COMPLETED Tasks Are Immutable
 
 Once a task's `run()` completes and status becomes `COMPLETED`:

--- a/packages/task-graph/src/task-graph/ConditionalBuilder.ts
+++ b/packages/task-graph/src/task-graph/ConditionalBuilder.ts
@@ -8,6 +8,7 @@ import { uuid4 } from "@workglow/util";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { ConditionalTask } from "../task/ConditionalTask";
 import type { ITask, ITaskConstructor } from "../task/ITask";
+import { WorkflowError } from "../task/TaskError";
 import type { DataPorts, TaskConfig, TaskInput } from "../task/TaskTypes";
 import { Dataflow } from "./Dataflow";
 import type { Workflow } from "./Workflow";
@@ -70,7 +71,7 @@ export class ConditionalBuilder {
    */
   public endIf(): Workflow {
     if (!this.thenSpec) {
-      throw new Error(".endIf() called without a prior .then(...) call");
+      throw new WorkflowError(".endIf() called without a prior .then(...) call");
     }
 
     const thenPort = "then";
@@ -86,16 +87,12 @@ export class ConditionalBuilder {
 
     if (this.elseSpec) {
       // Inverse condition so the "else" branch is mutually exclusive with "then".
-      // Wrapped in try/catch to match ConditionalTask's internal error-as-false semantics.
+      // If the user's condition throws, ConditionalTask's own error handling
+      // treats both branches as not-matched; `defaultBranch: elsePort` below
+      // then routes to else — matching ConditionalTask's error-as-false semantics.
       branches.push({
         id: elsePort,
-        condition: (input: TaskInput) => {
-          try {
-            return !this.condition(input);
-          } catch {
-            return true;
-          }
-        },
+        condition: (input: TaskInput) => !this.condition(input),
         outputPort: elsePort,
       });
     }

--- a/packages/task-graph/src/task-graph/ConditionalBuilder.ts
+++ b/packages/task-graph/src/task-graph/ConditionalBuilder.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { uuid4 } from "@workglow/util";
+import type { ConditionFn } from "../task/ConditionalTask";
+import { ConditionalTask } from "../task/ConditionalTask";
+import type { ITask, ITaskConstructor } from "../task/ITask";
+import type { DataPorts, TaskConfig, TaskInput } from "../task/TaskTypes";
+import { Dataflow } from "./Dataflow";
+import type { Workflow } from "./Workflow";
+
+/**
+ * Fluent builder for constructing a {@link ConditionalTask} with a
+ * canonical then/else shape. Created by {@link Workflow.if} and closed via
+ * {@link ConditionalBuilder.endIf}. Each arm accepts a single task class
+ * (with optional input/config), which the builder instantiates and wires
+ * from the conditional's matching output port.
+ *
+ * Usage:
+ *
+ * ```ts
+ * workflow
+ *   .if((input) => input.kind === "text")
+ *   .then(TextTask)
+ *   .else(ImageTask)
+ *   .endIf();
+ * ```
+ */
+export class ConditionalBuilder {
+  private thenSpec: BranchTaskSpec | undefined;
+  private elseSpec: BranchTaskSpec | undefined;
+
+  constructor(
+    private readonly workflow: Workflow,
+    private readonly condition: ConditionFn<TaskInput>
+  ) {}
+
+  /**
+   * Register the task that runs when the condition matches. Accepts the
+   * same (taskClass, input?, config?) triple as {@link Workflow.addTask}.
+   */
+  public then<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I> = TaskConfig<I>>(
+    taskClass: ITaskConstructor<I, O, C>,
+    input?: Partial<I>,
+    config?: Partial<C>
+  ): this {
+    this.thenSpec = { taskClass, input, config };
+    return this;
+  }
+
+  /**
+   * Register the task that runs when the condition does not match. Optional.
+   */
+  public else<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I> = TaskConfig<I>>(
+    taskClass: ITaskConstructor<I, O, C>,
+    input?: Partial<I>,
+    config?: Partial<C>
+  ): this {
+    this.elseSpec = { taskClass, input, config };
+    return this;
+  }
+
+  /**
+   * Finalize the if/else arms into a {@link ConditionalTask} plus the
+   * downstream branch tasks, wired via dataflows from the conditional's
+   * matching output ports. Returns the parent workflow for continued chaining.
+   */
+  public endIf(): Workflow {
+    if (!this.thenSpec) {
+      throw new Error(".endIf() called without a prior .then(...) call");
+    }
+
+    const thenPort = "then";
+    const elsePort = "else";
+
+    const branches = [
+      {
+        id: thenPort,
+        condition: this.condition,
+        outputPort: thenPort,
+      },
+    ];
+
+    if (this.elseSpec) {
+      // Inverse condition so the "else" branch is mutually exclusive with "then".
+      // Wrapped in try/catch to match ConditionalTask's internal error-as-false semantics.
+      branches.push({
+        id: elsePort,
+        condition: (input: TaskInput) => {
+          try {
+            return !this.condition(input);
+          } catch {
+            return true;
+          }
+        },
+        outputPort: elsePort,
+      });
+    }
+
+    const conditionalTask = new ConditionalTask({
+      id: uuid4(),
+      branches,
+      exclusive: true,
+      defaultBranch: this.elseSpec ? elsePort : undefined,
+    });
+    this.workflow.graph.addTask(conditionalTask);
+
+    const thenTask = instantiate(this.thenSpec);
+    this.workflow.graph.addTask(thenTask);
+    this.workflow.graph.addDataflow(
+      new Dataflow(conditionalTask.id, thenPort, thenTask.id, "*")
+    );
+
+    if (this.elseSpec) {
+      const elseTask = instantiate(this.elseSpec);
+      this.workflow.graph.addTask(elseTask);
+      this.workflow.graph.addDataflow(
+        new Dataflow(conditionalTask.id, elsePort, elseTask.id, "*")
+      );
+    }
+
+    return this.workflow;
+  }
+}
+
+interface BranchTaskSpec {
+  readonly taskClass: ITaskConstructor<any, any, any>;
+  readonly input?: unknown;
+  readonly config?: unknown;
+}
+
+function instantiate(spec: BranchTaskSpec): ITask<any, any, any> {
+  const config = {
+    id: uuid4(),
+    ...(spec.config as Record<string, unknown> | undefined),
+    defaults: spec.input,
+  };
+  return new spec.taskClass(config as any);
+}

--- a/packages/task-graph/src/task-graph/GraphToWorkflowCode.ts
+++ b/packages/task-graph/src/task-graph/GraphToWorkflowCode.ts
@@ -50,6 +50,7 @@ function getMethodNameMap(): Map<string, string> {
  */
 const LOOP_TASK_TYPES: Record<string, { method: string; endMethod: string }> = {
   MapTask: { method: "map", endMethod: "endMap" },
+  ForEachTask: { method: "forEach", endMethod: "endForEach" },
   ReduceTask: { method: "reduce", endMethod: "endReduce" },
   WhileTask: { method: "while", endMethod: "endWhile" },
   GraphAsTask: { method: "group", endMethod: "endGroup" },
@@ -402,7 +403,8 @@ function extractLoopConfig(task: ITask): Record<string, unknown> {
       }
       break;
     }
-    case "MapTask": {
+    case "MapTask":
+    case "ForEachTask": {
       if (rawConfig.preserveOrder !== undefined && rawConfig.preserveOrder !== true) {
         config.preserveOrder = rawConfig.preserveOrder;
       }

--- a/packages/task-graph/src/task-graph/GraphToWorkflowCode.ts
+++ b/packages/task-graph/src/task-graph/GraphToWorkflowCode.ts
@@ -415,16 +415,22 @@ function extractLoopConfig(task: ITask): Record<string, unknown> {
       if (rawConfig.batchSize !== undefined) {
         config.batchSize = rawConfig.batchSize;
       }
+      if (rawConfig.maxIterations !== undefined) {
+        config.maxIterations = rawConfig.maxIterations;
+      }
       break;
     }
     case "ReduceTask": {
       if (rawConfig.initialValue !== undefined) {
         config.initialValue = rawConfig.initialValue;
       }
+      if (rawConfig.maxIterations !== undefined) {
+        config.maxIterations = rawConfig.maxIterations;
+      }
       break;
     }
     case "WhileTask": {
-      if (rawConfig.maxIterations !== undefined && rawConfig.maxIterations !== 100) {
+      if (rawConfig.maxIterations !== undefined) {
         config.maxIterations = rawConfig.maxIterations;
       }
       if (rawConfig.chainIterations !== undefined && rawConfig.chainIterations !== true) {

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -222,6 +222,15 @@ export class TaskGraph implements ITaskGraph {
   }
 
   /**
+   * Returns true if the underlying DAG is acyclic. Cycles are already rejected
+   * synchronously by {@link addDataflow}, so this is a defensive check for
+   * direct `_dag` manipulation or invariant re-assertion after cloning.
+   */
+  public isAcyclic(): boolean {
+    return this._dag.isAcyclic();
+  }
+
+  /**
    * Adds a task to the task graph
    * @param task The task to add
    * @returns The current task graph

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -9,6 +9,7 @@ import { EventEmitter, getLogger, ServiceRegistry, uuid4 } from "@workglow/util"
 import type { DataPortSchema } from "@workglow/util/schema";
 import { JsonSchema } from "@workglow/util/schema";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
 import type { ITask, ITaskConstructor } from "../task/ITask";
 import type { StreamEvent } from "../task/StreamTypes";
@@ -17,7 +18,8 @@ import { Task } from "../task/Task";
 import type { TaskEntitlements } from "../task/TaskEntitlements";
 import { WorkflowError } from "../task/TaskError";
 import type { JsonTaskItem, TaskGraphJson, TaskGraphJsonOptions } from "../task/TaskJSON";
-import type { DataPorts, TaskConfig, TaskIdType } from "../task/TaskTypes";
+import type { DataPorts, TaskConfig, TaskIdType, TaskInput } from "../task/TaskTypes";
+import { ConditionalBuilder } from "./ConditionalBuilder";
 import type { PipeFunction, Taskish } from "./Conversions";
 import { ensureTask } from "./Conversions";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
@@ -1078,6 +1080,24 @@ export class Workflow<
   }
 
   /**
+   * Opens a conditional branch. Returns a {@link ConditionalBuilder} that
+   * accepts `.then(taskClass)` and optional `.else(taskClass)` arms and is
+   * closed via `.endIf()` to return to this workflow.
+   *
+   * @example
+   * ```ts
+   * workflow
+   *   .if((input) => input.kind === "text")
+   *   .then(TextTask)
+   *   .else(ImageTask)
+   *   .endIf();
+   * ```
+   */
+  public if(condition: ConditionFn<TaskInput>): ConditionalBuilder {
+    return new ConditionalBuilder(this, condition);
+  }
+
+  /**
    * Runs deferred auto-connect for a loop task on this (parent) workflow's graph.
    * Called after finalizeTemplate() populates the iterator task's template graph,
    * so that the iterator task's dynamic inputSchema() is available for matching.
@@ -1700,6 +1720,7 @@ export class Workflow<
     }
 
     this._iteratorTask.subGraph = this.graph;
+    this._iteratorTask.validateAcyclic();
   }
 
   /**

--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -5,6 +5,7 @@
  */
 
 import { getLogger } from "@workglow/util";
+import { CycleError } from "@workglow/util/graph";
 import type { DataPortSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
 import { computeGraphEntitlements } from "../task-graph/GraphEntitlementUtils";
@@ -322,6 +323,27 @@ export class GraphAsTask<
   // ========================================================================
   //  Compound task methods
   // ========================================================================
+
+  /**
+   * Defensive re-assertion of the DAG invariant for the subgraph. `TaskGraph`
+   * already rejects cycle-creating dataflows at `addDataflow` time, but this
+   * runs a full topo sort so that any direct `_dag` manipulation or cycle
+   * introduced via recursive subgraph composition surfaces here with a clear
+   * error rather than deep inside the runner.
+   */
+  public validateAcyclic(): void {
+    if (!this.hasChildren()) return;
+    if (!this.subGraph.isAcyclic()) {
+      throw new CycleError(
+        `${this.type} (${this.id}): subgraph contains a cycle — loop tasks must wrap an acyclic subgraph.`
+      );
+    }
+    for (const child of this.subGraph.getTasks()) {
+      if (child instanceof GraphAsTask) {
+        child.validateAcyclic();
+      }
+    }
+  }
 
   /**
    * Regenerates the subtask graph and emits a "regenerate" event

--- a/packages/task-graph/src/task/IteratorTask.ts
+++ b/packages/task-graph/src/task/IteratorTask.ts
@@ -8,7 +8,7 @@ import type { DataPortSchema, PropertySchema } from "@workglow/util/schema";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { GraphAsTask, graphAsTaskConfigSchema } from "./GraphAsTask";
 import type { GraphAsTaskConfig } from "./GraphAsTask";
-import type { IExecuteContext } from "./ITask";
+import type { IExecuteContext, IRunConfig } from "./ITask";
 import { IteratorTaskRunner } from "./IteratorTaskRunner";
 import type { StreamEvent, StreamFinish } from "./StreamTypes";
 import { TaskConfigurationError } from "./TaskError";
@@ -55,6 +55,21 @@ export type ExecutionMode = "parallel" | "parallel-limited";
 export type IterationInputMode = "array" | "scalar" | "flexible";
 
 /**
+ * Upper bound for iteration. Either a positive integer or the string
+ * sentinel `"unbounded"` — which the runner treats as `Number.POSITIVE_INFINITY`.
+ * The string form forces every caller to explicitly acknowledge the opt-out
+ * instead of silently dropping the safety ceiling.
+ */
+export type IterationBound = number | "unbounded";
+
+/**
+ * Resolves an IterationBound to a numeric cap the runner can compare against.
+ */
+export function resolveIterationBound(bound: IterationBound): number {
+  return bound === "unbounded" ? Number.POSITIVE_INFINITY : bound;
+}
+
+/**
  * Configuration for a single property in the iteration input schema.
  */
 export interface IterationPropertyConfig {
@@ -70,9 +85,12 @@ export const iteratorTaskConfigSchema = {
     ...graphAsTaskConfigSchema["properties"],
     concurrencyLimit: { type: "integer", minimum: 1 },
     batchSize: { type: "integer", minimum: 1 },
-    maxIterations: { type: "integer", minimum: 1 },
+    maxIterations: {
+      oneOf: [{ type: "integer", minimum: 1 }, { type: "string", const: "unbounded" }],
+    },
     iterationInputConfig: { type: "object", additionalProperties: true },
   },
+  required: ["maxIterations"],
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
@@ -94,10 +112,11 @@ export type IteratorTaskConfig<Input extends TaskInput = TaskInput> = GraphAsTas
   readonly batchSize?: number;
 
   /**
-   * Maximum number of iterations allowed. When set, the iteration count is capped
-   * to this value regardless of input array length. Prevents runaway iteration.
+   * Upper bound on the number of iterations. Required — pass `"unbounded"` to
+   * explicitly opt out of the safety ceiling, or a positive integer to cap.
+   * Prevents runaway iteration on unexpectedly large input arrays.
    */
-  readonly maxIterations?: number;
+  readonly maxIterations: IterationBound;
 
   /**
    * User-defined iteration input schema configuration.
@@ -281,6 +300,16 @@ export abstract class IteratorTask<
 
   public static override configSchema(): DataPortSchema {
     return iteratorTaskConfigSchema;
+  }
+
+  constructor(config: Partial<Config> = {}, runConfig: Partial<IRunConfig> = {}) {
+    if ((config as Partial<IteratorTaskConfig<Input>>).maxIterations === undefined) {
+      throw new TaskConfigurationError(
+        `${(new.target as typeof IteratorTask).type ?? "IteratorTask"}: maxIterations is required. ` +
+          `Pass a positive integer to cap iteration, or "unbounded" to opt out explicitly.`
+      );
+    }
+    super(config, runConfig);
   }
 
   /**

--- a/packages/task-graph/src/task/IteratorTaskRunner.ts
+++ b/packages/task-graph/src/task/IteratorTaskRunner.ts
@@ -9,7 +9,12 @@ import { Dataflow } from "../task-graph/Dataflow";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
 import type { ITaskConstructor } from "./ITask";
-import type { IterationAnalysisResult, IteratorTask, IteratorTaskConfig } from "./IteratorTask";
+import {
+  resolveIterationBound,
+  type IterationAnalysisResult,
+  type IteratorTask,
+  type IteratorTaskConfig,
+} from "./IteratorTask";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
 /**
@@ -36,13 +41,11 @@ export class IteratorTaskRunner<
   protected override async executeTask(input: Input): Promise<Output | undefined> {
     let analysis = this.task.analyzeIterationInput(input);
 
-    // Enforce maxIterations limit from config
-    const maxIterations = this.task.config.maxIterations;
-    if (
-      maxIterations !== undefined &&
-      maxIterations > 0 &&
-      analysis.iterationCount > maxIterations
-    ) {
+    // Enforce maxIterations cap. Config is required (construction-time guard),
+    // so the bound is always set; `"unbounded"` resolves to Infinity, which
+    // leaves the natural array-length count untouched.
+    const maxIterations = resolveIterationBound(this.task.config.maxIterations);
+    if (analysis.iterationCount > maxIterations) {
       analysis = { ...analysis, iterationCount: maxIterations };
     }
 

--- a/packages/task-graph/src/task/MapTask.ts
+++ b/packages/task-graph/src/task/MapTask.ts
@@ -15,7 +15,9 @@ export const mapTaskConfigSchema = {
     ...iteratorTaskConfigSchema["properties"],
     preserveOrder: { type: "boolean" },
     flatten: { type: "boolean" },
+    discardResults: { type: "boolean" },
   },
+  required: iteratorTaskConfigSchema.required,
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
@@ -36,6 +38,14 @@ export type MapTaskConfig<Input extends TaskInput = TaskInput> = IteratorTaskCon
    * @default false
    */
   readonly flatten?: boolean;
+
+  /**
+   * When true, iteration results are discarded rather than collected into
+   * per-property arrays. Used by the `.forEach()` workflow combinator for
+   * side-effect-only loops where the caller does not need the return value.
+   * @default false
+   */
+  readonly discardResults?: boolean;
 };
 
 /**
@@ -97,6 +107,14 @@ export class MapTask<
     return this.config.flatten ?? false;
   }
 
+  /**
+   * Whether to drop iteration outputs rather than collect them. Used by
+   * `.forEach()` for side-effect iteration.
+   */
+  public get discardResults(): boolean {
+    return this.config.discardResults ?? false;
+  }
+
   public override preserveIterationOrder(): boolean {
     return this.preserveOrder;
   }
@@ -131,9 +149,15 @@ export class MapTask<
   }
 
   /**
-   * Collects and optionally flattens results from all iterations.
+   * Collects and optionally flattens results from all iterations. When
+   * `discardResults` is set (via `.forEach()`), returns the empty result
+   * without touching the per-iteration outputs.
    */
   public override collectResults(results: TaskOutput[]): Output {
+    if (this.discardResults) {
+      return this.getEmptyResult();
+    }
+
     const collected = super.collectResults(results);
 
     if (!this.flatten || typeof collected !== "object" || collected === null) {
@@ -153,6 +177,25 @@ export class MapTask<
   }
 }
 
+/**
+ * ForEachTask is a `MapTask` variant that discards iteration results by default.
+ * Used via the `.forEach()` workflow combinator for side-effect-only loops.
+ */
+export class ForEachTask<
+  Input extends TaskInput = TaskInput,
+  Output extends TaskOutput = TaskOutput,
+  Config extends MapTaskConfig<Input> = MapTaskConfig<Input>,
+> extends MapTask<Input, Output, Config> {
+  public static override type: TaskTypeName = "ForEachTask";
+  public static override title: string = "For Each";
+  public static override description: string =
+    "Runs a workflow per array item for side effects; discards collected results";
+
+  constructor(config: Partial<Config> = {}) {
+    super({ discardResults: true, ...config } as Partial<Config>);
+  }
+}
+
 // ============================================================================
 // Workflow Prototype Extensions
 // ============================================================================
@@ -169,8 +212,22 @@ declare module "../task-graph/Workflow" {
      * Ends the map loop and returns to the parent workflow.
      */
     endMap(): Workflow;
+
+    /**
+     * Starts a forEach loop — iterates array input ports for side effects and
+     * discards collected results. Use .endForEach() to close the loop and
+     * return to the parent workflow. `maxIterations` is still required.
+     */
+    forEach: CreateLoopWorkflow<TaskInput, TaskOutput, MapTaskConfig<TaskInput>>;
+
+    /**
+     * Ends the forEach loop and returns to the parent workflow.
+     */
+    endForEach(): Workflow;
   }
 }
 
 Workflow.prototype.map = CreateLoopWorkflow(MapTask);
 Workflow.prototype.endMap = CreateEndLoopWorkflow("endMap");
+Workflow.prototype.forEach = CreateLoopWorkflow(ForEachTask);
+Workflow.prototype.endForEach = CreateEndLoopWorkflow("endForEach");

--- a/packages/task-graph/src/task/MapTask.ts
+++ b/packages/task-graph/src/task/MapTask.ts
@@ -7,6 +7,7 @@
 import type { DataPortSchema } from "@workglow/util/schema";
 import { PROPERTY_ARRAY } from "../task-graph/TaskGraphRunner";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import type { IRunConfig } from "./ITask";
 import { IteratorTask, IteratorTaskConfig, iteratorTaskConfigSchema } from "./IteratorTask";
 import type { TaskInput, TaskOutput, TaskTypeName } from "./TaskTypes";
 export const mapTaskConfigSchema = {
@@ -191,8 +192,8 @@ export class ForEachTask<
   public static override description: string =
     "Runs a workflow per array item for side effects; discards collected results";
 
-  constructor(config: Partial<Config> = {}) {
-    super({ discardResults: true, ...config } as Partial<Config>);
+  constructor(config: Partial<Config> = {}, runConfig: Partial<IRunConfig> = {}) {
+    super({ discardResults: true, ...config } as Partial<Config>, runConfig);
   }
 }
 

--- a/packages/task-graph/src/task/ReduceTask.ts
+++ b/packages/task-graph/src/task/ReduceTask.ts
@@ -6,6 +6,7 @@
 
 import type { DataPortSchema } from "@workglow/util/schema";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import type { IRunConfig } from "./ITask";
 import {
   IterationAnalysisResult,
   IteratorTask,
@@ -54,14 +55,14 @@ export class ReduceTask<
     return reduceTaskConfigSchema;
   }
 
-  constructor(config: Partial<Config> = {}) {
+  constructor(config: Partial<Config> = {}, runConfig: Partial<IRunConfig> = {}) {
     // Reduce is always sequential
     const reduceConfig = {
       ...config,
       concurrencyLimit: 1,
       batchSize: 1,
     };
-    super(reduceConfig as Partial<Config>);
+    super(reduceConfig as Partial<Config>, runConfig);
   }
 
   /**

--- a/packages/task-graph/src/task/TaskJSON.ts
+++ b/packages/task-graph/src/task/TaskJSON.ts
@@ -35,8 +35,15 @@ export type JsonTaskConfig = Omit<
     ReduceTaskConfig &
     MapTaskConfig &
     ConditionalTaskConfig,
-  "id" | "defaults"
->;
+  "id" | "defaults" | "maxIterations"
+> & {
+  /**
+   * Optional in the JSON union because non-loop tasks don't carry it —
+   * each loop task class still enforces required-at-construction via its
+   * own config type.
+   */
+  readonly maxIterations?: WhileTaskConfig["maxIterations"];
+};
 
 export type JsonTaskItem = {
   /** Unique identifier for the task */

--- a/packages/task-graph/src/task/WhileTask.ts
+++ b/packages/task-graph/src/task/WhileTask.ts
@@ -8,7 +8,8 @@ import type { DataPortSchema } from "@workglow/util/schema";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
 import { evaluateCondition, getNestedValue } from "./ConditionUtils";
 import { GraphAsTask, GraphAsTaskConfig, graphAsTaskConfigSchema } from "./GraphAsTask";
-import type { IExecuteContext } from "./ITask";
+import type { IExecuteContext, IRunConfig } from "./ITask";
+import { resolveIterationBound, type IterationBound } from "./IteratorTask";
 import type { StreamEvent, StreamFinish } from "./StreamTypes";
 import { TaskConfigurationError, TaskFailedError } from "./TaskError";
 import type { TaskInput, TaskOutput, TaskTypeName } from "./TaskTypes";
@@ -47,13 +48,16 @@ export const whileTaskConfigSchema = {
   properties: {
     ...graphAsTaskConfigSchema["properties"],
     condition: {},
-    maxIterations: { type: "integer", minimum: 1 },
+    maxIterations: {
+      oneOf: [{ type: "integer", minimum: 1 }, { type: "string", const: "unbounded" }],
+    },
     chainIterations: { type: "boolean" },
     conditionField: { type: "string" },
     conditionOperator: { type: "string" },
     conditionValue: { type: "string" },
     iterationInputConfig: { type: "object", additionalProperties: true },
   },
+  required: ["maxIterations"],
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
@@ -72,10 +76,12 @@ export type WhileTaskConfig<
   readonly condition?: WhileConditionFn<Output>;
 
   /**
-   * Maximum number of iterations to prevent infinite loops.
-   * @default 100
+   * Upper bound on the number of iterations. Required — pass `"unbounded"` to
+   * explicitly opt out of the safety ceiling, or a positive integer to cap.
+   * Prevents infinite loops when the condition function can't disqualify
+   * unbounded runaway input.
    */
-  readonly maxIterations?: number;
+  readonly maxIterations: IterationBound;
 
   /**
    * Whether to pass the output of each iteration as input to the next.
@@ -157,6 +163,16 @@ export class WhileTask<
     return whileTaskConfigSchema;
   }
 
+  constructor(config: Partial<Config> = {}, runConfig: Partial<IRunConfig> = {}) {
+    if ((config as Partial<WhileTaskConfig<Input, Output>>).maxIterations === undefined) {
+      throw new TaskConfigurationError(
+        `${(new.target as typeof WhileTask).type ?? "WhileTask"}: maxIterations is required. ` +
+          `Pass a positive integer to cap iteration, or "unbounded" to opt out explicitly.`
+      );
+    }
+    super(config, runConfig);
+  }
+
   /**
    * Returns the schema for iteration-context inputs that will be
    * injected into the subgraph InputTask at runtime.
@@ -202,10 +218,13 @@ export class WhileTask<
   }
 
   /**
-   * Gets the maximum iterations limit.
+   * Gets the maximum iterations limit, resolved to a numeric cap. The raw
+   * `config.maxIterations` accepts `"unbounded"` as an explicit opt-out — that
+   * sentinel resolves to `Number.POSITIVE_INFINITY` here so the loop logic can
+   * compare against it directly.
    */
   public get maxIterations(): number {
-    return this.config.maxIterations ?? 100;
+    return resolveIterationBound(this.config.maxIterations);
   }
 
   /**

--- a/packages/test/src/test/ai-provider/TextEmbeddingTask.integration.test.ts
+++ b/packages/test/src/test/ai-provider/TextEmbeddingTask.integration.test.ts
@@ -195,7 +195,10 @@ describe("TextEmbeddingTask with real models", () => {
       ];
 
       const workflow = new Workflow();
-      workflow.map().textEmbedding({ model: "onnx:Xenova/gte-small:q8" }).endMap();
+      workflow
+        .map({ maxIterations: "unbounded" })
+        .textEmbedding({ model: "onnx:Xenova/gte-small:q8" })
+        .endMap();
 
       const result = (await workflow.run({ text: texts })) as {
         vector: readonly (Float32Array | number[])[];

--- a/packages/test/src/test/task-graph/ConditionalBuilder.test.ts
+++ b/packages/test/src/test/task-graph/ConditionalBuilder.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConditionalTask, Workflow, WorkflowError } from "@workglow/task-graph";
+import { setLogger } from "@workglow/util";
+import { describe, expect, it } from "vitest";
+
+import { getTestingLogger } from "../../binding/TestingLogger";
+import { DoubleToDoubledTask, HalveTask } from "../task/TestTasks";
+
+describe("ConditionalBuilder (Workflow.if)", () => {
+  let logger = getTestingLogger();
+  setLogger(logger);
+
+  it("creates a ConditionalTask + then-only branch with a wired dataflow", () => {
+    const workflow = new Workflow();
+    workflow
+      .if((input: any) => input.value > 5)
+      .then(DoubleToDoubledTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    expect(tasks.some((t) => t instanceof ConditionalTask)).toBe(true);
+    expect(tasks.some((t) => t instanceof DoubleToDoubledTask)).toBe(true);
+
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+    const thenTask = tasks.find((t) => t instanceof DoubleToDoubledTask)!;
+
+    const dataflows = workflow.graph.getDataflows();
+    const thenEdge = dataflows.find(
+      (df) => df.sourceTaskId === conditional.id && df.targetTaskId === thenTask.id
+    );
+    expect(thenEdge).toBeDefined();
+    expect(thenEdge!.sourceTaskPortId).toBe("then");
+  });
+
+  it("creates then + else branches with both dataflows wired", () => {
+    const workflow = new Workflow();
+    workflow
+      .if((input: any) => input.value > 5)
+      .then(DoubleToDoubledTask)
+      .else(HalveTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+    const thenTask = tasks.find((t) => t instanceof DoubleToDoubledTask)!;
+    const elseTask = tasks.find((t) => t instanceof HalveTask)!;
+
+    const dataflows = workflow.graph.getDataflows();
+    const thenEdge = dataflows.find(
+      (df) => df.sourceTaskId === conditional.id && df.targetTaskId === thenTask.id
+    );
+    const elseEdge = dataflows.find(
+      (df) => df.sourceTaskId === conditional.id && df.targetTaskId === elseTask.id
+    );
+
+    expect(thenEdge?.sourceTaskPortId).toBe("then");
+    expect(elseEdge?.sourceTaskPortId).toBe("else");
+  });
+
+  it("throws WorkflowError when endIf() is called without then()", () => {
+    const workflow = new Workflow();
+    const builder = workflow.if((input: any) => input.value > 5);
+
+    expect(() => builder.endIf()).toThrow(WorkflowError);
+  });
+
+  it("activates only the then branch when condition matches", async () => {
+    const workflow = new Workflow();
+    workflow
+      .if((input: any) => input.value > 5)
+      .then(DoubleToDoubledTask)
+      .else(HalveTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+
+    await conditional.run({ value: 10 });
+
+    expect(conditional.isBranchActive("then")).toBe(true);
+    expect(conditional.isBranchActive("else")).toBe(false);
+  });
+
+  it("activates only the else branch when condition does not match", async () => {
+    const workflow = new Workflow();
+    workflow
+      .if((input: any) => input.value > 5)
+      .then(DoubleToDoubledTask)
+      .else(HalveTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+
+    await conditional.run({ value: 3 });
+
+    expect(conditional.isBranchActive("then")).toBe(false);
+    expect(conditional.isBranchActive("else")).toBe(true);
+  });
+
+  it("routes a throwing condition consistently with ConditionalTask error-as-false semantics", async () => {
+    // If the primary condition throws, it should be treated as false
+    // (matching ConditionalTask.ts:339-343). With an else arm defined,
+    // the else branch runs via defaultBranch — NOT because the inverted
+    // condition's own try/catch forces it true. The observable outcome is
+    // the same (else runs), but the internals must not rely on a wrapper
+    // that diverges from the documented error-as-false behavior.
+    const workflow = new Workflow();
+    workflow
+      .if(() => {
+        throw new Error("boom");
+      })
+      .then(DoubleToDoubledTask)
+      .else(HalveTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+
+    // The else-branch condition, when invoked directly, must propagate
+    // the underlying error (or return false) — not silently return true.
+    // ConditionalTask itself is responsible for catching and treating-as-false.
+    const branches = conditional.config.branches!;
+    const elseBranch = branches.find((b) => b.id === "else")!;
+    expect(() => elseBranch.condition({})).toThrow("boom");
+
+    // End-to-end behavior: condition throws → then inactive → defaultBranch (else) fires.
+    await conditional.run({});
+    expect(conditional.isBranchActive("then")).toBe(false);
+    expect(conditional.isBranchActive("else")).toBe(true);
+  });
+
+  it("with no else arm, a throwing condition leaves all branches inactive", async () => {
+    const workflow = new Workflow();
+    workflow
+      .if(() => {
+        throw new Error("boom");
+      })
+      .then(DoubleToDoubledTask)
+      .endIf();
+
+    const tasks = workflow.graph.getTasks();
+    const conditional = tasks.find((t) => t instanceof ConditionalTask) as ConditionalTask;
+
+    await conditional.run({});
+    expect(conditional.isBranchActive("then")).toBe(false);
+    expect(conditional.getActiveBranches().size).toBe(0);
+  });
+});

--- a/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
+++ b/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
@@ -230,6 +230,32 @@ describe("GraphToWorkflowCode", () => {
     });
   });
 
+  describe("forEach task", () => {
+    it("should generate forEach builder code with inner task and endForEach", () => {
+      const workflow = new Workflow();
+      workflow
+        .forEach({ maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .endForEach();
+
+      const code = graphToWorkflowCode(workflow.graph);
+
+      expect(code).toContain(".forEach(");
+      expect(code).toContain("processItem");
+      expect(code).toContain(".endForEach()");
+      // Must not fall through to a regular .addTask(ForEachTask) call
+      expect(code).not.toContain("ForEachTask");
+    });
+
+    it("should emit maxIterations in forEach code", () => {
+      const workflow = new Workflow();
+      workflow.forEach({ maxIterations: 5 }).addTask(ProcessItemTask).endForEach();
+
+      const code = graphToWorkflowCode(workflow.graph);
+      expect(code).toContain("maxIterations: 5");
+    });
+  });
+
   describe("reduce task", () => {
     it("should generate reduce builder code", () => {
       const workflow = new Workflow();

--- a/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
+++ b/packages/test/src/test/task-graph/GraphToWorkflowCode.test.ts
@@ -175,7 +175,7 @@ describe("GraphToWorkflowCode", () => {
   describe("map task", () => {
     it("should generate map builder code", () => {
       const workflow = new Workflow();
-      workflow.map().addTask(ProcessItemTask).endMap();
+      workflow.map({ maxIterations: "unbounded" }).addTask(ProcessItemTask).endMap();
 
       const code = graphToWorkflowCode(workflow.graph);
 
@@ -187,7 +187,12 @@ describe("GraphToWorkflowCode", () => {
     it("should generate map with config options", () => {
       const workflow = new Workflow();
       workflow
-        .map({ preserveOrder: false, concurrencyLimit: 5, flatten: true })
+        .map({
+          preserveOrder: false,
+          concurrencyLimit: 5,
+          flatten: true,
+          maxIterations: "unbounded",
+        })
         .addTask(ProcessItemTask)
         .endMap();
 
@@ -200,7 +205,10 @@ describe("GraphToWorkflowCode", () => {
 
     it("should not emit preserveOrder when default (true)", () => {
       const workflow = new Workflow();
-      workflow.map({ preserveOrder: true }).addTask(ProcessItemTask).endMap();
+      workflow
+        .map({ preserveOrder: true, maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .endMap();
 
       const code = graphToWorkflowCode(workflow.graph);
       expect(code).not.toContain("preserveOrder");
@@ -208,7 +216,11 @@ describe("GraphToWorkflowCode", () => {
 
     it("should generate map with multiple inner tasks", () => {
       const workflow = new Workflow();
-      workflow.map().addTask(ProcessItemTask).addTask(DoubleTask).endMap();
+      workflow
+        .map({ maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .addTask(DoubleTask)
+        .endMap();
 
       const code = graphToWorkflowCode(workflow.graph);
 
@@ -222,7 +234,7 @@ describe("GraphToWorkflowCode", () => {
     it("should generate reduce builder code", () => {
       const workflow = new Workflow();
       workflow
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -275,19 +287,20 @@ describe("GraphToWorkflowCode", () => {
       expect(code).toContain("condition");
     });
 
-    it("should not emit maxIterations when default (100)", () => {
+    it("should round-trip explicit unbounded maxIterations", () => {
       const workflow = new Workflow();
       workflow
         .while({
           conditionField: "done",
           conditionOperator: "eq",
           conditionValue: "false",
+          maxIterations: "unbounded",
         })
         .addTask(RefineTask)
         .endWhile();
 
       const code = graphToWorkflowCode(workflow.graph);
-      expect(code).not.toContain("maxIterations");
+      expect(code).toContain('maxIterations: "unbounded"');
     });
   });
 
@@ -295,7 +308,7 @@ describe("GraphToWorkflowCode", () => {
     it("should generate map with while inside", () => {
       const workflow = new Workflow();
       workflow
-        .map()
+        .map({ maxIterations: "unbounded" })
         .while({
           conditionField: "quality",
           conditionOperator: "lt",
@@ -323,7 +336,7 @@ describe("GraphToWorkflowCode", () => {
           conditionValue: "false",
           maxIterations: 5,
         })
-        .map()
+        .map({ maxIterations: "unbounded" })
         .addTask(ProcessItemTask)
         .endMap()
         .endWhile();
@@ -339,10 +352,10 @@ describe("GraphToWorkflowCode", () => {
     it("should generate chained map then reduce", () => {
       const workflow = new Workflow();
       workflow
-        .map({ concurrencyLimit: 1 })
+        .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
         .addTask(ProcessItemTask)
         .endMap()
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -357,11 +370,11 @@ describe("GraphToWorkflowCode", () => {
     it("should generate map -> rename -> reduce", () => {
       const workflow = new Workflow();
       workflow
-        .map({ concurrencyLimit: 1 })
+        .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
         .addTask(ProcessItemTask)
         .endMap()
         .rename("processed", "currentItem")
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -401,7 +414,12 @@ describe("GraphToWorkflowCode", () => {
 
     it("should generate group with map inside", () => {
       const workflow = new Workflow();
-      workflow.group().map().addTask(ProcessItemTask).endMap().endGroup();
+      workflow
+        .group()
+        .map({ maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .endMap()
+        .endGroup();
 
       const code = graphToWorkflowCode(workflow.graph);
 
@@ -453,7 +471,7 @@ describe("GraphToWorkflowCode", () => {
 
     it("should round-trip a map workflow", () => {
       const original = new Workflow();
-      original.map().addTask(ProcessItemTask).endMap();
+      original.map({ maxIterations: "unbounded" }).addTask(ProcessItemTask).endMap();
 
       const code = graphToWorkflowCode(original.graph, { includeDeclaration: false });
       const rebuilt = rebuildFromCode(code);
@@ -469,7 +487,7 @@ describe("GraphToWorkflowCode", () => {
     it("should round-trip a reduce workflow", () => {
       const original = new Workflow();
       original
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -512,7 +530,7 @@ describe("GraphToWorkflowCode", () => {
     it("should round-trip nested map with while inside", () => {
       const original = new Workflow();
       original
-        .map()
+        .map({ maxIterations: "unbounded" })
         .while({
           conditionField: "quality",
           conditionOperator: "lt",
@@ -539,10 +557,10 @@ describe("GraphToWorkflowCode", () => {
     it("should round-trip chained map then reduce", () => {
       const original = new Workflow();
       original
-        .map({ concurrencyLimit: 1 })
+        .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
         .addTask(ProcessItemTask)
         .endMap()
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -598,7 +616,7 @@ describe("GraphToWorkflowCode", () => {
     it("should generate code for document ingestion pipeline", () => {
       const workflow = new Workflow()
         .input({ url: ["file:///test.md", "file:///test2.md"] })
-        .map()
+        .map({ maxIterations: "unbounded" })
         .fileLoader({
           format: "markdown",
         })

--- a/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
+++ b/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
@@ -84,7 +84,7 @@ class HighRateProducer extends Task<PromptInput, TextOutput> {
       for (let i = 0; i < this.totalEvents; i++) {
         if (context.signal.aborted) return;
         this.yieldCount++;
-        yield { type: "text-delta", port: "text", textDelta: "x" };
+        yield { type: "text-delta", port: "text", textDelta: `${i}|` };
       }
       yield { type: "finish", data: {} as TextOutput };
     } finally {
@@ -94,8 +94,14 @@ class HighRateProducer extends Task<PromptInput, TextOutput> {
   }
 
   override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
-    return { text: "x".repeat(this.totalEvents) };
+    return { text: expectedAccumulatedText(this.totalEvents) };
   }
+}
+
+function expectedAccumulatedText(totalEvents: number): string {
+  let out = "";
+  for (let i = 0; i < totalEvents; i++) out += `${i}|`;
+  return out;
 }
 
 /**
@@ -206,10 +212,14 @@ describe("Streaming backpressure and stress", () => {
       expect(deltaEvents.length).toBe(totalEvents);
       expect(finishEvents.length).toBe(1);
 
+      // Deltas arrived in strict index order (order-sensitive payloads).
+      const expectedDeltas = Array.from({ length: totalEvents }, (_, i) => `${i}|`);
+      const observedDeltas = deltaEvents.map((e) => (e as { textDelta: string }).textDelta);
+      expect(observedDeltas).toEqual(expectedDeltas);
+
       // Accumulated text materialised correctly for the downstream consumer.
       const consumerOutput = consumer.runOutputData as TextOutput;
-      expect(consumerOutput.text.length).toBe(totalEvents);
-      expect(consumerOutput.text).toBe("x".repeat(totalEvents));
+      expect(consumerOutput.text).toBe(expectedDeltas.join(""));
     });
   });
 
@@ -224,18 +234,34 @@ describe("Streaming backpressure and stress", () => {
       graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
 
       const runner = new TaskGraphRunner(graph);
-      const runPromise = runner.runGraph({ prompt: "" });
 
-      // Abort as soon as the producer has started streaming.
-      await new Promise<void>((resolve) => {
+      // Attach the status listener BEFORE starting the run so we cannot
+      // miss the PROCESSING/STREAMING transition. Short-circuit if the
+      // producer has already reached STREAMING, and time out defensively.
+      const streamingPromise = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          producer.off("status", onStatus);
+          reject(new Error("Timed out waiting for producer to reach STREAMING"));
+        }, 5_000);
+
         const onStatus = (s: TaskStatus) => {
           if (s === TaskStatus.STREAMING) {
+            clearTimeout(timeout);
             producer.off("status", onStatus);
             resolve();
           }
         };
         producer.on("status", onStatus);
+
+        if (producer.status === TaskStatus.STREAMING) {
+          clearTimeout(timeout);
+          producer.off("status", onStatus);
+          resolve();
+        }
       });
+
+      const runPromise = runner.runGraph({ prompt: "" });
+      await streamingPromise;
 
       const yieldCountAtAbort = producer.yieldCount;
       runner.abort();
@@ -278,11 +304,12 @@ describe("Streaming backpressure and stress", () => {
       const runner = new TaskGraphRunner(graph);
       await runner.runGraph({ prompt: "" });
 
+      // Every consumer sees the identical, order-sensitive sequence.
+      const expected = expectedAccumulatedText(totalEvents);
       for (const consumer of [consumerA, consumerB, consumerC]) {
         expect(consumer.status).toBe(TaskStatus.COMPLETED);
         const output = consumer.runOutputData as TextOutput;
-        expect(output.text.length).toBe(totalEvents);
-        expect(output.text).toBe("x".repeat(totalEvents));
+        expect(output.text).toBe(expected);
       }
     });
   });

--- a/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
+++ b/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
@@ -1,0 +1,317 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stress tests for the streaming layer covering high event rates, abort
+ * responsiveness, fan-out, and error propagation.
+ *
+ * These tests exercise behaviour that is difficult to observe in ordinary
+ * streaming tests:
+ *   - A producer generator that yields thousands of events in a tight loop
+ *     must deliver every event without dropping or reordering.
+ *   - AsyncIterable is pull-based, so an abort signal must stop the producer
+ *     promptly rather than after the generator has drained on its own.
+ *   - Fan-out via engine-internal ReadableStream.tee() must deliver identical
+ *     event sequences to every downstream consumer.
+ *   - A StreamError event mid-stream must fail the source task and prevent
+ *     downstream tasks from starting.
+ */
+
+import {
+  Dataflow,
+  IExecuteContext,
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskStatus,
+} from "@workglow/task-graph";
+import type { StreamEvent } from "@workglow/task-graph";
+import { setLogger } from "@workglow/util";
+import { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+import { getTestingLogger } from "../../binding/TestingLogger";
+
+setLogger(getTestingLogger());
+
+// ============================================================================
+// Test tasks
+// ============================================================================
+
+type PromptInput = { prompt: string };
+type TextOutput = { text: string };
+
+/**
+ * Streaming producer that yields `totalEvents` text-delta events in a tight
+ * async generator loop, then a finish event. Exposes `yieldCount` so tests
+ * can observe how far the generator progressed before abort.
+ */
+class HighRateProducer extends Task<PromptInput, TextOutput> {
+  public static override type = "StreamingBackpressure_HighRateProducer";
+  public static override cacheable = false;
+
+  public totalEvents: number;
+  public yieldCount = 0;
+
+  constructor(config: { id: string; totalEvents: number }) {
+    super({ id: config.id, defaults: { prompt: "" } });
+    this.totalEvents = config.totalEvents;
+  }
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: PromptInput,
+    context: IExecuteContext
+  ): AsyncIterable<StreamEvent<TextOutput>> {
+    try {
+      for (let i = 0; i < this.totalEvents; i++) {
+        if (context.signal.aborted) return;
+        this.yieldCount++;
+        yield { type: "text-delta", port: "text", textDelta: "x" };
+      }
+      yield { type: "finish", data: {} as TextOutput };
+    } finally {
+      // `finally` runs when the consumer stops iterating (abort, throw, return)
+      // so resource cleanup in real tasks is guaranteed.
+    }
+  }
+
+  override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
+    return { text: "x".repeat(this.totalEvents) };
+  }
+}
+
+/**
+ * Non-streaming downstream consumer: receives fully-materialised text from
+ * an upstream streaming producer and returns it unchanged.
+ */
+class MaterialisedConsumer extends Task<{ text: string }, TextOutput> {
+  public static override type = "StreamingBackpressure_MaterialisedConsumer";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: { text: string }): Promise<TextOutput | undefined> {
+    return { text: input.text ?? "" };
+  }
+}
+
+/**
+ * Producer that yields `preErrorEvents` text-deltas and then a StreamError.
+ */
+class ErroringProducer extends Task<PromptInput, TextOutput> {
+  public static override type = "StreamingBackpressure_ErroringProducer";
+  public static override cacheable = false;
+
+  public preErrorEvents: number;
+  public readonly errorMessage = "producer failed mid-stream";
+
+  constructor(config: { id: string; preErrorEvents: number }) {
+    super({ id: config.id, defaults: { prompt: "" } });
+    this.preErrorEvents = config.preErrorEvents;
+  }
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: PromptInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<TextOutput>> {
+    for (let i = 0; i < this.preErrorEvents; i++) {
+      yield { type: "text-delta", port: "text", textDelta: "x" };
+    }
+    yield { type: "error", error: new Error(this.errorMessage) };
+  }
+
+  override async execute(_input: PromptInput): Promise<TextOutput | undefined> {
+    throw new Error(this.errorMessage);
+  }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Streaming backpressure and stress", () => {
+  describe("High-rate event delivery", () => {
+    it("delivers 10,000 text-delta events in order with no drops", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 10_000;
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const chunkEvents: StreamEvent[] = [];
+      producer.on("stream_chunk", (event: StreamEvent) => chunkEvents.push(event));
+
+      const runner = new TaskGraphRunner(graph);
+      await runner.runGraph({ prompt: "" });
+
+      expect(producer.status).toBe(TaskStatus.COMPLETED);
+      expect(consumer.status).toBe(TaskStatus.COMPLETED);
+
+      // Producer yielded exactly `totalEvents` deltas.
+      expect(producer.yieldCount).toBe(totalEvents);
+
+      // Every delta plus one finish were observed by the task.
+      const deltaEvents = chunkEvents.filter((e) => e.type === "text-delta");
+      const finishEvents = chunkEvents.filter((e) => e.type === "finish");
+      expect(deltaEvents.length).toBe(totalEvents);
+      expect(finishEvents.length).toBe(1);
+
+      // Accumulated text materialised correctly for the downstream consumer.
+      const consumerOutput = consumer.runOutputData as TextOutput;
+      expect(consumerOutput.text.length).toBe(totalEvents);
+      expect(consumerOutput.text).toBe("x".repeat(totalEvents));
+    });
+  });
+
+  describe("Abort responsiveness", () => {
+    it("stops the producer generator promptly when the runner is aborted", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 100_000; // deliberately huge so abort must short-circuit
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+      const runPromise = runner.runGraph({ prompt: "" });
+
+      // Abort as soon as the producer has started streaming.
+      await new Promise<void>((resolve) => {
+        const onStatus = (s: TaskStatus) => {
+          if (s === TaskStatus.STREAMING) {
+            producer.off("status", onStatus);
+            resolve();
+          }
+        };
+        producer.on("status", onStatus);
+      });
+
+      const yieldCountAtAbort = producer.yieldCount;
+      runner.abort();
+
+      try {
+        await runPromise;
+      } catch {
+        // Abort errors are expected.
+      }
+
+      // The producer generator halted instead of draining to `totalEvents`.
+      expect(producer.yieldCount).toBeLessThan(totalEvents);
+
+      // At most a small number of additional events slipped through between
+      // the abort call and the next signal check in the generator.
+      expect(producer.yieldCount - yieldCountAtAbort).toBeLessThan(1_000);
+
+      // Producer ends up in an abort-adjacent state, not COMPLETED.
+      expect([TaskStatus.ABORTING, TaskStatus.FAILED]).toContain(producer.status);
+
+      // Downstream consumer never reaches COMPLETED for a valid result.
+      expect(consumer.status).not.toBe(TaskStatus.COMPLETED);
+    });
+  });
+
+  describe("Fan-out", () => {
+    it("delivers identical event sequences to every downstream consumer", async () => {
+      const graph = new TaskGraph();
+      const totalEvents = 1_000;
+      const producer = new HighRateProducer({ id: "producer", totalEvents });
+      const consumerA = new MaterialisedConsumer({ id: "consumerA" });
+      const consumerB = new MaterialisedConsumer({ id: "consumerB" });
+      const consumerC = new MaterialisedConsumer({ id: "consumerC" });
+
+      graph.addTasks([producer, consumerA, consumerB, consumerC]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumerA", "text"));
+      graph.addDataflow(new Dataflow("producer", "text", "consumerB", "text"));
+      graph.addDataflow(new Dataflow("producer", "text", "consumerC", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+      await runner.runGraph({ prompt: "" });
+
+      for (const consumer of [consumerA, consumerB, consumerC]) {
+        expect(consumer.status).toBe(TaskStatus.COMPLETED);
+        const output = consumer.runOutputData as TextOutput;
+        expect(output.text.length).toBe(totalEvents);
+        expect(output.text).toBe("x".repeat(totalEvents));
+      }
+    });
+  });
+
+  describe("StreamError propagation", () => {
+    it("fails the source task on a StreamError event and keeps downstream from completing", async () => {
+      const graph = new TaskGraph();
+      const producer = new ErroringProducer({ id: "producer", preErrorEvents: 500 });
+      const consumer = new MaterialisedConsumer({ id: "consumer" });
+
+      graph.addTasks([producer, consumer]);
+      graph.addDataflow(new Dataflow("producer", "text", "consumer", "text"));
+
+      const runner = new TaskGraphRunner(graph);
+
+      let caught: unknown;
+      try {
+        await runner.runGraph({ prompt: "" });
+      } catch (err) {
+        caught = err;
+      }
+
+      // Either the graph throws, or the producer records the error on itself.
+      const producerFailed = producer.status === TaskStatus.FAILED;
+      const graphRejected = caught !== undefined;
+      expect(producerFailed || graphRejected).toBe(true);
+
+      // Downstream consumer must not claim a completed, valid result.
+      expect(consumer.status).not.toBe(TaskStatus.COMPLETED);
+    });
+  });
+});

--- a/packages/test/src/test/task-graph/SubgraphCycleGuard.test.ts
+++ b/packages/test/src/test/task-graph/SubgraphCycleGuard.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Dataflow, TaskGraph, Workflow } from "@workglow/task-graph";
+import { CycleError } from "@workglow/util/graph";
+import { setLogger } from "@workglow/util";
+import { describe, expect, it } from "vitest";
+import { getTestingLogger } from "../../binding/TestingLogger";
+import { ProcessItemTask, RefineTask } from "../task/TestTasks";
+
+describe("Subgraph cycle guard", () => {
+  setLogger(getTestingLogger());
+
+  it("throws CycleError synchronously when addDataflow would create a back-edge on a top-level graph", () => {
+    const graph = new TaskGraph();
+    const a = new ProcessItemTask({ id: "a" });
+    const b = new ProcessItemTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+    graph.addDataflow(new Dataflow("a", "processed", "b", "item"));
+
+    expect(() => graph.addDataflow(new Dataflow("b", "processed", "a", "item"))).toThrow(
+      CycleError
+    );
+  });
+
+  it("rejects cycles inside a while-loop subgraph at addDataflow time", () => {
+    const workflow = new Workflow();
+    workflow
+      .while({
+        condition: (out: { quality?: number }) => (out.quality ?? 0) < 0.9,
+        maxIterations: 3,
+      })
+      .addTask(RefineTask, undefined, { id: "refine-a" })
+      .addTask(RefineTask, undefined, { id: "refine-b" })
+      .endWhile();
+
+    const whileTask = workflow.graph.getTasks()[0];
+    const sub = whileTask.subGraph;
+    const [taskA, taskB] = sub.getTasks();
+
+    expect(() =>
+      sub.addDataflow(new Dataflow(taskB.id, "value", taskA.id, "value"))
+    ).toThrow(CycleError);
+  });
+
+  it("validateAcyclic() is a no-op on a healthy loop subgraph and runs cheaply", () => {
+    const workflow = new Workflow();
+    workflow
+      .while({
+        condition: () => false,
+        maxIterations: 1,
+      })
+      .addTask(RefineTask)
+      .endWhile();
+
+    const whileTask = workflow.graph.getTasks()[0] as unknown as {
+      validateAcyclic(): void;
+    };
+
+    expect(() => whileTask.validateAcyclic()).not.toThrow();
+  });
+
+  it("exposes TaskGraph.isAcyclic() as true for a healthy graph", () => {
+    const graph = new TaskGraph();
+    graph.addTask(new ProcessItemTask({ id: "x" }));
+    graph.addTask(new ProcessItemTask({ id: "y" }));
+    graph.addDataflow(new Dataflow("x", "processed", "y", "item"));
+
+    expect(graph.isAcyclic()).toBe(true);
+  });
+});

--- a/packages/test/src/test/task/GraphAsTask.test.ts
+++ b/packages/test/src/test/task/GraphAsTask.test.ts
@@ -781,7 +781,10 @@ describe("GraphAsTask Dynamic Schema", () => {
 
       // Build a MapTask that completes fast (producing a "Map N/N" message at the end).
       const workflow = new Workflow();
-      workflow.map({ concurrencyLimit: 4 }).addTask(MultiplyTask).endMap();
+      workflow
+        .map({ concurrencyLimit: 4, maxIterations: "unbounded" })
+        .addTask(MultiplyTask)
+        .endMap();
       const mapTask = workflow.graph.getTasks()[0] as MapTask;
 
       // Outer graph mirrors the real "Help/Blog Indexer" shape:

--- a/packages/test/src/test/task/IteratorTask.test.ts
+++ b/packages/test/src/test/task/IteratorTask.test.ts
@@ -44,8 +44,12 @@ describe("IteratorTask", () => {
 
   describe("IteratorTask", () => {
     describe("constructor and configuration", () => {
-      test("should create with default configuration", () => {
-        const task = new TestIteratorTask<ArrayInput>();
+      test("should throw when maxIterations is omitted", () => {
+        expect(() => new TestIteratorTask<ArrayInput>({} as any)).toThrow(/maxIterations/);
+      });
+
+      test("should create with explicit unbounded maxIterations", () => {
+        const task = new TestIteratorTask<ArrayInput>({ maxIterations: "unbounded" });
 
         expect(task.concurrencyLimit).toBe(undefined);
         expect(task.batchSize).toBe(undefined);
@@ -54,6 +58,7 @@ describe("IteratorTask", () => {
       test("should respect custom configuration", () => {
         const task = new TestIteratorTask<ArrayInput>({
           concurrencyLimit: 3,
+          maxIterations: "unbounded",
         });
 
         expect(task.concurrencyLimit).toBe(3);
@@ -62,6 +67,7 @@ describe("IteratorTask", () => {
       test("should support batchSize configuration", () => {
         const task = new TestIteratorTask<ArrayInput>({
           batchSize: 10,
+          maxIterations: "unbounded",
         });
 
         expect(task.batchSize).toBe(10);
@@ -75,6 +81,7 @@ describe("IteratorTask", () => {
         const task = new TestIteratorTask<ArrayInput>({
           concurrencyLimit: 2,
           batchSize: 5,
+          maxIterations: "unbounded",
         });
 
         expect(task.concurrencyLimit).toBe(2);
@@ -82,7 +89,7 @@ describe("IteratorTask", () => {
       });
 
       test("should have undefined batchSize by default", () => {
-        const task = new TestIteratorTask<ArrayInput>();
+        const task = new TestIteratorTask<ArrayInput>({ maxIterations: "unbounded" });
 
         expect(task.batchSize).toBeUndefined();
       });
@@ -105,7 +112,10 @@ describe("IteratorTask", () => {
           }
         }
 
-        const task = new TestIteratorWithArray({ defaults: { items: [1, 2, 3] } });
+        const task = new TestIteratorWithArray({
+          defaults: { items: [1, 2, 3] },
+          maxIterations: "unbounded",
+        });
         const subGraph = new TaskGraph();
         subGraph.addTask(new DoubleTask({ id: "double", defaults: { value: 0 } }));
 
@@ -138,14 +148,17 @@ describe("IteratorTask", () => {
           }
         }
 
-        const task = new TestMapTask({ defaults: { items: [] } });
+        const task = new TestMapTask({
+          defaults: { items: [] },
+          maxIterations: "unbounded",
+        });
         const result = await task.run();
 
         expect(result).toEqual({});
       });
 
       test("should have dynamic output schema", () => {
-        const task = new MapTask();
+        const task = new MapTask({ maxIterations: "unbounded" });
         const schema = task.outputSchema();
 
         // Without template graph, should return static schema
@@ -154,18 +167,26 @@ describe("IteratorTask", () => {
     });
 
     describe("configuration", () => {
+      test("should throw when maxIterations is omitted", () => {
+        expect(() => new MapTask({} as any)).toThrow(/maxIterations/);
+      });
+
       test("should default preserveOrder to true", () => {
-        const task = new MapTask();
+        const task = new MapTask({ maxIterations: "unbounded" });
         expect(task.preserveOrder).toBe(true);
       });
 
       test("should default flatten to false", () => {
-        const task = new MapTask();
+        const task = new MapTask({ maxIterations: "unbounded" });
         expect(task.flatten).toBe(false);
       });
 
       test("should respect custom configuration", () => {
-        const task = new MapTask({ preserveOrder: false, flatten: true });
+        const task = new MapTask({
+          preserveOrder: false,
+          flatten: true,
+          maxIterations: "unbounded",
+        });
         expect(task.preserveOrder).toBe(false);
         expect(task.flatten).toBe(true);
       });
@@ -178,12 +199,12 @@ describe("IteratorTask", () => {
 
   describe("Type Safety", () => {
     test("IteratorTask should be an instance of IteratorTask", () => {
-      const task = new TestIteratorTask();
+      const task = new TestIteratorTask({ maxIterations: "unbounded" });
       expect(task).toBeInstanceOf(IteratorTask);
     });
 
     test("MapTask should be an instance of IteratorTask", () => {
-      const task = new MapTask();
+      const task = new MapTask({ maxIterations: "unbounded" });
       expect(task).toBeInstanceOf(IteratorTask);
       expect(task).toBeInstanceOf(MapTask);
     });
@@ -214,13 +235,17 @@ describe("IteratorTask", () => {
 
   describe("WhileTask", () => {
     describe("configuration", () => {
-      test("should default maxIterations to 100", () => {
-        const task = new WhileTask();
-        expect(task.maxIterations).toBe(100);
+      test("should throw when maxIterations is omitted", () => {
+        expect(() => new WhileTask({} as any)).toThrow(/maxIterations/);
+      });
+
+      test("should resolve unbounded sentinel to Infinity", () => {
+        const task = new WhileTask({ maxIterations: "unbounded" });
+        expect(task.maxIterations).toBe(Number.POSITIVE_INFINITY);
       });
 
       test("should default chainIterations to true", () => {
-        const task = new WhileTask();
+        const task = new WhileTask({ maxIterations: "unbounded" });
         expect(task.chainIterations).toBe(true);
       });
 
@@ -240,7 +265,7 @@ describe("IteratorTask", () => {
 
     describe("subgraph", () => {
       test("should set and get subGraph", () => {
-        const task = new WhileTask();
+        const task = new WhileTask({ maxIterations: "unbounded" });
         const subGraph = new TaskGraph();
         subGraph.addTask(new DoubleTask({ id: "double", defaults: { value: 0 } }));
 
@@ -252,7 +277,7 @@ describe("IteratorTask", () => {
 
     describe("type safety", () => {
       test("WhileTask should not be an instance of IteratorTask", () => {
-        const task = new WhileTask();
+        const task = new WhileTask({ maxIterations: "unbounded" });
         // WhileTask extends GraphAsTask, not IteratorTask
         expect(task).toBeInstanceOf(WhileTask);
       });
@@ -279,18 +304,22 @@ describe("IteratorTask", () => {
 
   describe("ReduceTask", () => {
     describe("configuration", () => {
+      test("should throw when maxIterations is omitted", () => {
+        expect(() => new ReduceTask({} as any)).toThrow(/maxIterations/);
+      });
+
       test("should default initialValue to empty object", () => {
-        const task = new ReduceTask();
+        const task = new ReduceTask({ maxIterations: "unbounded" });
         expect(task.initialValue).toEqual({});
       });
 
       test("should respect custom initialValue", () => {
-        const task = new ReduceTask({ initialValue: { sum: 0 } });
+        const task = new ReduceTask({ initialValue: { sum: 0 }, maxIterations: "unbounded" });
         expect(task.initialValue).toEqual({ sum: 0 });
       });
 
       test("should force sequential execution mode (parallel-limited with concurrency 1)", () => {
-        const task = new ReduceTask({ concurrencyLimit: 5 });
+        const task = new ReduceTask({ concurrencyLimit: 5, maxIterations: "unbounded" });
         expect(task.concurrencyLimit).toBe(1);
         expect(task.batchSize).toBe(1);
       });
@@ -298,7 +327,7 @@ describe("IteratorTask", () => {
 
     describe("type safety", () => {
       test("ReduceTask should be an instance of IteratorTask", () => {
-        const task = new ReduceTask();
+        const task = new ReduceTask({ maxIterations: "unbounded" });
         expect(task).toBeInstanceOf(IteratorTask);
         expect(task).toBeInstanceOf(ReduceTask);
       });
@@ -337,7 +366,7 @@ describe("IteratorTask", () => {
 
     test("map should return a LoopWorkflowBuilder", () => {
       const workflow = new Workflow();
-      const builder = workflow.map();
+      const builder = workflow.map({ maxIterations: "unbounded" });
 
       expect(builder).toBeDefined();
       expect(typeof builder.endMap).toBe("function");
@@ -353,7 +382,10 @@ describe("IteratorTask", () => {
 
     test("reduce should return a LoopWorkflowBuilder", () => {
       const workflow = new Workflow();
-      const builder = workflow.reduce({ initialValue: { count: 0 } });
+      const builder = workflow.reduce({
+        initialValue: { count: 0 },
+        maxIterations: "unbounded",
+      });
 
       expect(builder).toBeDefined();
       expect(typeof builder.endReduce).toBe("function");
@@ -361,7 +393,7 @@ describe("IteratorTask", () => {
 
     test("map should add a MapTask to the graph", () => {
       const workflow = new Workflow();
-      workflow.map().endMap();
+      workflow.map({ maxIterations: "unbounded" }).endMap();
 
       const tasks = workflow.graph.getTasks();
       expect(tasks).toHaveLength(1);
@@ -370,7 +402,7 @@ describe("IteratorTask", () => {
 
     test("while should add a WhileTask to the graph", () => {
       const workflow = new Workflow();
-      workflow.while({ condition: () => false }).endWhile();
+      workflow.while({ condition: () => false, maxIterations: 10 }).endWhile();
 
       const tasks = workflow.graph.getTasks();
       expect(tasks).toHaveLength(1);
@@ -379,7 +411,7 @@ describe("IteratorTask", () => {
 
     test("reduce should add a ReduceTask to the graph", () => {
       const workflow = new Workflow();
-      workflow.reduce({ initialValue: {} }).endReduce();
+      workflow.reduce({ initialValue: {}, maxIterations: "unbounded" }).endReduce();
 
       const tasks = workflow.graph.getTasks();
       expect(tasks).toHaveLength(1);
@@ -408,7 +440,10 @@ describe("IteratorTask", () => {
     test("should build workflow with map loop for transformation", () => {
       const workflow = new Workflow();
 
-      workflow.map({ preserveOrder: true }).addTask(TextEmbeddingTask).endMap();
+      workflow
+        .map({ preserveOrder: true, maxIterations: "unbounded" })
+        .addTask(TextEmbeddingTask)
+        .endMap();
 
       const tasks = workflow.graph.getTasks();
       expect(tasks).toHaveLength(1);
@@ -427,7 +462,10 @@ describe("IteratorTask", () => {
     test("map with flatten option should configure correctly", () => {
       const workflow = new Workflow();
 
-      workflow.map({ flatten: true, concurrencyLimit: 5 }).addTask(TextEmbeddingTask).endMap();
+      workflow
+        .map({ flatten: true, concurrencyLimit: 5, maxIterations: "unbounded" })
+        .addTask(TextEmbeddingTask)
+        .endMap();
 
       const mapTask = workflow.graph.getTasks()[0] as MapTask;
       expect(mapTask.flatten).toBe(true);
@@ -517,7 +555,7 @@ describe("IteratorTask", () => {
       const workflow = new Workflow();
 
       workflow
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -540,6 +578,7 @@ describe("IteratorTask", () => {
       workflow
         .reduce({
           initialValue: { count: 0, total: 0 },
+          maxIterations: "unbounded",
         })
         .addTask(AddToSumTask)
         .endReduce();
@@ -565,10 +604,10 @@ describe("IteratorTask", () => {
       const workflow = new Workflow();
 
       workflow
-        .map()
+        .map({ maxIterations: "unbounded" })
         .addTask(TextEmbeddingTask)
         .endMap()
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -582,10 +621,10 @@ describe("IteratorTask", () => {
       const workflow = new Workflow();
 
       workflow
-        .map({ concurrencyLimit: 1 })
+        .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
         .addTask(ProcessItemTask)
         .endMap()
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -609,7 +648,11 @@ describe("IteratorTask", () => {
     test("should support multiple tasks inside a loop", () => {
       const workflow = new Workflow();
 
-      workflow.map().addTask(ProcessItemTask).addTask(DoubleTask).endMap();
+      workflow
+        .map({ maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .addTask(DoubleTask)
+        .endMap();
 
       const mapTask = workflow.graph.getTasks()[0] as MapTask;
       const templateGraph = mapTask.subGraph;
@@ -643,7 +686,7 @@ describe("IteratorTask", () => {
     test("loop builder graph should be accessible", () => {
       const workflow = new Workflow();
 
-      const builder = workflow.map();
+      const builder = workflow.map({ maxIterations: "unbounded" });
       expect(builder.graph).toBeInstanceOf(TaskGraph);
       builder.endMap();
     });
@@ -651,7 +694,11 @@ describe("IteratorTask", () => {
     test("template graph should contain added tasks with auto-generated IDs", () => {
       const workflow = new Workflow();
 
-      workflow.map().addTask(ProcessItemTask).addTask(DoubleTask).endMap();
+      workflow
+        .map({ maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .addTask(DoubleTask)
+        .endMap();
 
       const mapTask = workflow.graph.getTasks()[0] as MapTask;
       const templateTasks = mapTask.subGraph?.getTasks() ?? [];
@@ -719,7 +766,7 @@ describe("IteratorTask", () => {
 
       const workflow = new Workflow();
 
-      workflow.map().addTask(TaskA).addTask(TaskB).endMap();
+      workflow.map({ maxIterations: "unbounded" }).addTask(TaskA).addTask(TaskB).endMap();
 
       const mapTask = workflow.graph.getTasks()[0] as MapTask;
       const templateGraph = mapTask.subGraph;
@@ -740,14 +787,14 @@ describe("IteratorTask", () => {
     test("workflow map run should execute without pre-run scalar failure", async () => {
       const workflow = new Workflow();
 
-      workflow.map().addTask(ProcessItemTask).endMap();
+      workflow.map({ maxIterations: "unbounded" }).addTask(ProcessItemTask).endMap();
 
       const result = await workflow.run({ item: [1, 2, 3] });
       expect(result.processed).toEqual([2, 4, 6]);
     });
 
     test("direct MapTask.run should execute a reusable subgraph across iterations", async () => {
-      const mapTask = new MapTask();
+      const mapTask = new MapTask({ maxIterations: "unbounded" });
       const subGraph = new TaskGraph();
       subGraph.addTask(new ProcessItemTask({ id: "process", defaults: { item: 0 } }));
 
@@ -790,7 +837,10 @@ describe("IteratorTask", () => {
       }
 
       const workflow = new Workflow();
-      workflow.map({ preserveOrder: true, concurrencyLimit: 3 }).addTask(DelayedEchoTask).endMap();
+      workflow
+        .map({ preserveOrder: true, concurrencyLimit: 3, maxIterations: "unbounded" })
+        .addTask(DelayedEchoTask)
+        .endMap();
 
       const result = await workflow.run({ item: [1, 2, 3] });
       expect(result.item).toEqual([1, 2, 3]);
@@ -798,7 +848,10 @@ describe("IteratorTask", () => {
 
     test("map preserveOrder=false should still return complete results", async () => {
       const workflow = new Workflow();
-      workflow.map({ preserveOrder: false, concurrencyLimit: 3 }).addTask(ProcessItemTask).endMap();
+      workflow
+        .map({ preserveOrder: false, concurrencyLimit: 3, maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .endMap();
 
       const result = await workflow.run({ item: [1, 2, 3] });
       expect((result.processed as number[]).slice().sort((a, b) => a - b)).toEqual([2, 4, 6]);
@@ -806,7 +859,10 @@ describe("IteratorTask", () => {
 
     test("map should honor batchSize and concurrency settings without data loss", async () => {
       const workflow = new Workflow();
-      workflow.map({ concurrencyLimit: 2, batchSize: 2 }).addTask(ProcessItemTask).endMap();
+      workflow
+        .map({ concurrencyLimit: 2, batchSize: 2, maxIterations: "unbounded" })
+        .addTask(ProcessItemTask)
+        .endMap();
 
       const result = await workflow.run({ item: [1, 2, 3, 4, 5] });
       expect(result.processed).toEqual([2, 4, 6, 8, 10]);
@@ -861,7 +917,7 @@ describe("IteratorTask", () => {
 
       const workflow = new Workflow();
       workflow
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(ZipReduceTask)
         .endReduce();
 
@@ -872,7 +928,7 @@ describe("IteratorTask", () => {
     test("reduce with AddToSumTask should sum array via workflow.run", async () => {
       const workflow = new Workflow();
       workflow
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -925,10 +981,10 @@ describe("IteratorTask", () => {
 
       const workflow = new Workflow();
       workflow
-        .map({ concurrencyLimit: 1 })
+        .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
         .addTask(DoubleToCurrentItemTask)
         .endMap()
-        .reduce({ initialValue: { sum: 0 } })
+        .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
         .addTask(AddToSumTask)
         .endReduce();
 
@@ -939,7 +995,7 @@ describe("IteratorTask", () => {
 
     test("map with TextEmbeddingTask should produce embeddings via workflow.run", async () => {
       const workflow = new Workflow();
-      workflow.map().addTask(TextEmbeddingTask).endMap();
+      workflow.map({ maxIterations: "unbounded" }).addTask(TextEmbeddingTask).endMap();
 
       const result = (await workflow.run({ text: ["hi", "bye"] })) as {
         vector?: readonly (readonly number[])[];
@@ -979,7 +1035,7 @@ describe("IteratorTask", () => {
         }
       }
 
-      const task = new PrecedenceIterator();
+      const task = new PrecedenceIterator({ maxIterations: "unbounded" });
       const analysis = task.analyzeIterationInput({
         forceArray: [1, 2],
         forceScalar: [100, 200],
@@ -1080,7 +1136,7 @@ describe("IteratorTask", () => {
       const n = 4;
       const workflow = new Workflow();
       workflow
-        .map({ concurrencyLimit: n })
+        .map({ concurrencyLimit: n, maxIterations: "unbounded" })
         .addTask(EarlyProgressTask)
         .addTask(SlowWorkTask)
         .endMap();
@@ -1208,7 +1264,7 @@ describe("IteratorTask", () => {
         // RefineTask: quality += 0.2 per step, value += 1. So 5 steps to reach 1.0 from 0.
         const workflow = new Workflow();
         workflow
-          .map()
+          .map({ maxIterations: "unbounded" })
           .while({
             condition: (output: { quality?: number }) => (output?.quality ?? 0) < 0.9,
             maxIterations: 10,
@@ -1227,7 +1283,7 @@ describe("IteratorTask", () => {
       test("should respect maxIterations when while is inside map", async () => {
         const workflow = new Workflow();
         workflow
-          .map()
+          .map({ maxIterations: "unbounded" })
           .while({
             condition: () => true, // never exit by condition
             maxIterations: 2,
@@ -1259,7 +1315,7 @@ describe("IteratorTask", () => {
             maxIterations: 5,
             chainIterations: true,
           })
-          .map()
+          .map({ maxIterations: "unbounded" })
           .addTask(ProcessItemTask)
           .endMap()
           .endWhile();
@@ -1271,7 +1327,7 @@ describe("IteratorTask", () => {
             maxIterations: 5,
             chainIterations: false,
           })
-          .map()
+          .map({ maxIterations: "unbounded" })
           .addTask(ProcessItemTask)
           .endMap()
           .endWhile();
@@ -1287,11 +1343,11 @@ describe("IteratorTask", () => {
       test("map then reduce then run with array input", async () => {
         const workflow = new Workflow();
         workflow
-          .map({ concurrencyLimit: 1 })
+          .map({ concurrencyLimit: 1, maxIterations: "unbounded" })
           .addTask(ProcessItemTask)
           .endMap()
           .rename("processed", "currentItem")
-          .reduce({ initialValue: { sum: 0 } })
+          .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
           .addTask(AddToSumTask)
           .endReduce();
 
@@ -1306,7 +1362,7 @@ describe("IteratorTask", () => {
         // (ending node outputs {quality, value}), then DoubleTask after while completes.
         const workflow = new Workflow();
         workflow
-          .map()
+          .map({ maxIterations: "unbounded" })
           .while({
             condition: (output: { quality?: number }) => (output?.quality ?? 0) < 0.9,
             maxIterations: 10,
@@ -1327,7 +1383,7 @@ describe("IteratorTask", () => {
       test("should build reduce whose body contains a WhileTask", () => {
         const workflow = new Workflow();
         workflow
-          .reduce({ initialValue: { sum: 0 } })
+          .reduce({ initialValue: { sum: 0 }, maxIterations: "unbounded" })
           .while({
             condition: () => false,
             maxIterations: 2,
@@ -1351,7 +1407,7 @@ describe("IteratorTask", () => {
       test("map with empty while (condition false immediately) still returns structure", async () => {
         const workflow = new Workflow();
         workflow
-          .map()
+          .map({ maxIterations: "unbounded" })
           .while({
             condition: () => false,
             maxIterations: 5,
@@ -1370,9 +1426,9 @@ describe("IteratorTask", () => {
       test("chained map -> while -> map (outer map, inner while with inner map) via structure only", () => {
         const workflow = new Workflow();
         workflow
-          .map()
+          .map({ maxIterations: "unbounded" })
           .while({ condition: () => false, maxIterations: 2 })
-          .map()
+          .map({ maxIterations: "unbounded" })
           .addTask(ProcessItemTask)
           .endMap()
           .endWhile()

--- a/packages/test/src/test/task/IteratorTask.test.ts
+++ b/packages/test/src/test/task/IteratorTask.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  ForEachTask,
   IExecuteContext,
   IteratorTask,
   MapTask,
@@ -416,6 +417,59 @@ describe("IteratorTask", () => {
       const tasks = workflow.graph.getTasks();
       expect(tasks).toHaveLength(1);
       expect(tasks[0]).toBeInstanceOf(ReduceTask);
+    });
+
+    test("Workflow should have forEach method", () => {
+      const workflow = new Workflow();
+      expect(typeof workflow.forEach).toBe("function");
+    });
+
+    test("forEach should add a ForEachTask to the graph", () => {
+      const workflow = new Workflow();
+      workflow.forEach({ maxIterations: "unbounded" }).endForEach();
+
+      const tasks = workflow.graph.getTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]).toBeInstanceOf(ForEachTask);
+      // ForEachTask extends MapTask
+      expect(tasks[0]).toBeInstanceOf(MapTask);
+    });
+  });
+
+  // ============================================================================
+  // ForEachTask Tests
+  // ============================================================================
+
+  describe("ForEachTask", () => {
+    test("should default discardResults to true", () => {
+      const task = new ForEachTask({ maxIterations: "unbounded" });
+      expect(task.discardResults).toBe(true);
+    });
+
+    test("should allow explicit override of discardResults", () => {
+      const task = new ForEachTask({ maxIterations: "unbounded", discardResults: false });
+      expect(task.discardResults).toBe(false);
+    });
+
+    test("should throw when maxIterations is omitted", () => {
+      expect(() => new ForEachTask({} as any)).toThrow(/maxIterations/);
+    });
+
+    test("should forward runConfig to base Task", () => {
+      // Regression: the constructor must accept and forward the runConfig
+      // parameter required by ITaskConstructor. IteratorTaskRunner clones
+      // tasks via `new ctor(config, task.runConfig)` — dropping runConfig
+      // here silently loses per-call DI/service bindings for deserialized
+      // or cloned ForEachTasks.
+      const runConfig = { cacheable: false };
+      const task = new ForEachTask({ maxIterations: "unbounded" }, runConfig);
+      expect(task.runConfig).toEqual(runConfig);
+    });
+
+    test("should return empty result when discardResults is true", () => {
+      const task = new ForEachTask({ maxIterations: "unbounded" });
+      const result = task.collectResults([{ out: 1 }, { out: 2 }, { out: 3 }]);
+      expect(result).toEqual({});
     });
   });
 

--- a/packages/test/src/test/task/TaskJSON.test.ts
+++ b/packages/test/src/test/task/TaskJSON.test.ts
@@ -676,7 +676,10 @@ describe("TaskJSON", () => {
     });
 
     test("WhileTask with function condition is not serializable", () => {
-      const task = new WhileTask({ condition: (_output: any, _i: number) => true });
+      const task = new WhileTask({
+        condition: (_output: any, _i: number) => true,
+        maxIterations: 10,
+      });
       expect(task.canSerializeConfig()).toBe(false);
       expect(() => task.toJSON()).toThrow(TaskSerializationError);
     });
@@ -686,6 +689,7 @@ describe("TaskJSON", () => {
         conditionField: "done",
         conditionOperator: "equals",
         conditionValue: "false",
+        maxIterations: 10,
       });
       expect(task.canSerializeConfig()).toBe(true);
       expect(() => task.toJSON()).not.toThrow();

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -58,6 +58,17 @@ const PROVIDER_LLAMACPP_FILES = [
   "LlamaCpp_NativeToolCalling",
 ];
 
+/** node-llama-cpp/ipull downloads use shared ./models paths; parallel test files corrupt the same .gguf.ipull partial. */
+function isLlamaCppProviderIntegrationFile(filePath: string): boolean {
+  const base = filePath.split("/").pop() ?? filePath;
+  return (PROVIDER_LLAMACPP_FILES as readonly string[]).some((stem) => base.startsWith(`${stem}.`));
+}
+
+function shouldRunLlamaCppIntegrationFilesSequentially(files: string[]): boolean {
+  const n = files.filter(isLlamaCppProviderIntegrationFile).length;
+  return n > 1;
+}
+
 const SECTION_DIRS: Record<Section, string[]> = {
   graph: [
     join(TEST_BASE, "task-graph"),
@@ -155,8 +166,12 @@ function collectFiles(
 }
 
 async function runBunTest(files: string[]): Promise<number> {
+  const parallelFlag =
+    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
+      ? "--parallel=1"
+      : "--parallel";
   const proc = Bun.spawn(
-    files.length > 0 ? ["bun", "test", "--parallel", ...files] : ["bun", "test", "--parallel"],
+    files.length > 0 ? ["bun", "test", parallelFlag, ...files] : ["bun", "test", parallelFlag],
     {
       cwd: ROOT,
       stdio: ["inherit", "inherit", "inherit"],
@@ -173,6 +188,9 @@ async function runVitest(files: string[]): Promise<number> {
   // When no file filter: run all. Otherwise pass relative paths as name filters.
   const relFiles = files.length > 0 ? files.map((f) => relative(ROOT, f)) : [];
   const args = ["npx", "vitest", "run", ...relFiles];
+  if (files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)) {
+    args.push("--no-file-parallelism");
+  }
   if (process.env.CI) {
     args.push("--coverage");
   }


### PR DESCRIPTION
## Summary

This PR makes `maxIterations` a required configuration parameter for all loop tasks (`IteratorTask`, `WhileTask`, `ReduceTask`, `MapTask`) to enforce explicit iteration bounds and prevent runaway loops. It also introduces `ForEachTask` for side-effect-only iteration and adds a new `ConditionalBuilder` for fluent if/else branching in workflows.

## Key Changes

### Loop Task Configuration
- **Made `maxIterations` required** across `IteratorTask`, `WhileTask`, and `ReduceTask`
  - Accepts either a positive integer or the string sentinel `"unbounded"` (which resolves to `Number.POSITIVE_INFINITY`)
  - The string form forces explicit acknowledgment of unbounded iteration rather than silent opt-out
  - Added `resolveIterationBound()` helper to convert the bound to a numeric cap
  - Updated schema validation to enforce the requirement at construction time

### New ForEachTask
- Added `ForEachTask` as a `MapTask` variant that discards iteration results by default
- Useful for side-effect-only loops where the caller doesn't need collected outputs
- Exposed via new `.forEach()` and `.endForEach()` workflow combinators
- Shares all `MapTask` configuration options but sets `discardResults: true` by default

### Conditional Branching
- Added `ConditionalBuilder` class for fluent if/else construction
- Exposed via new `.if(condition)` workflow method
- Supports `.then(taskClass)` and optional `.else(taskClass)` arms, closed via `.endIf()`
- Automatically wires dataflows from conditional output ports to branch tasks
- Handles mutually exclusive branch conditions with inverse logic for the else arm

### Cycle Detection & Validation
- Added `TaskGraph.isAcyclic()` method to check DAG invariant
- Added `GraphAsTask.validateAcyclic()` for defensive re-assertion of acyclic subgraphs
- `TaskGraph.addDataflow()` already rejects cycle-creating edges synchronously; new methods support explicit validation

### Code Generation
- Updated `GraphToWorkflowCode` to emit `maxIterations` in generated workflow code
- Properly round-trips explicit `"unbounded"` sentinel in serialized workflows

## Implementation Details

- All loop task constructors now validate `maxIterations` presence and throw `TaskConfigurationError` if omitted
- `WhileTask` constructor resolves `"unbounded"` to `Number.POSITIVE_INFINITY` for internal comparison
- `IteratorTaskRunner` uses `resolveIterationBound()` to enforce the cap during iteration analysis
- Test suite updated to pass `maxIterations` to all loop task instantiations
- JSON serialization updated to handle optional `maxIterations` in the union type while preserving per-task requirements

https://claude.ai/code/session_017cRvYZrvC1aGKDk6FVXA3M