### PR TITLE
perf(job-queue): same-process hot-path optimization + correctness fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: canary
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -179,7 +179,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: canary
+          bun-version: latest
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/packages/ai/src/execution/QueuedExecutionStrategy.ts
+++ b/packages/ai/src/execution/QueuedExecutionStrategy.ts
@@ -148,23 +148,19 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
   }
 
   /**
-   * Spin-wait on `limiter.canProceed()` until a slot is available or the
-   * abort signal fires. Yields to the microtask queue between polls; for
-   * concurrency=1 with one caller at a time this usually takes one check.
+   * Atomically acquire a limiter slot, retrying with backoff until success or
+   * abort. Uses {@link ILimiter.tryAcquire} so concurrent callers cannot both
+   * pass a check-then-record sequence and overshoot the configured limit.
    */
   private async acquireLimiterSlot(limiter: ILimiter, signal: AbortSignal): Promise<void> {
-    const poll = async (): Promise<void> => {
-      while (!(await limiter.canProceed())) {
-        if (signal.aborted) {
-          throw signal.reason ?? new AbortSignalJobError("The operation was aborted");
-        }
-        const next = await limiter.getNextAvailableTime();
-        const delay = Math.max(0, next.getTime() - Date.now());
-        await new Promise<void>((resolve) => setTimeout(resolve, Math.min(delay, 50)));
+    while (!(await limiter.tryAcquire())) {
+      if (signal.aborted) {
+        throw signal.reason ?? new AbortSignalJobError("The operation was aborted");
       }
-    };
-    await poll();
-    await limiter.recordJobStart();
+      const next = await limiter.getNextAvailableTime();
+      const delay = Math.max(0, next.getTime() - Date.now());
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.min(delay, 50)));
+    }
   }
 
   private ensureQueue(): Promise<RegisteredQueue<AiJobInput<TaskInput>, TaskOutput>> {

--- a/packages/ai/src/execution/QueuedExecutionStrategy.ts
+++ b/packages/ai/src/execution/QueuedExecutionStrategy.ts
@@ -143,6 +143,11 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
         updateProgress: context.updateProgress,
       });
     } finally {
+      // The token was inserted by acquireLimiterSlot; we don't carry it
+      // through here because the queue's own AiJob/limiter lifecycle owns the
+      // matching release/recordJobCompletion. recordJobCompletion remains the
+      // contract for "this job finished" — token-based release is only for
+      // rolling back an unused acquisition.
       await limiter.recordJobCompletion();
     }
   }
@@ -153,14 +158,21 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
    * pass a check-then-record sequence and overshoot the configured limit.
    */
   private async acquireLimiterSlot(limiter: ILimiter, signal: AbortSignal): Promise<void> {
-    while (!(await limiter.tryAcquire())) {
+    let token = await limiter.tryAcquire();
+    while (token === null || token === undefined) {
       if (signal.aborted) {
         throw signal.reason ?? new AbortSignalJobError("The operation was aborted");
       }
       const next = await limiter.getNextAvailableTime();
       const delay = Math.max(0, next.getTime() - Date.now());
       await new Promise<void>((resolve) => setTimeout(resolve, Math.min(delay, 50)));
+      token = await limiter.tryAcquire();
     }
+    // Token discarded — the surrounding finally calls recordJobCompletion()
+    // on the happy path. If acquire-then-throw happens after this returns,
+    // the outer try/finally would leak a slot until the rate-limit window
+    // rolls — acceptable here since the AiJob path is single-use per call.
+    void token;
   }
 
   private ensureQueue(): Promise<RegisteredQueue<AiJobInput<TaskInput>, TaskOutput>> {

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -135,6 +135,25 @@ export class JobQueueServer<
     this.running = true;
     this.events.emit("server_start", this.queueName);
 
+    // Warn when a process-scoped limiter is paired with a cluster-scoped
+    // queue storage. The user almost certainly meant their configured limit
+    // to be enforced cluster-wide; with a process-scoped limiter they get
+    // N× the limit (one bucket per process).
+    if (
+      this.limiter.scope === "process" &&
+      this.storage.scope === "cluster" &&
+      !(this.limiter instanceof NullLimiter)
+    ) {
+      getLogger().warn(
+        "Process-scoped limiter on cluster-scoped queue storage — limit is enforced per-process, not cluster-wide. Use a cluster-scoped rate limiter storage (Postgres/Supabase) for global enforcement.",
+        {
+          queueName: this.queueName,
+          limiterScope: this.limiter.scope,
+          storage: this.storage.constructor.name,
+        }
+      );
+    }
+
     // Fix stuck jobs from previous runs
     await this.fixupJobs();
 
@@ -153,6 +172,7 @@ export class JobQueueServer<
         (change: QueueChangePayload<Input, Output>) => {
           if (
             change.type === "INSERT" ||
+            change.type === "RESYNC" ||
             (change.type === "UPDATE" && change.new?.status === JobStatus.PENDING)
           ) {
             this.notifyWorkers();

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -28,6 +28,14 @@ import { withJobErrorDiagnostics } from "./JobErrorDiagnostics";
 import { classToStorage, storageToClass } from "./JobStorageConverters";
 
 /**
+ * Upper bound on {@link JobQueueWorker.getLimiterWakeDelay}. Prevents a
+ * misconfigured or stuck limiter (e.g. one whose `getNextAvailableTime`
+ * returns hours in the future) from making the worker unresponsive — it
+ * wakes at least this often regardless of what the limiter says.
+ */
+const MAX_LIMITER_WAKE_MS = 30_000;
+
+/**
  * Events emitted by JobQueueWorker
  */
 export type JobQueueWorkerEventListeners<Input, Output> = {
@@ -234,19 +242,22 @@ export class JobQueueWorker<
   }
 
   /**
-   * Process a single job manually (useful for testing or manual control)
+   * Process a single job manually (useful for testing or manual control).
+   *
+   * Uses the atomic claim->acquire->release pattern: claim a job, then atomically
+   * reserve a limiter slot. If the limiter rejects (e.g. raced another worker
+   * to the last slot), the claimed job is released back to PENDING.
    */
   public async processNext(): Promise<boolean> {
-    const canProceed = await this.limiter.canProceed();
-    if (!canProceed) {
-      return false;
-    }
-
     const job = await this.next();
     if (!job) {
       return false;
     }
-
+    const acquired = await this.limiter.tryAcquire();
+    if (!acquired) {
+      await this.releaseClaimedJob(job);
+      return false;
+    }
     await this.processSingleJob(job);
     return true;
   }
@@ -323,44 +334,75 @@ export class JobQueueWorker<
         // Check for aborting jobs
         await this.checkForAbortingJobs();
 
-        const canProceed = await this.limiter.canProceed();
-        if (canProceed) {
-          const job = await this.next();
-          if (job) {
-            if (!this.running) {
-              // We were stopped during one of the awaits above and `next()`
-              // claimed this job after the fact. Release it back to PENDING
-              // so it isn't stuck PROCESSING on a worker that's no longer
-              // running — `fixupJobs()` skips current-server worker IDs, so
-              // nothing else would clean it up.
-              await this.releaseClaimedJob(job);
-              return;
-            }
-            // Don't await - process in background to allow concurrent jobs.
-            // The loop will re-check canProceed on the next iteration; if the
-            // limiter is at capacity it will wait for a notify (fired by the
-            // server when a job completes and frees a slot).
-            this.processSingleJob(job);
-            continue;
-          }
-        }
-
-        // Either no jobs available or limiter is at capacity — wait for
-        // something to change before re-checking.
-        if (canProceed) {
-          // Queue is empty — sleep until notified of new work or until
-          // the next deferred job becomes ready.
+        // Claim first, then atomically reserve a limiter slot. Doing the claim
+        // before the acquire avoids a race window: with the previous "check
+        // canProceed -> claim -> recordJobStart" sequence, two workers could
+        // both observe count < max, both claim, and both then increment —
+        // overshooting the configured limit by exactly the worker concurrency.
+        // The atomic tryAcquire guarantees only one of N concurrent acquirers
+        // succeeds when there's one slot left.
+        const job = await this.next();
+        if (!job) {
+          // Queue is empty — sleep until notified of new work or until the
+          // next deferred job becomes ready.
           const delay = await this.getIdleDelay();
           await this.waitForWakeOrTimeout(delay);
-        } else {
-          // At capacity — wait until notified (a job completes and frees a
-          // slot) or the poll interval expires as a fallback.
-          await this.waitForWakeOrTimeout(this.pollIntervalMs);
+          continue;
         }
+
+        if (!this.running) {
+          // Stopped during the await. Release the job back to PENDING.
+          await this.releaseClaimedJob(job);
+          return;
+        }
+
+        const acquired = await this.limiter.tryAcquire();
+        if (!acquired) {
+          // Lost the race for the last slot, or hit the rate-limit window.
+          // Give the job back and wait for capacity.
+          await this.releaseClaimedJob(job);
+          await this.waitForWakeOrTimeout(await this.getLimiterWakeDelay());
+          continue;
+        }
+
+        if (!this.running) {
+          // Stop fired while tryAcquire was in flight. Undo both the limiter
+          // reservation and the job claim so we don't start processing on a
+          // worker that's about to exit.
+          try {
+            await this.limiter.release();
+          } catch {
+            // best-effort
+          }
+          await this.releaseClaimedJob(job);
+          return;
+        }
+
+        // Don't await - process in background to allow concurrent jobs.
+        // The loop will claim+acquire on the next iteration.
+        this.processSingleJob(job);
       } catch {
         // Don't let transient errors kill the loop
         await sleep(this.pollIntervalMs);
       }
+    }
+  }
+
+  /**
+   * How long to sleep when the limiter rejected an acquire. Reads the limiter's
+   * own next-available time so we wake exactly when capacity opens, instead of
+   * polling every {@link pollIntervalMs}. Clamped to {@link pollIntervalMs}
+   * (lower bound) and {@link MAX_LIMITER_WAKE_MS} (upper bound) so a
+   * misconfigured/stuck limiter still wakes occasionally.
+   */
+  private async getLimiterWakeDelay(): Promise<number> {
+    try {
+      const next = await this.limiter.getNextAvailableTime();
+      const delay = next.getTime() - Date.now();
+      if (delay <= 0) return this.pollIntervalMs;
+      return Math.min(Math.max(delay, this.pollIntervalMs), MAX_LIMITER_WAKE_MS);
+    } catch {
+      return this.pollIntervalMs;
     }
   }
 
@@ -460,9 +502,28 @@ export class JobQueueWorker<
         })
       : undefined;
 
+    // Set when validateJobState fails and we release() the limiter slot
+    // ourselves — the finally block then skips recordJobCompletion to avoid
+    // double-decrementing limiters where release() and recordJobCompletion()
+    // both decrement (e.g. ConcurrencyLimiter).
+    let slotReleased = false;
     try {
-      await this.validateJobState(job);
-      await this.limiter.recordJobStart();
+      // The limiter slot was already atomically reserved by tryAcquire() in
+      // the main loop (or processNext), so we no longer call recordJobStart
+      // here — doing so would double-count.
+      try {
+        await this.validateJobState(job);
+      } catch (validationErr) {
+        // Validation failed before we ran any actual work — release the slot
+        // we reserved so it doesn't count toward the rate limit.
+        try {
+          await this.limiter.release();
+          slotReleased = true;
+        } catch {
+          // best-effort
+        }
+        throw validationErr;
+      }
 
       const abortController = this.createAbortController(job.id);
       this.events.emit("job_start", job.id);
@@ -505,7 +566,9 @@ export class JobQueueWorker<
     } finally {
       span?.end();
       try {
-        await this.limiter.recordJobCompletion();
+        if (!slotReleased) {
+          await this.limiter.recordJobCompletion();
+        }
       } finally {
         this.inFlight.delete(job.id);
         resolveInFlight();

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -253,12 +253,12 @@ export class JobQueueWorker<
     if (!job) {
       return false;
     }
-    const acquired = await this.limiter.tryAcquire();
-    if (!acquired) {
+    const limiterToken = await this.limiter.tryAcquire();
+    if (limiterToken === null || limiterToken === undefined) {
       await this.releaseClaimedJob(job);
       return false;
     }
-    await this.processSingleJob(job);
+    await this.processSingleJob(job, limiterToken);
     return true;
   }
 
@@ -356,8 +356,8 @@ export class JobQueueWorker<
           return;
         }
 
-        const acquired = await this.limiter.tryAcquire();
-        if (!acquired) {
+        const limiterToken = await this.limiter.tryAcquire();
+        if (limiterToken === null || limiterToken === undefined) {
           // Lost the race for the last slot, or hit the rate-limit window.
           // Give the job back and wait for capacity.
           await this.releaseClaimedJob(job);
@@ -367,10 +367,11 @@ export class JobQueueWorker<
 
         if (!this.running) {
           // Stop fired while tryAcquire was in flight. Undo both the limiter
-          // reservation and the job claim so we don't start processing on a
-          // worker that's about to exit.
+          // reservation (release THIS token, not "the most recent") and the
+          // job claim so we don't start processing on a worker that's about
+          // to exit.
           try {
-            await this.limiter.release();
+            await this.limiter.release(limiterToken);
           } catch {
             // best-effort
           }
@@ -380,7 +381,7 @@ export class JobQueueWorker<
 
         // Don't await - process in background to allow concurrent jobs.
         // The loop will claim+acquire on the next iteration.
-        this.processSingleJob(job);
+        this.processSingleJob(job, limiterToken);
       } catch {
         // Don't let transient errors kill the loop
         await sleep(this.pollIntervalMs);
@@ -478,7 +479,10 @@ export class JobQueueWorker<
   /**
    * Process a single job
    */
-  protected async processSingleJob(job: Job<Input, Output>): Promise<void> {
+  protected async processSingleJob(
+    job: Job<Input, Output>,
+    limiterToken: unknown
+  ): Promise<void> {
     if (!job || !job.id) {
       throw new JobNotFoundError("Invalid job provided for processing");
     }
@@ -514,10 +518,12 @@ export class JobQueueWorker<
       try {
         await this.validateJobState(job);
       } catch (validationErr) {
-        // Validation failed before we ran any actual work — release the slot
-        // we reserved so it doesn't count toward the rate limit.
+        // Validation failed before we ran any actual work — release THIS
+        // limiter slot (by token, not by recency) so it doesn't count toward
+        // the rate limit and we don't accidentally release another worker's
+        // slot.
         try {
-          await this.limiter.release();
+          await this.limiter.release(limiterToken);
           slotReleased = true;
         } catch {
           // best-effort

--- a/packages/job-queue/src/limiter/CompositeLimiter.ts
+++ b/packages/job-queue/src/limiter/CompositeLimiter.ts
@@ -4,13 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ILimiter } from "./ILimiter";
+import { ILimiter, LimiterScope } from "./ILimiter";
 
 export class CompositeLimiter implements ILimiter {
   private limiters: ILimiter[] = [];
 
   constructor(limiters: ILimiter[] = []) {
     this.limiters = limiters;
+  }
+
+  /**
+   * `"cluster"` only when EVERY child is cluster-scoped. A single process-scoped
+   * child means the composite as a whole can't enforce a cluster-wide limit.
+   */
+  public get scope(): LimiterScope {
+    return this.limiters.every((l) => l.scope === "cluster") && this.limiters.length > 0
+      ? "cluster"
+      : "process";
   }
 
   addLimiter(limiter: ILimiter): void {
@@ -24,6 +34,35 @@ export class CompositeLimiter implements ILimiter {
       }
     }
     return true; // All limiters agree
+  }
+
+  /**
+   * Atomic against the composite: acquires children sequentially and rolls
+   * back any successfully-acquired prefix if a later child rejects, so the
+   * "all-or-nothing" semantics hold under concurrency.
+   */
+  async tryAcquire(): Promise<boolean> {
+    const acquired: ILimiter[] = [];
+    for (const limiter of this.limiters) {
+      const ok = await limiter.tryAcquire();
+      if (!ok) {
+        // Roll back the partial acquisition.
+        for (const previous of acquired.reverse()) {
+          try {
+            await previous.release();
+          } catch {
+            // best-effort
+          }
+        }
+        return false;
+      }
+      acquired.push(limiter);
+    }
+    return true;
+  }
+
+  async release(): Promise<void> {
+    await Promise.all(this.limiters.map((l) => l.release().catch(() => {})));
   }
 
   async recordJobStart(): Promise<void> {

--- a/packages/job-queue/src/limiter/CompositeLimiter.ts
+++ b/packages/job-queue/src/limiter/CompositeLimiter.ts
@@ -40,29 +40,37 @@ export class CompositeLimiter implements ILimiter {
    * Atomic against the composite: acquires children sequentially and rolls
    * back any successfully-acquired prefix if a later child rejects, so the
    * "all-or-nothing" semantics hold under concurrency.
+   *
+   * The returned token is an array of per-child tokens (parallel to
+   * `this.limiters`) so {@link release} can free each child's specific slot
+   * — never "the most recent", which would race other acquirers.
    */
-  async tryAcquire(): Promise<boolean> {
-    const acquired: ILimiter[] = [];
+  async tryAcquire(): Promise<unknown | null> {
+    const tokens: unknown[] = [];
     for (const limiter of this.limiters) {
-      const ok = await limiter.tryAcquire();
-      if (!ok) {
-        // Roll back the partial acquisition.
-        for (const previous of acquired.reverse()) {
+      const t = await limiter.tryAcquire();
+      if (t === null || t === undefined) {
+        // Roll back the partial acquisition. Iterate in reverse so children
+        // are released in opposite order of acquisition.
+        for (let i = tokens.length - 1; i >= 0; i--) {
           try {
-            await previous.release();
+            await this.limiters[i].release(tokens[i]);
           } catch {
             // best-effort
           }
         }
-        return false;
+        return null;
       }
-      acquired.push(limiter);
+      tokens.push(t);
     }
-    return true;
+    return tokens;
   }
 
-  async release(): Promise<void> {
-    await Promise.all(this.limiters.map((l) => l.release().catch(() => {})));
+  async release(token: unknown): Promise<void> {
+    if (!Array.isArray(token)) return;
+    await Promise.all(
+      this.limiters.map((l, i) => l.release(token[i]).catch(() => {}))
+    );
   }
 
   async recordJobStart(): Promise<void> {

--- a/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
+++ b/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
@@ -30,22 +30,26 @@ export class ConcurrencyLimiter implements ILimiter {
     );
   }
 
+  /** Sentinel token; ConcurrencyLimiter has no per-row identity, just a counter. */
+  private static readonly SENTINEL = Symbol("ConcurrencyLimiter.acquired");
+
   /**
    * Atomic in JS's single-threaded sense: the read-then-increment runs without
    * an `await` between them, so no other task can interleave.
    */
-  async tryAcquire(): Promise<boolean> {
+  async tryAcquire(): Promise<unknown | null> {
     if (
       this.currentRunningJobs >= this.maxConcurrentJobs ||
       Date.now() < this.nextAllowedStartTime.getTime()
     ) {
-      return false;
+      return null;
     }
     this.currentRunningJobs++;
-    return true;
+    return ConcurrencyLimiter.SENTINEL;
   }
 
-  async release(): Promise<void> {
+  async release(token: unknown): Promise<void> {
+    if (token !== ConcurrencyLimiter.SENTINEL) return;
     this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
   }
 

--- a/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
+++ b/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServiceToken } from "@workglow/util";
-import { ILimiter } from "./ILimiter";
+import { ILimiter, LimiterScope } from "./ILimiter";
 
 export const CONCURRENT_JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.limiter.concurrent");
 
@@ -13,6 +13,8 @@ export const CONCURRENT_JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.lim
  * Concurrency limiter that limits the number of concurrent jobs.
  */
 export class ConcurrencyLimiter implements ILimiter {
+  /** In-memory counter — not shared across processes. */
+  public readonly scope: LimiterScope = "process";
   private currentRunningJobs: number = 0;
   private readonly maxConcurrentJobs: number;
   private nextAllowedStartTime: Date = new Date();
@@ -26,6 +28,25 @@ export class ConcurrencyLimiter implements ILimiter {
       this.currentRunningJobs < this.maxConcurrentJobs &&
       Date.now() >= this.nextAllowedStartTime.getTime()
     );
+  }
+
+  /**
+   * Atomic in JS's single-threaded sense: the read-then-increment runs without
+   * an `await` between them, so no other task can interleave.
+   */
+  async tryAcquire(): Promise<boolean> {
+    if (
+      this.currentRunningJobs >= this.maxConcurrentJobs ||
+      Date.now() < this.nextAllowedStartTime.getTime()
+    ) {
+      return false;
+    }
+    this.currentRunningJobs++;
+    return true;
+  }
+
+  async release(): Promise<void> {
+    this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
   }
 
   async recordJobStart(): Promise<void> {

--- a/packages/job-queue/src/limiter/DelayLimiter.ts
+++ b/packages/job-queue/src/limiter/DelayLimiter.ts
@@ -19,22 +19,28 @@ export class DelayLimiter implements ILimiter {
   }
 
   /**
-   * Atomic: read-and-set runs in one synchronous slice with no awaits between
-   * the check and the write.
+   * Token records the previous nextAvailableTime so release can roll back to
+   * exactly the state before this acquire — even if other acquires (or
+   * setNextAvailableTime calls) ran in between.
    */
-  async tryAcquire(): Promise<boolean> {
+  async tryAcquire(): Promise<unknown | null> {
     const now = Date.now();
     if (now < this.nextAvailableTime.getTime()) {
-      return false;
+      return null;
     }
-    this.lastAcquireBaseline = this.nextAvailableTime.getTime();
+    const previous = this.nextAvailableTime.getTime();
+    this.lastAcquireBaseline = previous;
     this.nextAvailableTime = new Date(now + this.delayInMilliseconds);
-    return true;
+    return previous;
   }
 
-  async release(): Promise<void> {
-    // Roll back the delay window so the next caller can proceed immediately.
-    this.nextAvailableTime = new Date(this.lastAcquireBaseline);
+  async release(token: unknown): Promise<void> {
+    if (typeof token !== "number") return;
+    // Only roll back if no later acquire/setNextAvailableTime moved the
+    // window forward — otherwise we'd undo someone else's reservation.
+    if (this.nextAvailableTime.getTime() === this.lastAcquireBaseline + this.delayInMilliseconds) {
+      this.nextAvailableTime = new Date(token);
+    }
   }
 
   async recordJobStart(): Promise<void> {

--- a/packages/job-queue/src/limiter/DelayLimiter.ts
+++ b/packages/job-queue/src/limiter/DelayLimiter.ts
@@ -4,14 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ILimiter } from "./ILimiter";
+import { ILimiter, LimiterScope } from "./ILimiter";
 
 export class DelayLimiter implements ILimiter {
+  /** In-memory state — not shared across processes. */
+  public readonly scope: LimiterScope = "process";
   private nextAvailableTime: Date = new Date();
+  /** Time of the most recent successful tryAcquire, used to undo on release. */
+  private lastAcquireBaseline: number = 0;
   constructor(private delayInMilliseconds: number = 50) {}
 
   async canProceed(): Promise<boolean> {
     return Date.now() >= this.nextAvailableTime.getTime();
+  }
+
+  /**
+   * Atomic: read-and-set runs in one synchronous slice with no awaits between
+   * the check and the write.
+   */
+  async tryAcquire(): Promise<boolean> {
+    const now = Date.now();
+    if (now < this.nextAvailableTime.getTime()) {
+      return false;
+    }
+    this.lastAcquireBaseline = this.nextAvailableTime.getTime();
+    this.nextAvailableTime = new Date(now + this.delayInMilliseconds);
+    return true;
+  }
+
+  async release(): Promise<void> {
+    // Roll back the delay window so the next caller can proceed immediately.
+    this.nextAvailableTime = new Date(this.lastAcquireBaseline);
   }
 
   async recordJobStart(): Promise<void> {

--- a/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
+++ b/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
@@ -27,15 +27,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
   private durations: number[] = [];
   /** Promise chain used to serialize concurrent {@link tryAcquire} callers. */
   private acquireChain: Promise<unknown> = Promise.resolve();
-  /**
-   * Stack of `nextAvailableTime` snapshots captured BEFORE each successful
-   * {@link tryAcquire} advanced it. {@link release} pops the top and restores
-   * the snapshot, which correctly rolls back the most recent acquire even
-   * with multiple in-flight slots. Out-of-order releases (popping a snapshot
-   * that doesn't belong to the released acquire) are best-effort and may
-   * give back a slightly different amount of time than the released slot took.
-   */
-  private acquireSnapshots: number[] = [];
 
   constructor({ maxExecutions, windowSizeInSeconds }: RateLimiterOptions) {
     if (maxExecutions <= 0) {
@@ -59,8 +50,10 @@ export class EvenlySpacedRateLimiter implements ILimiter {
   /**
    * Atomic acquire: serialized by an internal promise chain so two concurrent
    * acquirers cannot both observe `now >= nextAvailableTime` and both proceed.
+   * Returns a token capturing the prior `nextAvailableTime` so {@link release}
+   * can roll back to the exact state before this acquire.
    */
-  async tryAcquire(): Promise<boolean> {
+  async tryAcquire(): Promise<unknown | null> {
     const previous = this.acquireChain;
     let release!: (v: unknown) => void;
     const next = new Promise((r) => {
@@ -71,11 +64,9 @@ export class EvenlySpacedRateLimiter implements ILimiter {
       await previous;
       const now = Date.now();
       if (now < this.nextAvailableTime) {
-        return false;
+        return null;
       }
-      // Snapshot the pre-acquire state so a paired release() can roll back
-      // exactly this acquire's advance even with multiple slots in flight.
-      this.acquireSnapshots.push(this.nextAvailableTime);
+      const priorNextAvailable = this.nextAvailableTime;
       // Reserve the slot by advancing nextAvailableTime now (recordJobStart-style)
       // so a follow-up tryAcquire from another caller in the same tick blocks.
       this.lastStartTime = now;
@@ -87,25 +78,28 @@ export class EvenlySpacedRateLimiter implements ILimiter {
         const waitMs = Math.max(0, this.idealInterval - avgDuration);
         this.nextAvailableTime = now + waitMs;
       }
-      return true;
+      return { priorNextAvailable, advancedTo: this.nextAvailableTime };
     } finally {
       release(undefined);
     }
   }
 
   /**
-   * Roll back a previously acquired slot. Pops the top snapshot from the
-   * acquire stack and restores `nextAvailableTime` to the value it had BEFORE
-   * the most recent acquire advanced it. With multiple in-flight slots this
-   * is exactly right when releases happen in LIFO order; out-of-order
-   * releases give back the most recent acquire's advance regardless, which
-   * is best-effort but never breaks the rate-limit invariant the way the
-   * old `nextAvailableTime = lastStartTime` reset did.
+   * Roll back the slot identified by `token`. Only undoes the advance if no
+   * later acquire moved the window forward — otherwise we'd undo someone
+   * else's reservation.
    */
-  async release(): Promise<void> {
-    const snapshot = this.acquireSnapshots.pop();
-    if (snapshot !== undefined) {
-      this.nextAvailableTime = snapshot;
+  async release(token: unknown): Promise<void> {
+    if (
+      !token ||
+      typeof token !== "object" ||
+      typeof (token as { advancedTo?: unknown }).advancedTo !== "number"
+    ) {
+      return;
+    }
+    const t = token as { priorNextAvailable: number; advancedTo: number };
+    if (this.nextAvailableTime === t.advancedTo) {
+      this.nextAvailableTime = t.priorNextAvailable;
     }
   }
 
@@ -156,6 +150,5 @@ export class EvenlySpacedRateLimiter implements ILimiter {
     this.durations = [];
     this.nextAvailableTime = Date.now();
     this.lastStartTime = 0;
-    this.acquireSnapshots = [];
   }
 }

--- a/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
+++ b/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServiceToken } from "@workglow/util";
-import { ILimiter, RateLimiterOptions } from "./ILimiter";
+import { ILimiter, LimiterScope, RateLimiterOptions } from "./ILimiter";
 
 export const EVENLY_SPACED_JOB_RATE_LIMITER = createServiceToken<ILimiter>(
   "jobqueue.limiter.rate.evenlyspaced"
@@ -17,12 +17,25 @@ export const EVENLY_SPACED_JOB_RATE_LIMITER = createServiceToken<ILimiter>(
  * this limiter spaces out the requests evenly across the window.
  */
 export class EvenlySpacedRateLimiter implements ILimiter {
+  /** In-memory per-instance state — not shared across processes. */
+  public readonly scope: LimiterScope = "process";
   private readonly maxExecutions: number;
   private readonly windowSizeMs: number;
   private readonly idealInterval: number;
   private nextAvailableTime: number = Date.now();
   private lastStartTime: number = 0;
   private durations: number[] = [];
+  /** Promise chain used to serialize concurrent {@link tryAcquire} callers. */
+  private acquireChain: Promise<unknown> = Promise.resolve();
+  /**
+   * Stack of `nextAvailableTime` snapshots captured BEFORE each successful
+   * {@link tryAcquire} advanced it. {@link release} pops the top and restores
+   * the snapshot, which correctly rolls back the most recent acquire even
+   * with multiple in-flight slots. Out-of-order releases (popping a snapshot
+   * that doesn't belong to the released acquire) are best-effort and may
+   * give back a slightly different amount of time than the released slot took.
+   */
+  private acquireSnapshots: number[] = [];
 
   constructor({ maxExecutions, windowSizeInSeconds }: RateLimiterOptions) {
     if (maxExecutions <= 0) {
@@ -41,6 +54,59 @@ export class EvenlySpacedRateLimiter implements ILimiter {
   async canProceed(): Promise<boolean> {
     const now = Date.now();
     return now >= this.nextAvailableTime;
+  }
+
+  /**
+   * Atomic acquire: serialized by an internal promise chain so two concurrent
+   * acquirers cannot both observe `now >= nextAvailableTime` and both proceed.
+   */
+  async tryAcquire(): Promise<boolean> {
+    const previous = this.acquireChain;
+    let release!: (v: unknown) => void;
+    const next = new Promise((r) => {
+      release = r;
+    });
+    this.acquireChain = next;
+    try {
+      await previous;
+      const now = Date.now();
+      if (now < this.nextAvailableTime) {
+        return false;
+      }
+      // Snapshot the pre-acquire state so a paired release() can roll back
+      // exactly this acquire's advance even with multiple slots in flight.
+      this.acquireSnapshots.push(this.nextAvailableTime);
+      // Reserve the slot by advancing nextAvailableTime now (recordJobStart-style)
+      // so a follow-up tryAcquire from another caller in the same tick blocks.
+      this.lastStartTime = now;
+      if (this.durations.length === 0) {
+        this.nextAvailableTime = now + this.idealInterval;
+      } else {
+        const sum = this.durations.reduce((a, b) => a + b, 0);
+        const avgDuration = sum / this.durations.length;
+        const waitMs = Math.max(0, this.idealInterval - avgDuration);
+        this.nextAvailableTime = now + waitMs;
+      }
+      return true;
+    } finally {
+      release(undefined);
+    }
+  }
+
+  /**
+   * Roll back a previously acquired slot. Pops the top snapshot from the
+   * acquire stack and restores `nextAvailableTime` to the value it had BEFORE
+   * the most recent acquire advanced it. With multiple in-flight slots this
+   * is exactly right when releases happen in LIFO order; out-of-order
+   * releases give back the most recent acquire's advance regardless, which
+   * is best-effort but never breaks the rate-limit invariant the way the
+   * old `nextAvailableTime = lastStartTime` reset did.
+   */
+  async release(): Promise<void> {
+    const snapshot = this.acquireSnapshots.pop();
+    if (snapshot !== undefined) {
+      this.nextAvailableTime = snapshot;
+    }
   }
 
   /** Record that a job is starting now. */
@@ -90,5 +156,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
     this.durations = [];
     this.nextAvailableTime = Date.now();
     this.lastStartTime = 0;
+    this.acquireSnapshots = [];
   }
 }

--- a/packages/job-queue/src/limiter/ILimiter.ts
+++ b/packages/job-queue/src/limiter/ILimiter.ts
@@ -9,11 +9,66 @@ import { createServiceToken } from "@workglow/util";
 export const JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.limiter");
 
 /**
+ * Whether a limiter's state is shared across processes.
+ *
+ * - `"process"` — state lives in this process only. Multiple workers in the
+ *   same process share it, but separate processes do not. The configured limit
+ *   is multiplied by the number of processes.
+ * - `"cluster"` — state lives in shared storage (Postgres, Supabase, etc.)
+ *   visible to every process in the cluster. The configured limit is enforced
+ *   globally.
+ */
+export type LimiterScope = "process" | "cluster";
+
+/**
  * Interface for a job limiter.
+ *
+ * The atomic primitive is {@link tryAcquire}: it both checks whether a job may
+ * proceed and reserves the slot in a single uninterruptible step. Callers
+ * MUST use {@link tryAcquire}/{@link release} (not the legacy
+ * {@link canProceed}/{@link recordJobStart} pair) when correctness matters
+ * under concurrency.
  */
 export interface ILimiter {
+  /**
+   * Whether this limiter's state is shared across processes. See
+   * {@link LimiterScope}. In-memory limiters MUST report `"process"` so users
+   * don't mistake them for cluster-safe.
+   */
+  readonly scope: LimiterScope;
+
+  /**
+   * Atomic check-and-record. Returns `true` iff a slot was reserved (i.e. the
+   * caller may proceed AND the reservation has been recorded). Returns `false`
+   * without side effects if the limiter is at capacity.
+   *
+   * Implementations must be safe under concurrent callers — two parallel
+   * `tryAcquire()` calls with one slot remaining must result in exactly one
+   * `true` and one `false`.
+   */
+  tryAcquire(): Promise<boolean>;
+
+  /**
+   * Release a slot previously reserved by {@link tryAcquire}. Used when the
+   * caller cannot actually use the slot it acquired (e.g. claimed a job that
+   * vanished, executor failed before running, worker shut down).
+   */
+  release(): Promise<void>;
+
+  /**
+   * Legacy non-binding "would tryAcquire succeed?" probe. SUBJECT TO RACES —
+   * do not use this followed by {@link recordJobStart} in production code; use
+   * {@link tryAcquire} instead. Retained for observability and tests.
+   */
   canProceed(): Promise<boolean>;
+
+  /**
+   * Legacy "force-record an execution" hook. SUBJECT TO RACES when paired with
+   * {@link canProceed} — use {@link tryAcquire} instead. Retained for tests
+   * and external bookkeeping.
+   */
   recordJobStart(): Promise<void>;
+
   recordJobCompletion(): Promise<void>;
   getNextAvailableTime(): Promise<Date>;
   setNextAvailableTime(date: Date): Promise<void>;

--- a/packages/job-queue/src/limiter/ILimiter.ts
+++ b/packages/job-queue/src/limiter/ILimiter.ts
@@ -38,22 +38,29 @@ export interface ILimiter {
   readonly scope: LimiterScope;
 
   /**
-   * Atomic check-and-record. Returns `true` iff a slot was reserved (i.e. the
-   * caller may proceed AND the reservation has been recorded). Returns `false`
-   * without side effects if the limiter is at capacity.
+   * Atomic check-and-record. Returns an opaque, non-null token on success
+   * (the caller may proceed AND the reservation has been recorded). Returns
+   * `null` without side effects if the limiter is at capacity.
+   *
+   * The returned token MUST be passed to {@link release} to free the slot —
+   * otherwise rolling back the reservation under contention would race to
+   * delete some other worker's slot. Tokens are implementation-defined and
+   * callers must treat them as opaque.
    *
    * Implementations must be safe under concurrent callers — two parallel
    * `tryAcquire()` calls with one slot remaining must result in exactly one
-   * `true` and one `false`.
+   * non-null token and one `null`.
    */
-  tryAcquire(): Promise<boolean>;
+  tryAcquire(): Promise<unknown | null>;
 
   /**
-   * Release a slot previously reserved by {@link tryAcquire}. Used when the
-   * caller cannot actually use the slot it acquired (e.g. claimed a job that
-   * vanished, executor failed before running, worker shut down).
+   * Release a slot previously reserved by {@link tryAcquire}. The token must
+   * be the value that {@link tryAcquire} returned for the slot being freed.
+   * Used when the caller cannot actually use the slot it acquired (e.g.
+   * claimed a job that vanished, executor failed before running, worker
+   * shut down).
    */
-  release(): Promise<void>;
+  release(token: unknown): Promise<void>;
 
   /**
    * Legacy non-binding "would tryAcquire succeed?" probe. SUBJECT TO RACES —

--- a/packages/job-queue/src/limiter/NullLimiter.ts
+++ b/packages/job-queue/src/limiter/NullLimiter.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServiceToken } from "@workglow/util";
-import { ILimiter } from "./ILimiter";
+import { ILimiter, LimiterScope } from "./ILimiter";
 
 export const NULL_JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.limiter.null");
 
@@ -13,6 +13,16 @@ export const NULL_JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.limiter.n
  * Null limiter that does nothing.
  */
 export class NullLimiter implements ILimiter {
+  public readonly scope: LimiterScope = "process";
+
+  async tryAcquire(): Promise<boolean> {
+    return true;
+  }
+
+  async release(): Promise<void> {
+    // Do nothing
+  }
+
   async canProceed(): Promise<boolean> {
     return true;
   }

--- a/packages/job-queue/src/limiter/NullLimiter.ts
+++ b/packages/job-queue/src/limiter/NullLimiter.ts
@@ -15,11 +15,14 @@ export const NULL_JOB_LIMITER = createServiceToken<ILimiter>("jobqueue.limiter.n
 export class NullLimiter implements ILimiter {
   public readonly scope: LimiterScope = "process";
 
-  async tryAcquire(): Promise<boolean> {
-    return true;
+  /** Sentinel token — non-null so callers' truthy checks see it as a success. */
+  private static readonly SENTINEL = Symbol("NullLimiter.acquired");
+
+  async tryAcquire(): Promise<unknown | null> {
+    return NullLimiter.SENTINEL;
   }
 
-  async release(): Promise<void> {
+  async release(_token: unknown): Promise<void> {
     // Do nothing
   }
 

--- a/packages/job-queue/src/limiter/RateLimiter.ts
+++ b/packages/job-queue/src/limiter/RateLimiter.ts
@@ -5,7 +5,7 @@
  */
 
 import { IRateLimiterStorage } from "@workglow/storage";
-import { ILimiter, RateLimiterWithBackoffOptions } from "./ILimiter";
+import { ILimiter, LimiterScope, RateLimiterWithBackoffOptions } from "./ILimiter";
 
 /**
  * Base rate limiter implementation that uses a storage backend.
@@ -18,6 +18,14 @@ export class RateLimiter implements ILimiter {
   protected readonly initialBackoffDelay: number;
   protected readonly backoffMultiplier: number;
   protected readonly maxBackoffDelay: number;
+  /**
+   * Per-instance backoff hint set by the most recent failed {@link tryAcquire}.
+   * Exposed via {@link getNextAvailableTime} so this process's worker sleeps
+   * until the hint expires, but NOT written to storage so a parallel worker's
+   * {@link release} can't clobber it. Cross-process workers each maintain
+   * their own hint.
+   */
+  protected localBackoffUntilMs: number = 0;
 
   constructor(
     protected readonly storage: IRateLimiterStorage,
@@ -52,6 +60,56 @@ export class RateLimiter implements ILimiter {
     this.backoffMultiplier = backoffMultiplier;
     this.maxBackoffDelay = maxBackoffDelay;
     this.currentBackoffDelay = initialBackoffDelay;
+  }
+
+  /**
+   * Inherits its scope from the underlying storage. Storage-backed RateLimiter
+   * is `"cluster"` for Postgres/Supabase, `"process"` for InMemory/IndexedDb/Sqlite.
+   */
+  public get scope(): LimiterScope {
+    return this.storage.scope;
+  }
+
+  /**
+   * Atomic check-and-record. Delegates to {@link IRateLimiterStorage.tryReserveExecution}
+   * which performs the count, next-available, and insert under a single
+   * critical section per backend (advisory xact lock for Postgres, BEGIN
+   * IMMEDIATE for SQLite, per-key promise mutex for in-memory).
+   */
+  async tryAcquire(): Promise<boolean> {
+    const reserved = await this.storage.tryReserveExecution(
+      this.queueName,
+      this.maxExecutions,
+      this.windowSizeInMilliseconds
+    );
+    if (reserved) {
+      this.currentBackoffDelay = this.initialBackoffDelay;
+      this.localBackoffUntilMs = 0;
+      return true;
+    }
+
+    // Capacity reached — apply jittered exponential backoff. We hold this
+    // hint on the instance only; writing to the shared storage sentinel
+    // would race with parallel acquire/release calls (a peer's release()
+    // could clobber our hint, and clobbering the storage sentinel is
+    // dangerous because tryReserveExecution treats it as a hard gate).
+    this.localBackoffUntilMs = Date.now() + this.addJitter(this.currentBackoffDelay);
+    this.increaseBackoff();
+    return false;
+  }
+
+  /**
+   * Release the slot reserved by the most recent {@link tryAcquire}. Best-effort:
+   * removes the most recent execution row. Does NOT touch the shared storage
+   * `nextAvailableAt` sentinel — that field is reserved for explicit
+   * external pauses set via {@link setNextAvailableTime}, and clearing it
+   * here would clobber a parallel worker's failed-acquire backoff or, worse,
+   * a deliberate cluster-wide pause.
+   */
+  async release(): Promise<void> {
+    await this.storage.releaseExecution(this.queueName);
+    this.currentBackoffDelay = this.initialBackoffDelay;
+    this.localBackoffUntilMs = 0;
   }
 
   protected addJitter(base: number): number {
@@ -130,8 +188,10 @@ export class RateLimiter implements ILimiter {
   }
 
   /**
-   * Retrieves the next available time for the specific queue.
-   * @returns The next available time
+   * Retrieves the next available time for the specific queue. Returns the
+   * latest of: the rate-limit wall (oldest execution + window), any externally
+   * set storage sentinel (explicit pause), and this instance's local backoff
+   * hint from the most recent failed {@link tryAcquire}.
    */
   async getNextAvailableTime(): Promise<Date> {
     // Get the time when the rate limit will allow the next job execution
@@ -140,22 +200,28 @@ export class RateLimiter implements ILimiter {
       this.maxExecutions - 1
     );
 
-    let rateLimitedTime = new Date();
+    let latestMs = Date.now();
     if (oldestExecution) {
-      rateLimitedTime = new Date(oldestExecution);
-      rateLimitedTime.setSeconds(
-        rateLimitedTime.getSeconds() + this.windowSizeInMilliseconds / 1000
+      latestMs = Math.max(
+        latestMs,
+        new Date(oldestExecution).getTime() + this.windowSizeInMilliseconds
       );
     }
 
-    // Get the next available time set externally, if any
+    // External pause set via setNextAvailableTime (cluster-visible).
     const nextAvailableStr = await this.storage.getNextAvailableTime(this.queueName);
-    let nextAvailableTime = new Date();
     if (nextAvailableStr) {
-      nextAvailableTime = new Date(nextAvailableStr);
+      latestMs = Math.max(latestMs, new Date(nextAvailableStr).getTime());
     }
 
-    return nextAvailableTime > rateLimitedTime ? nextAvailableTime : rateLimitedTime;
+    // Local backoff hint from the most recent failed tryAcquire on this
+    // instance — keeps this process's worker from re-acquiring before the
+    // hint expires without polluting cluster state.
+    if (this.localBackoffUntilMs > latestMs) {
+      latestMs = this.localBackoffUntilMs;
+    }
+
+    return new Date(latestMs);
   }
 
   /**
@@ -172,5 +238,6 @@ export class RateLimiter implements ILimiter {
   async clear(): Promise<void> {
     await this.storage.clear(this.queueName);
     this.currentBackoffDelay = this.initialBackoffDelay;
+    this.localBackoffUntilMs = 0;
   }
 }

--- a/packages/job-queue/src/limiter/RateLimiter.ts
+++ b/packages/job-queue/src/limiter/RateLimiter.ts
@@ -75,17 +75,22 @@ export class RateLimiter implements ILimiter {
    * which performs the count, next-available, and insert under a single
    * critical section per backend (advisory xact lock for Postgres, BEGIN
    * IMMEDIATE for SQLite, per-key promise mutex for in-memory).
+   *
+   * Returns the storage-assigned row id as an opaque token on success, or
+   * `null` on failure. The caller MUST pass the token to {@link release} to
+   * roll back — releasing without a token would race to delete the wrong
+   * worker's slot under contention.
    */
-  async tryAcquire(): Promise<boolean> {
-    const reserved = await this.storage.tryReserveExecution(
+  async tryAcquire(): Promise<unknown | null> {
+    const token = await this.storage.tryReserveExecution(
       this.queueName,
       this.maxExecutions,
       this.windowSizeInMilliseconds
     );
-    if (reserved) {
+    if (token !== null && token !== undefined) {
       this.currentBackoffDelay = this.initialBackoffDelay;
       this.localBackoffUntilMs = 0;
-      return true;
+      return token;
     }
 
     // Capacity reached — apply jittered exponential backoff. We hold this
@@ -95,19 +100,23 @@ export class RateLimiter implements ILimiter {
     // dangerous because tryReserveExecution treats it as a hard gate).
     this.localBackoffUntilMs = Date.now() + this.addJitter(this.currentBackoffDelay);
     this.increaseBackoff();
-    return false;
+    return null;
   }
 
   /**
-   * Release the slot reserved by the most recent {@link tryAcquire}. Best-effort:
-   * removes the most recent execution row. Does NOT touch the shared storage
-   * `nextAvailableAt` sentinel — that field is reserved for explicit
-   * external pauses set via {@link setNextAvailableTime}, and clearing it
-   * here would clobber a parallel worker's failed-acquire backoff or, worse,
-   * a deliberate cluster-wide pause.
+   * Release the slot identified by `token` (a value returned from
+   * {@link tryAcquire}). Deletes the specific row by id — NOT the most recent
+   * — so two concurrent acquirers don't race to release each other's slots.
+   * Does NOT touch the shared storage `nextAvailableAt` sentinel; that field
+   * is reserved for explicit external pauses (e.g. cluster-wide rate-limit
+   * cool-down set via {@link setNextAvailableTime}), and clearing it here
+   * would clobber a parallel worker's failed-acquire backoff or a deliberate
+   * cluster-wide pause. Local per-instance backoff is cleared via
+   * {@link localBackoffUntilMs}.
    */
-  async release(): Promise<void> {
-    await this.storage.releaseExecution(this.queueName);
+  async release(token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
+    await this.storage.releaseExecution(this.queueName, token);
     this.currentBackoffDelay = this.initialBackoffDelay;
     this.localBackoffUntilMs = 0;
   }

--- a/packages/storage/src/common-server.ts
+++ b/packages/storage/src/common-server.ts
@@ -34,5 +34,6 @@ export * from "./kv/IndexedDbKvStorage";
 export * from "./queue-limiter/IndexedDbRateLimiterStorage";
 export * from "./queue/IndexedDbQueueStorage";
 export * from "./tabular/IndexedDbTabularStorage";
+export * from "./tabular/SharedInMemoryTabularStorage";
 export * from "./vector/IndexedDbVectorStorage";
 export * from "./util/IndexedDbTable";

--- a/packages/storage/src/queue-limiter/IRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/IRateLimiterStorage.ts
@@ -10,6 +10,16 @@ import type { PrefixColumn } from "../queue/IQueueStorage";
 export const RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>("ratelimiter.storage");
 
 /**
+ * Whether a rate-limiter storage's state is shared across processes.
+ *
+ * - `"process"` — in-memory / per-process state. Multiple workers in the same
+ *   process share it, but separate processes do not.
+ * - `"cluster"` — state lives in shared external storage (Postgres, Supabase,
+ *   etc.) visible to every process.
+ */
+export type RateLimiterStorageScope = "process" | "cluster";
+
+/**
  * Options for configuring rate limiter storage with prefix filters.
  */
 export interface RateLimiterStorageOptions {
@@ -42,11 +52,45 @@ export interface NextAvailableRecord {
  */
 export interface IRateLimiterStorage {
   /**
+   * Whether this storage is shared across processes. In-memory backends MUST
+   * report `"process"`. Shared databases (Postgres, Supabase) report
+   * `"cluster"`.
+   */
+  readonly scope: RateLimiterStorageScope;
+
+  /**
    * Sets up the database schema and tables.
    * This method should be called before using the storage.
    * For production use, database setup should be done via migrations.
    */
   setupDatabase(): Promise<void>;
+
+  /**
+   * Atomic check-and-record. Returns `true` and inserts an execution row iff
+   * BOTH (a) fewer than `maxExecutions` rows have `executed_at >
+   * (now - windowMs)` AND (b) any persisted `nextAvailableAt` is in the past
+   * or absent. Returns `false` without writing anything otherwise.
+   *
+   * Implementations MUST serialize concurrent callers (advisory locks,
+   * `BEGIN IMMEDIATE`, per-key mutex, etc.) so the count-then-insert window
+   * is uninterruptible.
+   *
+   * @param queueName - The name of the queue
+   * @param maxExecutions - Max allowed executions in the window
+   * @param windowMs - Window size in milliseconds
+   */
+  tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean>;
+
+  /**
+   * Best-effort release: remove the most recent execution row for this queue.
+   * Used when a caller reserved a slot via {@link tryReserveExecution} but
+   * could not actually use it.
+   */
+  releaseExecution(queueName: string): Promise<void>;
 
   /**
    * Records a job execution for rate limiting tracking.

--- a/packages/storage/src/queue-limiter/IRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/IRateLimiterStorage.ts
@@ -66,10 +66,15 @@ export interface IRateLimiterStorage {
   setupDatabase(): Promise<void>;
 
   /**
-   * Atomic check-and-record. Returns `true` and inserts an execution row iff
-   * BOTH (a) fewer than `maxExecutions` rows have `executed_at >
-   * (now - windowMs)` AND (b) any persisted `nextAvailableAt` is in the past
-   * or absent. Returns `false` without writing anything otherwise.
+   * Atomic check-and-record. Inserts an execution row and returns the
+   * inserted row's id iff BOTH (a) fewer than `maxExecutions` rows have
+   * `executed_at > (now - windowMs)` AND (b) any persisted `nextAvailableAt`
+   * is in the past or absent. Returns `null` without writing anything
+   * otherwise.
+   *
+   * The returned id MUST be passed to {@link releaseExecution} to free the
+   * slot — otherwise concurrent acquirers would race to delete the wrong
+   * worker's row when one of them rolls back.
    *
    * Implementations MUST serialize concurrent callers (advisory locks,
    * `BEGIN IMMEDIATE`, per-key mutex, etc.) so the count-then-insert window
@@ -78,19 +83,24 @@ export interface IRateLimiterStorage {
    * @param queueName - The name of the queue
    * @param maxExecutions - Max allowed executions in the window
    * @param windowMs - Window size in milliseconds
+   * @returns the inserted row's id on success, or `null` on failure
    */
   tryReserveExecution(
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean>;
+  ): Promise<unknown | null>;
 
   /**
-   * Best-effort release: remove the most recent execution row for this queue.
-   * Used when a caller reserved a slot via {@link tryReserveExecution} but
-   * could not actually use it.
+   * Release the execution row identified by `token` (the value previously
+   * returned from {@link tryReserveExecution}). No-op if the row no longer
+   * exists.
+   *
+   * Critical: implementations MUST delete by id, NOT by recency or position.
+   * Two concurrent workers can hold tokens for different rows; deleting the
+   * "most recent" row would release another worker's reservation.
    */
-  releaseExecution(queueName: string): Promise<void>;
+  releaseExecution(queueName: string, token: unknown): Promise<void>;
 
   /**
    * Records a job execution for rate limiting tracking.

--- a/packages/storage/src/queue-limiter/InMemoryRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/InMemoryRateLimiterStorage.ts
@@ -5,7 +5,11 @@
  */
 
 import { createServiceToken, sleep } from "@workglow/util";
-import { IRateLimiterStorage, RateLimiterStorageOptions } from "./IRateLimiterStorage";
+import {
+  IRateLimiterStorage,
+  RateLimiterStorageOptions,
+  RateLimiterStorageScope,
+} from "./IRateLimiterStorage";
 
 export const IN_MEMORY_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>(
   "ratelimiter.storage.inMemory"
@@ -24,6 +28,8 @@ interface ExecutionEntry {
  * Manages execution records and next available times for rate limiting.
  */
 export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
+  public readonly scope: RateLimiterStorageScope = "process";
+
   /** The prefix values for filtering */
   protected readonly prefixValues: Readonly<Record<string, string | number>>;
 
@@ -32,6 +38,14 @@ export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
 
   /** Next available times keyed by a composite of prefix values and queue name */
   private readonly nextAvailableTimes: Map<string, Date> = new Map();
+
+  /**
+   * Per-key promise chain used to serialize {@link tryReserveExecution} so
+   * concurrent callers cannot both observe `count < max` before either
+   * inserts. Each key's chain is replaced with the next pending operation
+   * before the current one returns, giving FIFO mutex semantics.
+   */
+  private readonly reserveChains: Map<string, Promise<unknown>> = new Map();
 
   constructor(options?: RateLimiterStorageOptions) {
     this.prefixValues = options?.prefixValues ?? {};
@@ -50,6 +64,74 @@ export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
 
   public async setupDatabase(): Promise<void> {
     // No-op for in-memory storage
+  }
+
+  /**
+   * Run `fn` under a per-key mutex. Without this, two concurrent
+   * `tryReserveExecution` calls would both `await sleep(0)`, both observe the
+   * same execution count, and both insert — overshooting the configured limit.
+   */
+  private async withKeyLock<T>(key: string, fn: () => T | Promise<T>): Promise<T> {
+    const previous = this.reserveChains.get(key) ?? Promise.resolve();
+    let release!: (value: unknown) => void;
+    const next = new Promise((resolve) => {
+      release = resolve;
+    });
+    this.reserveChains.set(key, next);
+    try {
+      await previous;
+      return await fn();
+    } finally {
+      release(undefined);
+      if (this.reserveChains.get(key) === next) {
+        this.reserveChains.delete(key);
+      }
+    }
+  }
+
+  public async tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean> {
+    const key = this.makeKey(queueName);
+    return this.withKeyLock(key, () => {
+      const now = Date.now();
+      const windowStart = new Date(now - windowMs);
+      const executions = this.executions.get(key) ?? [];
+      const live = executions.filter((e) => e.executedAt > windowStart);
+      if (live.length >= maxExecutions) {
+        // Compact while we're here.
+        if (live.length !== executions.length) {
+          this.executions.set(key, live);
+        }
+        return false;
+      }
+      const next = this.nextAvailableTimes.get(key);
+      if (next && next.getTime() > now) {
+        return false;
+      }
+      live.push({ queueName, executedAt: new Date(now) });
+      this.executions.set(key, live);
+      return true;
+    });
+  }
+
+  public async releaseExecution(queueName: string): Promise<void> {
+    const key = this.makeKey(queueName);
+    await this.withKeyLock(key, () => {
+      const executions = this.executions.get(key);
+      if (!executions || executions.length === 0) return;
+      // Pop the most recent.
+      let latestIdx = 0;
+      for (let i = 1; i < executions.length; i++) {
+        if (executions[i].executedAt > executions[latestIdx].executedAt) {
+          latestIdx = i;
+        }
+      }
+      executions.splice(latestIdx, 1);
+      this.executions.set(key, executions);
+    });
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue-limiter/InMemoryRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/InMemoryRateLimiterStorage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createServiceToken, sleep } from "@workglow/util";
+import { createServiceToken, sleep, uuid4 } from "@workglow/util";
 import {
   IRateLimiterStorage,
   RateLimiterStorageOptions,
@@ -19,6 +19,8 @@ export const IN_MEMORY_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterSto
  * Record of a job execution stored in memory.
  */
 interface ExecutionEntry {
+  /** Per-row id; serves as the opaque token returned by tryReserveExecution. */
+  readonly id: string;
   readonly queueName: string;
   readonly executedAt: Date;
 }
@@ -93,7 +95,7 @@ export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean> {
+  ): Promise<unknown | null> {
     const key = this.makeKey(queueName);
     return this.withKeyLock(key, () => {
       const now = Date.now();
@@ -105,31 +107,31 @@ export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
         if (live.length !== executions.length) {
           this.executions.set(key, live);
         }
-        return false;
+        return null;
       }
       const next = this.nextAvailableTimes.get(key);
       if (next && next.getTime() > now) {
-        return false;
+        return null;
       }
-      live.push({ queueName, executedAt: new Date(now) });
+      const id = uuid4();
+      live.push({ id, queueName, executedAt: new Date(now) });
       this.executions.set(key, live);
-      return true;
+      return id;
     });
   }
 
-  public async releaseExecution(queueName: string): Promise<void> {
+  public async releaseExecution(queueName: string, token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
     const key = this.makeKey(queueName);
     await this.withKeyLock(key, () => {
       const executions = this.executions.get(key);
       if (!executions || executions.length === 0) return;
-      // Pop the most recent.
-      let latestIdx = 0;
-      for (let i = 1; i < executions.length; i++) {
-        if (executions[i].executedAt > executions[latestIdx].executedAt) {
-          latestIdx = i;
-        }
-      }
-      executions.splice(latestIdx, 1);
+      // Delete by id — NEVER by recency. Two concurrent acquirers can hold
+      // tokens for different rows; popping the most recent would release the
+      // other worker's slot.
+      const idx = executions.findIndex((e) => e.id === token);
+      if (idx === -1) return;
+      executions.splice(idx, 1);
       this.executions.set(key, executions);
     });
   }
@@ -139,6 +141,7 @@ export class InMemoryRateLimiterStorage implements IRateLimiterStorage {
     const key = this.makeKey(queueName);
     const executions = this.executions.get(key) ?? [];
     executions.push({
+      id: uuid4(),
       queueName,
       executedAt: new Date(),
     });

--- a/packages/storage/src/queue-limiter/IndexedDbRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/IndexedDbRateLimiterStorage.ts
@@ -11,7 +11,11 @@ import {
   MigrationOptions,
 } from "../util/IndexedDbTable";
 import type { PrefixColumn } from "../queue/IQueueStorage";
-import { IRateLimiterStorage, RateLimiterStorageOptions } from "./IRateLimiterStorage";
+import {
+  IRateLimiterStorage,
+  RateLimiterStorageOptions,
+  RateLimiterStorageScope,
+} from "./IRateLimiterStorage";
 
 export const INDEXED_DB_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>(
   "ratelimiter.storage.indexedDb"
@@ -45,8 +49,19 @@ interface NextAvailableRecord {
 /**
  * IndexedDB implementation of rate limiter storage.
  * Manages execution records and next available times for rate limiting.
+ *
+ * Atomicity is `"process"`-scoped (browser tab) and the `next_available_at`
+ * pre-check inside {@link tryReserveExecution} runs in a separate IDB
+ * transaction from the count-and-insert. See {@link tryReserveExecution} for
+ * the full caveat — do not assume cross-store atomicity.
  */
 export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
+  /**
+   * `"process"` — IndexedDB is per-origin and shared across tabs but not across
+   * processes (different machines, server processes). Within a single tab the
+   * `readwrite` transaction below provides atomicity.
+   */
+  public readonly scope: RateLimiterStorageScope = "process";
   private executionDb: IDBDatabase | undefined;
   private nextAvailableDb: IDBDatabase | undefined;
   private readonly executionTableName: string;
@@ -148,6 +163,127 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
       nextAvailableIndexes,
       this.migrationOptions
     );
+  }
+
+  /**
+   * Atomically reserves an execution slot in IndexedDB.
+   *
+   * Atomicity caveat: this implementation only serializes the `count + insert`
+   * pair (under a single `readwrite` IDB transaction over the executions
+   * store). The `next_available_at` lookup is a soft pre-check performed
+   * BEFORE the tx, because the executions and next-available object stores
+   * live in separate `IDBDatabase` instances by design (one
+   * `ensureIndexedDbTable` call each) and IDB transaction scope cannot cross
+   * databases. This is acceptable for IndexedDB's `"process"` scope: rate-
+   * limit overshoot from a stale next-available read is bounded by single-
+   * tab serial execution, and the stricter count check is what protects the
+   * primary maxExecutions invariant.
+   */
+  public async tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean> {
+    // Soft pre-check against external backoff. Done before opening the tx
+    // because next-available lives in a separate IDBDatabase.
+    const nextIso = await this.getNextAvailableTime(queueName);
+    if (nextIso && new Date(nextIso).getTime() > Date.now()) {
+      return false;
+    }
+
+    const execDb = await this.getExecutionDb();
+    const prefixKeyValues = this.getPrefixKeyValues();
+    const windowStartIso = new Date(Date.now() - windowMs).toISOString();
+    const execTx = execDb.transaction(this.executionTableName, "readwrite");
+    const execStore = execTx.objectStore(this.executionTableName);
+
+    return new Promise<boolean>((resolve, reject) => {
+      let liveCount = 0;
+      let inserted = false;
+      const liveRange = IDBKeyRange.bound(
+        [...prefixKeyValues, queueName, windowStartIso],
+        [...prefixKeyValues, queueName, "￿"],
+        true,
+        false
+      );
+      const cursorReq = execStore.index("queue_executed_at").openCursor(liveRange);
+
+      cursorReq.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor) {
+          const record = cursor.value as ExecutionRecord;
+          if (this.matchesPrefixes(record)) {
+            liveCount++;
+          }
+          cursor.continue();
+          return;
+        }
+
+        if (liveCount >= maxExecutions) {
+          // Aborting fires execTx.onabort below, which resolves with `false`.
+          // No INSERT happened, so capacity is preserved.
+          execTx.abort();
+          return;
+        }
+
+        const record: ExecutionRecord = {
+          id: crypto.randomUUID(),
+          queue_name: queueName,
+          executed_at: new Date().toISOString(),
+        };
+        for (const [k, v] of Object.entries(this.prefixValues)) {
+          (record as Record<string, unknown>)[k] = v;
+        }
+        const addReq = execStore.add(record);
+        inserted = true;
+        addReq.onerror = () => {
+          try {
+            execTx.abort();
+          } catch {
+            // already aborted
+          }
+          reject(addReq.error);
+        };
+      };
+
+      cursorReq.onerror = () => reject(cursorReq.error);
+      execTx.oncomplete = () => resolve(inserted);
+      execTx.onerror = () => reject(execTx.error);
+      execTx.onabort = () => resolve(false);
+    });
+  }
+
+  public async releaseExecution(queueName: string): Promise<void> {
+    const db = await this.getExecutionDb();
+    const tx = db.transaction(this.executionTableName, "readwrite");
+    const store = tx.objectStore(this.executionTableName);
+    const index = store.index("queue_executed_at");
+    const prefixKeyValues = this.getPrefixKeyValues();
+
+    return new Promise<void>((resolve, reject) => {
+      const range = IDBKeyRange.bound(
+        [...prefixKeyValues, queueName, ""],
+        [...prefixKeyValues, queueName, "￿"]
+      );
+      // Open a descending cursor and delete the first matching record.
+      const req = index.openCursor(range, "prev");
+      let deleted = false;
+      req.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor && !deleted) {
+          const record = cursor.value as ExecutionRecord;
+          if (this.matchesPrefixes(record)) {
+            cursor.delete();
+            deleted = true;
+            return;
+          }
+          cursor.continue();
+        }
+      };
+      req.onerror = () => reject(req.error);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue-limiter/IndexedDbRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/IndexedDbRateLimiterStorage.ts
@@ -183,12 +183,12 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean> {
+  ): Promise<unknown | null> {
     // Soft pre-check against external backoff. Done before opening the tx
     // because next-available lives in a separate IDBDatabase.
     const nextIso = await this.getNextAvailableTime(queueName);
     if (nextIso && new Date(nextIso).getTime() > Date.now()) {
-      return false;
+      return null;
     }
 
     const execDb = await this.getExecutionDb();
@@ -196,10 +196,11 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
     const windowStartIso = new Date(Date.now() - windowMs).toISOString();
     const execTx = execDb.transaction(this.executionTableName, "readwrite");
     const execStore = execTx.objectStore(this.executionTableName);
+    const insertedId = crypto.randomUUID();
 
-    return new Promise<boolean>((resolve, reject) => {
+    return new Promise<unknown | null>((resolve, reject) => {
       let liveCount = 0;
-      let inserted = false;
+      let didInsert = false;
       const liveRange = IDBKeyRange.bound(
         [...prefixKeyValues, queueName, windowStartIso],
         [...prefixKeyValues, queueName, "￿"],
@@ -227,7 +228,7 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
         }
 
         const record: ExecutionRecord = {
-          id: crypto.randomUUID(),
+          id: insertedId,
           queue_name: queueName,
           executed_at: new Date().toISOString(),
         };
@@ -235,7 +236,7 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
           (record as Record<string, unknown>)[k] = v;
         }
         const addReq = execStore.add(record);
-        inserted = true;
+        didInsert = true;
         addReq.onerror = () => {
           try {
             execTx.abort();
@@ -247,39 +248,22 @@ export class IndexedDbRateLimiterStorage implements IRateLimiterStorage {
       };
 
       cursorReq.onerror = () => reject(cursorReq.error);
-      execTx.oncomplete = () => resolve(inserted);
+      execTx.oncomplete = () => resolve(didInsert ? insertedId : null);
       execTx.onerror = () => reject(execTx.error);
-      execTx.onabort = () => resolve(false);
+      execTx.onabort = () => resolve(null);
     });
   }
 
-  public async releaseExecution(queueName: string): Promise<void> {
+  public async releaseExecution(queueName: string, token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
     const db = await this.getExecutionDb();
     const tx = db.transaction(this.executionTableName, "readwrite");
     const store = tx.objectStore(this.executionTableName);
-    const index = store.index("queue_executed_at");
-    const prefixKeyValues = this.getPrefixKeyValues();
-
     return new Promise<void>((resolve, reject) => {
-      const range = IDBKeyRange.bound(
-        [...prefixKeyValues, queueName, ""],
-        [...prefixKeyValues, queueName, "￿"]
-      );
-      // Open a descending cursor and delete the first matching record.
-      const req = index.openCursor(range, "prev");
-      let deleted = false;
-      req.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
-        if (cursor && !deleted) {
-          const record = cursor.value as ExecutionRecord;
-          if (this.matchesPrefixes(record)) {
-            cursor.delete();
-            deleted = true;
-            return;
-          }
-          cursor.continue();
-        }
-      };
+      // Delete by id — NEVER by recency. Two concurrent acquirers can hold
+      // tokens for different rows; deleting "the most recent" would release
+      // the other worker's slot.
+      const req = store.delete(token as IDBValidKey);
       req.onerror = () => reject(req.error);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);

--- a/packages/storage/src/queue-limiter/PostgresRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/PostgresRateLimiterStorage.ts
@@ -7,7 +7,11 @@
 import { createServiceToken } from "@workglow/util";
 import type { Pool } from "@workglow/storage/postgres";
 import type { PrefixColumn } from "../queue/IQueueStorage";
-import { IRateLimiterStorage, RateLimiterStorageOptions } from "./IRateLimiterStorage";
+import {
+  IRateLimiterStorage,
+  RateLimiterStorageOptions,
+  RateLimiterStorageScope,
+} from "./IRateLimiterStorage";
 
 export const POSTGRES_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>(
   "ratelimiter.storage.postgres"
@@ -18,6 +22,7 @@ export const POSTGRES_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStor
  * Manages execution records and next available times for rate limiting.
  */
 export class PostgresRateLimiterStorage implements IRateLimiterStorage {
+  public readonly scope: RateLimiterStorageScope = "cluster";
   /** The prefix column definitions */
   protected readonly prefixes: readonly PrefixColumn[];
   /** The prefix values for filtering */
@@ -125,6 +130,132 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
         PRIMARY KEY (${primaryKeyColumns})
       )
     `);
+  }
+
+  public async tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean> {
+    const prefixColumnNames = this.getPrefixColumnNames();
+    const prefixParamValues = this.getPrefixParamValues();
+    const prefixCount = prefixColumnNames.length;
+
+    // Parameter layout:
+    //   $1..$N           prefix values (used in lock-key, count, next-available, and INSERT)
+    //   $(N+1)           queueName
+    //   $(N+2)           windowStart timestamp
+    //   $(N+3)           maxExecutions
+    const queueParam = `$${prefixCount + 1}`;
+    const windowStartParam = `$${prefixCount + 2}`;
+
+    // For the advisory lock we hash table-name + prefix values + queue-name into a bigint.
+    // Use hashtextextended which returns int8 (advisory_xact_lock takes bigint).
+    const lockKeyParts: string[] = [`'${this.executionTableName}'`];
+    for (let i = 0; i < prefixCount; i++) {
+      lockKeyParts.push(`$${i + 1}::text`);
+    }
+    lockKeyParts.push(`${queueParam}::text`);
+    const lockKeyExpr = `hashtextextended(${lockKeyParts.join(" || '|' || ")}, 0)`;
+
+    const prefixWhere =
+      prefixCount > 0
+        ? " AND " +
+          prefixColumnNames
+            .map((p, i) => `${p} = $${i + 1}`)
+            .join(" AND ")
+        : "";
+
+    const prefixInsertCols = prefixCount > 0 ? prefixColumnNames.join(", ") + ", " : "";
+    const prefixInsertPlaceholders =
+      prefixCount > 0 ? prefixColumnNames.map((_, i) => `$${i + 1}`).join(", ") + ", " : "";
+
+    const windowStart = new Date(Date.now() - windowMs).toISOString();
+
+    // Use a dedicated client when the pool supports connect() (real pg.Pool).
+    // PGLitePool runs single-connection in-process so plain `db.query` calls
+    // are already serialized and BEGIN/COMMIT around them is safe.
+    const supportsConnect =
+      typeof (this.db as unknown as { connect?: unknown }).connect === "function";
+    const conn = supportsConnect
+      ? await (this.db as unknown as { connect: () => Promise<{
+          query: Pool["query"];
+          release: () => void;
+        }> }).connect()
+      : { query: this.db.query.bind(this.db), release: () => {} };
+
+    try {
+      await conn.query("BEGIN");
+      try {
+        await conn.query(
+          `SELECT pg_advisory_xact_lock(${lockKeyExpr})`,
+          [...prefixParamValues, queueName]
+        );
+
+        const countResult = await conn.query(
+          `
+          SELECT COUNT(*)::int AS n
+          FROM ${this.executionTableName}
+          WHERE queue_name = ${queueParam} AND executed_at > ${windowStartParam}${prefixWhere}
+          `,
+          [...prefixParamValues, queueName, windowStart]
+        );
+        const n: number = countResult.rows[0]?.n ?? 0;
+        if (n >= maxExecutions) {
+          await conn.query("COMMIT");
+          return false;
+        }
+
+        const naResult = await conn.query(
+          `
+          SELECT next_available_at
+          FROM ${this.nextAvailableTableName}
+          WHERE queue_name = ${queueParam}${prefixWhere}
+          `,
+          [...prefixParamValues, queueName]
+        );
+        const nextAvailableAt: Date | null = naResult.rows[0]?.next_available_at ?? null;
+        if (nextAvailableAt && new Date(nextAvailableAt).getTime() > Date.now()) {
+          await conn.query("COMMIT");
+          return false;
+        }
+
+        await conn.query(
+          `
+          INSERT INTO ${this.executionTableName} (${prefixInsertCols}queue_name)
+          VALUES (${prefixInsertPlaceholders}${queueParam})
+          `,
+          [...prefixParamValues, queueName]
+        );
+        await conn.query("COMMIT");
+        return true;
+      } catch (err) {
+        try {
+          await conn.query("ROLLBACK");
+        } catch {
+          // best-effort
+        }
+        throw err;
+      }
+    } finally {
+      conn.release();
+    }
+  }
+
+  public async releaseExecution(queueName: string): Promise<void> {
+    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(2);
+    await this.db.query(
+      `
+      DELETE FROM ${this.executionTableName}
+      WHERE id = (
+        SELECT id FROM ${this.executionTableName}
+        WHERE queue_name = $1${prefixConditions}
+        ORDER BY executed_at DESC, id DESC
+        LIMIT 1
+      )
+      `,
+      [queueName, ...prefixParams]
+    );
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue-limiter/PostgresRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/PostgresRateLimiterStorage.ts
@@ -136,7 +136,7 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean> {
+  ): Promise<unknown | null> {
     const prefixColumnNames = this.getPrefixColumnNames();
     const prefixParamValues = this.getPrefixParamValues();
     const prefixCount = prefixColumnNames.length;
@@ -172,11 +172,40 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
 
     const windowStart = new Date(Date.now() - windowMs).toISOString();
 
-    // Use a dedicated client when the pool supports connect() (real pg.Pool).
-    // PGLitePool runs single-connection in-process so plain `db.query` calls
-    // are already serialized and BEGIN/COMMIT around them is safe.
+    // Use a dedicated client when the pool supports connect() (real pg.Pool)
+    // — the advisory xact lock + transaction MUST run on the same connection
+    // for atomicity. Without connect(), only known single-connection wrappers
+    // (PGLitePool, raw PGlite) are safe, since they implicitly serialize all
+    // queries through one underlying connection. Anything else (e.g. a custom
+    // multi-connection adapter without connect()) would dispatch the lock and
+    // the INSERT to different sessions, defeating the lock entirely.
     const supportsConnect =
       typeof (this.db as unknown as { connect?: unknown }).connect === "function";
+    if (!supportsConnect) {
+      // Without connect() we run BEGIN/advisory_lock/INSERT/COMMIT directly on
+      // `db.query`. That's only safe if `db` is a single-connection wrapper
+      // (every query goes through the same underlying session). Recognize:
+      //   - PGLitePool  — our own wrapper class; constructor name preserved.
+      //   - PGlite      — third-party, ships minified so `constructor.name`
+      //     can be obfuscated (observed: "q"). Detect via duck-typing on
+      //     methods PGlite uniquely exposes (`waitReady` Promise + `exec`).
+      // Any other no-connect() pool would dispatch the lock and the INSERT
+      // to potentially different sessions, breaking atomicity.
+      const dbAny = this.db as unknown as {
+        waitReady?: unknown;
+        exec?: unknown;
+        constructor?: { name?: string };
+      };
+      const ctorName = dbAny.constructor?.name;
+      const looksLikePGlite =
+        typeof dbAny.exec === "function" && dbAny.waitReady !== undefined;
+      const looksLikePGLitePool = ctorName === "PGLitePool";
+      if (!looksLikePGlite && !looksLikePGLitePool) {
+        throw new Error(
+          `PostgresRateLimiterStorage.tryReserveExecution requires a pg.Pool with connect() or a known single-connection wrapper (PGLitePool, PGlite); got ${ctorName ?? typeof this.db}. A multi-connection pool without connect() would dispatch the advisory lock and the INSERT to different sessions, breaking atomicity.`
+        );
+      }
+    }
     const conn = supportsConnect
       ? await (this.db as unknown as { connect: () => Promise<{
           query: Pool["query"];
@@ -203,7 +232,7 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
         const n: number = countResult.rows[0]?.n ?? 0;
         if (n >= maxExecutions) {
           await conn.query("COMMIT");
-          return false;
+          return null;
         }
 
         const naResult = await conn.query(
@@ -217,18 +246,19 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
         const nextAvailableAt: Date | null = naResult.rows[0]?.next_available_at ?? null;
         if (nextAvailableAt && new Date(nextAvailableAt).getTime() > Date.now()) {
           await conn.query("COMMIT");
-          return false;
+          return null;
         }
 
-        await conn.query(
+        const insertResult = await conn.query(
           `
           INSERT INTO ${this.executionTableName} (${prefixInsertCols}queue_name)
           VALUES (${prefixInsertPlaceholders}${queueParam})
+          RETURNING id
           `,
           [...prefixParamValues, queueName]
         );
         await conn.query("COMMIT");
-        return true;
+        return insertResult.rows[0]?.id ?? null;
       } catch (err) {
         try {
           await conn.query("ROLLBACK");
@@ -242,19 +272,15 @@ export class PostgresRateLimiterStorage implements IRateLimiterStorage {
     }
   }
 
-  public async releaseExecution(queueName: string): Promise<void> {
-    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(2);
+  public async releaseExecution(queueName: string, token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
+    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(3);
+    // Delete by id — NEVER by recency. Two concurrent acquirers can hold
+    // tokens for different rows; deleting "the most recent" would release the
+    // other worker's slot.
     await this.db.query(
-      `
-      DELETE FROM ${this.executionTableName}
-      WHERE id = (
-        SELECT id FROM ${this.executionTableName}
-        WHERE queue_name = $1${prefixConditions}
-        ORDER BY executed_at DESC, id DESC
-        LIMIT 1
-      )
-      `,
-      [queueName, ...prefixParams]
+      `DELETE FROM ${this.executionTableName} WHERE id = $1 AND queue_name = $2${prefixConditions}`,
+      [token as string | number, queueName, ...prefixParams]
     );
   }
 

--- a/packages/storage/src/queue-limiter/SqliteRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/SqliteRateLimiterStorage.ts
@@ -131,7 +131,7 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean> {
+  ): Promise<unknown | null> {
     const prefixColumnNames = this.getPrefixColumnNames();
     const prefixParamValues = this.getPrefixParamValues();
     const prefixConditions = this.buildPrefixWhereClause();
@@ -144,8 +144,8 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
 
     // Use a synchronous transaction so the count + insert is atomic against
     // other writers. The canonical Sqlite.Database.transaction() returns void
-    // by contract, so we capture the result via a closure variable.
-    let result = false;
+    // by contract, so we capture the inserted id via a closure variable.
+    let insertedId: number | bigint | null = null;
     const txn = this.db.transaction((): void => {
       const countStmt = this.db.prepare<unknown[], { count: number }>(`
         SELECT COUNT(*) AS count
@@ -154,7 +154,6 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
       `);
       const countRow = countStmt.get(queueName, windowStart, ...prefixParamValues);
       if ((countRow?.count ?? 0) >= maxExecutions) {
-        result = false;
         return;
       }
 
@@ -167,7 +166,6 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
       if (naRow?.next_available_at) {
         const nextAvailable = new Date(naRow.next_available_at + "Z").getTime();
         if (nextAvailable > Date.now()) {
-          result = false;
           return;
         }
       }
@@ -176,30 +174,29 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
         INSERT INTO ${this.executionTableName} (${prefixColumnsInsert}queue_name)
         VALUES (${prefixPlaceholders}?)
       `);
-      insertStmt.run(...prefixParamValues, queueName);
-      result = true;
+      const info = insertStmt.run(...prefixParamValues, queueName);
+      insertedId = info.lastInsertRowid;
     });
 
     txn();
-    return result;
+    if (insertedId == null) return null;
+    // Coerce bigint to number when it fits — primary key here is a SQLite
+    // INTEGER which always fits in JS Number for any practical row count.
+    return typeof insertedId === "bigint" ? Number(insertedId) : insertedId;
   }
 
-  public async releaseExecution(queueName: string): Promise<void> {
+  public async releaseExecution(queueName: string, token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();
+    // Delete by id — NEVER by recency. Two concurrent acquirers can hold
+    // tokens for different rows; deleting "the most recent" would release the
+    // other worker's slot.
     this.db
       .prepare(
-        `
-        DELETE FROM ${this.executionTableName}
-        WHERE rowid = (
-          SELECT rowid FROM ${this.executionTableName}
-          WHERE queue_name = ?${prefixConditions}
-          ORDER BY executed_at DESC, rowid DESC
-          LIMIT 1
-        )
-        `
+        `DELETE FROM ${this.executionTableName} WHERE id = ? AND queue_name = ?${prefixConditions}`
       )
-      .run(queueName, ...prefixParams);
+      .run(token as number, queueName, ...prefixParams);
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue-limiter/SqliteRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/SqliteRateLimiterStorage.ts
@@ -7,7 +7,11 @@
 import type { Sqlite } from "@workglow/storage/sqlite";
 import { createServiceToken, sleep, toSQLiteTimestamp } from "@workglow/util";
 import type { PrefixColumn } from "../queue/IQueueStorage";
-import { IRateLimiterStorage, RateLimiterStorageOptions } from "./IRateLimiterStorage";
+import {
+  IRateLimiterStorage,
+  RateLimiterStorageOptions,
+  RateLimiterStorageScope,
+} from "./IRateLimiterStorage";
 
 export const SQLITE_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>(
   "ratelimiter.storage.sqlite"
@@ -18,6 +22,13 @@ export const SQLITE_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorag
  * Manages execution records and next available times for rate limiting.
  */
 export class SqliteRateLimiterStorage implements IRateLimiterStorage {
+  /**
+   * `"process"` because a typical SQLite deployment uses a single-process
+   * file. Multi-process SQLite (multiple worker processes opening the same
+   * file) is not safe for rate limiting even with WAL — separate processes
+   * can interleave between BEGIN IMMEDIATE acquisition retries.
+   */
+  public readonly scope: RateLimiterStorageScope = "process";
   /** The prefix column definitions */
   protected readonly prefixes: readonly PrefixColumn[];
   /** The prefix values for filtering */
@@ -114,6 +125,81 @@ export class SqliteRateLimiterStorage implements IRateLimiterStorage {
         next_available_at TEXT
       );
     `);
+  }
+
+  public async tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean> {
+    const prefixColumnNames = this.getPrefixColumnNames();
+    const prefixParamValues = this.getPrefixParamValues();
+    const prefixConditions = this.buildPrefixWhereClause();
+    const prefixColumnsInsert =
+      prefixColumnNames.length > 0 ? prefixColumnNames.join(", ") + ", " : "";
+    const prefixPlaceholders =
+      prefixColumnNames.length > 0 ? prefixColumnNames.map(() => "?").join(", ") + ", " : "";
+
+    const windowStart = toSQLiteTimestamp(new Date(Date.now() - windowMs))!;
+
+    // Use a synchronous transaction so the count + insert is atomic against
+    // other writers. The canonical Sqlite.Database.transaction() returns void
+    // by contract, so we capture the result via a closure variable.
+    let result = false;
+    const txn = this.db.transaction((): void => {
+      const countStmt = this.db.prepare<unknown[], { count: number }>(`
+        SELECT COUNT(*) AS count
+        FROM ${this.executionTableName}
+        WHERE queue_name = ? AND executed_at > ?${prefixConditions}
+      `);
+      const countRow = countStmt.get(queueName, windowStart, ...prefixParamValues);
+      if ((countRow?.count ?? 0) >= maxExecutions) {
+        result = false;
+        return;
+      }
+
+      const naStmt = this.db.prepare<unknown[], { next_available_at: string }>(`
+        SELECT next_available_at
+        FROM ${this.nextAvailableTableName}
+        WHERE queue_name = ?${prefixConditions}
+      `);
+      const naRow = naStmt.get(queueName, ...prefixParamValues);
+      if (naRow?.next_available_at) {
+        const nextAvailable = new Date(naRow.next_available_at + "Z").getTime();
+        if (nextAvailable > Date.now()) {
+          result = false;
+          return;
+        }
+      }
+
+      const insertStmt = this.db.prepare(`
+        INSERT INTO ${this.executionTableName} (${prefixColumnsInsert}queue_name)
+        VALUES (${prefixPlaceholders}?)
+      `);
+      insertStmt.run(...prefixParamValues, queueName);
+      result = true;
+    });
+
+    txn();
+    return result;
+  }
+
+  public async releaseExecution(queueName: string): Promise<void> {
+    const prefixConditions = this.buildPrefixWhereClause();
+    const prefixParams = this.getPrefixParamValues();
+    this.db
+      .prepare(
+        `
+        DELETE FROM ${this.executionTableName}
+        WHERE rowid = (
+          SELECT rowid FROM ${this.executionTableName}
+          WHERE queue_name = ?${prefixConditions}
+          ORDER BY executed_at DESC, rowid DESC
+          LIMIT 1
+        )
+        `
+      )
+      .run(queueName, ...prefixParams);
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue-limiter/SupabaseRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/SupabaseRateLimiterStorage.ts
@@ -166,21 +166,23 @@ export class SupabaseRateLimiterStorage implements IRateLimiterStorage {
     const createFnSql = `
       CREATE OR REPLACE FUNCTION ${fnName}(
         ${prefixSigPrefix}_queue_name TEXT, _window_start TIMESTAMPTZ, _max_exec INT
-      ) RETURNS BOOLEAN AS $fn$
+      ) RETURNS BIGINT AS $fn$
       DECLARE
         _count INT;
         _next TIMESTAMPTZ;
+        _new_id BIGINT;
       BEGIN
         PERFORM pg_advisory_xact_lock(${lockKeyExpr});
         SELECT COUNT(*) INTO _count FROM ${this.executionTableName}
           WHERE queue_name = _queue_name AND executed_at > _window_start${prefixWhere};
-        IF _count >= _max_exec THEN RETURN FALSE; END IF;
+        IF _count >= _max_exec THEN RETURN NULL; END IF;
         SELECT next_available_at INTO _next FROM ${this.nextAvailableTableName}
           WHERE queue_name = _queue_name${prefixWhere};
-        IF _next IS NOT NULL AND _next > NOW() THEN RETURN FALSE; END IF;
+        IF _next IS NOT NULL AND _next > NOW() THEN RETURN NULL; END IF;
         INSERT INTO ${this.executionTableName} (${prefixInsertCols}queue_name)
-          VALUES (${prefixInsertVals}_queue_name);
-        RETURN TRUE;
+          VALUES (${prefixInsertVals}_queue_name)
+          RETURNING id INTO _new_id;
+        RETURN _new_id;
       END;
       $fn$ LANGUAGE plpgsql;
     `;
@@ -199,7 +201,7 @@ export class SupabaseRateLimiterStorage implements IRateLimiterStorage {
     queueName: string,
     maxExecutions: number,
     windowMs: number
-  ): Promise<boolean> {
+  ): Promise<unknown | null> {
     const args: Record<string, unknown> = {
       _queue_name: queueName,
       _window_start: new Date(Date.now() - windowMs).toISOString(),
@@ -208,31 +210,35 @@ export class SupabaseRateLimiterStorage implements IRateLimiterStorage {
     for (const p of this.prefixes) {
       args[`_${p.name}`] = this.prefixValues[p.name];
     }
+    // The PL/pgSQL function returns the inserted id BIGINT on success and
+    // NULL when capacity is reached or external backoff is active.
     const { data, error } = await this.client.rpc(this.atomicReserveFunctionName(), args);
     if (error) throw error;
-    // Real Supabase RPC returns the scalar directly for a function returning
-    // BOOLEAN. The pglite-backed mock executes `SELECT * FROM fn()` and returns
-    // a row array — accept both shapes.
-    if (data === true) return true;
-    if (Array.isArray(data) && data.length > 0) {
+    // The function now returns the inserted row id BIGINT (or NULL when
+    // capacity is reached). Real Supabase RPC returns the scalar directly;
+    // the pglite-backed mock executes `SELECT * FROM fn()` and returns a row
+    // array — accept both shapes.
+    if (data === null || data === undefined) return null;
+    if (Array.isArray(data)) {
+      if (data.length === 0) return null;
       const first = Object.values(data[0] as Record<string, unknown>)[0];
-      return first === true;
+      return first ?? null;
     }
-    return false;
+    // Supabase RPC returns BIGINTs as either numbers or strings depending on
+    // size; both are valid as opaque tokens.
+    return data;
   }
 
-  public async releaseExecution(queueName: string): Promise<void> {
-    // Best-effort: delete the most recent row for this queue/prefix.
-    let select = this.client
+  public async releaseExecution(queueName: string, token: unknown): Promise<void> {
+    if (token === null || token === undefined) return;
+    // Delete by id — NEVER by recency. Two concurrent acquirers can hold
+    // tokens for different rows; deleting "the most recent" would release the
+    // other worker's slot.
+    let del = this.client
       .from(this.executionTableName)
-      .select("id")
+      .delete()
+      .eq("id", token as number | string)
       .eq("queue_name", queueName);
-    select = this.applyPrefixFilters(select);
-    const { data, error } = await select.order("executed_at", { ascending: false }).limit(1);
-    if (error) throw error;
-    if (!data || data.length === 0) return;
-    const id = (data[0] as { id: number | string }).id;
-    let del = this.client.from(this.executionTableName).delete().eq("id", id);
     del = this.applyPrefixFilters(del);
     const { error: delError } = await del;
     if (delError) throw delError;

--- a/packages/storage/src/queue-limiter/SupabaseRateLimiterStorage.ts
+++ b/packages/storage/src/queue-limiter/SupabaseRateLimiterStorage.ts
@@ -7,7 +7,11 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { createServiceToken } from "@workglow/util";
 import type { PrefixColumn } from "../queue/IQueueStorage";
-import { IRateLimiterStorage, RateLimiterStorageOptions } from "./IRateLimiterStorage";
+import {
+  IRateLimiterStorage,
+  RateLimiterStorageOptions,
+  RateLimiterStorageScope,
+} from "./IRateLimiterStorage";
 
 export const SUPABASE_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStorage>(
   "ratelimiter.storage.supabase"
@@ -18,6 +22,7 @@ export const SUPABASE_RATE_LIMITER_STORAGE = createServiceToken<IRateLimiterStor
  * Manages execution records and next available times for rate limiting.
  */
 export class SupabaseRateLimiterStorage implements IRateLimiterStorage {
+  public readonly scope: RateLimiterStorageScope = "cluster";
   protected readonly client: SupabaseClient;
   protected readonly prefixes: readonly PrefixColumn[];
   protected readonly prefixValues: Readonly<Record<string, string | number>>;
@@ -137,6 +142,100 @@ export class SupabaseRateLimiterStorage implements IRateLimiterStorage {
     if (nextTableError && nextTableError.code !== "42P07") {
       throw nextTableError;
     }
+
+    // Install the atomic reserve function. The function takes the queue name,
+    // window-start cutoff, and max executions; returns true iff a row was
+    // inserted. Advisory xact lock keyed on (table, prefixes, queue) ensures
+    // concurrent acquirers serialize without contending on unrelated buckets.
+    const fnName = this.atomicReserveFunctionName();
+    const prefixSig = this.prefixes
+      .map((p) => `${p.name} ${this.getPrefixColumnType(p.type)}`)
+      .join(", ");
+    const prefixSigPrefix = prefixSig ? prefixSig + ", " : "";
+    const prefixWhere =
+      this.prefixes.length > 0
+        ? " AND " + this.prefixes.map((p) => `${p.name} = _${p.name}`).join(" AND ")
+        : "";
+    const prefixInsertCols =
+      this.prefixes.length > 0 ? this.prefixes.map((p) => p.name).join(", ") + ", " : "";
+    const prefixInsertVals =
+      this.prefixes.length > 0 ? this.prefixes.map((p) => `_${p.name}`).join(", ") + ", " : "";
+    const lockKeyParts = [`'${this.executionTableName}'`, ...this.prefixes.map((p) => `_${p.name}::text`), `_queue_name::text`];
+    const lockKeyExpr = `hashtextextended(${lockKeyParts.join(" || '|' || ")}, 0)`;
+
+    const createFnSql = `
+      CREATE OR REPLACE FUNCTION ${fnName}(
+        ${prefixSigPrefix}_queue_name TEXT, _window_start TIMESTAMPTZ, _max_exec INT
+      ) RETURNS BOOLEAN AS $fn$
+      DECLARE
+        _count INT;
+        _next TIMESTAMPTZ;
+      BEGIN
+        PERFORM pg_advisory_xact_lock(${lockKeyExpr});
+        SELECT COUNT(*) INTO _count FROM ${this.executionTableName}
+          WHERE queue_name = _queue_name AND executed_at > _window_start${prefixWhere};
+        IF _count >= _max_exec THEN RETURN FALSE; END IF;
+        SELECT next_available_at INTO _next FROM ${this.nextAvailableTableName}
+          WHERE queue_name = _queue_name${prefixWhere};
+        IF _next IS NOT NULL AND _next > NOW() THEN RETURN FALSE; END IF;
+        INSERT INTO ${this.executionTableName} (${prefixInsertCols}queue_name)
+          VALUES (${prefixInsertVals}_queue_name);
+        RETURN TRUE;
+      END;
+      $fn$ LANGUAGE plpgsql;
+    `;
+    const { error: fnError } = await this.client.rpc("exec_sql", { query: createFnSql });
+    if (fnError) {
+      throw fnError;
+    }
+  }
+
+  /** Stable function name derived from table name (Postgres identifiers ≤63 chars). */
+  private atomicReserveFunctionName(): string {
+    return `${this.executionTableName}_try_reserve`.slice(0, 63);
+  }
+
+  public async tryReserveExecution(
+    queueName: string,
+    maxExecutions: number,
+    windowMs: number
+  ): Promise<boolean> {
+    const args: Record<string, unknown> = {
+      _queue_name: queueName,
+      _window_start: new Date(Date.now() - windowMs).toISOString(),
+      _max_exec: maxExecutions,
+    };
+    for (const p of this.prefixes) {
+      args[`_${p.name}`] = this.prefixValues[p.name];
+    }
+    const { data, error } = await this.client.rpc(this.atomicReserveFunctionName(), args);
+    if (error) throw error;
+    // Real Supabase RPC returns the scalar directly for a function returning
+    // BOOLEAN. The pglite-backed mock executes `SELECT * FROM fn()` and returns
+    // a row array — accept both shapes.
+    if (data === true) return true;
+    if (Array.isArray(data) && data.length > 0) {
+      const first = Object.values(data[0] as Record<string, unknown>)[0];
+      return first === true;
+    }
+    return false;
+  }
+
+  public async releaseExecution(queueName: string): Promise<void> {
+    // Best-effort: delete the most recent row for this queue/prefix.
+    let select = this.client
+      .from(this.executionTableName)
+      .select("id")
+      .eq("queue_name", queueName);
+    select = this.applyPrefixFilters(select);
+    const { data, error } = await select.order("executed_at", { ascending: false }).limit(1);
+    if (error) throw error;
+    if (!data || data.length === 0) return;
+    const id = (data[0] as { id: number | string }).id;
+    let del = this.client.from(this.executionTableName).delete().eq("id", id);
+    del = this.applyPrefixFilters(del);
+    const { error: delError } = await del;
+    if (delError) throw delError;
   }
 
   public async recordExecution(queueName: string): Promise<void> {

--- a/packages/storage/src/queue/IQueueStorage.ts
+++ b/packages/storage/src/queue/IQueueStorage.ts
@@ -44,9 +44,15 @@ export const JobStatus = {
 } as const satisfies Record<JobStatus, JobStatus>;
 
 /**
- * Type of change that occurred in the queue
+ * Type of change that occurred in the queue.
+ *
+ * `RESYNC` is a synthetic event emitted by some backends (e.g. Postgres
+ * LISTEN/NOTIFY) after a (re)connect to indicate that arbitrary changes may
+ * have happened during a disconnect window. Subscribers should treat it as a
+ * "kick the workers, re-poll state" signal — `old` and `new` are both
+ * undefined.
  */
-export type QueueChangeType = "INSERT" | "UPDATE" | "DELETE";
+export type QueueChangeType = "INSERT" | "UPDATE" | "DELETE" | "RESYNC";
 
 /**
  * Payload describing a change to a job
@@ -113,9 +119,28 @@ export type JobStorageFormat<Input, Output> = {
 };
 
 /**
+ * Whether a queue storage's state is shared across processes.
+ *
+ * - `"process"` — in-memory / per-process state. Workers in the same process
+ *   share it, but separate processes do not.
+ * - `"cluster"` — state lives in shared external storage (Postgres, Supabase,
+ *   etc.) visible to every process. Pairing a `"process"`-scoped limiter with
+ *   a `"cluster"`-scoped queue almost always indicates a misconfiguration.
+ */
+export type QueueStorageScope = "process" | "cluster";
+
+/**
  * Interface defining the storage operations for a job queue
  */
 export interface IQueueStorage<Input, Output> {
+  /**
+   * Whether this storage is shared across processes. In-memory / browser
+   * backends MUST report `"process"`. Shared databases (Postgres, Supabase)
+   * report `"cluster"`. Used by JobQueueServer to detect process-scoped
+   * limiters paired with cluster-scoped queues.
+   */
+  readonly scope: QueueStorageScope;
+
   /**
    * Adds a job to the queue storage
    * @param job - The job to add to the queue storage

--- a/packages/storage/src/queue/InMemoryQueueStorage.ts
+++ b/packages/storage/src/queue/InMemoryQueueStorage.ts
@@ -37,6 +37,7 @@ export const IN_MEMORY_QUEUE_STORAGE = createServiceToken<IQueueStorage<any, any
  * Supports job scheduling, status tracking, result caching, and prefix-based filtering.
  */
 export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input, Output> {
+  public readonly scope = "process" as const;
   /** The prefix values for filtering jobs */
   protected readonly prefixValues: Readonly<Record<string, string | number>>;
   /** Event emitter for change notifications */

--- a/packages/storage/src/queue/IndexedDbQueueStorage.ts
+++ b/packages/storage/src/queue/IndexedDbQueueStorage.ts
@@ -40,6 +40,7 @@ export interface IndexedDbQueueStorageOptions extends QueueStorageOptions, Migra
  * Provides storage and retrieval for job execution states using IndexedDB.
  */
 export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input, Output> {
+  public readonly scope = "process" as const;
   private db: IDBDatabase | undefined;
   private readonly tableName: string;
   private readonly migrationOptions: MigrationOptions;

--- a/packages/storage/src/queue/PostgresQueueStorage.ts
+++ b/packages/storage/src/queue/PostgresQueueStorage.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from "node:crypto";
 import type { Pool } from "@workglow/storage/postgres";
-import { createServiceToken, makeFingerprint, uuid4 } from "@workglow/util";
+import { createServiceToken, getLogger, makeFingerprint, uuid4 } from "@workglow/util";
 import {
   IQueueStorage,
   JobStatus,
@@ -24,10 +25,22 @@ export const POSTGRES_QUEUE_STORAGE = createServiceToken<IQueueStorage<any, any>
 const SAFE_IDENTIFIER = /^[a-zA-Z][a-zA-Z0-9_]*$/;
 
 /**
+ * Subset of pg.PoolClient that {@link PostgresQueueStorage.subscribeToChanges}
+ * needs. Typed locally so we don't require `pg` types at the storage layer.
+ */
+interface ListenClient {
+  query: (sql: string) => Promise<unknown>;
+  release: () => void;
+  removeAllListeners?: (event: string) => void;
+  on: (event: string, listener: (...args: any[]) => void) => void;
+}
+
+/**
  * PostgreSQL implementation of a job queue.
  * Provides storage and retrieval for job execution states using PostgreSQL.
  */
 export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input, Output> {
+  public readonly scope = "cluster" as const;
   /** The prefix column definitions */
   protected readonly prefixes: readonly PrefixColumn[];
   /** The prefix values for filtering */
@@ -172,9 +185,61 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
     await this.db.query(sql);
 
     sql = `
-      CREATE INDEX IF NOT EXISTS jobs_fingerprint${indexSuffix}_unique_idx 
+      CREATE INDEX IF NOT EXISTS jobs_fingerprint${indexSuffix}_unique_idx
         ON ${this.tableName} (${prefixIndexPrefix}queue, fingerprint, status)`;
     await this.db.query(sql);
+
+    // Install LISTEN/NOTIFY plumbing so subscribers can wake on INSERT/UPDATE
+    // without polling. The channel name is derived from md5(table || queue) so
+    // (a) it fits Postgres's 63-char identifier limit even with long queue
+    // names, and (b) different queues on the same table don't share a channel.
+    //
+    // Best-effort: in-process Postgres-compatible engines like PGLite may not
+    // implement pg_notify or plpgsql. Skip trigger installation in that case
+    // — subscribeToChanges will throw synchronously for those engines anyway,
+    // so callers fall back to polling.
+    const fnName = `${this.tableName}_notify`;
+    const trgName = `${this.tableName}_notify_trg`;
+    try {
+      await this.db.query(`
+        CREATE OR REPLACE FUNCTION ${fnName}() RETURNS trigger AS $fn$
+        DECLARE
+          channel TEXT := 'wglw_q_' || md5('${this.tableName}' || COALESCE(NEW.queue, OLD.queue));
+          payload TEXT;
+        BEGIN
+          payload := json_build_object(
+            'op', TG_OP,
+            'id', COALESCE(NEW.id, OLD.id),
+            'queue', COALESCE(NEW.queue, OLD.queue),
+            'status', COALESCE(NEW.status::text, OLD.status::text)
+          )::text;
+          PERFORM pg_notify(channel, payload);
+          RETURN NULL;
+        END;
+        $fn$ LANGUAGE plpgsql;
+      `);
+      await this.db.query(`DROP TRIGGER IF EXISTS ${trgName} ON ${this.tableName}`);
+      await this.db.query(`
+        CREATE TRIGGER ${trgName}
+          AFTER INSERT OR UPDATE ON ${this.tableName}
+          FOR EACH ROW EXECUTE FUNCTION ${fnName}();
+      `);
+    } catch {
+      // best-effort — the engine doesn't support LISTEN/NOTIFY; subscribers
+      // will get a synchronous throw and fall back to polling.
+    }
+  }
+
+  /**
+   * Channel name for this storage's LISTEN/NOTIFY. Mirrors the trigger's
+   * computation so subscriber and notifier agree.
+   */
+  private notifyChannelName(): string {
+    // md5() returns 32 hex chars; combined with the 7-char prefix this is well
+    // under Postgres's 63-byte identifier limit.
+    const tableAndQueue = `${this.tableName}${this.queueName}`;
+    const hash = createHash("md5").update(tableAndQueue).digest("hex");
+    return `wglw_q_${hash}`;
   }
 
   /**
@@ -562,15 +627,189 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Subscribes to changes in the queue.
-   * NOT IMPLEMENTED for PostgreSQL storage.
+   * Subscribe to INSERT/UPDATE notifications via PostgreSQL LISTEN/NOTIFY.
+   * Replaces 100ms-poll fallback for cluster Postgres deployments — workers
+   * wake within network-latency of an actual change rather than on a timer.
    *
-   * @throws Error always - subscribeToChanges is not supported for PostgreSQL storage
+   * Acquires a dedicated client from the pool (LISTEN occupies a connection
+   * for its lifetime). On unsubscribe, runs UNLISTEN and releases the client.
+   * On connection loss, attempts to reconnect with bounded backoff and
+   * re-LISTEN. After every successful (re)connect — including the initial
+   * one — emits a synthetic `{ type: "RESYNC" }` event so subscribers can
+   * re-poll state and pick up any rows inserted during the disconnect window
+   * (or between subscribe and the first NOTIFY landing).
+   *
+   * Throws synchronously when the underlying pool lacks `connect()`
+   * (single-connection wrappers like PGLite) so the caller's try/catch can
+   * fall back to polling. JobQueueServer.start does this and logs at debug.
+   *
+   * `options.prefixFilter` follows {@link QueueSubscribeOptions.prefixFilter}:
+   * `undefined` means "use the storage instance's configured prefixValues",
+   * `{}` means "receive all changes regardless of prefix".
    */
   public subscribeToChanges(
     callback: (change: QueueChangePayload<Input, Output>) => void,
     options?: QueueSubscribeOptions
   ): () => void {
-    throw new Error("subscribeToChanges is not supported for PostgresQueueStorage");
+    type PoolWithConnect = { connect: () => Promise<ListenClient> };
+    const poolMaybe = this.db as unknown as Partial<PoolWithConnect>;
+    if (typeof poolMaybe.connect !== "function") {
+      // Detect synchronously so callers can catch and fall back to polling
+      // without leaving a dangling unhandled promise rejection behind.
+      throw new Error(
+        "PostgresQueueStorage.subscribeToChanges requires a pg.Pool (got a single-connection wrapper)"
+      );
+    }
+    const pool = poolMaybe as PoolWithConnect;
+
+    const channel = this.notifyChannelName();
+    // undefined -> default to instance prefixValues; {} -> no filtering;
+    // partial -> filter by the provided subset (matches QueueSubscribeOptions docs).
+    const effectivePrefixFilter: Readonly<Record<string, string | number>> | null =
+      options?.prefixFilter === undefined
+        ? this.prefixes.length > 0
+          ? this.prefixValues
+          : null
+        : Object.keys(options.prefixFilter).length === 0
+          ? null
+          : options.prefixFilter;
+
+    let unsubscribed = false;
+    let activeClient: ListenClient | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = 250;
+
+    const dispatch = (change: QueueChangePayload<Input, Output>): void => {
+      try {
+        callback(change);
+      } catch (err) {
+        // Never let user callbacks tear down the listener loop.
+        getLogger().debug("PostgresQueueStorage subscribe callback threw", {
+          channel,
+          changeType: change.type,
+          error: err,
+        });
+      }
+    };
+
+    const matchesPrefix = (
+      change: QueueChangePayload<Input, Output>,
+      filter: Readonly<Record<string, string | number>>
+    ): boolean => {
+      const row = (change.new ?? change.old) as Record<string, unknown> | undefined;
+      if (!row) return false;
+      for (const [k, v] of Object.entries(filter)) {
+        if (row[k] !== v) return false;
+      }
+      return true;
+    };
+
+    // Hydrate the row referenced by a notification. Postgres NOTIFY is capped
+    // at 8 KB so we ship only {id, queue, status} in the payload and fetch the
+    // full row here — keeps subscriber payloads consistent with other backends
+    // (e.g. Supabase realtime, IndexedDb) and lets prefixFilter inspect the
+    // prefix columns the row actually has.
+    const hydrate = async (
+      id: unknown
+    ): Promise<JobStorageFormat<Input, Output> | undefined> => {
+      try {
+        return await this.get(id);
+      } catch {
+        return undefined;
+      }
+    };
+
+    const handleNotification = (msg: { channel: string; payload?: string }): void => {
+      if (msg.channel !== channel || !msg.payload) return;
+      let parsed: { op: string; id: number; queue: string; status: string };
+      try {
+        parsed = JSON.parse(msg.payload);
+      } catch {
+        return;
+      }
+      void (async () => {
+        const op = parsed.op;
+        const fallback = {
+          id: parsed.id,
+          queue: parsed.queue,
+          status: parsed.status,
+        } as unknown as JobStorageFormat<Input, Output>;
+        const fullRow = op === "DELETE" ? undefined : await hydrate(parsed.id);
+        const change: QueueChangePayload<Input, Output> = {
+          type: op === "INSERT" ? "INSERT" : op === "DELETE" ? "DELETE" : "UPDATE",
+          new: op === "DELETE" ? undefined : (fullRow ?? fallback),
+          old: op === "DELETE" ? fallback : undefined,
+        };
+        if (effectivePrefixFilter && !matchesPrefix(change, effectivePrefixFilter)) return;
+        dispatch(change);
+      })();
+    };
+
+    const connect = async (): Promise<void> => {
+      if (unsubscribed) return;
+      try {
+        const client = await pool.connect();
+        if (unsubscribed) {
+          client.release();
+          return;
+        }
+        activeClient = client;
+        client.on("notification", handleNotification);
+        client.on("error", () => scheduleReconnect());
+        await client.query(`LISTEN ${channel}`);
+        backoffMs = 250; // reset on successful (re)connect
+        // Synthetic resync: any rows inserted between subscribe and LISTEN
+        // landing (or during a reconnect window) have no NOTIFY backing.
+        // Fire a no-payload event so subscribers can re-poll state.
+        dispatch({ type: "RESYNC" });
+      } catch {
+        scheduleReconnect();
+      }
+    };
+
+    const scheduleReconnect = (): void => {
+      if (unsubscribed || reconnectTimer) return;
+      const c = activeClient;
+      activeClient = null;
+      try {
+        c?.removeAllListeners?.("notification");
+        c?.removeAllListeners?.("error");
+        c?.release();
+      } catch {
+        // best-effort
+      }
+      const delay = Math.min(backoffMs, 30_000);
+      backoffMs = Math.min(backoffMs * 2, 30_000);
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        void connect();
+      }, delay);
+    };
+
+    void connect();
+
+    return () => {
+      unsubscribed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      const c = activeClient;
+      activeClient = null;
+      if (c) {
+        // Best-effort UNLISTEN; ignore errors (connection may already be dead).
+        c.query(`UNLISTEN ${channel}`)
+          .catch(() => {})
+          .finally(() => {
+            try {
+              c.removeAllListeners?.("notification");
+              c.removeAllListeners?.("error");
+              c.release();
+            } catch {
+              // best-effort
+            }
+          });
+      }
+    };
   }
 }

--- a/packages/storage/src/queue/SqliteQueueStorage.ts
+++ b/packages/storage/src/queue/SqliteQueueStorage.ts
@@ -38,6 +38,14 @@ export interface SqliteQueueStorageOptions extends QueueStorageOptions {
  * Provides storage and retrieval for job execution states using SQLite.
  */
 export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, Output> {
+  /**
+   * SQLite is in-process only at the application layer (no LISTEN/NOTIFY,
+   * no shared client across processes). Even if the underlying file is
+   * shared via NFS, the queue contract requires cross-process change
+   * notification we don't provide here, so callers must treat it as
+   * `"process"` scope.
+   */
+  public readonly scope = "process" as const;
   /** The prefix column definitions */
   protected readonly prefixes: readonly PrefixColumn[];
   /** The prefix values for filtering */

--- a/packages/storage/src/queue/SupabaseQueueStorage.ts
+++ b/packages/storage/src/queue/SupabaseQueueStorage.ts
@@ -27,6 +27,7 @@ export const SUPABASE_QUEUE_STORAGE = createServiceToken<IQueueStorage<any, any>
  * Provides storage and retrieval for job execution states using Supabase.
  */
 export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input, Output> {
+  public readonly scope = "cluster" as const;
   protected readonly client: SupabaseClient;
   protected readonly prefixes: readonly PrefixColumn[];
   protected readonly prefixValues: Readonly<Record<string, string | number>>;

--- a/packages/storage/src/queue/TelemetryQueueStorage.ts
+++ b/packages/storage/src/queue/TelemetryQueueStorage.ts
@@ -10,6 +10,7 @@ import type {
   JobStatus,
   JobStorageFormat,
   QueueChangePayload,
+  QueueStorageScope,
   QueueSubscribeOptions,
 } from "./IQueueStorage";
 
@@ -22,6 +23,10 @@ export class TelemetryQueueStorage<Input, Output> implements IQueueStorage<Input
     private readonly storageName: string,
     private readonly inner: IQueueStorage<Input, Output>
   ) {}
+
+  public get scope(): QueueStorageScope {
+    return this.inner.scope;
+  }
 
   add(job: JobStorageFormat<Input, Output>): Promise<unknown> {
     return traced("workglow.storage.queue.add", this.storageName, () => this.inner.add(job));

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -22,8 +22,8 @@ describe("NullLimiter", () => {
   });
 
   it("should always tryAcquire successfully", async () => {
-    expect(await limiter.tryAcquire()).toBe(true);
-    expect(await limiter.tryAcquire()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should report process scope", () => {
@@ -33,7 +33,7 @@ describe("NullLimiter", () => {
   it("should not throw on any method call", async () => {
     await expect(limiter.recordJobStart()).resolves.toBeUndefined();
     await expect(limiter.recordJobCompletion()).resolves.toBeUndefined();
-    await expect(limiter.release()).resolves.toBeUndefined();
+    await expect(limiter.release(null)).resolves.toBeUndefined();
     await expect(limiter.setNextAvailableTime(new Date())).resolves.toBeUndefined();
     await expect(limiter.clear()).resolves.toBeUndefined();
   });
@@ -60,16 +60,18 @@ describe("ConcurrencyLimiter", () => {
     const results = await Promise.all(
       Array.from({ length: 10 }, () => limiter.tryAcquire())
     );
-    const successes = results.filter((r) => r === true).length;
+    const successes = results.filter((r) => r !== null && r !== undefined).length;
     expect(successes).toBe(2);
   });
 
   it("release should free a slot for a follow-up tryAcquire", async () => {
-    expect(await limiter.tryAcquire()).toBe(true);
-    expect(await limiter.tryAcquire()).toBe(true);
-    expect(await limiter.tryAcquire()).toBe(false);
-    await limiter.release();
-    expect(await limiter.tryAcquire()).toBe(true);
+    const t1 = await limiter.tryAcquire();
+    const t2 = await limiter.tryAcquire();
+    expect(t1).not.toBeNull();
+    expect(t2).not.toBeNull();
+    expect(await limiter.tryAcquire()).toBeNull();
+    await limiter.release(t1);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should allow proceeding when under limit", async () => {
@@ -125,7 +127,7 @@ describe("DelayLimiter", () => {
     const results = await Promise.all(
       Array.from({ length: 5 }, () => limiter.tryAcquire())
     );
-    const successes = results.filter((r) => r === true).length;
+    const successes = results.filter((r) => r !== null && r !== undefined).length;
     expect(successes).toBe(1);
   });
 
@@ -247,7 +249,7 @@ describe("EvenlySpacedRateLimiter", () => {
     const results = await Promise.all(
       Array.from({ length: 5 }, () => limiter.tryAcquire())
     );
-    const successes = results.filter((r) => r === true).length;
+    const successes = results.filter((r) => r !== null && r !== undefined).length;
     expect(successes).toBe(1);
   });
 

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -21,9 +21,19 @@ describe("NullLimiter", () => {
     expect(await limiter.canProceed()).toBe(true);
   });
 
+  it("should always tryAcquire successfully", async () => {
+    expect(await limiter.tryAcquire()).toBe(true);
+    expect(await limiter.tryAcquire()).toBe(true);
+  });
+
+  it("should report process scope", () => {
+    expect(limiter.scope).toBe("process");
+  });
+
   it("should not throw on any method call", async () => {
     await expect(limiter.recordJobStart()).resolves.toBeUndefined();
     await expect(limiter.recordJobCompletion()).resolves.toBeUndefined();
+    await expect(limiter.release()).resolves.toBeUndefined();
     await expect(limiter.setNextAvailableTime(new Date())).resolves.toBeUndefined();
     await expect(limiter.clear()).resolves.toBeUndefined();
   });
@@ -40,6 +50,26 @@ describe("ConcurrencyLimiter", () => {
 
   beforeEach(() => {
     limiter = new ConcurrencyLimiter(2);
+  });
+
+  it("should report process scope", () => {
+    expect(limiter.scope).toBe("process");
+  });
+
+  it("tryAcquire should be atomic under concurrency=2 with 10 parallel acquirers", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => limiter.tryAcquire())
+    );
+    const successes = results.filter((r) => r === true).length;
+    expect(successes).toBe(2);
+  });
+
+  it("release should free a slot for a follow-up tryAcquire", async () => {
+    expect(await limiter.tryAcquire()).toBe(true);
+    expect(await limiter.tryAcquire()).toBe(true);
+    expect(await limiter.tryAcquire()).toBe(false);
+    await limiter.release();
+    expect(await limiter.tryAcquire()).toBe(true);
   });
 
   it("should allow proceeding when under limit", async () => {
@@ -85,6 +115,18 @@ describe("DelayLimiter", () => {
 
   beforeEach(() => {
     limiter = new DelayLimiter(100);
+  });
+
+  it("should report process scope", () => {
+    expect(limiter.scope).toBe("process");
+  });
+
+  it("tryAcquire should be atomic — only one of 5 parallel acquirers wins per delay window", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => limiter.tryAcquire())
+    );
+    const successes = results.filter((r) => r === true).length;
+    expect(successes).toBe(1);
   });
 
   it("should allow proceeding initially", async () => {
@@ -164,6 +206,18 @@ describe("CompositeLimiter", () => {
   });
 });
 
+describe("CompositeLimiter scope", () => {
+  it("should be process when any child is process-scoped", () => {
+    const composite = new CompositeLimiter([new NullLimiter(), new ConcurrencyLimiter(1)]);
+    expect(composite.scope).toBe("process");
+  });
+
+  it("should be process when no children are present", () => {
+    const composite = new CompositeLimiter();
+    expect(composite.scope).toBe("process");
+  });
+});
+
 describe("EvenlySpacedRateLimiter", () => {
   it("should throw for invalid maxExecutions", () => {
     expect(
@@ -180,6 +234,21 @@ describe("EvenlySpacedRateLimiter", () => {
   it("should allow proceeding initially", async () => {
     const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 1 });
     expect(await limiter.canProceed()).toBe(true);
+  });
+
+  it("should report process scope", () => {
+    const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 1 });
+    expect(limiter.scope).toBe("process");
+  });
+
+  it("tryAcquire should be atomic under contention", async () => {
+    const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 10 });
+    // idealInterval = 1000ms, so only the first acquirer in a tight burst wins.
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => limiter.tryAcquire())
+    );
+    const successes = results.filter((r) => r === true).length;
+    expect(successes).toBe(1);
   });
 
   it("should space requests by setting next available time", async () => {

--- a/packages/test/src/test/job-queue/RateLimiter.test.ts
+++ b/packages/test/src/test/job-queue/RateLimiter.test.ts
@@ -19,10 +19,20 @@ function createMockStorage(): MockRateLimiterStorage {
   let oldestExecution: string | undefined = undefined;
 
   return {
+    scope: "process" as const,
     setupDatabase: vi.fn(async () => {}),
     getExecutionCount: vi.fn(async () => executionCount),
     recordExecution: vi.fn(async () => {
       executionCount++;
+    }),
+    tryReserveExecution: vi.fn(async (_q: string, max: number) => {
+      const next = nextAvailableTime ? new Date(nextAvailableTime).getTime() : 0;
+      if (executionCount >= max || next > Date.now()) return false;
+      executionCount++;
+      return true;
+    }),
+    releaseExecution: vi.fn(async () => {
+      executionCount = Math.max(0, executionCount - 1);
     }),
     getNextAvailableTime: vi.fn(async () => nextAvailableTime),
     setNextAvailableTime: vi.fn(async (_queue: string, time: string) => {
@@ -169,6 +179,71 @@ describe("RateLimiter", () => {
       const date = new Date(Date.now() + 5000);
       await limiter.setNextAvailableTime(date);
       expect(storage.setNextAvailableTime).toHaveBeenCalledWith("queue", date.toISOString());
+    });
+  });
+
+  describe("scope", () => {
+    it("should reflect storage scope", () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 5,
+        windowSizeInSeconds: 60,
+      });
+      expect(limiter.scope).toBe("process");
+    });
+  });
+
+  describe("tryAcquire", () => {
+    it("should return true and reserve a slot when capacity is available", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 5,
+        windowSizeInSeconds: 60,
+      });
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(storage.tryReserveExecution).toHaveBeenCalledWith("queue", 5, 60_000);
+    });
+
+    it("should return false when storage rejects the reservation", async () => {
+      storage._setExecutionCount(5);
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 5,
+        windowSizeInSeconds: 60,
+      });
+      expect(await limiter.tryAcquire()).toBe(false);
+    });
+
+    it("should be atomic: 100 parallel acquirers with max=10 produce exactly 10 trues", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 10,
+        windowSizeInSeconds: 60,
+      });
+      const results = await Promise.all(
+        Array.from({ length: 100 }, () => limiter.tryAcquire())
+      );
+      const successes = results.filter((r) => r === true).length;
+      expect(successes).toBe(10);
+    });
+  });
+
+  describe("release", () => {
+    it("should delegate to storage.releaseExecution", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 5,
+        windowSizeInSeconds: 60,
+      });
+      await limiter.tryAcquire();
+      await limiter.release();
+      expect(storage.releaseExecution).toHaveBeenCalledWith("queue");
+    });
+
+    it("should free a slot so a follow-up tryAcquire succeeds", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 1,
+        windowSizeInSeconds: 60,
+      });
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(false);
+      await limiter.release();
+      expect(await limiter.tryAcquire()).toBe(true);
     });
   });
 });

--- a/packages/test/src/test/job-queue/RateLimiter.test.ts
+++ b/packages/test/src/test/job-queue/RateLimiter.test.ts
@@ -17,6 +17,10 @@ function createMockStorage(): MockRateLimiterStorage {
   let executionCount = 0;
   let nextAvailableTime: string | undefined = undefined;
   let oldestExecution: string | undefined = undefined;
+  // Track issued tokens so releaseExecution can delete by id (matching the
+  // real backends' contract).
+  const liveIds: string[] = [];
+  let nextId = 1;
 
   return {
     scope: "process" as const,
@@ -24,14 +28,20 @@ function createMockStorage(): MockRateLimiterStorage {
     getExecutionCount: vi.fn(async () => executionCount),
     recordExecution: vi.fn(async () => {
       executionCount++;
+      liveIds.push(String(nextId++));
     }),
     tryReserveExecution: vi.fn(async (_q: string, max: number) => {
       const next = nextAvailableTime ? new Date(nextAvailableTime).getTime() : 0;
-      if (executionCount >= max || next > Date.now()) return false;
+      if (executionCount >= max || next > Date.now()) return null;
       executionCount++;
-      return true;
+      const id = String(nextId++);
+      liveIds.push(id);
+      return id;
     }),
-    releaseExecution: vi.fn(async () => {
+    releaseExecution: vi.fn(async (_q: string, token: unknown) => {
+      const idx = liveIds.indexOf(String(token));
+      if (idx === -1) return;
+      liveIds.splice(idx, 1);
       executionCount = Math.max(0, executionCount - 1);
     }),
     getNextAvailableTime: vi.fn(async () => nextAvailableTime),
@@ -41,6 +51,7 @@ function createMockStorage(): MockRateLimiterStorage {
     getOldestExecutionAtOffset: vi.fn(async () => oldestExecution),
     clear: vi.fn(async () => {
       executionCount = 0;
+      liveIds.length = 0;
       nextAvailableTime = undefined;
       oldestExecution = undefined;
     }),
@@ -193,25 +204,27 @@ describe("RateLimiter", () => {
   });
 
   describe("tryAcquire", () => {
-    it("should return true and reserve a slot when capacity is available", async () => {
+    it("should return a non-null token and reserve a slot when capacity is available", async () => {
       const limiter = new RateLimiter(storage, "queue", {
         maxExecutions: 5,
         windowSizeInSeconds: 60,
       });
-      expect(await limiter.tryAcquire()).toBe(true);
+      const token = await limiter.tryAcquire();
+      expect(token).not.toBeNull();
+      expect(token).not.toBeUndefined();
       expect(storage.tryReserveExecution).toHaveBeenCalledWith("queue", 5, 60_000);
     });
 
-    it("should return false when storage rejects the reservation", async () => {
+    it("should return null when storage rejects the reservation", async () => {
       storage._setExecutionCount(5);
       const limiter = new RateLimiter(storage, "queue", {
         maxExecutions: 5,
         windowSizeInSeconds: 60,
       });
-      expect(await limiter.tryAcquire()).toBe(false);
+      expect(await limiter.tryAcquire()).toBeNull();
     });
 
-    it("should be atomic: 100 parallel acquirers with max=10 produce exactly 10 trues", async () => {
+    it("should be atomic: 100 parallel acquirers with max=10 produce exactly 10 non-null tokens", async () => {
       const limiter = new RateLimiter(storage, "queue", {
         maxExecutions: 10,
         windowSizeInSeconds: 60,
@@ -219,20 +232,31 @@ describe("RateLimiter", () => {
       const results = await Promise.all(
         Array.from({ length: 100 }, () => limiter.tryAcquire())
       );
-      const successes = results.filter((r) => r === true).length;
+      const successes = results.filter((r) => r !== null && r !== undefined).length;
       expect(successes).toBe(10);
+    });
+
+    it("should return distinct tokens to concurrent acquirers", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 10,
+        windowSizeInSeconds: 60,
+      });
+      const tokens = (
+        await Promise.all(Array.from({ length: 5 }, () => limiter.tryAcquire()))
+      ).filter((t) => t !== null);
+      expect(new Set(tokens).size).toBe(5);
     });
   });
 
   describe("release", () => {
-    it("should delegate to storage.releaseExecution", async () => {
+    it("should delegate to storage.releaseExecution with the acquired token", async () => {
       const limiter = new RateLimiter(storage, "queue", {
         maxExecutions: 5,
         windowSizeInSeconds: 60,
       });
-      await limiter.tryAcquire();
-      await limiter.release();
-      expect(storage.releaseExecution).toHaveBeenCalledWith("queue");
+      const token = await limiter.tryAcquire();
+      await limiter.release(token);
+      expect(storage.releaseExecution).toHaveBeenCalledWith("queue", token);
     });
 
     it("should free a slot so a follow-up tryAcquire succeeds", async () => {
@@ -240,10 +264,29 @@ describe("RateLimiter", () => {
         maxExecutions: 1,
         windowSizeInSeconds: 60,
       });
-      expect(await limiter.tryAcquire()).toBe(true);
-      expect(await limiter.tryAcquire()).toBe(false);
-      await limiter.release();
-      expect(await limiter.tryAcquire()).toBe(true);
+      const t1 = await limiter.tryAcquire();
+      expect(t1).not.toBeNull();
+      expect(await limiter.tryAcquire()).toBeNull();
+      await limiter.release(t1);
+      expect(await limiter.tryAcquire()).not.toBeNull();
+    });
+
+    it("should release THIS slot, not the most recent — under contention worker A's release frees worker A's row", async () => {
+      const limiter = new RateLimiter(storage, "queue", {
+        maxExecutions: 2,
+        windowSizeInSeconds: 60,
+      });
+      const tA = await limiter.tryAcquire();
+      const tB = await limiter.tryAcquire();
+      expect(tA).not.toBeNull();
+      expect(tB).not.toBeNull();
+      expect(tA).not.toBe(tB);
+      // Worker A releases its slot. Worker B's slot must remain.
+      await limiter.release(tA);
+      expect(storage.releaseExecution).toHaveBeenLastCalledWith("queue", tA);
+      // Capacity is now 1/2; one more acquire should succeed, the next should fail.
+      expect(await limiter.tryAcquire()).not.toBeNull();
+      expect(await limiter.tryAcquire()).toBeNull();
     });
   });
 });

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -16,6 +16,7 @@ import {
   PermanentJobError,
   RetryableJobError,
 } from "@workglow/job-queue";
+import type { JobHandle } from "@workglow/job-queue";
 import { IQueueStorage } from "@workglow/storage";
 import type { ISpan, ITelemetryProvider } from "@workglow/util";
 import {
@@ -886,7 +887,7 @@ export function runGenericJobQueueTests(
 
     it("should respect rate limits over time", async () => {
       const numJobs = 20;
-      const handles = [];
+      const handles: Array<JobHandle<TOutput>> = [];
 
       // Add burst of jobs
       for (let i = 0; i < numJobs; i++) {
@@ -912,27 +913,36 @@ export function runGenericJobQueueTests(
         }
       }
 
-      // Helper function to get job counts with retries
+      // Helper function to get job counts with retries. Read each known job by
+      // id instead of issuing three independent size() queries: under load a
+      // job can legitimately move PENDING -> PROCESSING -> PENDING/COMPLETED
+      // between those reads, producing transient under/over-count snapshots on
+      // faster Vitest/Node runs.
       async function getJobCounts(
-        runAttempts = 5,
-        retryDelay = 3
+        runAttempts = 50,
+        retryDelay = 5
       ): Promise<{ pending: number; processing: number; completed: number }> {
+        let lastCounts = { pending: 0, processing: 0, completed: 0 };
         for (let i = 0; i < runAttempts; i++) {
           try {
-            const pending = await client.size(JobStatus.PENDING);
-            const processing = await client.size(JobStatus.PROCESSING);
-            const completed = await client.size(JobStatus.COMPLETED);
+            const jobs = await Promise.all(handles.map((handle) => client.getJob(handle.id)));
+            const pending = jobs.filter((job) => job?.status === JobStatus.PENDING).length;
+            const processing = jobs.filter((job) => job?.status === JobStatus.PROCESSING).length;
+            const completed = jobs.filter((job) => job?.status === JobStatus.COMPLETED).length;
 
-            // Verify we're not counting any jobs multiple times
-            if (pending + processing + completed <= numJobs) {
-              return { pending, processing, completed };
+            lastCounts = { pending, processing, completed };
+
+            if (pending > 0 && completed > 0 && pending + processing + completed === numJobs) {
+              return lastCounts;
             }
           } catch (err) {
             if (i === runAttempts - 1) throw err;
-            await sleep(retryDelay);
           }
+          await sleep(retryDelay);
         }
-        throw new JobError("Failed to get consistent job counts");
+        throw new JobError(
+          `Failed to get consistent job counts: pending=${lastCounts.pending}, processing=${lastCounts.processing}, completed=${lastCounts.completed}`
+        );
       }
 
       // Check job states

--- a/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Imported directly from source — `@workglow/storage` only exposes this class in
-// its `browser` conditional export and these tests run under Node.
-import { SharedInMemoryTabularStorage } from "../../../../storage/src/tabular/SharedInMemoryTabularStorage";
+import { SharedInMemoryTabularStorage } from "@workglow/storage";
 import { setLogger } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
Reduce latency and per-call overhead for the default same-process
deployment (client attached to server in the same process — typically
a browser), while keeping storage as the source of truth for crash
recovery and cross-process consumers.

- Submit directly notifies the attached server's workers, bypassing
  the poll interval. Critical for Sqlite/Postgres whose
  subscribeToChanges throws — without this their attached workers
  would never wake.
- worker.stop() drains in-flight jobs up to stopTimeoutMs (default
  30s) before aborting, replacing a fixed-heuristic sleep.
- abort() fires the in-memory AbortController first; storage.abort
  is only written when no local worker is running the job, avoiding
  a last-writer race between ABORTING and FAILED on async storages.
- updateProgress no longer writes mid-job progress to storage. In-
  process consumers still get job_progress events; storage subscribers
  see state transitions only.
- Cleanup loop only starts when at least one retention TTL is set.
- checkForAbortingJobs early-returns when no jobs are active —
  saves a storage round-trip per loop iteration when idle.

- handleAbort terminal-state guard: prevents the COMPLETED→FAILED
  clobber when a late abort races a successful completion. Returns
  early when the job is still in this worker's inFlight map (let
  processSingleJob's catch own the terminal write); for jobs that
  have already settled, guards against COMPLETED/FAILED/DISABLED
  before calling failJob. Side benefit: kills the duplicate
  job_error emit that fired when both the signal listener and
  processSingleJob's catch raced to failJob the same abort.
- waitFor registers its resolver before reading storage. A fast
  same-process abort could previously fire handleJobError between
  the read and the registration, leaving waitFor to register against
  an already-finished job and hang forever.
- notify latches a wakePending flag if it fires while the worker
  is not yet idle. The next waitForWakeOrTimeout consumes it and
  returns immediately. Without this, a notify arriving during the
  worker's pre-idle awaits (storage.next, storage.peek) was dropped
  on the floor — observed under load on IndexedDb.
- subscribeToChanges throws are logged at debug instead of swallowed
  silently. Sqlite/Postgres throw here by design, but a misconfigured
  Supabase realtime would otherwise be undiagnosable.
- JobQueueClient.abort no longer emits job_aborting from a finally
  when storage.abort threw — the throw propagates without misleading
  observers.

- Storage subscribers observe state transitions only (no mid-job
  progress).
- Attached same-process servers used to skip storage.subscribeToChanges
  entirely; current code subscribes on every server (the optimization
  was reverted during review for cross-process correctness).
- abort() can cause job re-execution on a crash between the in-memory
  abort firing and FAILED being persisted; handlers must be idempotent.
- worker.stop() now waits up to stopTimeoutMs (default 30s) for drain.

- Strengthen worker.stop drain test: use a slow-but-completing task,
  wait for PROCESSING (not PROCESSING-or-COMPLETED), assert COMPLETED
  + a stop duration that proves drain actually waited.
- Add stopTimeoutMs:0 test that asserts stop returns promptly with
  an in-flight long-running job.
- Add `submit wakes the worker` and `abort resolves quickly` direct-
  notify tests.
- Add `updateProgress does not write to storage mid-job` test.
- Add `attached server still subscribes to storage changes` test.
- Budgets fit within vitest's 15s testTimeout under heavy parallel
  load (13 storage backends concurrently); still well below the 60s
  poll intervals being contrasted against.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>