### PR TITLE
refactor(task-graph): decompose TaskGraphRunner (1478→774 lines)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - run: bun run build
       - name: Upload build artifacts
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -67,7 +67,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -91,7 +91,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -115,7 +115,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -135,7 +135,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -155,7 +155,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -179,7 +179,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -207,7 +207,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -239,7 +239,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -271,7 +271,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -299,7 +299,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -327,7 +327,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -365,7 +365,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download Vitest coverage fragments
         run: mkdir -p coverage-parts
@@ -416,9 +416,22 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [test-bun-unit, test-vitest-unit, test-bun-integration, test-vitest-integration, test-bun-rag, test-vitest-rag, test-bun-ai-provider-hft, test-bun-ai-provider-llamacpp, test-bun-ai-provider-api, test-vitest-ai-provider-hft, test-vitest-ai-provider-llamacpp, test-vitest-ai-provider-api]
+    needs:
+      [
+        test-bun-unit,
+        test-vitest-unit,
+        test-bun-integration,
+        test-vitest-integration,
+        test-bun-rag,
+        test-vitest-rag,
+        test-bun-ai-provider-hft,
+        test-bun-ai-provider-llamacpp,
+        test-bun-ai-provider-api,
+        test-vitest-ai-provider-hft,
+        test-vitest-ai-provider-llamacpp,
+        test-vitest-ai-provider-api,
+      ]
     steps:
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: build-output
-

--- a/docs/technical/01-task-graph-dag-engine.md
+++ b/docs/technical/01-task-graph-dag-engine.md
@@ -325,6 +325,22 @@ Long-lived state from `config` (`registry`, `outputCache`, `resourceScope`, `acc
 
 **Mnemonic:** `TaskGraphRunConfig` is what the caller asks for; `RunContext` is what the runner is doing right now.
 
+#### `resourceScope` ownership
+
+`resourceScope` is special: the runner sets `this.resourceScope` from
+`config.resourceScope` when present, but if the caller did not provide one,
+`runGraph` allocates a private `ResourceScope` and `disposeAll()`s it in a
+`finally` block when the run terminates (success, error, or abort). Casual
+callers get automatic cleanup of heavyweight resources (model unload, AI
+session close, browser disconnect) with no ceremony. Caller-passed scopes are
+never touched by the runner — expert callers retain full lifecycle control.
+
+The same auto-ownership pattern applies to `TaskRunner.run` for the bare-task
+path. Nested runs (`GraphAsTask`, `IteratorTask`, `runTask`, `subGraph.run`)
+always forward `this.resourceScope`, which is defined post-`handleStart`, so
+child runners observe a "caller-passed" scope and never own it. Disposal
+happens exactly once, at the top of the call stack.
+
 ---
 
 ## Execution Flow

--- a/docs/technical/01-task-graph-dag-engine.md
+++ b/docs/technical/01-task-graph-dag-engine.md
@@ -270,6 +270,63 @@ graph.resetGraph();  // Reset all tasks to PENDING
 
 ---
 
+## Runtime Architecture
+
+`TaskGraphRunner` is a thin facade that owns three internal collaborator classes plus a per-run state object. Each collaborator has one responsibility; the facade orchestrates them.
+
+```
+TaskGraphRunner (facade)
+  long-lived: graph, outputCache, processScheduler, previewScheduler,
+              registry, resourceScope, accumulateLeafOutputs
+  per-run anchor: currentCtx?: RunContext
+
+  owns instances of:
+    ├── RunScheduler       — run-loop, abort/timeout, disabled cascade, progress
+    ├── EdgeMaterializer   — edge read/write, transforms, error routing
+    └── StreamPump         — streaming inputs, tee fan-out, accumulation
+                              │
+                              ▼
+                          RunContext  ── per-run, built by handleStart,
+                                          discarded by terminal handlers
+```
+
+| Class | Responsibility | Lifetime |
+|---|---|---|
+| `TaskGraphRunner` | Public API, lifecycle handlers, per-task orchestration in `runTask`, `runGraphPreview` body | Whole runner |
+| `RunScheduler` | For-await run loop, `pushStatusFromNodeToEdges`, disabled cascade, progress aggregation, timeout arm/clear | Whole runner |
+| `EdgeMaterializer` | `copyInputFromEdgesToNode`, `pushOutputFromNodeToEdges`, error-port routing, `resetTask` | Whole runner |
+| `StreamPump` | `prepareStreamingInputs` (tee), `runStreamingTask`, accumulation policy, stream fan-out | Whole runner |
+| `RunContext` | One run's mutable state — abort controller, in-progress maps, error map, telemetry span, timeout timer, entitlement enforcer | Single `runGraph()` call |
+
+All four collaborator classes are marked `@internal` and re-exported from `@workglow/task-graph` so unit tests can construct them directly.
+
+### `TaskGraphRunConfig` vs `RunContext`
+
+These are easy to confuse — both relate to a single run, but they live on opposite sides of the start of execution.
+
+| | `TaskGraphRunConfig` | `RunContext` |
+|---|---|---|
+| **Direction** | Caller → runner (input) | Runner-internal (state) |
+| **Lifetime** | Provided once before the run starts | Created at run start, destroyed at run end |
+| **Mutability** | Caller-built; runner reads it | Runner-mutated throughout the run |
+| **Visibility** | Public (part of `runGraph` API) | `@internal` collaborator state |
+| **Purpose** | Wishes/policy for the run | Bookkeeping while the run is in flight |
+
+`handleStart` translates the caller's wishes into runtime state:
+
+```
+config.parentSignal     → ctx.abortController (wired listener)
+config.timeout          → ctx.graphTimeoutTimer + ctx.pendingGraphTimeoutError on fire
+config.enforceEntitlements + registry → ctx.activeEnforcer
+(no config equivalent)  → ctx.runId, ctx.inProgressTasks, ctx.failedTaskErrors, ctx.telemetrySpan
+```
+
+Long-lived state from `config` (`registry`, `outputCache`, `resourceScope`, `accumulateLeafOutputs`) goes onto the facade — not into `RunContext`. Only state that exists *only while a run is in flight* belongs in `RunContext`.
+
+**Mnemonic:** `TaskGraphRunConfig` is what the caller asks for; `RunContext` is what the runner is doing right now.
+
+---
+
 ## Execution Flow
 
 ### Graph-Level Execution (run)
@@ -279,12 +336,17 @@ TaskGraph.run(input, config)
   |
   v
 TaskGraphRunner.runGraph(input, config)
-  |
-  v
-For each task in topological order:
-  1. copyInputFromEdgesToNode(task)  -- Pull data from incoming dataflows
-  2. runTask(task, input)            -- Execute via TaskRunner.run()
-  3. pushOutputFromNodeToEdges(task) -- Push output to outgoing dataflows
+  1. handleStart(config)                  -- Build RunContext, arm timeout, start telemetry
+  2. runScheduler.runLoop(input, config, ctx, edgeMat)
+       For each task from processScheduler.tasks():
+         a. streamPump.prepareStreamingInputs(task)        -- Tee streaming inputs
+         b. streamPump.awaitStreamInputs(task, registry)   -- Materialize pending streams
+         c. edgeMaterializer.copyInputFromEdgesToNode(task) -- Pull edge values
+         d. ctx.activeEnforcer?.checkTask(task)            -- Runtime entitlement
+         e. Streaming branch: streamPump.runStreamingTask(...)
+            Non-streaming:    task.runner.run(...) → edgeMaterializer.pushOutputFromNodeToEdges
+         f. runScheduler.pushStatusFromNodeToEdges + processScheduler.onTaskCompleted
+  3. Terminal precedence: timeout > task error > abort > complete
   |
   v
 Collect results from ending nodes (no outgoing dataflows)

--- a/packages/ai-provider/src/provider-model-search.test.ts
+++ b/packages/ai-provider/src/provider-model-search.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { ModelSearchTask } from "@workglow/ai";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "vitest";
 import { Anthropic_ModelSearch } from "./provider-anthropic/common/Anthropic_ModelSearch";
 import { Gemini_ModelSearch } from "./provider-gemini/common/Gemini_ModelSearch";
 import { HFI_ModelSearch } from "./provider-hf-inference/common/HFI_ModelSearch";

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -93,15 +93,23 @@ Return runOutputData (locked)
 ```
 TaskGraph.run(input)
     ↓
-TaskGraphRunner.runGraph(input)
+TaskGraphRunner.runGraph(input)        # facade: lifecycle + terminal precedence
     ↓
-For each task (in topological order):
-    1. copyInputFromEdgesToNode()  # Pull data from incoming dataflows
-    2. runTask(task, input)        # Execute the task
-    3. pushOutputFromNodeToEdges() # Push output to outgoing dataflows
+RunScheduler.runLoop(...)              # owns the for-await loop
+    ↓
+For each task (from processScheduler.tasks()):
+    1. StreamPump.prepareStreamingInputs(task)          # Tee streaming inputs
+    2. StreamPump.awaitStreamInputs(task, registry)     # Materialize pending streams
+    3. EdgeMaterializer.copyInputFromEdgesToNode(task)  # Pull data from incoming dataflows
+    4. ctx.activeEnforcer?.checkTask(task)              # Runtime entitlement
+    5. Streaming:     StreamPump.runStreamingTask(...)
+       Non-streaming: task.runner.run(...) → EdgeMaterializer.pushOutputFromNodeToEdges()
+    6. RunScheduler.pushStatusFromNodeToEdges + processScheduler.onTaskCompleted
     ↓
 Return results from ending nodes (no outgoing dataflows)
 ```
+
+`TaskGraphRunner` is a thin facade. The for-await loop lives in `RunScheduler`; per-task choreography lives in the facade's `runTask`; per-run mutable state (abort controller, in-progress maps, timeout timer, telemetry span, entitlement enforcer) lives in a `RunContext` value object built by `handleStart` and discarded by terminal handlers. See `docs/technical/01-task-graph-dag-engine.md` for the full architecture and the `TaskGraphRunConfig` vs `RunContext` distinction.
 
 ### Runtime guard
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -37,6 +37,7 @@ export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
 export * from "./task/CacheCoordinator";
+export * from "./task/StreamProcessor";
 export * from "./task/TaskRunContext";
 export * from "./task";
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -13,6 +13,7 @@ export * from "./task-graph/GraphSchemaUtils";
 export * from "./task-graph/ITaskGraph";
 export * from "./task-graph/TaskGraph";
 export * from "./task-graph/TaskGraphEvents";
+export * from "./task-graph/EdgeMaterializer";
 export * from "./task-graph/RunContext";
 export * from "./task-graph/TaskGraphRunner";
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -36,6 +36,7 @@ export * from "./task-graph/TransformTypes";
 export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
+export * from "./task/TaskRunContext";
 export * from "./task";
 
 export * from "./storage/TaskGraphRepository";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -22,9 +22,14 @@ export * from "./task-graph/TaskGraphRunner";
 export * from "./task-graph/Conversions";
 export * from "./task-graph/GraphToWorkflowCode";
 export * from "./task-graph/IWorkflow";
+export * from "./task-graph/LoopBuilderContext";
 export * from "./task-graph/Workflow";
+export * from "./task-graph/WorkflowBuilder";
+export * from "./task-graph/WorkflowCacheAdapter";
+export * from "./task-graph/WorkflowEventBridge";
 export * from "./task-graph/WorkflowFactories";
 export * from "./task-graph/WorkflowPipe";
+export * from "./task-graph/WorkflowRunContext";
 
 export * from "./task-graph/TransformRegistry";
 export * from "./task-graph/TransformTypes";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -36,6 +36,7 @@ export * from "./task-graph/TransformTypes";
 export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
+export * from "./task/CacheCoordinator";
 export * from "./task/TaskRunContext";
 export * from "./task";
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -23,6 +23,7 @@ export * from "./task-graph/Conversions";
 export * from "./task-graph/GraphToWorkflowCode";
 export * from "./task-graph/IWorkflow";
 export * from "./task-graph/Workflow";
+export * from "./task-graph/WorkflowFactories";
 export * from "./task-graph/WorkflowPipe";
 
 export * from "./task-graph/TransformRegistry";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -23,6 +23,7 @@ export * from "./task-graph/Conversions";
 export * from "./task-graph/GraphToWorkflowCode";
 export * from "./task-graph/IWorkflow";
 export * from "./task-graph/Workflow";
+export * from "./task-graph/WorkflowPipe";
 
 export * from "./task-graph/TransformRegistry";
 export * from "./task-graph/TransformTypes";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -15,6 +15,7 @@ export * from "./task-graph/TaskGraph";
 export * from "./task-graph/TaskGraphEvents";
 export * from "./task-graph/EdgeMaterializer";
 export * from "./task-graph/RunContext";
+export * from "./task-graph/RunScheduler";
 export * from "./task-graph/StreamPump";
 export * from "./task-graph/TaskGraphRunner";
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -15,6 +15,7 @@ export * from "./task-graph/TaskGraph";
 export * from "./task-graph/TaskGraphEvents";
 export * from "./task-graph/EdgeMaterializer";
 export * from "./task-graph/RunContext";
+export * from "./task-graph/StreamPump";
 export * from "./task-graph/TaskGraphRunner";
 
 export * from "./task-graph/Conversions";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -13,6 +13,7 @@ export * from "./task-graph/GraphSchemaUtils";
 export * from "./task-graph/ITaskGraph";
 export * from "./task-graph/TaskGraph";
 export * from "./task-graph/TaskGraphEvents";
+export * from "./task-graph/RunContext";
 export * from "./task-graph/TaskGraphRunner";
 
 export * from "./task-graph/Conversions";

--- a/packages/task-graph/src/task-graph/Dataflow.ts
+++ b/packages/task-graph/src/task-graph/Dataflow.ts
@@ -110,7 +110,7 @@ export class Dataflow {
    * Consumes the active stream to completion and materializes the value.
    *
    * Accumulation of text-delta chunks is the responsibility of the **source
-   * task** (via TaskRunner.executeStreamingTask when shouldAccumulate=true).
+   * task** (via StreamProcessor when shouldAccumulate=true).
    * When accumulation is needed the source task emits an enriched finish event
    * that carries the fully-assembled port data. All downstream edges share that
    * enriched event through tee'd ReadableStreams, so no edge needs to

--- a/packages/task-graph/src/task-graph/EdgeMaterializer.ts
+++ b/packages/task-graph/src/task-graph/EdgeMaterializer.ts
@@ -24,10 +24,8 @@ import type { TaskGraphRunner } from "./TaskGraphRunner";
  * any errors that bubble out of these methods into ctx.failedTaskErrors.
  *
  * Holds a back-reference to the facade so it can read facade-owned long-lived
- * state (`registry`, `previewRunning`) and call facade-side helpers
- * (`propagateDisabledStatus`, `pushStatusFromNodeToEdges`) that have not yet
- * been migrated to dedicated collaborators. This back-ref will be slimmed in
- * later refactor tasks as those helpers move to `RunScheduler`.
+ * state (`registry`, `previewRunning`) and route through the facade's
+ * `runScheduler` for status push and disabled cascade.
  */
 export class EdgeMaterializer {
   constructor(
@@ -196,7 +194,7 @@ export class EdgeMaterializer {
     }
 
     // Cascade disabled status to downstream tasks whose ALL inputs are now disabled
-    this.runner.propagateDisabledStatus(this.graph);
+    this.runner.runScheduler.propagateDisabledStatus(this.runner["currentCtx"]);
   }
 
   /**
@@ -215,7 +213,12 @@ export class EdgeMaterializer {
     task.error = undefined;
     task.progress = 0;
     task.runConfig = { ...task.runConfig, runnerId: runId };
-    this.runner.pushStatusFromNodeToEdges(graph, task);
+    this.runner.runScheduler.pushStatusFromNodeToEdges(
+      task,
+      this.runner["currentCtx"],
+      undefined,
+      graph
+    );
     // Inline the error-edge reset using the per-call graph (this.pushErrorFromNodeToEdges
     // would use this.graph, which is wrong for recursive subgraph resets).
     if (task?.config?.id) {

--- a/packages/task-graph/src/task-graph/EdgeMaterializer.ts
+++ b/packages/task-graph/src/task-graph/EdgeMaterializer.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+import type { ImageValue } from "@workglow/util/media";
+import { previewSource } from "@workglow/util/media";
+import type { ITask } from "../task/ITask";
+import type { TaskInput, TaskOutput } from "../task/TaskTypes";
+import { TaskStatus } from "../task/TaskTypes";
+import { DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
+import type { TaskGraph } from "./TaskGraph";
+import type { TaskGraphRunner } from "./TaskGraphRunner";
+
+/**
+ * @internal
+ * Reads inputs from incoming dataflows, writes outputs/errors to outgoing dataflows.
+ * Owns dataflow transforms and error-port routing.
+ *
+ * Methods take the task they operate on. None take a RunContext — the caller
+ * (TaskGraphRunner.runTask or RunScheduler.runLoop) is responsible for routing
+ * any errors that bubble out of these methods into ctx.failedTaskErrors.
+ *
+ * Holds a back-reference to the facade so it can read facade-owned long-lived
+ * state (`registry`, `previewRunning`) and call facade-side helpers
+ * (`propagateDisabledStatus`, `pushStatusFromNodeToEdges`) that have not yet
+ * been migrated to dedicated collaborators. This back-ref will be slimmed in
+ * later refactor tasks as those helpers move to `RunScheduler`.
+ */
+export class EdgeMaterializer {
+  constructor(
+    private readonly graph: TaskGraph,
+    private readonly runner: TaskGraphRunner
+  ) {}
+
+  /**
+   * Filters graph-level input to only include properties that are not connected via dataflows for a given task
+   * @param task The task to filter input for
+   * @param input The graph-level input
+   * @returns Filtered input containing only unconnected properties
+   */
+  public filterInputForTask(task: ITask, input: TaskInput): TaskInput {
+    // Get all inputs that are connected to this task via dataflows
+    const sourceDataflows = this.graph.getSourceDataflows(task.id);
+    const connectedInputs = new Set(sourceDataflows.map((df) => df.targetTaskPortId));
+
+    // If DATAFLOW_ALL_PORTS ("*") is in the set, all inputs are connected
+    const allPortsConnected = connectedInputs.has(DATAFLOW_ALL_PORTS);
+
+    // Filter out connected inputs from the graph input
+    const filteredInput: TaskInput = {};
+    for (const [key, value] of Object.entries(input)) {
+      // Skip this input if it's explicitly connected OR if all ports are connected
+      if (!connectedInputs.has(key) && !allPortsConnected) {
+        filteredInput[key] = value;
+      }
+    }
+
+    return filteredInput;
+  }
+
+  /**
+   * Copies input data from edges to a task
+   * @param task The task to copy input data to
+   */
+  public copyInputFromEdgesToNode(task: ITask) {
+    const dataflows = this.graph.getSourceDataflows(task.id);
+    // Sort by dataflow id for deterministic input merging regardless of insertion order
+    dataflows.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    for (const dataflow of dataflows) {
+      // Use getCurrentValue() to pick up latestSnapshot when the edge is
+      // mid-stream (i.e. value is undefined but latestSnapshot is populated).
+      // We re-implement getPortData()'s wrapping with the live value.
+      const live = dataflow.getCurrentValue();
+      const port = dataflow.targetTaskPortId;
+      let portData: TaskOutput;
+      if (port === DATAFLOW_ALL_PORTS) {
+        portData = live as TaskOutput;
+      } else if (port === DATAFLOW_ERROR_PORT) {
+        portData = { [DATAFLOW_ERROR_PORT]: dataflow.error } as unknown as TaskOutput;
+      } else {
+        portData = { [port]: live } as TaskOutput;
+      }
+      this.runner.addInputData(task, portData);
+    }
+  }
+
+  /**
+   * Pushes the output of a task to its target tasks
+   * @param node The task that produced the output
+   * @param results The output of the task
+   */
+  public async pushOutputFromNodeToEdges(node: ITask, results: TaskOutput) {
+    const dataflows = this.graph.getTargetDataflows(node.id);
+
+    // Preview-mode chain-head downscale: apply `previewSource` to any
+    // image-shaped output before it's pushed downstream. This relocates the
+    // per-task `executePreview` invocation of `previewSource` to the engine,
+    // where it fires once per chain head and is idempotent on already-small
+    // images (returns the input unchanged when within budget).
+    if (this.runner.previewRunning && Object.keys(results).length > 0) {
+      for (const port of Object.keys(results)) {
+        const value = (results as Record<string, unknown>)[port];
+        if (EdgeMaterializer.isImageValueShape(value)) {
+          (results as Record<string, unknown>)[port] = await previewSource(value as ImageValue);
+        }
+      }
+    }
+
+    for (const dataflow of dataflows) {
+      // Edges with an active stream have their final value materialised by the
+      // downstream task's awaitStreamInputs (which uses Dataflow.awaitStreamValue
+      // to read the raw snapshot/finish data and then applies transforms).
+      // Setting port data here would be overwritten by the finish event, and
+      // applying transforms again on this path would double-apply
+      // non-idempotent transforms, so skip the whole post-materialisation step.
+      if (dataflow.stream !== undefined) continue;
+      const compatibility = dataflow.semanticallyCompatible(
+        this.graph,
+        dataflow,
+        this.runner.registry
+      );
+      if (compatibility === "static") {
+        dataflow.setPortData(results);
+        await dataflow.applyTransforms(this.runner.registry);
+      } else if (compatibility === "runtime") {
+        const task = this.graph.getTask(dataflow.targetTaskId)!;
+        const narrowed = await task.narrowInput({ ...results }, this.runner.registry);
+        dataflow.setPortData(narrowed);
+        await dataflow.applyTransforms(this.runner.registry);
+      } else {
+        // Warn only when we had data to push; empty results (e.g. progress mid-run) are expected
+        const resultsKeys = Object.keys(results);
+        if (resultsKeys.length > 0) {
+          getLogger().warn("pushOutputFromNodeToEdge not compatible, not setting port data", {
+            dataflowId: dataflow.id,
+            compatibility,
+            resultsKeys,
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Pushes the error of a task to its target edges
+   * @param node The task that produced the error
+   */
+  public pushErrorFromNodeToEdges(node: ITask): void {
+    if (!node?.config?.id) return;
+    this.graph.getTargetDataflows(node.id).forEach((dataflow) => {
+      dataflow.error = node.error;
+    });
+  }
+
+  /**
+   * Returns true if the task has any outgoing dataflow edges that use the
+   * error output port (`[error]`). These edges indicate that the task's
+   * errors should be routed to downstream handler tasks instead of failing
+   * the entire graph.
+   */
+  public hasErrorOutputEdges(task: ITask): boolean {
+    const dataflows = this.graph.getTargetDataflows(task.id);
+    return dataflows.some((df) => df.sourceTaskPortId === DATAFLOW_ERROR_PORT);
+  }
+
+  /**
+   * Routes a failed task's error through its error-port dataflow edges.
+   *
+   * For each outgoing dataflow:
+   * - Error-port edges (`[error]`) receive the error data and get COMPLETED status
+   * - Non-error-port edges get DISABLED status (the task didn't produce normal output)
+   *
+   * After setting edge statuses, propagateDisabledStatus() cascades DISABLED
+   * through any downstream tasks that only had non-error inputs from this task.
+   */
+  public pushErrorOutputToEdges(task: ITask): void {
+    const taskError = task.error;
+    const errorData = {
+      error: taskError?.message ?? "Unknown error",
+      errorType: (taskError?.constructor as { type?: string })?.type ?? "TaskError",
+    };
+
+    const dataflows = this.graph.getTargetDataflows(task.id);
+    for (const df of dataflows) {
+      if (df.sourceTaskPortId === DATAFLOW_ERROR_PORT) {
+        // Route error data to the error-port edge
+        df.value = errorData;
+        df.setStatus(TaskStatus.COMPLETED);
+      } else {
+        // Normal output edges are disabled — this task didn't produce output
+        df.setStatus(TaskStatus.DISABLED);
+      }
+    }
+
+    // Cascade disabled status to downstream tasks whose ALL inputs are now disabled
+    this.runner.propagateDisabledStatus(this.graph);
+  }
+
+  /**
+   * Resets a task. Takes an explicit `graph` because `resetGraph` recurses
+   * into `node.subGraph` for nested tasks and the EdgeMaterializer's own
+   * `this.graph` reference is bound to the top-level graph only.
+   *
+   * @param graph The task graph that owns the task being reset
+   * @param task The task to reset
+   * @param runId The run ID
+   */
+  public resetTask(graph: TaskGraph, task: ITask, runId: string) {
+    task.status = TaskStatus.PENDING;
+    task.resetInputData();
+    task.runOutputData = {};
+    task.error = undefined;
+    task.progress = 0;
+    task.runConfig = { ...task.runConfig, runnerId: runId };
+    this.runner.pushStatusFromNodeToEdges(graph, task);
+    // Inline the error-edge reset using the per-call graph (this.pushErrorFromNodeToEdges
+    // would use this.graph, which is wrong for recursive subgraph resets).
+    if (task?.config?.id) {
+      graph.getTargetDataflows(task.id).forEach((dataflow) => {
+        dataflow.error = task.error;
+      });
+    }
+    task.emit("reset");
+    task.emit("status", task.status);
+  }
+
+  /**
+   * Duck-typed predicate for an `ImageValue`-shaped output, used by the engine
+   * to decide whether to apply `previewSource` during `runPreview`. Unlike
+   * `isImageValue` from `@workglow/util/media`, this predicate does not check
+   * `instanceof ImageBitmap` / `Buffer.isBuffer`, so it remains correct across
+   * realm boundaries (e.g. bundle copies in test harnesses) where those identity
+   * checks can spuriously fail.
+   */
+  private static isImageValueShape(
+    v: unknown
+  ): v is { width: number; height: number; previewScale: number } {
+    if (v === null || typeof v !== "object") return false;
+    const o = v as Record<string, unknown>;
+    return (
+      typeof o.width === "number" &&
+      typeof o.height === "number" &&
+      typeof o.previewScale === "number"
+    );
+  }
+}

--- a/packages/task-graph/src/task-graph/EdgeMaterializer.ts
+++ b/packages/task-graph/src/task-graph/EdgeMaterializer.ts
@@ -98,7 +98,8 @@ export class EdgeMaterializer {
     // per-task `executePreview` invocation of `previewSource` to the engine,
     // where it fires once per chain head and is idempotent on already-small
     // images (returns the input unchanged when within budget).
-    if (this.runner.previewRunning && Object.keys(results).length > 0) {
+    // Bracket access — previewRunning stays protected on the facade.
+    if (this.runner["previewRunning"] && Object.keys(results).length > 0) {
       for (const port of Object.keys(results)) {
         const value = (results as Record<string, unknown>)[port];
         if (EdgeMaterializer.isImageValueShape(value)) {
@@ -115,19 +116,17 @@ export class EdgeMaterializer {
       // applying transforms again on this path would double-apply
       // non-idempotent transforms, so skip the whole post-materialisation step.
       if (dataflow.stream !== undefined) continue;
-      const compatibility = dataflow.semanticallyCompatible(
-        this.graph,
-        dataflow,
-        this.runner.registry
-      );
+      // Bracket access — registry stays protected on the facade.
+      const registry = this.runner["registry"];
+      const compatibility = dataflow.semanticallyCompatible(this.graph, dataflow, registry);
       if (compatibility === "static") {
         dataflow.setPortData(results);
-        await dataflow.applyTransforms(this.runner.registry);
+        await dataflow.applyTransforms(registry);
       } else if (compatibility === "runtime") {
         const task = this.graph.getTask(dataflow.targetTaskId)!;
-        const narrowed = await task.narrowInput({ ...results }, this.runner.registry);
+        const narrowed = await task.narrowInput({ ...results }, registry);
         dataflow.setPortData(narrowed);
-        await dataflow.applyTransforms(this.runner.registry);
+        await dataflow.applyTransforms(registry);
       } else {
         // Warn only when we had data to push; empty results (e.g. progress mid-run) are expected
         const resultsKeys = Object.keys(results);
@@ -193,9 +192,9 @@ export class EdgeMaterializer {
       }
     }
 
-    // Cascade disabled status to downstream tasks whose ALL inputs are now disabled
-    // Bracket access — currentCtx stays protected on the facade.
-    this.runner.runScheduler.propagateDisabledStatus(this.runner["currentCtx"]);
+    // Cascade disabled status to downstream tasks whose ALL inputs are now disabled.
+    // Bracket access — runScheduler and currentCtx stay protected on the facade.
+    this.runner["runScheduler"].propagateDisabledStatus(this.runner["currentCtx"]);
   }
 
   /**
@@ -214,8 +213,8 @@ export class EdgeMaterializer {
     task.error = undefined;
     task.progress = 0;
     task.runConfig = { ...task.runConfig, runnerId: runId };
-    // Bracket access — currentCtx stays protected on the facade.
-    this.runner.runScheduler.pushStatusFromNodeToEdges(
+    // Bracket access — runScheduler and currentCtx stay protected on the facade.
+    this.runner["runScheduler"].pushStatusFromNodeToEdges(
       task,
       this.runner["currentCtx"],
       undefined,

--- a/packages/task-graph/src/task-graph/EdgeMaterializer.ts
+++ b/packages/task-graph/src/task-graph/EdgeMaterializer.ts
@@ -194,6 +194,7 @@ export class EdgeMaterializer {
     }
 
     // Cascade disabled status to downstream tasks whose ALL inputs are now disabled
+    // Bracket access — currentCtx stays protected on the facade.
     this.runner.runScheduler.propagateDisabledStatus(this.runner["currentCtx"]);
   }
 
@@ -213,6 +214,7 @@ export class EdgeMaterializer {
     task.error = undefined;
     task.progress = 0;
     task.runConfig = { ...task.runConfig, runnerId: runId };
+    // Bracket access — currentCtx stays protected on the facade.
     this.runner.runScheduler.pushStatusFromNodeToEdges(
       task,
       this.runner["currentCtx"],

--- a/packages/task-graph/src/task-graph/GraphSchemaUtils.ts
+++ b/packages/task-graph/src/task-graph/GraphSchemaUtils.ts
@@ -5,7 +5,9 @@
  */
 
 import { uuid4 } from "@workglow/util";
-import type { DataPortSchema } from "@workglow/util/schema";
+import type { DataPortSchema, JsonSchema } from "@workglow/util/schema";
+import type { ITask } from "../task/ITask";
+import { Task } from "../task/Task";
 import type {
   DataflowJson,
   JsonTaskItem,
@@ -499,4 +501,186 @@ export function addBoundaryNodesToDependencyJson(
   }
 
   return [...prependItems, ...items, ...appendItems];
+}
+
+const TYPED_ARRAY_FORMAT_PREFIX = "TypedArray";
+
+/**
+ * Returns true if the given JSON schema (or any nested schema) has a format
+ * string starting with "TypedArray" (e.g. "TypedArray" or "TypedArray:Float32Array").
+ * Walks oneOf/anyOf wrappers and array items.
+ */
+function schemaHasTypedArrayFormat(schema: JsonSchema): boolean {
+  if (typeof schema === "boolean") return false;
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return false;
+
+  const s = schema as Record<string, unknown>;
+  if (typeof s.format === "string" && s.format.startsWith(TYPED_ARRAY_FORMAT_PREFIX)) {
+    return true;
+  }
+
+  const checkUnion = (schemas: unknown): boolean => {
+    if (!Array.isArray(schemas)) return false;
+    return schemas.some((sub) => schemaHasTypedArrayFormat(sub as JsonSchema));
+  };
+  if (checkUnion(s.oneOf) || checkUnion(s.anyOf)) return true;
+
+  const items = s.items;
+  if (items && typeof items === "object" && !Array.isArray(items)) {
+    if (schemaHasTypedArrayFormat(items as JsonSchema)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the task's output schema has any port with TypedArray format.
+ * Used by adaptive workflow methods to choose scalar vs vector task variant.
+ */
+export function hasVectorOutput(task: ITask): boolean {
+  const outputSchema = task.outputSchema();
+  if (typeof outputSchema === "boolean" || !outputSchema?.properties) return false;
+  return Object.values(outputSchema.properties).some((prop) =>
+    schemaHasTypedArrayFormat(prop as JsonSchema)
+  );
+}
+
+/**
+ * Returns true if the input object looks like vector task input: has a "vectors"
+ * property that is an array with at least one TypedArray element. Used by
+ * adaptive workflow methods so that e.g. sum({ vectors: [new Float32Array(...)] })
+ * chooses the vector variant even with no previous task.
+ */
+export function hasVectorLikeInput(input: unknown): boolean {
+  if (!input || typeof input !== "object") return false;
+  const v = (input as Record<string, unknown>).vectors;
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    typeof v[0] === "object" &&
+    v[0] !== null &&
+    ArrayBuffer.isView(v[0])
+  );
+}
+
+/**
+ * Updates InputTask/OutputTask config schemas based on their connected dataflows.
+ * InputTask schema reflects its outgoing dataflow targets' input schemas.
+ * OutputTask schema reflects its incoming dataflow sources' output schemas.
+ */
+export function updateBoundaryTaskSchemas(graph: TaskGraph): void {
+  const tasks = graph.getTasks();
+
+  for (const task of tasks) {
+    if (task.type === "InputTask") {
+      // If the schema is marked as fully manual (x-ui-manual at schema level),
+      // skip edge-based regeneration — the user explicitly defined this schema.
+      const existingConfig = (task as ITask).config;
+      const existingSchema = existingConfig?.inputSchema ?? existingConfig?.outputSchema;
+      if (
+        existingSchema &&
+        typeof existingSchema === "object" &&
+        (existingSchema as Record<string, unknown>)["x-ui-manual"] === true
+      ) {
+        continue;
+      }
+
+      const outgoing = graph.getTargetDataflows(task.id);
+      if (outgoing.length === 0) continue;
+
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
+
+      for (const df of outgoing) {
+        const targetTask = graph.getTask(df.targetTaskId);
+        if (!targetTask) continue;
+        const targetSchema = targetTask.inputSchema();
+        if (typeof targetSchema === "boolean") continue;
+        const prop = (targetSchema.properties as any)?.[df.targetTaskPortId];
+        if (prop && typeof prop !== "boolean") {
+          properties[df.sourceTaskPortId] = prop;
+          if (targetSchema.required?.includes(df.targetTaskPortId)) {
+            if (!required.includes(df.sourceTaskPortId)) {
+              required.push(df.sourceTaskPortId);
+            }
+          }
+        }
+      }
+
+      const schema = {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      } as DataPortSchema;
+
+      // @ts-expect-error - config is readonly
+      task.config = {
+        ...task.config,
+        inputSchema: schema,
+        outputSchema: schema,
+      };
+    }
+
+    if (task.type === "OutputTask") {
+      const incoming = graph.getSourceDataflows(task.id);
+      if (incoming.length === 0) continue;
+
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
+
+      for (const df of incoming) {
+        const sourceTask = graph.getTask(df.sourceTaskId);
+        if (!sourceTask) continue;
+        const sourceSchema = sourceTask.outputSchema();
+        if (typeof sourceSchema === "boolean") continue;
+        let prop = (sourceSchema.properties as any)?.[df.sourceTaskPortId];
+        let propRequired = sourceSchema.required?.includes(df.sourceTaskPortId) ?? false;
+
+        // For passthrough tasks with additionalProperties (e.g. DebugLogTask),
+        // the port won't appear in the static output schema. Trace back through
+        // the passthrough task's own incoming dataflows to find the actual schema.
+        if (
+          !prop &&
+          sourceSchema.additionalProperties === true &&
+          (sourceTask.constructor as typeof Task).passthroughInputsToOutputs === true
+        ) {
+          const upstreamDfs = graph.getSourceDataflows(sourceTask.id);
+          for (const udf of upstreamDfs) {
+            if (udf.targetTaskPortId !== df.sourceTaskPortId) continue;
+            const upstreamTask = graph.getTask(udf.sourceTaskId);
+            if (!upstreamTask) continue;
+            const upstreamSchema = upstreamTask.outputSchema();
+            if (typeof upstreamSchema === "boolean") continue;
+            prop = (upstreamSchema.properties as any)?.[udf.sourceTaskPortId];
+            if (prop) {
+              propRequired = upstreamSchema.required?.includes(udf.sourceTaskPortId) ?? false;
+              break;
+            }
+          }
+        }
+
+        if (prop && typeof prop !== "boolean") {
+          properties[df.targetTaskPortId] = prop;
+          if (propRequired && !required.includes(df.targetTaskPortId)) {
+            required.push(df.targetTaskPortId);
+          }
+        }
+      }
+
+      const schema = {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      } as DataPortSchema;
+
+      // @ts-expect-error - config is readonly
+      task.config = {
+        ...task.config,
+        inputSchema: schema,
+        outputSchema: schema,
+      };
+    }
+  }
 }

--- a/packages/task-graph/src/task-graph/IWorkflow.ts
+++ b/packages/task-graph/src/task-graph/IWorkflow.ts
@@ -12,7 +12,17 @@ import { GraphResult, PROPERTY_ARRAY } from "./TaskGraphRunner";
 export interface WorkflowRunConfig {
   /** Optional service registry to use for this workflow run */
   readonly registry?: ServiceRegistry;
-  /** Resource scope for collecting heavyweight resource disposers. */
+  /**
+   * Resource scope for collecting heavyweight resource disposers during the
+   * workflow run.
+   *
+   * If omitted, the underlying graph runner creates a private scope and
+   * disposes it when the run finishes — automatic cleanup for casual callers.
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`. Use this to share resources (e.g., a loaded AI model) across
+   * multiple runs, then dispose at app shutdown.
+   */
   readonly resourceScope?: ResourceScope;
 }
 

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+import type { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask } from "../task/ITask";
+import { autoConnect } from "./autoConnect";
+import type { TaskGraph } from "./TaskGraph";
+import type { Workflow } from "./Workflow";
+
+export interface PendingLoopConnect {
+  readonly parent: ITask;
+  readonly iteratorTask: ITask;
+}
+
+/**
+ * Runs deferred auto-connect for a loop iterator task on the parent
+ * workflow's graph. Extracted as a free function so it can be invoked
+ * from both {@link LoopBuilderContext.autoConnectLoopTask} and from
+ * the parent {@link Workflow}'s public delegate method (the parent is
+ * not itself in loop-builder mode and has no context of its own).
+ */
+export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopConnect): void {
+  const { parent, iteratorTask } = pending;
+  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return;
+
+  const nodes = parentGraph.getTasks();
+  const parentIndex = nodes.findIndex((n) => n.id === parent.id);
+  const earlierTasks: ITask[] = [];
+  for (let i = parentIndex - 1; i >= 0; i--) {
+    earlierTasks.push(nodes[i]);
+  }
+
+  const result = autoConnect(parentGraph, parent, iteratorTask, { earlierTasks });
+  if (result.error) {
+    getLogger().error(result.error + " Task not added.");
+    parentGraph.removeTask(iteratorTask.id);
+  }
+}
+
+/**
+ * Holds the parent <-> child relationship for a Workflow operating in
+ * loop-builder mode (created by parent.addLoopTask). Owns deferred
+ * auto-connect state. Has no events, no DSL.
+ */
+export class LoopBuilderContext {
+  public readonly parent: Workflow;
+  public readonly iteratorTask: GraphAsTask;
+  public pendingLoopConnect?: PendingLoopConnect;
+
+  constructor(parent: Workflow, iteratorTask: GraphAsTask) {
+    this.parent = parent;
+    this.iteratorTask = iteratorTask;
+  }
+
+  /**
+   * Promotes a populated child template graph into the iterator task's
+   * subGraph. No-op on empty graphs.
+   */
+  public finalizeTemplate(childGraph: TaskGraph): void {
+    if (childGraph.getTasks().length === 0) return;
+    this.iteratorTask.subGraph = childGraph;
+    this.iteratorTask.validateAcyclic();
+  }
+
+  /** Runs auto-connect for the pending loop connect (if any), then clears it. */
+  public consumePendingConnect(): void {
+    const pending = this.pendingLoopConnect;
+    if (!pending) return;
+    runLoopAutoConnect(this.parent.graph, pending);
+    this.pendingLoopConnect = undefined;
+  }
+
+  /** Finalizes the template and returns the parent workflow. */
+  public finalizeAndReturn(childGraph: TaskGraph): Workflow {
+    this.finalizeTemplate(childGraph);
+    this.consumePendingConnect();
+    return this.parent;
+  }
+}

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -11,12 +11,16 @@ import { autoConnect } from "./autoConnect";
 import type { TaskGraph } from "./TaskGraph";
 import type { Workflow } from "./Workflow";
 
+/**
+ * @internal
+ */
 export interface PendingLoopConnect {
   readonly parent: ITask;
   readonly iteratorTask: ITask;
 }
 
 /**
+ * @internal
  * Runs deferred auto-connect for a loop iterator task on the parent
  * workflow's graph. Extracted as a free function so it can be invoked
  * from both {@link LoopBuilderContext.consumePendingConnect} and from
@@ -53,6 +57,7 @@ export function runLoopAutoConnect(
 }
 
 /**
+ * @internal
  * Holds the parent <-> child relationship for a Workflow operating in
  * loop-builder mode (created by parent.addLoopTask). Owns deferred
  * auto-connect state. Has no events, no DSL.

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -19,13 +19,21 @@ export interface PendingLoopConnect {
 /**
  * Runs deferred auto-connect for a loop iterator task on the parent
  * workflow's graph. Extracted as a free function so it can be invoked
- * from both {@link LoopBuilderContext.autoConnectLoopTask} and from
+ * from both {@link LoopBuilderContext.consumePendingConnect} and from
  * the parent {@link Workflow}'s public delegate method (the parent is
  * not itself in loop-builder mode and has no context of its own).
+ *
+ * Returns the error message if auto-connect failed, otherwise undefined.
+ * On failure the iterator task is removed from the parent graph; the
+ * caller is responsible for surfacing the error onto the parent
+ * workflow's `.error` (matches the non-loop auto-connect path).
  */
-export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopConnect): void {
+export function runLoopAutoConnect(
+  parentGraph: TaskGraph,
+  pending: PendingLoopConnect
+): string | undefined {
   const { parent, iteratorTask } = pending;
-  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return;
+  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return undefined;
 
   const nodes = parentGraph.getTasks();
   const parentIndex = nodes.findIndex((n) => n.id === parent.id);
@@ -36,9 +44,12 @@ export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopC
 
   const result = autoConnect(parentGraph, parent, iteratorTask, { earlierTasks });
   if (result.error) {
-    getLogger().error(result.error + " Task not added.");
+    const message = result.error + " Task not added.";
+    getLogger().error(message);
     parentGraph.removeTask(iteratorTask.id);
+    return message;
   }
+  return undefined;
 }
 
 /**
@@ -66,18 +77,28 @@ export class LoopBuilderContext {
     this.iteratorTask.validateAcyclic();
   }
 
-  /** Runs auto-connect for the pending loop connect (if any), then clears it. */
-  public consumePendingConnect(): void {
+  /**
+   * Runs auto-connect for the pending loop connect (if any), then clears it.
+   * Returns the error message if auto-connect failed, otherwise undefined,
+   * so the caller can propagate the failure to the parent workflow's `.error`.
+   */
+  public consumePendingConnect(): string | undefined {
     const pending = this.pendingLoopConnect;
-    if (!pending) return;
-    runLoopAutoConnect(this.parent.graph, pending);
+    if (!pending) return undefined;
+    const error = runLoopAutoConnect(this.parent.graph, pending);
     this.pendingLoopConnect = undefined;
+    return error;
   }
 
-  /** Finalizes the template and returns the parent workflow. */
+  /**
+   * Finalizes the template and returns the parent workflow. Any deferred
+   * auto-connect error is surfaced onto the parent's `.error` to match the
+   * non-loop auto-connect path.
+   */
   public finalizeAndReturn(childGraph: TaskGraph): Workflow {
     this.finalizeTemplate(childGraph);
-    this.consumePendingConnect();
+    const error = this.consumePendingConnect();
+    if (error) this.parent.builder.setError(error);
     return this.parent;
   }
 }

--- a/packages/task-graph/src/task-graph/RunContext.ts
+++ b/packages/task-graph/src/task-graph/RunContext.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ISpan } from "@workglow/util";
+import { uuid4 } from "@workglow/util";
+import type { IEntitlementEnforcer } from "../task/EntitlementEnforcer";
+import type { TaskError, TaskGraphTimeoutError } from "../task/TaskError";
+import type { TaskOutput } from "../task/TaskTypes";
+
+/**
+ * @internal
+ * Per-run mutable state for a single TaskGraphRunner.runGraph() invocation.
+ * Built by TaskGraphRunner.handleStart(), discarded by handleComplete/Error/Abort.
+ *
+ * All long-lived state (graph, schedulers, registry, resourceScope, outputCache,
+ * accumulateLeafOutputs) stays on the facade. RunContext only holds state that is
+ * created at the start of a run and torn down when the run terminates.
+ */
+export class RunContext {
+  readonly runId: string;
+  readonly abortController: AbortController;
+  readonly inProgressTasks: Map<unknown, Promise<TaskOutput>> = new Map();
+  readonly inProgressFunctions: Map<unknown, Promise<void>> = new Map();
+  readonly failedTaskErrors: Map<unknown, TaskError> = new Map();
+
+  telemetrySpan?: ISpan;
+  graphTimeoutTimer?: ReturnType<typeof setTimeout>;
+  pendingGraphTimeoutError?: TaskGraphTimeoutError;
+  activeEnforcer?: IEntitlementEnforcer;
+
+  constructor(parentSignal?: AbortSignal) {
+    this.runId = uuid4();
+    this.abortController = new AbortController();
+    if (parentSignal) {
+      // Listen first, then check — addEventListener on an already-aborted signal
+      // does not fire, so checking .aborted after ensures we never miss an abort.
+      // Pattern preserved from commit 4e50c99e.
+      const onParentAbort = () => this.abortController.abort();
+      parentSignal.addEventListener("abort", onParentAbort, { once: true });
+      if (parentSignal.aborted) {
+        parentSignal.removeEventListener("abort", onParentAbort);
+        this.abortController.abort();
+      }
+    }
+  }
+}

--- a/packages/task-graph/src/task-graph/RunContext.ts
+++ b/packages/task-graph/src/task-graph/RunContext.ts
@@ -31,6 +31,10 @@ export class RunContext {
   pendingGraphTimeoutError?: TaskGraphTimeoutError;
   activeEnforcer?: IEntitlementEnforcer;
 
+  // Removes the parentSignal abort listener, if one was registered. Set in the
+  // constructor when parentSignal is provided; called from dispose().
+  private parentSignalCleanup?: () => void;
+
   constructor(parentSignal?: AbortSignal) {
     this.runId = uuid4();
     this.abortController = new AbortController();
@@ -40,10 +44,24 @@ export class RunContext {
       // Pattern preserved from commit 4e50c99e.
       const onParentAbort = () => this.abortController.abort();
       parentSignal.addEventListener("abort", onParentAbort, { once: true });
-      if (parentSignal.aborted) {
+      this.parentSignalCleanup = () =>
         parentSignal.removeEventListener("abort", onParentAbort);
+      if (parentSignal.aborted) {
+        this.parentSignalCleanup();
+        this.parentSignalCleanup = undefined;
         this.abortController.abort();
       }
     }
+  }
+
+  /**
+   * Releases external listeners (parentSignal abort handler). Idempotent.
+   * Called by terminal handlers (handleComplete/Error/Abort) so a parent abort
+   * fired after this run completes does not re-trigger our abort path and emit
+   * a duplicate terminal event.
+   */
+  dispose(): void {
+    this.parentSignalCleanup?.();
+    this.parentSignalCleanup = undefined;
   }
 }

--- a/packages/task-graph/src/task-graph/RunScheduler.ts
+++ b/packages/task-graph/src/task-graph/RunScheduler.ts
@@ -1,0 +1,308 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+import { ConditionalTask } from "../task/ConditionalTask";
+import type { ITask } from "../task/ITask";
+import { TaskError, TaskGraphTimeoutError } from "../task/TaskError";
+import type { TaskInput, TaskOutput } from "../task/TaskTypes";
+import { TaskStatus } from "../task/TaskTypes";
+import type { EdgeMaterializer } from "./EdgeMaterializer";
+import type { RunContext } from "./RunContext";
+import type { TaskGraph, TaskGraphRunConfig } from "./TaskGraph";
+import type { GraphResultArray, GraphSingleTaskResult, TaskGraphRunner } from "./TaskGraphRunner";
+import { taskPrototypeHasOwnExecute } from "./TaskGraphRunner";
+import type { ITaskGraphScheduler } from "./TaskGraphScheduler";
+
+/**
+ * @internal
+ * Run-loop coordinator. Drives task selection via processScheduler,
+ * arms graph-level timeout, propagates disabled cascade, aggregates progress,
+ * and pushes status to outgoing edges.
+ *
+ * Stateless across runs — all per-run state arrives via `ctx`.
+ *
+ * Holds a back-reference to the facade so runLoop can call facade.runTask().
+ * This keeps runTask as the single per-task choreography point that wires
+ * EdgeMaterializer + StreamPump + the integration with TaskRunner.
+ */
+export class RunScheduler {
+  constructor(
+    private readonly graph: TaskGraph,
+    private readonly processScheduler: ITaskGraphScheduler,
+    private readonly facade: TaskGraphRunner
+  ) {}
+
+  /**
+   * Pushes the status of a task to its target edges
+   * @param node The task that produced the status
+   *
+   * For ConditionalTask, this method handles selective dataflow status:
+   * - Active branch dataflows get COMPLETED status
+   * - Inactive branch dataflows get DISABLED status
+   */
+  pushStatusFromNodeToEdges(
+    node: ITask,
+    ctx: RunContext | undefined,
+    status?: TaskStatus,
+    graph: TaskGraph = this.graph
+  ): void {
+    if (!node?.config?.id) return;
+
+    const dataflows = graph.getTargetDataflows(node.id);
+    const effectiveStatus = status ?? node.status;
+
+    // Check if this is a ConditionalTask with selective branching
+    if (node instanceof ConditionalTask && effectiveStatus === TaskStatus.COMPLETED) {
+      // Build a map of output port -> branch ID for lookup
+      const branches = node.config.branches ?? [];
+      const portToBranch = new Map<string, string>();
+      for (const branch of branches) {
+        portToBranch.set(branch.outputPort, branch.id);
+      }
+
+      const activeBranches = node.getActiveBranches();
+
+      for (const dataflow of dataflows) {
+        // Preserve FAILED edges (e.g. transform chain failure) rather than
+        // overwriting with the source task's completion status.
+        if (dataflow.status === TaskStatus.FAILED) continue;
+        const branchId = portToBranch.get(dataflow.sourceTaskPortId);
+        if (branchId !== undefined) {
+          // This dataflow is from a branch port
+          if (activeBranches.has(branchId)) {
+            // Branch is active - dataflow gets completed status
+            dataflow.setStatus(TaskStatus.COMPLETED);
+          } else {
+            // Branch is inactive - dataflow gets disabled status
+            dataflow.setStatus(TaskStatus.DISABLED);
+          }
+        } else {
+          // Not a branch port (e.g., _activeBranches metadata) - use normal status
+          dataflow.setStatus(effectiveStatus);
+        }
+      }
+
+      // Cascade disabled status to downstream tasks
+      this.propagateDisabledStatus(ctx, graph);
+      return;
+    }
+
+    // Default behavior for non-conditional tasks
+    dataflows.forEach((dataflow) => {
+      // Preserve FAILED edges (e.g. transform chain failure) rather than
+      // overwriting with the source task's completion status.
+      if (dataflow.status === TaskStatus.FAILED) return;
+      dataflow.setStatus(effectiveStatus);
+    });
+  }
+
+  /**
+   * Propagates DISABLED status through the graph.
+   *
+   * When a task's ALL incoming dataflows are DISABLED, that task becomes unreachable
+   * and should also be disabled. This cascades through the graph until no more
+   * tasks can be disabled.
+   *
+   * This is used by ConditionalTask to disable downstream tasks on inactive branches.
+   */
+  propagateDisabledStatus(_ctx: RunContext | undefined, graph: TaskGraph = this.graph): void {
+    let changed = true;
+
+    // Keep iterating until no more changes (fixed-point iteration)
+    while (changed) {
+      changed = false;
+
+      for (const task of graph.getTasks()) {
+        // Only consider tasks that are still pending
+        if (task.status !== TaskStatus.PENDING) {
+          continue;
+        }
+
+        const incomingDataflows = graph.getSourceDataflows(task.id);
+
+        // Skip tasks with no incoming dataflows (root tasks)
+        if (incomingDataflows.length === 0) {
+          continue;
+        }
+
+        // Check if ALL incoming dataflows are DISABLED
+        const allDisabled = incomingDataflows.every((df) => df.status === TaskStatus.DISABLED);
+
+        if (allDisabled) {
+          // This task is unreachable - disable it synchronously
+          // Set status directly to avoid async issues
+          task.status = TaskStatus.DISABLED;
+          task.progress = 100;
+          task.completedAt = new Date();
+          task.emit("disabled");
+          task.emit("status", task.status);
+
+          // Propagate disabled status to its outgoing dataflows
+          graph.getTargetDataflows(task.id).forEach((dataflow) => {
+            dataflow.setStatus(TaskStatus.DISABLED);
+          });
+
+          // Mark as completed in scheduler so it doesn't wait for this task
+          this.processScheduler.onTaskCompleted(task.id);
+
+          changed = true;
+        }
+      }
+    }
+  }
+
+  /**
+   * Handles progress updates for the task graph by averaging `progress` across tasks whose class
+   * declares its own `execute` (see {@link taskPrototypeHasOwnExecute}). Other nodes are ignored.
+   */
+  async handleProgress(
+    ctx: RunContext,
+    task: ITask,
+    progress: number | undefined,
+    message?: string,
+    ...args: any[]
+  ): Promise<void> {
+    const contributors = this.graph.getTasks().filter(taskPrototypeHasOwnExecute);
+    if (contributors.length > 1) {
+      const determinate = contributors.filter((t) => t.progress !== undefined);
+      if (determinate.length === 0) {
+        progress = undefined;
+      } else {
+        const sum = determinate.reduce((acc, t) => acc + t.progress!, 0);
+        progress = Math.round(sum / determinate.length);
+      }
+    } else if (contributors.length === 1) {
+      const [only] = contributors;
+      progress = only.progress;
+    }
+    this.pushStatusFromNodeToEdges(task, ctx);
+    // Emit aggregate progress before awaiting output push so UIs (and task `emit("progress")` in
+    // TaskRunner) are not blocked when pushOutput/narrowInput is slow or stalls mid-run.
+    this.graph.emit("graph_progress", progress, message, args);
+    // Only push output for mid-run progress ticks while the task is actively executing.
+    // Terminal-state handlers (complete, abort, error, disable) set task.status to their
+    // terminal value before calling handleProgress(100), so the output push is skipped here —
+    // the graph runner's own post-run pushOutputFromNodeToEdges handles the completed case.
+    const isActive = task.status === TaskStatus.PROCESSING || task.status === TaskStatus.STREAMING;
+    if (isActive && task.runOutputData && Object.keys(task.runOutputData).length > 0) {
+      await this.facade["edgeMaterializer"].pushOutputFromNodeToEdges(task, task.runOutputData);
+    }
+  }
+
+  /**
+   * Arms the graph-level timeout. The timer fires `pendingGraphTimeoutError`
+   * and aborts the run when elapsed. No-op when `timeoutMs <= 0`.
+   */
+  armGraphTimeout(timeoutMs: number, ctx: RunContext): void {
+    if (timeoutMs <= 0) return;
+    ctx.pendingGraphTimeoutError = undefined;
+    ctx.graphTimeoutTimer = setTimeout(() => {
+      ctx.pendingGraphTimeoutError = new TaskGraphTimeoutError(timeoutMs);
+      ctx.abortController.abort();
+    }, timeoutMs);
+  }
+
+  /**
+   * Clears the graph-level timeout timer if active.
+   */
+  clearGraphTimeout(ctx: RunContext): void {
+    if (ctx.graphTimeoutTimer !== undefined) {
+      clearTimeout(ctx.graphTimeoutTimer);
+      ctx.graphTimeoutTimer = undefined;
+    }
+  }
+
+  /**
+   * Inner for-await loop body of {@link TaskGraphRunner.runGraph}. Drives the
+   * processScheduler, dispatches tasks via `facade.runTask`, routes errors,
+   * and pushes status/error to outgoing edges. Returns the per-leaf results
+   * (terminal-state precedence is the facade's responsibility).
+   */
+  async runLoop<O extends TaskOutput>(
+    input: TaskInput,
+    config: TaskGraphRunConfig | undefined,
+    ctx: RunContext,
+    edgeMat: EdgeMaterializer
+  ): Promise<GraphResultArray<O>> {
+    const results: GraphResultArray<O> = [];
+
+    try {
+      // TODO: A different graph runner may chunk tasks that are in parallel
+      // rather them all currently available
+      for await (const task of this.processScheduler.tasks()) {
+        if (ctx.abortController.signal.aborted) {
+          break;
+        }
+
+        if (ctx.failedTaskErrors.size > 0) {
+          break;
+        }
+
+        const isRootTask = this.graph.getSourceDataflows(task.id).length === 0;
+
+        const runAsync = async () => {
+          let errorRouted = false;
+          try {
+            // Root tasks (no incoming dataflows) receive the graph run input so e.g.
+            // InputTask can seed the graph. Downstream tasks rely only on dataflow
+            // edges plus task defaults — unless matchAllEmptyInputs is true, in which case
+            // we filter the input to only include properties that are not connected via dataflows.
+            const taskInput = isRootTask
+              ? input
+              : config?.matchAllEmptyInputs
+                ? edgeMat.filterInputForTask(task, input)
+                : {};
+
+            const taskPromise = this.facade["runTask"](task, taskInput);
+            ctx.inProgressTasks.set(task.id, taskPromise);
+            const taskResult = await taskPromise;
+
+            if (this.graph.getTargetDataflows(task.id).length === 0) {
+              // we save the results of all the leaves
+              results.push(taskResult as GraphSingleTaskResult<O>);
+            }
+          } catch (error) {
+            if (edgeMat.hasErrorOutputEdges(task)) {
+              // Route the error through error-port dataflows instead of failing the graph.
+              // pushErrorOutputToEdges sets edge statuses directly (COMPLETED for error
+              // edges, DISABLED for normal edges), so we skip the normal status push.
+              errorRouted = true;
+              edgeMat.pushErrorOutputToEdges(task);
+            } else {
+              ctx.failedTaskErrors.set(task.id, error as TaskError);
+            }
+          } finally {
+            // IMPORTANT: Push status to edges BEFORE notifying scheduler
+            // This ensures dataflow statuses (including DISABLED) are set
+            // before the scheduler checks which tasks are ready.
+            // Skip normal status push when error routing already set edge statuses.
+            if (!errorRouted) {
+              this.pushStatusFromNodeToEdges(task, ctx);
+              edgeMat.pushErrorFromNodeToEdges(task);
+            }
+            this.processScheduler.onTaskCompleted(task.id);
+          }
+        };
+
+        // Start task execution without awaiting
+        // so we can have many tasks running in parallel
+        // but keep track of them to make sure they get awaited
+        // otherwise, things will finish after this promise is resolved
+        ctx.inProgressFunctions.set(Symbol(task.id as string), runAsync());
+      }
+    } catch (err) {
+      getLogger().error("Error running graph", { error: err });
+    }
+
+    // Wait for all tasks to complete since we did not await runAsync()/this.runTaskWithProvenance()
+    await Promise.allSettled(Array.from(ctx.inProgressTasks.values()));
+    // Clean up stragglers to avoid unhandled promise rejections
+    await Promise.allSettled(Array.from(ctx.inProgressFunctions.values()));
+
+    return results;
+  }
+}

--- a/packages/task-graph/src/task-graph/RunScheduler.ts
+++ b/packages/task-graph/src/task-graph/RunScheduler.ts
@@ -189,6 +189,7 @@ export class RunScheduler {
     // the graph runner's own post-run pushOutputFromNodeToEdges handles the completed case.
     const isActive = task.status === TaskStatus.PROCESSING || task.status === TaskStatus.STREAMING;
     if (isActive && task.runOutputData && Object.keys(task.runOutputData).length > 0) {
+      // Bracket access keeps `edgeMaterializer` protected on the facade — only `runScheduler` was widened to public.
       await this.facade["edgeMaterializer"].pushOutputFromNodeToEdges(task, task.runOutputData);
     }
   }
@@ -196,6 +197,10 @@ export class RunScheduler {
   /**
    * Arms the graph-level timeout. The timer fires `pendingGraphTimeoutError`
    * and aborts the run when elapsed. No-op when `timeoutMs <= 0`.
+   *
+   * @remarks Treats `timeoutMs <= 0` as "no timeout" (silent no-op), not as
+   * "fire immediately". Callers that want immediate cancellation should call
+   * `ctx.abortController.abort()` directly.
    */
   armGraphTimeout(timeoutMs: number, ctx: RunContext): void {
     if (timeoutMs <= 0) return;
@@ -257,6 +262,7 @@ export class RunScheduler {
                 ? edgeMat.filterInputForTask(task, input)
                 : {};
 
+            // Bracket access — runTask stays protected on purpose; this is the back-ref entry point.
             const taskPromise = this.facade["runTask"](task, taskInput);
             ctx.inProgressTasks.set(task.id, taskPromise);
             const taskResult = await taskPromise;

--- a/packages/task-graph/src/task-graph/RunScheduler.ts
+++ b/packages/task-graph/src/task-graph/RunScheduler.ts
@@ -108,6 +108,11 @@ export class RunScheduler {
    * tasks can be disabled.
    *
    * This is used by ConditionalTask to disable downstream tasks on inactive branches.
+   *
+   * `_ctx` is accepted for symmetry with other RunScheduler methods (which thread
+   * per-run state through the RunContext) and to leave room for future per-run
+   * scheduling state without a signature change. Currently unused — the cascade
+   * operates on graph-level task status alone.
    */
   propagateDisabledStatus(_ctx: RunContext | undefined, graph: TaskGraph = this.graph): void {
     let changed = true;

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -135,6 +135,11 @@ export class StreamPump {
     ctx: RunContext,
     options: StreamingRunOptions
   ): Promise<GraphSingleTaskResult<T>> {
+    if (!this.runScheduler) {
+      throw new Error(
+        "StreamPump.runStreamingTask called before setRunScheduler — facade construction is incomplete."
+      );
+    }
     const streamMode = getOutputStreamMode(task.outputSchema());
     const shouldAccumulate = this.taskNeedsAccumulation(
       task,

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -8,11 +8,7 @@ import type { ResourceScope, ServiceRegistry } from "@workglow/util";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ITask } from "../task/ITask";
 import type { StreamEvent, StreamMode } from "../task/StreamTypes";
-import {
-  edgeNeedsAccumulation,
-  getOutputStreamMode,
-  getStreamingPorts,
-} from "../task/StreamTypes";
+import { edgeNeedsAccumulation, getOutputStreamMode, getStreamingPorts } from "../task/StreamTypes";
 import type { TaskInput } from "../task/TaskTypes";
 import { TaskStatus } from "../task/TaskTypes";
 import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -300,7 +300,7 @@ export class StreamPump {
    * unfiltered streams for DATAFLOW_ALL_PORTS edges. Within each port group,
    * uses tee() for fan-out to multiple consumers.
    */
-  pushStreamToEdges(task: ITask, _streamMode: StreamMode): void {
+  private pushStreamToEdges(task: ITask, _streamMode: StreamMode): void {
     const targetDataflows = this.graph.getTargetDataflows(task.id);
     if (targetDataflows.length === 0) return;
 

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -1,0 +1,339 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ResourceScope, ServiceRegistry } from "@workglow/util";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { ITask } from "../task/ITask";
+import type { StreamEvent, StreamMode } from "../task/StreamTypes";
+import {
+  edgeNeedsAccumulation,
+  getOutputStreamMode,
+  getStreamingPorts,
+} from "../task/StreamTypes";
+import type { TaskInput } from "../task/TaskTypes";
+import { TaskStatus } from "../task/TaskTypes";
+import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
+import type { EdgeMaterializer } from "./EdgeMaterializer";
+import type { RunContext } from "./RunContext";
+import type { TaskGraph } from "./TaskGraph";
+import type { GraphSingleTaskResult } from "./TaskGraphRunner";
+import type { ITaskGraphScheduler } from "./TaskGraphScheduler";
+
+/**
+ * Per-call run-state inputs shared between {@link StreamPump.runStreamingTask}
+ * and the helpers it calls. Keeps StreamPump stateless beyond `graph`,
+ * `processScheduler`, and `edgeMaterializer` so the facade's mutable per-run
+ * state (`registry`, `outputCache`, `resourceScope`, `accumulateLeafOutputs`)
+ * is read at call time rather than captured at construction.
+ *
+ * @internal
+ */
+export interface StreamingRunOptions {
+  readonly registry: ServiceRegistry;
+  readonly outputCache: TaskOutputRepository | undefined;
+  readonly resourceScope: ResourceScope | undefined;
+  readonly accumulateLeafOutputs: boolean;
+  readonly updateProgress: (
+    task: ITask,
+    progress: number | undefined,
+    message?: string,
+    ...args: any[]
+  ) => Promise<void>;
+}
+
+/**
+ * @internal
+ * Streaming bridge. Awaits upstream streaming inputs, runs streaming tasks,
+ * tees stream events to downstream edges, decides accumulation policy.
+ *
+ * `awaitStreamInputs` and `runStreamingTask` take per-call run-state as
+ * arguments rather than holding references, because the facade's per-run
+ * state (`registry`, `outputCache`, `resourceScope`, `accumulateLeafOutputs`)
+ * is mutable and may be reassigned between runs. Method-arg injection lets the
+ * facade pass the current values at call time.
+ *
+ * `runStreamingTask` takes an `onStreamingStatus` callback for the
+ * `STREAMING`-status edge push. This is a temporary bridge so this class can
+ * land before `pushStatusFromNodeToEdges` itself moves to `RunScheduler`.
+ */
+export class StreamPump {
+  constructor(
+    private readonly graph: TaskGraph,
+    private readonly processScheduler: ITaskGraphScheduler,
+    private readonly edgeMaterializer: EdgeMaterializer
+  ) {}
+
+  /**
+   * Tees streaming inputs for a streamable task — one copy goes to the task's
+   * executeStream() (via inputStreams), one stays on the edge for materialization
+   * by awaitStreamInputs.
+   */
+  prepareStreamingInputs(task: ITask): void {
+    const dataflows = this.graph.getSourceDataflows(task.id);
+    const streamingEdges = dataflows.filter((df) => df.stream !== undefined);
+    if (streamingEdges.length === 0) return;
+    const inputStreams = new Map<string, ReadableStream<StreamEvent>>();
+    for (const df of streamingEdges) {
+      const stream = df.stream!;
+      const [forwardCopy, materializeCopy] = stream.tee();
+      inputStreams.set(df.targetTaskPortId, forwardCopy);
+      df.setStream(materializeCopy);
+    }
+    task.runner.inputStreams = inputStreams;
+  }
+
+  /**
+   * For non-streaming downstream tasks, awaits completion of any active
+   * streams on input dataflow edges, materializing their values.
+   *
+   * Streaming upstream tasks set a ReadableStream on outgoing edges.
+   * Non-streaming downstream tasks cannot consume streams directly, so
+   * this method reads each stream to completion and accumulates the
+   * value (via Dataflow.awaitStreamValue) before the task reads its
+   * inputs through the normal getPortData() path.
+   */
+  async awaitStreamInputs(task: ITask, registry: ServiceRegistry): Promise<void> {
+    const dataflows = this.graph.getSourceDataflows(task.id);
+    const streamingDataflows = dataflows.filter((df) => df.stream !== undefined);
+    if (streamingDataflows.length === 0) return;
+    await Promise.all(
+      streamingDataflows.map(async (df) => {
+        await df.awaitStreamValue();
+        // awaitStreamValue sets port data from the raw finish/snapshot event.
+        // Apply the edge's transform chain over the materialised value so the
+        // downstream task receives the transformed result. This is the sole
+        // transform application for streaming edges (pushOutputFromNodeToEdges
+        // deliberately skips them to avoid double-apply).
+        await df.applyTransforms(registry);
+      })
+    );
+  }
+
+  /**
+   * Runs a streaming task within the DAG.
+   * Listens for stream events to:
+   * - Notify the scheduler when streaming begins (unblocking downstream streamable tasks)
+   * - Push stream data to outgoing dataflow edges
+   * - Have the source task accumulate and emit enriched finish events for
+   *   non-streaming downstream tasks (when taskNeedsAccumulation() is true)
+   */
+  async runStreamingTask<T>(
+    task: ITask,
+    input: TaskInput,
+    _ctx: RunContext,
+    options: StreamingRunOptions,
+    onStreamingStatus: (task: ITask) => void
+  ): Promise<GraphSingleTaskResult<T>> {
+    const streamMode = getOutputStreamMode(task.outputSchema());
+    const shouldAccumulate = this.taskNeedsAccumulation(
+      task,
+      options.outputCache,
+      options.accumulateLeafOutputs
+    );
+
+    let streamingNotified = false;
+
+    const onStatus = (status: TaskStatus) => {
+      if (status === TaskStatus.STREAMING && !streamingNotified) {
+        streamingNotified = true;
+        onStreamingStatus(task);
+        this.pushStreamToEdges(task, streamMode);
+        this.processScheduler.onTaskStreaming(task.id);
+      }
+    };
+
+    const onStreamStart = () => {
+      this.graph.emit("task_stream_start", task.id);
+    };
+
+    const onStreamChunk = (event: StreamEvent) => {
+      this.graph.emit("task_stream_chunk", task.id, event);
+    };
+
+    const onStreamEnd = (output: Record<string, any>) => {
+      this.graph.emit("task_stream_end", task.id, output);
+    };
+
+    task.on("status", onStatus);
+    task.on("stream_start", onStreamStart);
+    task.on("stream_chunk", onStreamChunk);
+    task.on("stream_end", onStreamEnd);
+
+    try {
+      const results = await task.runner.run(input, {
+        outputCache: options.outputCache ?? false,
+        shouldAccumulate,
+        updateProgress: options.updateProgress,
+        registry: options.registry,
+        resourceScope: options.resourceScope,
+      });
+
+      await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);
+
+      return {
+        id: task.id,
+        type: (task.constructor as any).runtype || (task.constructor as any).type,
+        data: results as T,
+      };
+    } finally {
+      task.off("status", onStatus);
+      task.off("stream_start", onStreamStart);
+      task.off("stream_chunk", onStreamChunk);
+      task.off("stream_end", onStreamEnd);
+    }
+  }
+
+  /**
+   * Determines whether a streaming task needs to accumulate its text-delta
+   * chunks into an enriched finish event. Accumulation is needed when:
+   *
+   * 1. Output caching is active (the cached value must be fully materialised).
+   * 2. Any outgoing dataflow edge connects a streaming output port to an input
+   *    port that is not streaming with the same mode (i.e. the downstream task
+   *    cannot consume a raw stream and needs a completed value).
+   *
+   * When accumulation is required the source task runs with shouldAccumulate=true,
+   * emitting an enriched finish event that carries all accumulated port text.
+   * All downstream dataflow edges share that event via tee'd streams so no
+   * edge needs to re-accumulate independently.
+   */
+  private taskNeedsAccumulation(
+    task: ITask,
+    outputCache: TaskOutputRepository | undefined,
+    accumulateLeafOutputs: boolean
+  ): boolean {
+    if (outputCache) return true;
+
+    const outEdges = this.graph.getTargetDataflows(task.id);
+    if (outEdges.length === 0) return accumulateLeafOutputs;
+
+    const outSchema = task.outputSchema();
+
+    for (const df of outEdges) {
+      if (df.sourceTaskPortId === DATAFLOW_ALL_PORTS) {
+        // Conservative: if any streaming output port exists, accumulate.
+        // This covers the case where all-ports edges fan into non-streaming tasks.
+        if (getStreamingPorts(outSchema).length > 0) return true;
+        continue;
+      }
+
+      const targetTask = this.graph.getTask(df.targetTaskId);
+      if (!targetTask) continue;
+      const inSchema = targetTask.inputSchema();
+
+      if (edgeNeedsAccumulation(outSchema, df.sourceTaskPortId, inSchema, df.targetTaskPortId)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns true if an event carries a port-specific delta (text-delta or object-delta).
+   */
+  private static isPortDelta(event: StreamEvent): event is StreamEvent & { port: string } {
+    return event.type === "text-delta" || event.type === "object-delta";
+  }
+
+  /**
+   * Creates a ReadableStream from task streaming events, optionally filtered
+   * to a single port. When `portId` is undefined (DATAFLOW_ALL_PORTS), all
+   * events pass through. When set, only delta events matching the port plus
+   * control events (finish, error, snapshot) are enqueued.
+   *
+   * Also taps snapshot events to write per-port data into each edge's
+   * `latestSnapshot` slot for downstream peek-during-streaming.
+   */
+  private createStreamFromTaskEvents(
+    task: ITask,
+    portId: string | undefined,
+    edgesForGroup: ReadonlyArray<Dataflow>
+  ): ReadableStream<StreamEvent> {
+    return new ReadableStream<StreamEvent>({
+      start: (controller) => {
+        const onChunk = (event: StreamEvent) => {
+          try {
+            if (portId !== undefined && StreamPump.isPortDelta(event) && event.port !== portId) {
+              return;
+            }
+            // Tap: on snapshot events, write per-port data into each edge's
+            // latestSnapshot slot.
+            if (event.type === "snapshot") {
+              const data = event.data as Record<string, unknown> | undefined;
+              if (data) {
+                for (const edge of edgesForGroup) {
+                  const portValue =
+                    edge.sourceTaskPortId === DATAFLOW_ALL_PORTS
+                      ? data
+                      : data[edge.sourceTaskPortId];
+                  edge.latestSnapshot = portValue;
+                }
+              }
+            }
+            controller.enqueue(event);
+          } catch {
+            // Stream may be closed
+          }
+        };
+        const onEnd = () => {
+          try {
+            controller.close();
+          } catch {
+            // Stream may already be closed
+          }
+          task.off("stream_chunk", onChunk);
+          task.off("stream_end", onEnd);
+        };
+        task.on("stream_chunk", onChunk);
+        task.on("stream_end", onEnd);
+      },
+    });
+  }
+
+  /**
+   * Pushes stream events from a streaming task to its outgoing dataflow edges.
+   * Creates per-port filtered ReadableStreams for specific-port edges and
+   * unfiltered streams for DATAFLOW_ALL_PORTS edges. Within each port group,
+   * uses tee() for fan-out to multiple consumers.
+   */
+  pushStreamToEdges(task: ITask, _streamMode: StreamMode): void {
+    const targetDataflows = this.graph.getTargetDataflows(task.id);
+    if (targetDataflows.length === 0) return;
+
+    // Group edges by their source port
+    const groups = new Map<string, typeof targetDataflows>();
+    for (const df of targetDataflows) {
+      const key = df.sourceTaskPortId;
+      let group = groups.get(key);
+      if (!group) {
+        group = [];
+        groups.set(key, group);
+      }
+      group.push(df);
+    }
+
+    for (const [portKey, edges] of groups) {
+      const filterPort = portKey === DATAFLOW_ALL_PORTS ? undefined : portKey;
+      const stream = this.createStreamFromTaskEvents(task, filterPort, edges);
+
+      if (edges.length === 1) {
+        edges[0].setStream(stream);
+      } else {
+        let currentStream = stream;
+        for (let i = 0; i < edges.length; i++) {
+          if (i === edges.length - 1) {
+            edges[i].setStream(currentStream);
+          } else {
+            const [s1, s2] = currentStream.tee();
+            edges[i].setStream(s1);
+            currentStream = s2;
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -18,6 +18,7 @@ import { TaskStatus } from "../task/TaskTypes";
 import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
 import type { EdgeMaterializer } from "./EdgeMaterializer";
 import type { RunContext } from "./RunContext";
+import type { RunScheduler } from "./RunScheduler";
 import type { TaskGraph } from "./TaskGraph";
 import type { GraphSingleTaskResult } from "./TaskGraphRunner";
 import type { ITaskGraphScheduler } from "./TaskGraphScheduler";
@@ -55,16 +56,28 @@ export interface StreamingRunOptions {
  * is mutable and may be reassigned between runs. Method-arg injection lets the
  * facade pass the current values at call time.
  *
- * `runStreamingTask` takes an `onStreamingStatus` callback for the
- * `STREAMING`-status edge push. This is a temporary bridge so this class can
- * land before `pushStatusFromNodeToEdges` itself moves to `RunScheduler`.
+ * The {@link RunScheduler} back-reference is wired post-construction via
+ * {@link setRunScheduler} to break the StreamPump <-> RunScheduler import
+ * cycle (StreamPump calls RunScheduler for status pushes; RunScheduler
+ * dispatches into StreamPump indirectly via facade.runTask).
  */
 export class StreamPump {
+  // Set after construction (mutual reference) — see setRunScheduler.
+  private runScheduler!: RunScheduler;
+
   constructor(
     private readonly graph: TaskGraph,
     private readonly processScheduler: ITaskGraphScheduler,
     private readonly edgeMaterializer: EdgeMaterializer
   ) {}
+
+  /**
+   * Wires the {@link RunScheduler} back-reference. Must be called once after
+   * construction, before any call to {@link runStreamingTask}.
+   */
+  setRunScheduler(rs: RunScheduler): void {
+    this.runScheduler = rs;
+  }
 
   /**
    * Tees streaming inputs for a streamable task — one copy goes to the task's
@@ -123,9 +136,8 @@ export class StreamPump {
   async runStreamingTask<T>(
     task: ITask,
     input: TaskInput,
-    _ctx: RunContext,
-    options: StreamingRunOptions,
-    onStreamingStatus: (task: ITask) => void
+    ctx: RunContext,
+    options: StreamingRunOptions
   ): Promise<GraphSingleTaskResult<T>> {
     const streamMode = getOutputStreamMode(task.outputSchema());
     const shouldAccumulate = this.taskNeedsAccumulation(
@@ -139,7 +151,7 @@ export class StreamPump {
     const onStatus = (status: TaskStatus) => {
       if (status === TaskStatus.STREAMING && !streamingNotified) {
         streamingNotified = true;
-        onStreamingStatus(task);
+        this.runScheduler.pushStatusFromNodeToEdges(task, ctx, TaskStatus.STREAMING);
         this.pushStreamToEdges(task, streamMode);
         this.processScheduler.onTaskStreaming(task.id);
       }

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -69,8 +69,16 @@ export interface TaskGraphRunConfig {
    */
   enforceEntitlements?: boolean;
   /**
-   * Resource scope for collecting heavyweight resource disposers during graph execution.
-   * Threaded to all tasks via IExecuteContext. The caller controls disposal.
+   * Resource scope for collecting heavyweight resource disposers during graph
+   * execution. Threaded to all tasks via IExecuteContext.
+   *
+   * If omitted, the top-level runner creates a private scope and `disposeAll()`s
+   * it when the run finishes (success, error, or abort) — automatic cleanup for
+   * casual callers.
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`. Use this to share resources (e.g., a loaded AI model) across
+   * multiple runs, then dispose at app shutdown.
    */
   resourceScope?: ResourceScope;
 }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -100,12 +100,10 @@ export class TaskGraphRunner {
    */
   protected running = false;
   /**
-   * @internal Exposed for `EdgeMaterializer` back-reference. May be re-tightened
-   * once preview-mode signaling is moved off the facade.
-   *
    * Whether the task graph is currently running in preview mode.
+   * Read by EdgeMaterializer via bracket access (`runner["previewRunning"]`).
    */
-  public previewRunning = false;
+  protected previewRunning = false;
 
   /**
    * The task graph to run
@@ -122,12 +120,10 @@ export class TaskGraphRunner {
    */
   protected accumulateLeafOutputs: boolean = true;
   /**
-   * @internal Exposed for `EdgeMaterializer` back-reference. May be re-tightened
-   * once dataflow transforms no longer require the registry through the facade.
-   *
    * Service registry for this graph run.
+   * Read by EdgeMaterializer via bracket access (`runner["registry"]`).
    */
-  public registry: ServiceRegistry = globalServiceRegistry;
+  protected registry: ServiceRegistry = globalServiceRegistry;
   /**
    * Resource scope for this graph run
    */
@@ -152,13 +148,11 @@ export class TaskGraphRunner {
   protected readonly streamPump: StreamPump;
 
   /**
-   * @internal Exposed for `EdgeMaterializer` back-reference. EdgeMaterializer
-   * calls `runner.runScheduler.{pushStatusFromNodeToEdges,propagateDisabledStatus}`.
-   *
    * Run-loop coordinator — owns the for-await loop body, status push, disabled
    * cascade, progress aggregation, and graph-level timeout arm/clear.
+   * Read by EdgeMaterializer via bracket access (`runner["runScheduler"]`).
    */
-  public readonly runScheduler: RunScheduler;
+  protected readonly runScheduler: RunScheduler;
 
   /**
    * Constructor for TaskGraphRunner
@@ -174,6 +168,11 @@ export class TaskGraphRunner {
     protected previewScheduler = new TopologicalScheduler(graph)
   ) {
     this.graph = graph;
+    // Wire the constructor cache into both the runner (used by runTask) and the
+    // graph. Without `this.outputCache = outputCache`, a runner constructed as
+    // `new TaskGraphRunner(graph, cache).runGraph()` would silently never cache
+    // because runTask reads `this.outputCache`, not `graph.outputCache`.
+    this.outputCache = outputCache;
     graph.outputCache = outputCache;
     this.edgeMaterializer = new EdgeMaterializer(graph, this);
     this.streamPump = new StreamPump(graph, this.processScheduler, this.edgeMaterializer);
@@ -624,6 +623,7 @@ export class TaskGraphRunner {
       }
     } catch (err) {
       this.runScheduler.clearGraphTimeout(ctx);
+      ctx.dispose();
       this.currentCtx = undefined;
       this.running = false;
       throw err;
@@ -690,6 +690,7 @@ export class TaskGraphRunner {
       ctx.telemetrySpan.setStatus(SpanStatusCode.OK);
       ctx.telemetrySpan.end();
     }
+    ctx?.dispose();
     this.currentCtx = undefined;
 
     this.graph.emit("complete");
@@ -719,6 +720,7 @@ export class TaskGraphRunner {
       ctx.telemetrySpan.setAttributes({ "workglow.graph.error": error.message });
       ctx.telemetrySpan.end();
     }
+    ctx?.dispose();
     this.currentCtx = undefined;
 
     this.graph.emit("error", error);
@@ -748,6 +750,7 @@ export class TaskGraphRunner {
       ctx.telemetrySpan.addEvent("workglow.graph.aborted");
       ctx.telemetrySpan.end();
     }
+    ctx?.dispose();
     this.currentCtx = undefined;
 
     this.graph.emit("abort");

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -234,11 +234,11 @@ export class TaskGraphRunner {
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
+        // Only clear our auto-created reference. Caller-passed scopes keep the
+        // caller's lifecycle; `handleStart` overwrites the field on the next
+        // run anyway via `effectiveConfig`.
+        this.resourceScope = undefined;
       }
-      // Reset instance field so a subsequent run on this runner starts clean.
-      // handleStart already overwrites it on the next call, but a stale ref
-      // between runs is brittle.
-      this.resourceScope = undefined;
     }
   }
 

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -17,7 +17,6 @@ import {
   uuid4,
 } from "@workglow/util";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
-import { ConditionalTask } from "../task/ConditionalTask";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
 import { isTaskStreamable } from "../task/StreamTypes";
@@ -27,12 +26,12 @@ import {
   TaskConfigurationError,
   TaskEntitlementError,
   TaskError,
-  TaskGraphTimeoutError,
 } from "../task/TaskError";
 import { TaskInput, TaskOutput, TaskStatus } from "../task/TaskTypes";
 import { EdgeMaterializer } from "./EdgeMaterializer";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
 import { RunContext } from "./RunContext";
+import { RunScheduler } from "./RunScheduler";
 import { StreamPump } from "./StreamPump";
 import { TaskGraph, TaskGraphRunConfig, TaskGraphRunPreviewConfig } from "./TaskGraph";
 import { DependencyBasedScheduler, TopologicalScheduler } from "./TaskGraphScheduler";
@@ -153,6 +152,15 @@ export class TaskGraphRunner {
   protected readonly streamPump: StreamPump;
 
   /**
+   * @internal Exposed for `EdgeMaterializer` back-reference. EdgeMaterializer
+   * calls `runner.runScheduler.{pushStatusFromNodeToEdges,propagateDisabledStatus}`.
+   *
+   * Run-loop coordinator — owns the for-await loop body, status push, disabled
+   * cascade, progress aggregation, and graph-level timeout arm/clear.
+   */
+  public readonly runScheduler: RunScheduler;
+
+  /**
    * Constructor for TaskGraphRunner
    * @param graph The task graph to run
    * @param outputCache The task output repository to use for caching task outputs
@@ -167,9 +175,10 @@ export class TaskGraphRunner {
   ) {
     this.graph = graph;
     graph.outputCache = outputCache;
-    this.handleProgress = this.handleProgress.bind(this);
     this.edgeMaterializer = new EdgeMaterializer(graph, this);
     this.streamPump = new StreamPump(graph, this.processScheduler, this.edgeMaterializer);
+    this.runScheduler = new RunScheduler(graph, this.processScheduler, this);
+    this.streamPump.setRunScheduler(this.runScheduler);
   }
 
   // ========================================================================
@@ -188,81 +197,12 @@ export class TaskGraphRunner {
     // The local reference keeps per-run state readable until runGraph returns.
     const ctx = this.currentCtx!;
 
-    const results: GraphResultArray<ExecuteOutput> = [];
-    let error: TaskError | undefined;
-
-    try {
-      // TODO: A different graph runner may chunk tasks that are in parallel
-      // rather them all currently available
-      for await (const task of this.processScheduler.tasks()) {
-        if (ctx.abortController.signal.aborted) {
-          break;
-        }
-
-        if (ctx.failedTaskErrors.size > 0) {
-          break;
-        }
-
-        const isRootTask = this.graph.getSourceDataflows(task.id).length === 0;
-
-        const runAsync = async () => {
-          let errorRouted = false;
-          try {
-            // Root tasks (no incoming dataflows) receive the graph run input so e.g.
-            // InputTask can seed the graph. Downstream tasks rely only on dataflow
-            // edges plus task defaults — unless matchAllEmptyInputs is true, in which case
-            // we filter the input to only include properties that are not connected via dataflows.
-            const taskInput = isRootTask
-              ? input
-              : config?.matchAllEmptyInputs
-                ? this.edgeMaterializer.filterInputForTask(task, input)
-                : {};
-
-            const taskPromise = this.runTask(task, taskInput);
-            ctx.inProgressTasks.set(task.id, taskPromise);
-            const taskResult = await taskPromise;
-
-            if (this.graph.getTargetDataflows(task.id).length === 0) {
-              // we save the results of all the leaves
-              results.push(taskResult as GraphSingleTaskResult<ExecuteOutput>);
-            }
-          } catch (error) {
-            if (this.edgeMaterializer.hasErrorOutputEdges(task)) {
-              // Route the error through error-port dataflows instead of failing the graph.
-              // pushErrorOutputToEdges sets edge statuses directly (COMPLETED for error
-              // edges, DISABLED for normal edges), so we skip the normal status push.
-              errorRouted = true;
-              this.edgeMaterializer.pushErrorOutputToEdges(task);
-            } else {
-              ctx.failedTaskErrors.set(task.id, error as TaskError);
-            }
-          } finally {
-            // IMPORTANT: Push status to edges BEFORE notifying scheduler
-            // This ensures dataflow statuses (including DISABLED) are set
-            // before the scheduler checks which tasks are ready.
-            // Skip normal status push when error routing already set edge statuses.
-            if (!errorRouted) {
-              this.pushStatusFromNodeToEdges(this.graph, task);
-              this.edgeMaterializer.pushErrorFromNodeToEdges(task);
-            }
-            this.processScheduler.onTaskCompleted(task.id);
-          }
-        };
-
-        // Start task execution without awaiting
-        // so we can have many tasks running in parallel
-        // but keep track of them to make sure they get awaited
-        // otherwise, things will finish after this promise is resolved
-        ctx.inProgressFunctions.set(Symbol(task.id as string), runAsync());
-      }
-    } catch (err) {
-      error = err as Error;
-      getLogger().error("Error running graph", { error });
-    }
-    // Wait for all tasks to complete since we did not await runAsync()/this.runTaskWithProvenance()
-    await Promise.allSettled(Array.from(ctx.inProgressTasks.values()));
-    // Clean up stragglers to avoid unhandled promise rejections
-    await Promise.allSettled(Array.from(ctx.inProgressFunctions.values()));
+    const results = await this.runScheduler.runLoop<ExecuteOutput>(
+      input,
+      config,
+      ctx,
+      this.edgeMaterializer
+    );
 
     // Check graph-level timeout first — it is the root cause when tasks fail due
     // to the graph abort signal, and should take precedence over any task-level
@@ -506,128 +446,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * @internal Exposed for `EdgeMaterializer` back-reference. Will move to
-   * `RunScheduler` in a later refactor task.
-   *
-   * Pushes the status of a task to its target edges
-   * @param node The task that produced the status
-   *
-   * For ConditionalTask, this method handles selective dataflow status:
-   * - Active branch dataflows get COMPLETED status
-   * - Inactive branch dataflows get DISABLED status
-   */
-  public pushStatusFromNodeToEdges(graph: TaskGraph, node: ITask, status?: TaskStatus): void {
-    if (!node?.config?.id) return;
-
-    const dataflows = graph.getTargetDataflows(node.id);
-    const effectiveStatus = status ?? node.status;
-
-    // Check if this is a ConditionalTask with selective branching
-    if (node instanceof ConditionalTask && effectiveStatus === TaskStatus.COMPLETED) {
-      // Build a map of output port -> branch ID for lookup
-      const branches = node.config.branches ?? [];
-      const portToBranch = new Map<string, string>();
-      for (const branch of branches) {
-        portToBranch.set(branch.outputPort, branch.id);
-      }
-
-      const activeBranches = node.getActiveBranches();
-
-      for (const dataflow of dataflows) {
-        // Preserve FAILED edges (e.g. transform chain failure) rather than
-        // overwriting with the source task's completion status.
-        if (dataflow.status === TaskStatus.FAILED) continue;
-        const branchId = portToBranch.get(dataflow.sourceTaskPortId);
-        if (branchId !== undefined) {
-          // This dataflow is from a branch port
-          if (activeBranches.has(branchId)) {
-            // Branch is active - dataflow gets completed status
-            dataflow.setStatus(TaskStatus.COMPLETED);
-          } else {
-            // Branch is inactive - dataflow gets disabled status
-            dataflow.setStatus(TaskStatus.DISABLED);
-          }
-        } else {
-          // Not a branch port (e.g., _activeBranches metadata) - use normal status
-          dataflow.setStatus(effectiveStatus);
-        }
-      }
-
-      // Cascade disabled status to downstream tasks
-      this.propagateDisabledStatus(graph);
-      return;
-    }
-
-    // Default behavior for non-conditional tasks
-    dataflows.forEach((dataflow) => {
-      // Preserve FAILED edges (e.g. transform chain failure) rather than
-      // overwriting with the source task's completion status.
-      if (dataflow.status === TaskStatus.FAILED) return;
-      dataflow.setStatus(effectiveStatus);
-    });
-  }
-
-  /**
-   * @internal Exposed for `EdgeMaterializer` back-reference. Will move to
-   * `RunScheduler` in a later refactor task.
-   *
-   * Propagates DISABLED status through the graph.
-   *
-   * When a task's ALL incoming dataflows are DISABLED, that task becomes unreachable
-   * and should also be disabled. This cascades through the graph until no more
-   * tasks can be disabled.
-   *
-   * This is used by ConditionalTask to disable downstream tasks on inactive branches.
-   *
-   * @param graph The task graph to propagate disabled status through
-   */
-  public propagateDisabledStatus(graph: TaskGraph): void {
-    let changed = true;
-
-    // Keep iterating until no more changes (fixed-point iteration)
-    while (changed) {
-      changed = false;
-
-      for (const task of graph.getTasks()) {
-        // Only consider tasks that are still pending
-        if (task.status !== TaskStatus.PENDING) {
-          continue;
-        }
-
-        const incomingDataflows = graph.getSourceDataflows(task.id);
-
-        // Skip tasks with no incoming dataflows (root tasks)
-        if (incomingDataflows.length === 0) {
-          continue;
-        }
-
-        // Check if ALL incoming dataflows are DISABLED
-        const allDisabled = incomingDataflows.every((df) => df.status === TaskStatus.DISABLED);
-
-        if (allDisabled) {
-          // This task is unreachable - disable it synchronously
-          // Set status directly to avoid async issues
-          task.status = TaskStatus.DISABLED;
-          task.progress = 100;
-          task.completedAt = new Date();
-          task.emit("disabled");
-          task.emit("status", task.status);
-
-          // Propagate disabled status to its outgoing dataflows
-          graph.getTargetDataflows(task.id).forEach((dataflow) => {
-            dataflow.setStatus(TaskStatus.DISABLED);
-          });
-
-          // Mark as completed in scheduler so it doesn't wait for this task
-          this.processScheduler.onTaskCompleted(task.id);
-
-          changed = true;
-        }
-      }
-    }
-  }
-
-  /**
    * Runs a task
    * @param task The task to run
    * @param input The input for the task
@@ -669,19 +487,14 @@ export class TaskGraphRunner {
     }
 
     if (isStreamable) {
-      return this.streamPump.runStreamingTask<T>(
-        task,
-        input,
-        this.currentCtx!,
-        {
-          registry: this.registry,
-          outputCache: this.outputCache,
-          resourceScope: this.resourceScope,
-          accumulateLeafOutputs: this.accumulateLeafOutputs,
-          updateProgress: this.handleProgress,
-        },
-        (t) => this.pushStatusFromNodeToEdges(this.graph, t, TaskStatus.STREAMING)
-      );
+      return this.streamPump.runStreamingTask<T>(task, input, this.currentCtx!, {
+        registry: this.registry,
+        outputCache: this.outputCache,
+        resourceScope: this.resourceScope,
+        accumulateLeafOutputs: this.accumulateLeafOutputs,
+        updateProgress: (t, p, m, ...a) =>
+          this.runScheduler.handleProgress(this.currentCtx!, t, p, m, ...a),
+      });
     }
 
     const results = await task.runner.run(input, {
@@ -693,7 +506,7 @@ export class TaskGraphRunner {
         progress: number | undefined,
         message?: string,
         ...args: any[]
-      ) => await this.handleProgress(task, progress, message, ...args),
+      ) => await this.runScheduler.handleProgress(this.currentCtx!, task, progress, message, ...args),
       registry: this.registry,
       resourceScope: this.resourceScope,
     });
@@ -770,12 +583,8 @@ export class TaskGraphRunner {
     });
 
     // Set up graph-level timeout if configured
-    if (config?.timeout !== undefined && config.timeout > 0) {
-      ctx.pendingGraphTimeoutError = undefined;
-      ctx.graphTimeoutTimer = setTimeout(() => {
-        ctx.pendingGraphTimeoutError = new TaskGraphTimeoutError(config.timeout!);
-        ctx.abortController.abort();
-      }, config.timeout);
+    if (config?.timeout !== undefined) {
+      this.runScheduler.armGraphTimeout(config.timeout, ctx);
     }
 
     // Early-out if parent signal was already aborted (RunContext constructor
@@ -813,10 +622,7 @@ export class TaskGraphRunner {
         ctx.activeEnforcer = enforcer;
       }
     } catch (err) {
-      if (ctx.graphTimeoutTimer !== undefined) {
-        clearTimeout(ctx.graphTimeoutTimer);
-        ctx.graphTimeoutTimer = undefined;
-      }
+      this.runScheduler.clearGraphTimeout(ctx);
       this.currentCtx = undefined;
       this.running = false;
       throw err;
@@ -872,10 +678,8 @@ export class TaskGraphRunner {
    * Clears the graph-level timeout timer if active.
    */
   protected clearGraphTimeout(): void {
-    const ctx = this.currentCtx;
-    if (ctx?.graphTimeoutTimer !== undefined) {
-      clearTimeout(ctx.graphTimeoutTimer);
-      ctx.graphTimeoutTimer = undefined;
+    if (this.currentCtx) {
+      this.runScheduler.clearGraphTimeout(this.currentCtx);
     }
   }
 
@@ -970,43 +774,4 @@ export class TaskGraphRunner {
     this.graph.emit("disabled");
   }
 
-  /**
-   * Handles progress updates for the task graph by averaging `progress` across tasks whose class
-   * declares its own `execute` ({@link taskPrototypeHasOwnExecute}). Other nodes are ignored.
-   * @param progress Progress value (0-100), or `undefined` for indeterminate
-   * @param message Optional message
-   * @param args Additional arguments
-   */
-  protected async handleProgress(
-    task: ITask,
-    progress: number | undefined,
-    message?: string,
-    ...args: any[]
-  ): Promise<void> {
-    const contributors = this.graph.getTasks().filter(taskPrototypeHasOwnExecute);
-    if (contributors.length > 1) {
-      const determinate = contributors.filter((t) => t.progress !== undefined);
-      if (determinate.length === 0) {
-        progress = undefined;
-      } else {
-        const sum = determinate.reduce((acc, t) => acc + t.progress!, 0);
-        progress = Math.round(sum / determinate.length);
-      }
-    } else if (contributors.length === 1) {
-      const [only] = contributors;
-      progress = only.progress;
-    }
-    this.pushStatusFromNodeToEdges(this.graph, task);
-    // Emit aggregate progress before awaiting output push so UIs (and task `emit("progress")` in
-    // TaskRunner) are not blocked when pushOutput/narrowInput is slow or stalls mid-run.
-    this.graph.emit("graph_progress", progress, message, args);
-    // Only push output for mid-run progress ticks while the task is actively executing.
-    // Terminal-state handlers (complete, abort, error, disable) set task.status to their
-    // terminal value before calling handleProgress(100), so the output push is skipped here —
-    // the graph runner's own post-run pushOutputFromNodeToEdges handles the completed case.
-    const isActive = task.status === TaskStatus.PROCESSING || task.status === TaskStatus.STREAMING;
-    if (isActive && task.runOutputData && Object.keys(task.runOutputData).length > 0) {
-      await this.edgeMaterializer.pushOutputFromNodeToEdges(task, task.runOutputData);
-    }
-  }
 }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -731,9 +731,16 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Handles task graph abortion
+   * Handles task graph abortion.
+   *
+   * Single-fire: invoked from both the abort-signal listener installed in
+   * `handleStart` and the `runGraph` epilogue when `signal.aborted`. Without
+   * a guard, observers see two `"abort"` events for one logical abort. We
+   * latch on `this.running` synchronously so the second caller is a no-op.
    */
   protected async handleAbort(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
     this.clearGraphTimeout();
     await Promise.allSettled(
       this.graph.getTasks().map(async (task: ITask) => {
@@ -743,7 +750,6 @@ export class TaskGraphRunner {
       })
     );
     const ctx = this.currentCtx;
-    this.running = false;
 
     if (ctx?.telemetrySpan) {
       ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -220,7 +220,7 @@ export class TaskGraphRunner {
       }
       if (ctx.failedTaskErrors.size > 0) {
         const latestError = ctx.failedTaskErrors.values().next().value!;
-        this.handleError(latestError);
+        await this.handleError(latestError);
         throw latestError;
       }
       if (ctx.abortController.signal.aborted) {

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -188,43 +188,58 @@ export class TaskGraphRunner {
     input: TaskInput = {} as TaskInput,
     config?: TaskGraphRunConfig
   ): Promise<GraphResultArray<ExecuteOutput>> {
-    await this.handleStart(config);
+    const ownsScope = config?.resourceScope === undefined;
+    const effectiveConfig: TaskGraphRunConfig = ownsScope
+      ? { ...config, resourceScope: new ResourceScope() }
+      : config!;
 
-    // Capture ctx locally — terminal handlers (handleAbort/Error/Complete)
-    // clear this.currentCtx, but the abort signal listener may invoke
-    // handleAbort while runGraph's loop or epilogue is still running.
-    // The local reference keeps per-run state readable until runGraph returns.
-    const ctx = this.currentCtx!;
+    try {
+      await this.handleStart(effectiveConfig);
 
-    const results = await this.runScheduler.runLoop<ExecuteOutput>(
-      input,
-      config,
-      ctx,
-      this.edgeMaterializer
-    );
+      // Capture ctx locally — terminal handlers (handleAbort/Error/Complete)
+      // clear this.currentCtx, but the abort signal listener may invoke
+      // handleAbort while runGraph's loop or epilogue is still running.
+      // The local reference keeps per-run state readable until runGraph returns.
+      const ctx = this.currentCtx!;
 
-    // Check graph-level timeout first — it is the root cause when tasks fail due
-    // to the graph abort signal, and should take precedence over any task-level
-    // TaskAbortedError that was placed in failedTaskErrors as a consequence.
-    // Capture pendingGraphTimeoutError BEFORE calling handleAbort, which clears currentCtx.
-    const pendingTimeout = ctx.pendingGraphTimeoutError;
-    if (pendingTimeout) {
-      await this.handleAbort();
-      throw pendingTimeout;
+      const results = await this.runScheduler.runLoop<ExecuteOutput>(
+        input,
+        effectiveConfig,
+        ctx,
+        this.edgeMaterializer
+      );
+
+      // Check graph-level timeout first — it is the root cause when tasks fail due
+      // to the graph abort signal, and should take precedence over any task-level
+      // TaskAbortedError that was placed in failedTaskErrors as a consequence.
+      // Capture pendingGraphTimeoutError BEFORE calling handleAbort, which clears currentCtx.
+      const pendingTimeout = ctx.pendingGraphTimeoutError;
+      if (pendingTimeout) {
+        await this.handleAbort();
+        throw pendingTimeout;
+      }
+      if (ctx.failedTaskErrors.size > 0) {
+        const latestError = ctx.failedTaskErrors.values().next().value!;
+        this.handleError(latestError);
+        throw latestError;
+      }
+      if (ctx.abortController.signal.aborted) {
+        await this.handleAbort();
+        throw new TaskAbortedError();
+      }
+
+      await this.handleComplete();
+
+      return this.filterLeafResults(results);
+    } finally {
+      if (ownsScope) {
+        await effectiveConfig.resourceScope!.disposeAll();
+      }
+      // Reset instance field so a subsequent run on this runner starts clean.
+      // handleStart already overwrites it on the next call, but a stale ref
+      // between runs is brittle.
+      this.resourceScope = undefined;
     }
-    if (ctx.failedTaskErrors.size > 0) {
-      const latestError = ctx.failedTaskErrors.values().next().value!;
-      this.handleError(latestError);
-      throw latestError;
-    }
-    if (ctx.abortController.signal.aborted) {
-      await this.handleAbort();
-      throw new TaskAbortedError();
-    }
-
-    await this.handleComplete();
-
-    return this.filterLeafResults(results);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -20,13 +20,7 @@ import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOut
 import { ConditionalTask } from "../task/ConditionalTask";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
-import type { StreamEvent, StreamMode } from "../task/StreamTypes";
-import {
-  edgeNeedsAccumulation,
-  getOutputStreamMode,
-  getStreamingPorts,
-  isTaskStreamable,
-} from "../task/StreamTypes";
+import { isTaskStreamable } from "../task/StreamTypes";
 import { Task } from "../task/Task";
 import {
   TaskAbortedError,
@@ -36,10 +30,10 @@ import {
   TaskGraphTimeoutError,
 } from "../task/TaskError";
 import { TaskInput, TaskOutput, TaskStatus } from "../task/TaskTypes";
-import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
 import { EdgeMaterializer } from "./EdgeMaterializer";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
 import { RunContext } from "./RunContext";
+import { StreamPump } from "./StreamPump";
 import { TaskGraph, TaskGraphRunConfig, TaskGraphRunPreviewConfig } from "./TaskGraph";
 import { DependencyBasedScheduler, TopologicalScheduler } from "./TaskGraphScheduler";
 
@@ -153,6 +147,12 @@ export class TaskGraphRunner {
   protected readonly edgeMaterializer: EdgeMaterializer;
 
   /**
+   * Stream pump — owns streaming-input handoff, streaming task execution, and
+   * stream tee/fan-out to outgoing dataflow edges.
+   */
+  protected readonly streamPump: StreamPump;
+
+  /**
    * Constructor for TaskGraphRunner
    * @param graph The task graph to run
    * @param outputCache The task output repository to use for caching task outputs
@@ -169,6 +169,7 @@ export class TaskGraphRunner {
     graph.outputCache = outputCache;
     this.handleProgress = this.handleProgress.bind(this);
     this.edgeMaterializer = new EdgeMaterializer(graph, this);
+    this.streamPump = new StreamPump(graph, this.processScheduler, this.edgeMaterializer);
   }
 
   // ========================================================================
@@ -627,48 +628,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Determines whether a streaming task needs to accumulate its text-delta
-   * chunks into an enriched finish event. Accumulation is needed when:
-   *
-   * 1. Output caching is active (the cached value must be fully materialised).
-   * 2. Any outgoing dataflow edge connects a streaming output port to an input
-   *    port that is not streaming with the same mode (i.e. the downstream task
-   *    cannot consume a raw stream and needs a completed value).
-   *
-   * When accumulation is required the source task runs with shouldAccumulate=true,
-   * emitting an enriched finish event that carries all accumulated port text.
-   * All downstream dataflow edges share that event via tee'd streams so no
-   * edge needs to re-accumulate independently.
-   */
-  protected taskNeedsAccumulation(task: ITask): boolean {
-    if (this.outputCache) return true;
-
-    const outEdges = this.graph.getTargetDataflows(task.id);
-    if (outEdges.length === 0) return this.accumulateLeafOutputs;
-
-    const outSchema = task.outputSchema();
-
-    for (const df of outEdges) {
-      if (df.sourceTaskPortId === DATAFLOW_ALL_PORTS) {
-        // Conservative: if any streaming output port exists, accumulate.
-        // This covers the case where all-ports edges fan into non-streaming tasks.
-        if (getStreamingPorts(outSchema).length > 0) return true;
-        continue;
-      }
-
-      const targetTask = this.graph.getTask(df.targetTaskId);
-      if (!targetTask) continue;
-      const inSchema = targetTask.inputSchema();
-
-      if (edgeNeedsAccumulation(outSchema, df.sourceTaskPortId, inSchema, df.targetTaskPortId)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Runs a task
    * @param task The task to run
    * @param input The input for the task
@@ -682,18 +641,7 @@ export class TaskGraphRunner {
     // the task's executeStream() (via inputStreams) while the other stays
     // on the edge for materialization by awaitStreamInputs.
     if (isStreamable) {
-      const dataflows = this.graph.getSourceDataflows(task.id);
-      const streamingEdges = dataflows.filter((df) => df.stream !== undefined);
-      if (streamingEdges.length > 0) {
-        const inputStreams = new Map<string, ReadableStream<StreamEvent>>();
-        for (const df of streamingEdges) {
-          const stream = df.stream!;
-          const [forwardCopy, materializeCopy] = stream.tee();
-          inputStreams.set(df.targetTaskPortId, forwardCopy);
-          df.setStream(materializeCopy);
-        }
-        task.runner.inputStreams = inputStreams;
-      }
+      this.streamPump.prepareStreamingInputs(task);
     }
 
     // Await any active streams on input dataflow edges so their values
@@ -703,7 +651,7 @@ export class TaskGraphRunner {
     // Streaming downstream tasks are still unblocked early by the scheduler
     // (they can start setup while upstream is streaming), but their actual
     // input data waits for upstream completion.
-    await this.awaitStreamInputs(task);
+    await this.streamPump.awaitStreamInputs(task, this.registry);
 
     this.edgeMaterializer.copyInputFromEdgesToNode(task);
 
@@ -721,7 +669,19 @@ export class TaskGraphRunner {
     }
 
     if (isStreamable) {
-      return this.runStreamingTask<T>(task, input);
+      return this.streamPump.runStreamingTask<T>(
+        task,
+        input,
+        this.currentCtx!,
+        {
+          registry: this.registry,
+          outputCache: this.outputCache,
+          resourceScope: this.resourceScope,
+          accumulateLeafOutputs: this.accumulateLeafOutputs,
+          updateProgress: this.handleProgress,
+        },
+        (t) => this.pushStatusFromNodeToEdges(this.graph, t, TaskStatus.STREAMING)
+      );
     }
 
     const results = await task.runner.run(input, {
@@ -745,214 +705,6 @@ export class TaskGraphRunner {
       type: (task.constructor as any).runtype || (task.constructor as any).type,
       data: results as T,
     };
-  }
-
-  /**
-   * For non-streaming downstream tasks, awaits completion of any active
-   * streams on input dataflow edges, materializing their values.
-   *
-   * Streaming upstream tasks set a ReadableStream on outgoing edges.
-   * Non-streaming downstream tasks cannot consume streams directly, so
-   * this method reads each stream to completion and accumulates the
-   * value (via Dataflow.awaitStreamValue) before the task reads its
-   * inputs through the normal getPortData() path.
-   */
-  protected async awaitStreamInputs(task: ITask): Promise<void> {
-    const dataflows = this.graph.getSourceDataflows(task.id);
-    const streamingDataflows = dataflows.filter((df) => df.stream !== undefined);
-    if (streamingDataflows.length === 0) return;
-    await Promise.all(
-      streamingDataflows.map(async (df) => {
-        await df.awaitStreamValue();
-        // awaitStreamValue sets port data from the raw finish/snapshot event.
-        // Apply the edge's transform chain over the materialised value so the
-        // downstream task receives the transformed result. This is the sole
-        // transform application for streaming edges (pushOutputFromNodeToEdges
-        // deliberately skips them to avoid double-apply).
-        await df.applyTransforms(this.registry);
-      })
-    );
-  }
-
-  /**
-   * Runs a streaming task within the DAG.
-   * Listens for stream events to:
-   * - Notify the scheduler when streaming begins (unblocking downstream streamable tasks)
-   * - Push stream data to outgoing dataflow edges
-   * - Have the source task accumulate and emit enriched finish events for
-   *   non-streaming downstream tasks (when taskNeedsAccumulation() is true)
-   */
-  protected async runStreamingTask<T>(
-    task: ITask,
-    input: TaskInput
-  ): Promise<GraphSingleTaskResult<T>> {
-    const streamMode = getOutputStreamMode(task.outputSchema());
-    const shouldAccumulate = this.taskNeedsAccumulation(task);
-
-    let streamingNotified = false;
-
-    const onStatus = (status: TaskStatus) => {
-      if (status === TaskStatus.STREAMING && !streamingNotified) {
-        streamingNotified = true;
-        this.pushStatusFromNodeToEdges(this.graph, task, TaskStatus.STREAMING);
-        this.pushStreamToEdges(task, streamMode);
-        this.processScheduler.onTaskStreaming(task.id);
-      }
-    };
-
-    const onStreamStart = () => {
-      this.graph.emit("task_stream_start", task.id);
-    };
-
-    const onStreamChunk = (event: StreamEvent) => {
-      this.graph.emit("task_stream_chunk", task.id, event);
-    };
-
-    const onStreamEnd = (output: Record<string, any>) => {
-      this.graph.emit("task_stream_end", task.id, output);
-    };
-
-    task.on("status", onStatus);
-    task.on("stream_start", onStreamStart);
-    task.on("stream_chunk", onStreamChunk);
-    task.on("stream_end", onStreamEnd);
-
-    try {
-      const results = await task.runner.run(input, {
-        outputCache: this.outputCache ?? false,
-        shouldAccumulate,
-        updateProgress: async (
-          task: ITask,
-          progress: number | undefined,
-          message?: string,
-          ...args: any[]
-        ) => await this.handleProgress(task, progress, message, ...args),
-        registry: this.registry,
-        resourceScope: this.resourceScope,
-      });
-
-      await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);
-
-      return {
-        id: task.id,
-        type: (task.constructor as any).runtype || (task.constructor as any).type,
-        data: results as T,
-      };
-    } finally {
-      task.off("status", onStatus);
-      task.off("stream_start", onStreamStart);
-      task.off("stream_chunk", onStreamChunk);
-      task.off("stream_end", onStreamEnd);
-    }
-  }
-
-  /**
-   * Returns true if an event carries a port-specific delta (text-delta or object-delta).
-   */
-  private static isPortDelta(event: StreamEvent): event is StreamEvent & { port: string } {
-    return event.type === "text-delta" || event.type === "object-delta";
-  }
-
-  /**
-   * Creates a ReadableStream from task streaming events, optionally filtered
-   * to a single port. When `portId` is undefined (DATAFLOW_ALL_PORTS), all
-   * events pass through. When set, only delta events matching the port plus
-   * control events (finish, error, snapshot) are enqueued.
-   *
-   * Also taps snapshot events to write per-port data into each edge's
-   * `latestSnapshot` slot for downstream peek-during-streaming.
-   */
-  private createStreamFromTaskEvents(
-    task: ITask,
-    portId: string | undefined,
-    edgesForGroup: ReadonlyArray<Dataflow>
-  ): ReadableStream<StreamEvent> {
-    return new ReadableStream<StreamEvent>({
-      start: (controller) => {
-        const onChunk = (event: StreamEvent) => {
-          try {
-            if (
-              portId !== undefined &&
-              TaskGraphRunner.isPortDelta(event) &&
-              event.port !== portId
-            ) {
-              return;
-            }
-            // Tap: on snapshot events, write per-port data into each edge's
-            // latestSnapshot slot.
-            if (event.type === "snapshot") {
-              const data = event.data as Record<string, unknown> | undefined;
-              if (data) {
-                for (const edge of edgesForGroup) {
-                  const portValue =
-                    edge.sourceTaskPortId === DATAFLOW_ALL_PORTS
-                      ? data
-                      : data[edge.sourceTaskPortId];
-                  edge.latestSnapshot = portValue;
-                }
-              }
-            }
-            controller.enqueue(event);
-          } catch {
-            // Stream may be closed
-          }
-        };
-        const onEnd = () => {
-          try {
-            controller.close();
-          } catch {
-            // Stream may already be closed
-          }
-          task.off("stream_chunk", onChunk);
-          task.off("stream_end", onEnd);
-        };
-        task.on("stream_chunk", onChunk);
-        task.on("stream_end", onEnd);
-      },
-    });
-  }
-
-  /**
-   * Pushes stream events from a streaming task to its outgoing dataflow edges.
-   * Creates per-port filtered ReadableStreams for specific-port edges and
-   * unfiltered streams for DATAFLOW_ALL_PORTS edges. Within each port group,
-   * uses tee() for fan-out to multiple consumers.
-   */
-  protected pushStreamToEdges(task: ITask, _streamMode: StreamMode): void {
-    const targetDataflows = this.graph.getTargetDataflows(task.id);
-    if (targetDataflows.length === 0) return;
-
-    // Group edges by their source port
-    const groups = new Map<string, typeof targetDataflows>();
-    for (const df of targetDataflows) {
-      const key = df.sourceTaskPortId;
-      let group = groups.get(key);
-      if (!group) {
-        group = [];
-        groups.set(key, group);
-      }
-      group.push(df);
-    }
-
-    for (const [portKey, edges] of groups) {
-      const filterPort = portKey === DATAFLOW_ALL_PORTS ? undefined : portKey;
-      const stream = this.createStreamFromTaskEvents(task, filterPort, edges);
-
-      if (edges.length === 1) {
-        edges[0].setStream(stream);
-      } else {
-        let currentStream = stream;
-        for (let i = 0; i < edges.length; i++) {
-          if (i === edges.length - 1) {
-            edges[i].setStream(currentStream);
-          } else {
-            const [s1, s2] = currentStream.tee();
-            edges[i].setStream(s1);
-            currentStream = s2;
-          }
-        }
-      }
-    }
   }
 
   /**

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -16,8 +16,6 @@ import {
   SpanStatusCode,
   uuid4,
 } from "@workglow/util";
-import { previewSource } from "@workglow/util/media";
-import type { ImageValue } from "@workglow/util/media";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ConditionalTask } from "../task/ConditionalTask";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
@@ -38,7 +36,8 @@ import {
   TaskGraphTimeoutError,
 } from "../task/TaskError";
 import { TaskInput, TaskOutput, TaskStatus } from "../task/TaskTypes";
-import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
+import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
+import { EdgeMaterializer } from "./EdgeMaterializer";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
 import { RunContext } from "./RunContext";
 import { TaskGraph, TaskGraphRunConfig, TaskGraphRunPreviewConfig } from "./TaskGraph";
@@ -99,26 +98,6 @@ export type GraphResult<
 > = GraphResultMap<Output>[Merge];
 
 /**
- * Duck-typed predicate for an `ImageValue`-shaped output, used by the engine
- * to decide whether to apply `previewSource` during `runPreview`. Unlike
- * `isImageValue` from `@workglow/util/media`, this predicate does not check
- * `instanceof ImageBitmap` / `Buffer.isBuffer`, so it remains correct across
- * realm boundaries (e.g. bundle copies in test harnesses) where those identity
- * checks can spuriously fail.
- */
-function isImageValueShape(
-  v: unknown
-): v is { width: number; height: number; previewScale: number } {
-  if (v === null || typeof v !== "object") return false;
-  const o = v as Record<string, unknown>;
-  return (
-    typeof o.width === "number" &&
-    typeof o.height === "number" &&
-    typeof o.previewScale === "number"
-  );
-}
-
-/**
  * Class for running a task graph
  * Manages the execution of tasks in a task graph, including caching
  */
@@ -127,7 +106,7 @@ export class TaskGraphRunner {
    * Whether the task graph is currently running
    */
   protected running = false;
-  protected previewRunning = false;
+  public previewRunning = false;
 
   /**
    * The task graph to run
@@ -146,7 +125,7 @@ export class TaskGraphRunner {
   /**
    * Service registry for this graph run
    */
-  protected registry: ServiceRegistry = globalServiceRegistry;
+  public registry: ServiceRegistry = globalServiceRegistry;
   /**
    * Resource scope for this graph run
    */
@@ -158,6 +137,11 @@ export class TaskGraphRunner {
    * and disable() methods (which take no arguments) have something to act on.
    */
   protected currentCtx?: RunContext;
+
+  /**
+   * Edge materializer — owns dataflow read/write, transforms, and error-port routing.
+   */
+  protected readonly edgeMaterializer: EdgeMaterializer;
 
   /**
    * Constructor for TaskGraphRunner
@@ -175,6 +159,7 @@ export class TaskGraphRunner {
     this.graph = graph;
     graph.outputCache = outputCache;
     this.handleProgress = this.handleProgress.bind(this);
+    this.edgeMaterializer = new EdgeMaterializer(graph, this);
   }
 
   // ========================================================================
@@ -220,7 +205,7 @@ export class TaskGraphRunner {
             const taskInput = isRootTask
               ? input
               : config?.matchAllEmptyInputs
-                ? this.filterInputForTask(task, input)
+                ? this.edgeMaterializer.filterInputForTask(task, input)
                 : {};
 
             const taskPromise = this.runTask(task, taskInput);
@@ -232,12 +217,12 @@ export class TaskGraphRunner {
               results.push(taskResult as GraphSingleTaskResult<ExecuteOutput>);
             }
           } catch (error) {
-            if (this.hasErrorOutputEdges(task)) {
+            if (this.edgeMaterializer.hasErrorOutputEdges(task)) {
               // Route the error through error-port dataflows instead of failing the graph.
               // pushErrorOutputToEdges sets edge statuses directly (COMPLETED for error
               // edges, DISABLED for normal edges), so we skip the normal status push.
               errorRouted = true;
-              this.pushErrorOutputToEdges(task);
+              this.edgeMaterializer.pushErrorOutputToEdges(task);
             } else {
               ctx.failedTaskErrors.set(task.id, error as TaskError);
             }
@@ -248,7 +233,7 @@ export class TaskGraphRunner {
             // Skip normal status push when error routing already set edge statuses.
             if (!errorRouted) {
               this.pushStatusFromNodeToEdges(this.graph, task);
-              this.pushErrorFromNodeToEdges(this.graph, task);
+              this.edgeMaterializer.pushErrorFromNodeToEdges(task);
             }
             this.processScheduler.onTaskCompleted(task.id);
           }
@@ -342,7 +327,7 @@ export class TaskGraphRunner {
 
         if (task.status === TaskStatus.PENDING) {
           task.resetInputData();
-          this.copyInputFromEdgesToNode(task);
+          this.edgeMaterializer.copyInputFromEdgesToNode(task);
           // TODO: cacheable here??
           // if (task.cacheable) {
           //   const results = await this.outputCache?.getOutput(
@@ -368,7 +353,7 @@ export class TaskGraphRunner {
           const taskResult = await task.runPreview(taskInput);
           const runPreviewMs = performance.now() - tPreview;
           const tPush = performance.now();
-          await this.pushOutputFromNodeToEdges(task, taskResult);
+          await this.edgeMaterializer.pushOutputFromNodeToEdges(task, taskResult);
           const pushOutputMs = performance.now() - tPush;
           taskTimings.push({ id: task.id, type: taskType, runPreviewMs, pushOutputMs });
 
@@ -381,7 +366,7 @@ export class TaskGraphRunner {
           }
         } else {
           const taskResult = await task.runPreview(taskInput);
-          await this.pushOutputFromNodeToEdges(task, taskResult);
+          await this.edgeMaterializer.pushOutputFromNodeToEdges(task, taskResult);
 
           if (this.graph.getTargetDataflows(task.id).length === 0) {
             results.push({
@@ -449,32 +434,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Filters graph-level input to only include properties that are not connected via dataflows for a given task
-   * @param task The task to filter input for
-   * @param input The graph-level input
-   * @returns Filtered input containing only unconnected properties
-   */
-  protected filterInputForTask(task: ITask, input: TaskInput): TaskInput {
-    // Get all inputs that are connected to this task via dataflows
-    const sourceDataflows = this.graph.getSourceDataflows(task.id);
-    const connectedInputs = new Set(sourceDataflows.map((df) => df.targetTaskPortId));
-
-    // If DATAFLOW_ALL_PORTS ("*") is in the set, all inputs are connected
-    const allPortsConnected = connectedInputs.has(DATAFLOW_ALL_PORTS);
-
-    // Filter out connected inputs from the graph input
-    const filteredInput: TaskInput = {};
-    for (const [key, value] of Object.entries(input)) {
-      // Skip this input if it's explicitly connected OR if all ports are connected
-      if (!connectedInputs.has(key) && !allPortsConnected) {
-        filteredInput[key] = value;
-      }
-    }
-
-    return filteredInput;
-  }
-
-  /**
    * Adds input data to a task.
    * Delegates to {@link Task.addInput} for the actual merging logic.
    *
@@ -537,85 +496,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Copies input data from edges to a task
-   * @param task The task to copy input data to
-   */
-  protected copyInputFromEdgesToNode(task: ITask) {
-    const dataflows = this.graph.getSourceDataflows(task.id);
-    // Sort by dataflow id for deterministic input merging regardless of insertion order
-    dataflows.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-    for (const dataflow of dataflows) {
-      // Use getCurrentValue() to pick up latestSnapshot when the edge is
-      // mid-stream (i.e. value is undefined but latestSnapshot is populated).
-      // We re-implement getPortData()'s wrapping with the live value.
-      const live = dataflow.getCurrentValue();
-      const port = dataflow.targetTaskPortId;
-      let portData: TaskOutput;
-      if (port === DATAFLOW_ALL_PORTS) {
-        portData = live as TaskOutput;
-      } else if (port === DATAFLOW_ERROR_PORT) {
-        portData = { [DATAFLOW_ERROR_PORT]: dataflow.error } as unknown as TaskOutput;
-      } else {
-        portData = { [port]: live } as TaskOutput;
-      }
-      this.addInputData(task, portData);
-    }
-  }
-
-  /**
-   * Pushes the output of a task to its target tasks
-   * @param node The task that produced the output
-   * @param results The output of the task
-   */
-  protected async pushOutputFromNodeToEdges(node: ITask, results: TaskOutput) {
-    const dataflows = this.graph.getTargetDataflows(node.id);
-
-    // Preview-mode chain-head downscale: apply `previewSource` to any
-    // image-shaped output before it's pushed downstream. This relocates the
-    // per-task `executePreview` invocation of `previewSource` to the engine,
-    // where it fires once per chain head and is idempotent on already-small
-    // images (returns the input unchanged when within budget).
-    if (this.previewRunning && Object.keys(results).length > 0) {
-      for (const port of Object.keys(results)) {
-        const value = (results as Record<string, unknown>)[port];
-        if (isImageValueShape(value)) {
-          (results as Record<string, unknown>)[port] = await previewSource(value as ImageValue);
-        }
-      }
-    }
-
-    for (const dataflow of dataflows) {
-      // Edges with an active stream have their final value materialised by the
-      // downstream task's awaitStreamInputs (which uses Dataflow.awaitStreamValue
-      // to read the raw snapshot/finish data and then applies transforms).
-      // Setting port data here would be overwritten by the finish event, and
-      // applying transforms again on this path would double-apply
-      // non-idempotent transforms, so skip the whole post-materialisation step.
-      if (dataflow.stream !== undefined) continue;
-      const compatibility = dataflow.semanticallyCompatible(this.graph, dataflow, this.registry);
-      if (compatibility === "static") {
-        dataflow.setPortData(results);
-        await dataflow.applyTransforms(this.registry);
-      } else if (compatibility === "runtime") {
-        const task = this.graph.getTask(dataflow.targetTaskId)!;
-        const narrowed = await task.narrowInput({ ...results }, this.registry);
-        dataflow.setPortData(narrowed);
-        await dataflow.applyTransforms(this.registry);
-      } else {
-        // Warn only when we had data to push; empty results (e.g. progress mid-run) are expected
-        const resultsKeys = Object.keys(results);
-        if (resultsKeys.length > 0) {
-          getLogger().warn("pushOutputFromNodeToEdge not compatible, not setting port data", {
-            dataflowId: dataflow.id,
-            compatibility,
-            resultsKeys,
-          });
-        }
-      }
-    }
-  }
-
-  /**
    * Pushes the status of a task to its target edges
    * @param node The task that produced the status
    *
@@ -623,7 +503,7 @@ export class TaskGraphRunner {
    * - Active branch dataflows get COMPLETED status
    * - Inactive branch dataflows get DISABLED status
    */
-  protected pushStatusFromNodeToEdges(graph: TaskGraph, node: ITask, status?: TaskStatus): void {
+  public pushStatusFromNodeToEdges(graph: TaskGraph, node: ITask, status?: TaskStatus): void {
     if (!node?.config?.id) return;
 
     const dataflows = graph.getTargetDataflows(node.id);
@@ -675,61 +555,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Pushes the error of a task to its target edges
-   * @param node The task that produced the error
-   */
-  protected pushErrorFromNodeToEdges(graph: TaskGraph, node: ITask): void {
-    if (!node?.config?.id) return;
-    graph.getTargetDataflows(node.id).forEach((dataflow) => {
-      dataflow.error = node.error;
-    });
-  }
-
-  /**
-   * Returns true if the task has any outgoing dataflow edges that use the
-   * error output port (`[error]`). These edges indicate that the task's
-   * errors should be routed to downstream handler tasks instead of failing
-   * the entire graph.
-   */
-  protected hasErrorOutputEdges(task: ITask): boolean {
-    const dataflows = this.graph.getTargetDataflows(task.id);
-    return dataflows.some((df) => df.sourceTaskPortId === DATAFLOW_ERROR_PORT);
-  }
-
-  /**
-   * Routes a failed task's error through its error-port dataflow edges.
-   *
-   * For each outgoing dataflow:
-   * - Error-port edges (`[error]`) receive the error data and get COMPLETED status
-   * - Non-error-port edges get DISABLED status (the task didn't produce normal output)
-   *
-   * After setting edge statuses, propagateDisabledStatus() cascades DISABLED
-   * through any downstream tasks that only had non-error inputs from this task.
-   */
-  protected pushErrorOutputToEdges(task: ITask): void {
-    const taskError = task.error;
-    const errorData = {
-      error: taskError?.message ?? "Unknown error",
-      errorType: (taskError?.constructor as { type?: string })?.type ?? "TaskError",
-    };
-
-    const dataflows = this.graph.getTargetDataflows(task.id);
-    for (const df of dataflows) {
-      if (df.sourceTaskPortId === DATAFLOW_ERROR_PORT) {
-        // Route error data to the error-port edge
-        df.value = errorData;
-        df.setStatus(TaskStatus.COMPLETED);
-      } else {
-        // Normal output edges are disabled — this task didn't produce output
-        df.setStatus(TaskStatus.DISABLED);
-      }
-    }
-
-    // Cascade disabled status to downstream tasks whose ALL inputs are now disabled
-    this.propagateDisabledStatus(this.graph);
-  }
-
-  /**
    * Propagates DISABLED status through the graph.
    *
    * When a task's ALL incoming dataflows are DISABLED, that task becomes unreachable
@@ -740,7 +565,7 @@ export class TaskGraphRunner {
    *
    * @param graph The task graph to propagate disabled status through
    */
-  protected propagateDisabledStatus(graph: TaskGraph): void {
+  public propagateDisabledStatus(graph: TaskGraph): void {
     let changed = true;
 
     // Keep iterating until no more changes (fixed-point iteration)
@@ -865,7 +690,7 @@ export class TaskGraphRunner {
     // input data waits for upstream completion.
     await this.awaitStreamInputs(task);
 
-    this.copyInputFromEdgesToNode(task);
+    this.edgeMaterializer.copyInputFromEdgesToNode(task);
 
     // Runtime entitlement enforcement for tasks with dynamic entitlements
     if (
@@ -898,7 +723,7 @@ export class TaskGraphRunner {
       resourceScope: this.resourceScope,
     });
 
-    await this.pushOutputFromNodeToEdges(task, results);
+    await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);
 
     return {
       id: task.id,
@@ -991,7 +816,7 @@ export class TaskGraphRunner {
         resourceScope: this.resourceScope,
       });
 
-      await this.pushOutputFromNodeToEdges(task, results);
+      await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);
 
       return {
         id: task.id,
@@ -1116,31 +941,12 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Resets a task
-   * @param graph The task graph to reset
-   * @param task The task to reset
-   * @param runId The run ID
-   */
-  protected resetTask(graph: TaskGraph, task: ITask, runId: string) {
-    task.status = TaskStatus.PENDING;
-    task.resetInputData();
-    task.runOutputData = {};
-    task.error = undefined;
-    task.progress = 0;
-    task.runConfig = { ...task.runConfig, runnerId: runId };
-    this.pushStatusFromNodeToEdges(graph, task);
-    this.pushErrorFromNodeToEdges(graph, task);
-    task.emit("reset");
-    task.emit("status", task.status);
-  }
-
-  /**
    * Resets the task graph, recursively
    * @param graph The task graph to reset
    */
   public resetGraph(graph: TaskGraph, runnerId: string) {
     graph.getTasks().forEach((node) => {
-      this.resetTask(graph, node, runnerId);
+      this.edgeMaterializer.resetTask(graph, node, runnerId);
       node.regenerateGraph();
       if (node.hasChildren()) {
         this.resetGraph(node.subGraph, runnerId);
@@ -1433,7 +1239,7 @@ export class TaskGraphRunner {
     // the graph runner's own post-run pushOutputFromNodeToEdges handles the completed case.
     const isActive = task.status === TaskStatus.PROCESSING || task.status === TaskStatus.STREAMING;
     if (isActive && task.runOutputData && Object.keys(task.runOutputData).length > 0) {
-      await this.pushOutputFromNodeToEdges(task, task.runOutputData);
+      await this.edgeMaterializer.pushOutputFromNodeToEdges(task, task.runOutputData);
     }
   }
 }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -506,7 +506,8 @@ export class TaskGraphRunner {
         progress: number | undefined,
         message?: string,
         ...args: any[]
-      ) => await this.runScheduler.handleProgress(this.currentCtx!, task, progress, message, ...args),
+      ) =>
+        await this.runScheduler.handleProgress(this.currentCtx!, task, progress, message, ...args),
       registry: this.registry,
       resourceScope: this.resourceScope,
     });
@@ -672,9 +673,6 @@ export class TaskGraphRunner {
   }
 
   /**
-   * Handles the completion of task graph execution
-   */
-  /**
    * Clears the graph-level timeout timer if active.
    */
   protected clearGraphTimeout(): void {
@@ -773,5 +771,4 @@ export class TaskGraphRunner {
     this.running = false;
     this.graph.emit("disabled");
   }
-
 }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -106,6 +106,12 @@ export class TaskGraphRunner {
    * Whether the task graph is currently running
    */
   protected running = false;
+  /**
+   * @internal Exposed for `EdgeMaterializer` back-reference. May be re-tightened
+   * once preview-mode signaling is moved off the facade.
+   *
+   * Whether the task graph is currently running in preview mode.
+   */
   public previewRunning = false;
 
   /**
@@ -123,7 +129,10 @@ export class TaskGraphRunner {
    */
   protected accumulateLeafOutputs: boolean = true;
   /**
-   * Service registry for this graph run
+   * @internal Exposed for `EdgeMaterializer` back-reference. May be re-tightened
+   * once dataflow transforms no longer require the registry through the facade.
+   *
+   * Service registry for this graph run.
    */
   public registry: ServiceRegistry = globalServiceRegistry;
   /**
@@ -496,6 +505,9 @@ export class TaskGraphRunner {
   }
 
   /**
+   * @internal Exposed for `EdgeMaterializer` back-reference. Will move to
+   * `RunScheduler` in a later refactor task.
+   *
    * Pushes the status of a task to its target edges
    * @param node The task that produced the status
    *
@@ -555,6 +567,9 @@ export class TaskGraphRunner {
   }
 
   /**
+   * @internal Exposed for `EdgeMaterializer` back-reference. Will move to
+   * `RunScheduler` in a later refactor task.
+   *
    * Propagates DISABLED status through the graph.
    *
    * When a task's ALL incoming dataflows are DISABLED, that task becomes unreachable

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -20,7 +20,6 @@ import { previewSource } from "@workglow/util/media";
 import type { ImageValue } from "@workglow/util/media";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ConditionalTask } from "../task/ConditionalTask";
-import type { IEntitlementEnforcer } from "../task/EntitlementEnforcer";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
 import type { StreamEvent, StreamMode } from "../task/StreamTypes";
@@ -41,6 +40,7 @@ import {
 import { TaskInput, TaskOutput, TaskStatus } from "../task/TaskTypes";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
+import { RunContext } from "./RunContext";
 import { TaskGraph, TaskGraphRunConfig, TaskGraphRunPreviewConfig } from "./TaskGraph";
 import { DependencyBasedScheduler, TopologicalScheduler } from "./TaskGraphScheduler";
 
@@ -151,39 +151,13 @@ export class TaskGraphRunner {
    * Resource scope for this graph run
    */
   protected resourceScope?: ResourceScope;
-  /**
-   * AbortController for cancelling graph execution
-   */
-  protected abortController: AbortController | undefined;
 
   /**
-   * Maps to track task execution state
+   * Per-run state. Set by handleStart, cleared by handleComplete/Error/Abort.
+   * The only mutable per-run state on the facade — exists so the public abort()
+   * and disable() methods (which take no arguments) have something to act on.
    */
-  protected inProgressTasks: Map<unknown, Promise<TaskOutput>> = new Map();
-  protected inProgressFunctions: Map<unknown, Promise<void>> = new Map();
-  protected failedTaskErrors: Map<unknown, TaskError> = new Map();
-
-  /**
-   * Active telemetry span for the current graph run.
-   */
-  protected telemetrySpan?: ISpan;
-
-  /**
-   * Timer handle for graph-level timeout. Cleared on completion, error, or abort.
-   */
-  protected graphTimeoutTimer?: ReturnType<typeof setTimeout>;
-
-  /**
-   * When a graph-level timeout fires, this stores the error so handleAbort()
-   * can surface the correct error type.
-   */
-  protected pendingGraphTimeoutError?: TaskGraphTimeoutError;
-
-  /**
-   * The entitlement enforcer for the current run, if enforcement is enabled.
-   * Set during handleStart and cleared after the run completes.
-   */
-  protected activeEnforcer?: IEntitlementEnforcer;
+  protected currentCtx?: RunContext;
 
   /**
    * Constructor for TaskGraphRunner
@@ -203,11 +177,6 @@ export class TaskGraphRunner {
     this.handleProgress = this.handleProgress.bind(this);
   }
 
-  /**
-   * Unique ID for the current run, used for timing labels.
-   */
-  protected runId: string = "";
-
   // ========================================================================
   // Public methods
   // ========================================================================
@@ -218,6 +187,12 @@ export class TaskGraphRunner {
   ): Promise<GraphResultArray<ExecuteOutput>> {
     await this.handleStart(config);
 
+    // Capture ctx locally — terminal handlers (handleAbort/Error/Complete)
+    // clear this.currentCtx, but the abort signal listener may invoke
+    // handleAbort while runGraph's loop or epilogue is still running.
+    // The local reference keeps per-run state readable until runGraph returns.
+    const ctx = this.currentCtx!;
+
     const results: GraphResultArray<ExecuteOutput> = [];
     let error: TaskError | undefined;
 
@@ -225,11 +200,11 @@ export class TaskGraphRunner {
       // TODO: A different graph runner may chunk tasks that are in parallel
       // rather them all currently available
       for await (const task of this.processScheduler.tasks()) {
-        if (this.abortController?.signal.aborted) {
+        if (ctx.abortController.signal.aborted) {
           break;
         }
 
-        if (this.failedTaskErrors.size > 0) {
+        if (ctx.failedTaskErrors.size > 0) {
           break;
         }
 
@@ -249,7 +224,7 @@ export class TaskGraphRunner {
                 : {};
 
             const taskPromise = this.runTask(task, taskInput);
-            this.inProgressTasks!.set(task.id, taskPromise);
+            ctx.inProgressTasks.set(task.id, taskPromise);
             const taskResult = await taskPromise;
 
             if (this.graph.getTargetDataflows(task.id).length === 0) {
@@ -264,7 +239,7 @@ export class TaskGraphRunner {
               errorRouted = true;
               this.pushErrorOutputToEdges(task);
             } else {
-              this.failedTaskErrors.set(task.id, error as TaskError);
+              ctx.failedTaskErrors.set(task.id, error as TaskError);
             }
           } finally {
             // IMPORTANT: Push status to edges BEFORE notifying scheduler
@@ -283,30 +258,32 @@ export class TaskGraphRunner {
         // so we can have many tasks running in parallel
         // but keep track of them to make sure they get awaited
         // otherwise, things will finish after this promise is resolved
-        this.inProgressFunctions.set(Symbol(task.id as string), runAsync());
+        ctx.inProgressFunctions.set(Symbol(task.id as string), runAsync());
       }
     } catch (err) {
       error = err as Error;
       getLogger().error("Error running graph", { error });
     }
     // Wait for all tasks to complete since we did not await runAsync()/this.runTaskWithProvenance()
-    await Promise.allSettled(Array.from(this.inProgressTasks.values()));
+    await Promise.allSettled(Array.from(ctx.inProgressTasks.values()));
     // Clean up stragglers to avoid unhandled promise rejections
-    await Promise.allSettled(Array.from(this.inProgressFunctions.values()));
+    await Promise.allSettled(Array.from(ctx.inProgressFunctions.values()));
 
     // Check graph-level timeout first — it is the root cause when tasks fail due
     // to the graph abort signal, and should take precedence over any task-level
     // TaskAbortedError that was placed in failedTaskErrors as a consequence.
-    if (this.pendingGraphTimeoutError) {
+    // Capture pendingGraphTimeoutError BEFORE calling handleAbort, which clears currentCtx.
+    const pendingTimeout = ctx.pendingGraphTimeoutError;
+    if (pendingTimeout) {
       await this.handleAbort();
-      throw this.pendingGraphTimeoutError;
+      throw pendingTimeout;
     }
-    if (this.failedTaskErrors.size > 0) {
-      const latestError = this.failedTaskErrors.values().next().value!;
+    if (ctx.failedTaskErrors.size > 0) {
+      const latestError = ctx.failedTaskErrors.values().next().value!;
       this.handleError(latestError);
       throw latestError;
     }
-    if (this.abortController?.signal.aborted) {
+    if (ctx.abortController.signal.aborted) {
       await this.handleAbort();
       throw new TaskAbortedError();
     }
@@ -461,7 +438,7 @@ export class TaskGraphRunner {
    * Aborts the task graph execution
    */
   public abort(): void {
-    this.abortController?.abort();
+    this.currentCtx?.abortController.abort();
   }
 
   /**
@@ -891,8 +868,11 @@ export class TaskGraphRunner {
     this.copyInputFromEdgesToNode(task);
 
     // Runtime entitlement enforcement for tasks with dynamic entitlements
-    if (this.activeEnforcer && (task.constructor as typeof Task).hasDynamicEntitlements) {
-      const denied = await this.activeEnforcer.checkTask(task);
+    if (
+      this.currentCtx?.activeEnforcer &&
+      (task.constructor as typeof Task).hasDynamicEntitlements
+    ) {
+      const denied = await this.currentCtx.activeEnforcer.checkTask(task);
       if (denied.length > 0) {
         throw new TaskEntitlementError(
           `Task ${(task.constructor as typeof Task).type} denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`
@@ -1176,11 +1156,10 @@ export class TaskGraphRunner {
    * @param parentSignal Optional abort signal from parent
    */
   protected async handleStart(config?: TaskGraphRunConfig): Promise<void> {
-    // Setup registry - create child from global if not provided
+    // Setup registry — create child from global if not provided
     if (config?.registry !== undefined) {
       this.registry = config.registry;
     } else if (this.registry === undefined) {
-      // Create a child container that inherits from global but allows overrides
       this.registry = new ServiceRegistry(globalServiceRegistry.container.createChildContainer());
     }
     if (config?.resourceScope !== undefined) {
@@ -1208,46 +1187,33 @@ export class TaskGraphRunner {
     }
 
     this.running = true;
-    this.abortController = new AbortController();
-    this.abortController.signal.addEventListener("abort", () => {
+
+    // Build per-run context (handles abortController + parentSignal wiring)
+    const ctx = new RunContext(config?.parentSignal);
+    this.currentCtx = ctx;
+
+    ctx.abortController.signal.addEventListener("abort", () => {
       this.handleAbort();
     });
 
     // Set up graph-level timeout if configured
     if (config?.timeout !== undefined && config.timeout > 0) {
-      this.pendingGraphTimeoutError = undefined;
-      this.graphTimeoutTimer = setTimeout(() => {
-        this.pendingGraphTimeoutError = new TaskGraphTimeoutError(config.timeout);
-        this.abortController?.abort();
+      ctx.pendingGraphTimeoutError = undefined;
+      ctx.graphTimeoutTimer = setTimeout(() => {
+        ctx.pendingGraphTimeoutError = new TaskGraphTimeoutError(config.timeout!);
+        ctx.abortController.abort();
       }, config.timeout);
     }
 
-    // Listen first, then check — addEventListener on an already-aborted signal
-    // does not fire, so checking .aborted after ensures we never miss an abort.
-    if (config?.parentSignal) {
-      const onParentAbort = () => {
-        this.abortController?.abort();
-      };
-      config.parentSignal.addEventListener("abort", onParentAbort, { once: true });
-      if (config.parentSignal.aborted) {
-        config.parentSignal.removeEventListener("abort", onParentAbort);
-        this.abortController.abort();
-        return;
-      }
-    }
+    // Early-out if parent signal was already aborted (RunContext constructor
+    // already aborted ctx.abortController in that case)
+    if (ctx.abortController.signal.aborted) return;
 
-    this.runId = uuid4();
-    this.resetGraph(this.graph, this.runId); // Reset graph and regenerate sub-graphs, changes task count / entitlements
+    this.resetGraph(this.graph, ctx.runId);
     this.processScheduler.reset();
-    this.inProgressTasks.clear();
-    this.inProgressFunctions.clear();
-    this.failedTaskErrors.clear();
+    // (in-progress maps + failedTaskErrors start empty on a fresh RunContext)
 
-    // Validate and enforce after resetGraph (which regenerates sub-graphs and may
-    // change task count / entitlements). On failure, clean up running state so the
-    // runner remains reusable.
     try {
-      // Validate graph size limits
       if (config?.maxTasks !== undefined && config.maxTasks > 0) {
         const taskCount = this.graph.getTasks().length;
         if (taskCount > config.maxTasks) {
@@ -1257,7 +1223,6 @@ export class TaskGraphRunner {
         }
       }
 
-      // Opt-in entitlement enforcement (preflight)
       if (config?.enforceEntitlements) {
         if (!this.registry.has(ENTITLEMENT_ENFORCER)) {
           throw new TaskConfigurationError(
@@ -1272,28 +1237,23 @@ export class TaskGraphRunner {
             `Denied entitlements: ${denied.map(formatEntitlementDenial).join(", ")}`
           );
         }
-        this.activeEnforcer = enforcer;
-      } else {
-        this.activeEnforcer = undefined;
+        ctx.activeEnforcer = enforcer;
       }
     } catch (err) {
-      // Reset running state so the runner is reusable after validation failures
-      if (this.graphTimeoutTimer !== undefined) {
-        clearTimeout(this.graphTimeoutTimer);
-        this.graphTimeoutTimer = undefined;
+      if (ctx.graphTimeoutTimer !== undefined) {
+        clearTimeout(ctx.graphTimeoutTimer);
+        ctx.graphTimeoutTimer = undefined;
       }
-      this.abortController = undefined;
-      this.activeEnforcer = undefined;
+      this.currentCtx = undefined;
       this.running = false;
       throw err;
     }
 
-    // Start telemetry span for the graph run
     const telemetry = getTelemetryProvider();
     if (telemetry.isEnabled) {
-      this.telemetrySpan = telemetry.startSpan("workglow.graph.run", {
+      ctx.telemetrySpan = telemetry.startSpan("workglow.graph.run", {
         attributes: {
-          "workglow.graph.run_id": this.runId,
+          "workglow.graph.run_id": ctx.runId,
           "workglow.graph.task_count": this.graph.getTasks().length,
           "workglow.graph.dataflow_count": this.graph.getDataflows().length,
         },
@@ -1339,22 +1299,23 @@ export class TaskGraphRunner {
    * Clears the graph-level timeout timer if active.
    */
   protected clearGraphTimeout(): void {
-    if (this.graphTimeoutTimer !== undefined) {
-      clearTimeout(this.graphTimeoutTimer);
-      this.graphTimeoutTimer = undefined;
+    const ctx = this.currentCtx;
+    if (ctx?.graphTimeoutTimer !== undefined) {
+      clearTimeout(ctx.graphTimeoutTimer);
+      ctx.graphTimeoutTimer = undefined;
     }
   }
 
   protected async handleComplete(): Promise<void> {
     this.clearGraphTimeout();
+    const ctx = this.currentCtx;
     this.running = false;
-    this.activeEnforcer = undefined;
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.OK);
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.OK);
+      ctx.telemetrySpan.end();
     }
+    this.currentCtx = undefined;
 
     this.graph.emit("complete");
   }
@@ -1375,15 +1336,15 @@ export class TaskGraphRunner {
         }
       })
     );
+    const ctx = this.currentCtx;
     this.running = false;
-    this.activeEnforcer = undefined;
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, error.message);
-      this.telemetrySpan.setAttributes({ "workglow.graph.error": error.message });
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, error.message);
+      ctx.telemetrySpan.setAttributes({ "workglow.graph.error": error.message });
+      ctx.telemetrySpan.end();
     }
+    this.currentCtx = undefined;
 
     this.graph.emit("error", error);
   }
@@ -1404,15 +1365,15 @@ export class TaskGraphRunner {
         }
       })
     );
+    const ctx = this.currentCtx;
     this.running = false;
-    this.activeEnforcer = undefined;
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
-      this.telemetrySpan.addEvent("workglow.graph.aborted");
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
+      ctx.telemetrySpan.addEvent("workglow.graph.aborted");
+      ctx.telemetrySpan.end();
     }
+    this.currentCtx = undefined;
 
     this.graph.emit("abort");
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -33,6 +33,7 @@ import type { ITransformStep } from "./TransformTypes";
 import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
 export interface RenameOptions {
@@ -66,11 +67,6 @@ export type WorkflowEventParameters<Event extends WorkflowEvents> = EventParamet
   WorkflowEventListeners,
   Event
 >;
-
-class WorkflowTask<I extends DataPorts, O extends DataPorts> extends GraphAsTask<I, O> {
-  public static override readonly type = "Workflow";
-  public static override readonly compoundMerge = PROPERTY_ARRAY as CompoundMergeStrategy;
-}
 
 /**
  * Class for building and managing a task graph

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -33,6 +33,7 @@ import type { ITransformStep } from "./TransformTypes";
 import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -94,11 +95,11 @@ export class Workflow<
     iteratorTask?: GraphAsTask,
     registry?: ServiceRegistry
   ) {
-    this._outputCache = cache;
+    this._cache = new WorkflowCacheAdapter(cache);
     this._parentWorkflow = parent;
     this._iteratorTask = iteratorTask;
     this._registry = registry ?? parent?._registry;
-    this._graph = new TaskGraph({ outputCache: this._outputCache });
+    this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
     if (!parent) {
       this._onChanged = this._onChanged.bind(this);
@@ -110,7 +111,7 @@ export class Workflow<
   private _graph: TaskGraph;
   private _dataFlows: Dataflow[] = [];
   private _error: string = "";
-  private _outputCache?: TaskOutputRepository;
+  private _cache: WorkflowCacheAdapter;
   private _registry?: ServiceRegistry;
   private _entitlementUnsub?: () => void;
 
@@ -126,7 +127,7 @@ export class Workflow<
   };
 
   public outputCache(): TaskOutputRepository | undefined {
-    return this._outputCache;
+    return this._cache.outputCache();
   }
 
   /**
@@ -334,7 +335,7 @@ export class Workflow<
     try {
       const output = await this.graph.run<Output>(input, {
         parentSignal: this._abortController.signal,
-        outputCache: this._outputCache,
+        outputCache: this._cache.outputCache(),
         registry: config?.registry ?? this._registry,
         resourceScope: config?.resourceScope,
       });
@@ -634,7 +635,7 @@ export class Workflow<
 
     this.clearEvents();
     this._graph = new TaskGraph({
-      outputCache: this._outputCache,
+      outputCache: this._cache.outputCache(),
     });
     this._dataFlows = [];
     this._error = "";

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -29,95 +29,12 @@ import {
   hasVectorOutput,
   updateBoundaryTaskSchemas,
 } from "./GraphSchemaUtils";
-import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
-
-// ============================================================================
-// Standalone utility functions (moved from Conversions.ts to break circular
-// dependency — these need both Workflow and GraphAsTask which live here)
-// ============================================================================
-
-export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
-  const tasks = workflow.graph.getTasks();
-  return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
-}
-
-export function connect(
-  source: ITask<any, any, any>,
-  target: ITask<any, any, any>,
-  workflow: IWorkflow<any, any>
-): void {
-  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
-}
-
-export function pipe<A extends DataPorts, B extends DataPorts>(
-  [fn1]: [Taskish<A, B>],
-  workflow?: IWorkflow<A, B>
-): IWorkflow<A, B>;
-
-export function pipe<A extends DataPorts, B extends DataPorts, C extends DataPorts>(
-  [fn1, fn2]: [Taskish<A, B>, Taskish<B, C>],
-  workflow?: IWorkflow<A, C>
-): IWorkflow<A, C>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
->(
-  [fn1, fn2, fn3]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>],
-  workflow?: IWorkflow<A, D>
-): IWorkflow<A, D>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
-  E extends DataPorts,
->(
-  [fn1, fn2, fn3, fn4]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>, Taskish<D, E>],
-  workflow?: IWorkflow<A, E>
-): IWorkflow<A, E>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
-  E extends DataPorts,
-  F extends DataPorts,
->(
-  [fn1, fn2, fn3, fn4, fn5]: [
-    Taskish<A, B>,
-    Taskish<B, C>,
-    Taskish<C, D>,
-    Taskish<D, E>,
-    Taskish<E, F>,
-  ],
-  workflow?: IWorkflow<A, F>
-): IWorkflow<A, F>;
-
-export function pipe<I extends DataPorts, O extends DataPorts>(
-  args: Taskish<I, O>[],
-  workflow: IWorkflow<I, O> = new Workflow<I, O>()
-): IWorkflow<I, O> {
-  let previousTask = getLastTask(workflow);
-  const tasks = args.map((arg) => ensureTask(arg));
-  tasks.forEach((task) => {
-    workflow.graph.addTask(task);
-    if (previousTask) {
-      connect(previousTask, task, workflow);
-    }
-    previousTask = task;
-  });
-  return workflow;
-}
+import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 
 /** Options accepted by {@link Workflow.rename}. */
 export interface RenameOptions {
@@ -125,29 +42,6 @@ export interface RenameOptions {
   readonly index?: number;
   /** Transform chain applied to the dataflow edge this rename creates. */
   readonly transforms?: ReadonlyArray<ITransformStep>;
-}
-
-export function parallel<I extends DataPorts = DataPorts, O extends DataPorts = DataPorts>(
-  args: (PipeFunction<I, O> | ITask<I, O> | IWorkflow<I, O> | ITaskGraph)[],
-  mergeFn: CompoundMergeStrategy = PROPERTY_ARRAY,
-  workflow: IWorkflow<I, O> = new Workflow<I, O>()
-): IWorkflow<I, O> {
-  let previousTask = getLastTask(workflow);
-  const tasks = args.map((arg) => ensureTask(arg));
-  const config = {
-    compoundMerge: mergeFn,
-  };
-  const name = `‖${args.map((_arg) => "𝑓").join("‖")}‖`;
-  class ParallelTask extends GraphAsTask<I, O> {
-    public static override type = name;
-  }
-  const mergeTask = new ParallelTask(config);
-  mergeTask.subGraph!.addTasks(tasks);
-  workflow.graph.addTask(mergeTask);
-  if (previousTask) {
-    connect(previousTask, mergeTask, workflow);
-  }
-  return workflow;
 }
 
 // Type definitions for the workflow

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -253,8 +253,10 @@ export class Workflow<
     this.events.emit("start");
     this._abortController = new AbortController();
 
-    // Subscribe to graph-level streaming events and forward to workflow events
-    this._bridge?.beginRun();
+    // Subscribe to graph-level streaming events and forward to workflow events.
+    // The unsub token is held LOCAL to this run so concurrent run() calls don't
+    // clobber each other's streaming subscriptions.
+    const unsubStreaming = this._bridge?.beginRun();
 
     try {
       const output = await this.graph.run<Output>(input, {
@@ -273,7 +275,7 @@ export class Workflow<
       this.events.emit("error", String(error));
       throw error;
     } finally {
-      this._bridge?.endRun();
+      unsubStreaming?.();
       this._abortController = undefined;
     }
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -24,16 +24,14 @@ import { ensureTask } from "./Conversions";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
-import {
-  hasVectorLikeInput,
-  hasVectorOutput,
-  updateBoundaryTaskSchemas,
-} from "./GraphSchemaUtils";
+import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
+import type { CreateWorkflow } from "./WorkflowFactories";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -42,124 +40,6 @@ export interface RenameOptions {
   readonly index?: number;
   /** Transform chain applied to the dataflow edge this rename creates. */
   readonly transforms?: ReadonlyArray<ITransformStep>;
-}
-
-// Type definitions for the workflow
-export type CreateWorkflow<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I>> = (
-  input?: Partial<I>,
-  config?: Partial<C>
-) => Workflow<I, O>;
-
-export function CreateWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
->(taskClass: ITaskConstructor<I, O, C>): CreateWorkflow<I, O, C> {
-  return Workflow.createWorkflow<I, O, C>(taskClass);
-}
-
-/**
- * Type for loop workflow methods (map, while, reduce).
- * Represents the method signature with proper `this` context.
- * Loop methods take only a config parameter - input is not used for loop tasks.
- */
-export type CreateLoopWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
-> = (this: Workflow<I, O>, config?: Partial<C>) => Workflow<I, O>;
-
-/**
- * Factory function that creates a loop workflow method for a given task class.
- * Returns a method that can be assigned to Workflow.prototype.
- *
- * @param taskClass - The iterator task class (MapTask, ReduceTask, etc.)
- * @returns A method that creates the task and returns a loop builder workflow
- */
-export function CreateLoopWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
->(taskClass: ITaskConstructor<I, O, C>): CreateLoopWorkflow<I, O, C> {
-  return function (this: Workflow<I, O>, config: Partial<C> = {}): Workflow<I, O> {
-    return this.addLoopTask(taskClass, config);
-  };
-}
-
-/**
- * Type for end loop workflow methods (endMap, endBatch, etc.).
- */
-export type EndLoopWorkflow = (this: Workflow) => Workflow;
-
-/**
- * Factory function that creates an end loop workflow method.
- *
- * @param methodName - The name of the method (for error messages)
- * @returns A method that finalizes the loop and returns to the parent workflow
- */
-export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
-  return function (this: Workflow): Workflow {
-    if (!this.isLoopBuilder) {
-      throw new Error(`${methodName}() can only be called on loop workflows`);
-    }
-    return this.finalizeAndReturn();
-  };
-}
-
-/**
- * Type for adaptive workflow methods that dispatch to scalar or vector variant
- * based on the previous task's output schema.
- */
-export type CreateAdaptiveWorkflow<
-  IS extends DataPorts,
-  _OS extends DataPorts,
-  IV extends DataPorts,
-  _OV extends DataPorts,
-  CS extends TaskConfig<IS> = TaskConfig<IS>,
-  CV extends TaskConfig<IV> = TaskConfig<IV>,
-> = (
-  this: Workflow,
-  input?: Partial<IS> & Partial<IV>,
-  config?: Partial<CS> & Partial<CV>
-) => Workflow;
-
-/**
- * Factory that creates an adaptive workflow method: when called, inspects the
- * output schema of the last task in the chain and delegates to the vector
- * variant if it has TypedArray output, otherwise to the scalar variant.
- * If there is no previous task, defaults to the scalar variant.
- *
- * @param scalarClass - Task class for scalar path (e.g. ScalarAddTask)
- * @param vectorClass - Task class for vector path (e.g. VectorSumTask)
- * @returns A method suitable for Workflow.prototype
- */
-export function CreateAdaptiveWorkflow<
-  IS extends DataPorts,
-  OS extends DataPorts,
-  IV extends DataPorts,
-  OV extends DataPorts,
-  CS extends TaskConfig<IS> = TaskConfig<IS>,
-  CV extends TaskConfig<IV> = TaskConfig<IV>,
->(
-  scalarClass: ITaskConstructor<IS, OS, CS>,
-  vectorClass: ITaskConstructor<IV, OV, CV>
-): CreateAdaptiveWorkflow<IS, OS, IV, OV, CS, CV> {
-  const scalarHelper = Workflow.createWorkflow<IS, OS, CS>(scalarClass);
-  const vectorHelper = Workflow.createWorkflow<IV, OV, CV>(vectorClass);
-
-  return function (
-    this: Workflow<any, any>,
-    input: (Partial<IS> & Partial<IV>) | undefined = {},
-    config: (Partial<CS> & Partial<CV>) | undefined = {}
-  ): Workflow {
-    const parent = getLastTask(this);
-    const useVector =
-      (parent !== undefined && hasVectorOutput(parent)) || hasVectorLikeInput(input);
-    if (useVector) {
-      return vectorHelper.call(this, input, config) as Workflow;
-    }
-    return scalarHelper.call(this, input, config) as Workflow;
-  };
 }
 
 // Event types
@@ -1077,8 +957,10 @@ export class Workflow<
   }
 }
 
-// Module augmentation prototype assignments — placed here (not in GraphAsTask.ts)
-// so that Workflow is fully defined before assignment. GraphAsTask is already
-// imported at the top of this file, so it's safe to reference here.
+// Module augmentation prototype assignments — placed here (not in WorkflowFactories.ts)
+// so they run after the Workflow class declaration. Static imports in ESM are
+// hoisted and evaluated depth-first, so a side-effect tail import would run
+// before the class binding initializes. Inline assignments here are safe because
+// the class is already fully initialized by this point.
 Workflow.prototype.group = CreateLoopWorkflow(GraphAsTask);
 Workflow.prototype.endGroup = CreateEndLoopWorkflow("endGroup");

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -28,8 +28,10 @@ import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
 import { WorkflowBuilder } from "./WorkflowBuilder";
+import type { IWorkflowBuilderHandle } from "./WorkflowBuilder";
 import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
 import { WorkflowEventBridge } from "./WorkflowEventBridge";
+import { WorkflowRunContext } from "./WorkflowRunContext";
 import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { parallel, pipe } from "./WorkflowPipe";
@@ -118,16 +120,24 @@ export class Workflow<
   private _bridge?: WorkflowEventBridge;
   private _builder: WorkflowBuilder;
 
-  // Abort controller for cancelling task execution
-  private _abortController?: AbortController;
+  // Per-run state. Single field — concurrent run() calls overwrite (last-run-
+  // wins for abort), matching pre-refactor behavior of `_abortController`.
+  // Mirrors RunContext on the TaskGraphRunner side.
+  private _currentRun?: WorkflowRunContext;
 
   /** @internal — exposes the parent's registry so a child loop-builder can inherit it */
   private get builderRegistry(): ServiceRegistry | undefined {
     return this._builder.registry;
   }
 
-  /** @internal — exposes the builder for cross-instance loop-builder wiring */
-  public get builder(): WorkflowBuilder {
+  /**
+   * Internal cross-instance handle for loop-builder wiring and error
+   * propagation. Returns a NARROWED interface — only the two members the
+   * package actually needs externally — so consumers cannot reach
+   * `_dataFlows`, `_registry`, or other builder internals through `wf.builder`.
+   * @internal
+   */
+  public get builder(): IWorkflowBuilderHandle {
     return this._builder;
   }
 
@@ -251,16 +261,15 @@ export class Workflow<
     }
 
     this.events.emit("start");
-    this._abortController = new AbortController();
-
-    // Subscribe to graph-level streaming events and forward to workflow events.
-    // The unsub token is held LOCAL to this run so concurrent run() calls don't
-    // clobber each other's streaming subscriptions.
-    const unsubStreaming = this._bridge?.beginRun();
+    const ctx = new WorkflowRunContext();
+    this._currentRun = ctx;
+    // Streaming unsub lives on the context (not the bridge) so concurrent
+    // run() calls don't clobber each other's subscriptions.
+    ctx.unsubStreaming = this._bridge?.beginRun();
 
     try {
       const output = await this.graph.run<Output>(input, {
-        parentSignal: this._abortController.signal,
+        parentSignal: ctx.abortController.signal,
         outputCache: this._cache.outputCache(),
         registry: config?.registry ?? this._builder.registry,
         resourceScope: config?.resourceScope,
@@ -275,8 +284,10 @@ export class Workflow<
       this.events.emit("error", String(error));
       throw error;
     } finally {
-      unsubStreaming?.();
-      this._abortController = undefined;
+      ctx.dispose();
+      // Only clear the field if THIS run's context is still the current one.
+      // Concurrent run() may have reseated it; clobbering would orphan that run.
+      if (this._currentRun === ctx) this._currentRun = undefined;
     }
   }
 
@@ -289,7 +300,7 @@ export class Workflow<
     if (loopContext) {
       return loopContext.parent.abort();
     }
-    this._abortController?.abort();
+    this._currentRun?.abortController.abort();
   }
 
   /**

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -7,7 +7,6 @@
 import type { EventParameters } from "@workglow/util";
 import { EventEmitter, getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
-import { JsonSchema } from "@workglow/util/schema";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
@@ -25,6 +24,11 @@ import { ensureTask } from "./Conversions";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
+import {
+  hasVectorLikeInput,
+  hasVectorOutput,
+  updateBoundaryTaskSchemas,
+} from "./GraphSchemaUtils";
 import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
@@ -206,66 +210,6 @@ export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
     }
     return this.finalizeAndReturn();
   };
-}
-
-const TYPED_ARRAY_FORMAT_PREFIX = "TypedArray";
-
-/**
- * Returns true if the given JSON schema (or any nested schema) has a format
- * string starting with "TypedArray" (e.g. "TypedArray" or "TypedArray:Float32Array").
- * Walks oneOf/anyOf wrappers and array items.
- */
-function schemaHasTypedArrayFormat(schema: JsonSchema): boolean {
-  if (typeof schema === "boolean") return false;
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return false;
-
-  const s = schema as Record<string, unknown>;
-  if (typeof s.format === "string" && s.format.startsWith(TYPED_ARRAY_FORMAT_PREFIX)) {
-    return true;
-  }
-
-  const checkUnion = (schemas: unknown): boolean => {
-    if (!Array.isArray(schemas)) return false;
-    return schemas.some((sub) => schemaHasTypedArrayFormat(sub as JsonSchema));
-  };
-  if (checkUnion(s.oneOf) || checkUnion(s.anyOf)) return true;
-
-  const items = s.items;
-  if (items && typeof items === "object" && !Array.isArray(items)) {
-    if (schemaHasTypedArrayFormat(items as JsonSchema)) return true;
-  }
-
-  return false;
-}
-
-/**
- * Returns true if the task's output schema has any port with TypedArray format.
- * Used by adaptive workflow methods to choose scalar vs vector task variant.
- */
-export function hasVectorOutput(task: ITask): boolean {
-  const outputSchema = task.outputSchema();
-  if (typeof outputSchema === "boolean" || !outputSchema?.properties) return false;
-  return Object.values(outputSchema.properties).some((prop) =>
-    schemaHasTypedArrayFormat(prop as JsonSchema)
-  );
-}
-
-/**
- * Returns true if the input object looks like vector task input: has a "vectors"
- * property that is an array with at least one TypedArray element. Used by
- * adaptive workflow methods so that e.g. sum({ vectors: [new Float32Array(...)] })
- * chooses the vector variant even with no previous task.
- */
-export function hasVectorLikeInput(input: unknown): boolean {
-  if (!input || typeof input !== "object") return false;
-  const v = (input as Record<string, unknown>).vectors;
-  return (
-    Array.isArray(v) &&
-    v.length > 0 &&
-    typeof v[0] === "object" &&
-    v[0] !== null &&
-    ArrayBuffer.isView(v[0])
-  );
 }
 
 /**
@@ -516,7 +460,7 @@ export class Workflow<
 
       // Update InputTask/OutputTask schemas based on connected dataflows
       if (!this._error) {
-        Workflow.updateBoundaryTaskSchemas(this._graph);
+        updateBoundaryTaskSchemas(this._graph);
       }
 
       // Preserve input type from the start of the chain
@@ -1162,128 +1106,6 @@ export class Workflow<
         this._error = result.error + " Task not added.";
         getLogger().error(this._error);
         this.graph.removeTask(iteratorTask.id);
-      }
-    }
-  }
-
-  /**
-   * Updates InputTask/OutputTask config schemas based on their connected dataflows.
-   * InputTask schema reflects its outgoing dataflow targets' input schemas.
-   * OutputTask schema reflects its incoming dataflow sources' output schemas.
-   */
-  private static updateBoundaryTaskSchemas(graph: TaskGraph): void {
-    const tasks = graph.getTasks();
-
-    for (const task of tasks) {
-      if (task.type === "InputTask") {
-        // If the schema is marked as fully manual (x-ui-manual at schema level),
-        // skip edge-based regeneration — the user explicitly defined this schema.
-        const existingConfig = (task as ITask).config;
-        const existingSchema = existingConfig?.inputSchema ?? existingConfig?.outputSchema;
-        if (
-          existingSchema &&
-          typeof existingSchema === "object" &&
-          (existingSchema as Record<string, unknown>)["x-ui-manual"] === true
-        ) {
-          continue;
-        }
-
-        const outgoing = graph.getTargetDataflows(task.id);
-        if (outgoing.length === 0) continue;
-
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
-
-        for (const df of outgoing) {
-          const targetTask = graph.getTask(df.targetTaskId);
-          if (!targetTask) continue;
-          const targetSchema = targetTask.inputSchema();
-          if (typeof targetSchema === "boolean") continue;
-          const prop = (targetSchema.properties as any)?.[df.targetTaskPortId];
-          if (prop && typeof prop !== "boolean") {
-            properties[df.sourceTaskPortId] = prop;
-            if (targetSchema.required?.includes(df.targetTaskPortId)) {
-              if (!required.includes(df.sourceTaskPortId)) {
-                required.push(df.sourceTaskPortId);
-              }
-            }
-          }
-        }
-
-        const schema = {
-          type: "object",
-          properties,
-          ...(required.length > 0 ? { required } : {}),
-          additionalProperties: false,
-        } as DataPortSchema;
-
-        // @ts-expect-error - config is readonly
-        task.config = {
-          ...task.config,
-          inputSchema: schema,
-          outputSchema: schema,
-        };
-      }
-
-      if (task.type === "OutputTask") {
-        const incoming = graph.getSourceDataflows(task.id);
-        if (incoming.length === 0) continue;
-
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
-
-        for (const df of incoming) {
-          const sourceTask = graph.getTask(df.sourceTaskId);
-          if (!sourceTask) continue;
-          const sourceSchema = sourceTask.outputSchema();
-          if (typeof sourceSchema === "boolean") continue;
-          let prop = (sourceSchema.properties as any)?.[df.sourceTaskPortId];
-          let propRequired = sourceSchema.required?.includes(df.sourceTaskPortId) ?? false;
-
-          // For passthrough tasks with additionalProperties (e.g. DebugLogTask),
-          // the port won't appear in the static output schema. Trace back through
-          // the passthrough task's own incoming dataflows to find the actual schema.
-          if (
-            !prop &&
-            sourceSchema.additionalProperties === true &&
-            (sourceTask.constructor as typeof Task).passthroughInputsToOutputs === true
-          ) {
-            const upstreamDfs = graph.getSourceDataflows(sourceTask.id);
-            for (const udf of upstreamDfs) {
-              if (udf.targetTaskPortId !== df.sourceTaskPortId) continue;
-              const upstreamTask = graph.getTask(udf.sourceTaskId);
-              if (!upstreamTask) continue;
-              const upstreamSchema = upstreamTask.outputSchema();
-              if (typeof upstreamSchema === "boolean") continue;
-              prop = (upstreamSchema.properties as any)?.[udf.sourceTaskPortId];
-              if (prop) {
-                propRequired = upstreamSchema.required?.includes(udf.sourceTaskPortId) ?? false;
-                break;
-              }
-            }
-          }
-
-          if (prop && typeof prop !== "boolean") {
-            properties[df.targetTaskPortId] = prop;
-            if (propRequired && !required.includes(df.targetTaskPortId)) {
-              required.push(df.targetTaskPortId);
-            }
-          }
-        }
-
-        const schema = {
-          type: "object",
-          properties,
-          ...(required.length > 0 ? { required } : {}),
-          additionalProperties: false,
-        } as DataPortSchema;
-
-        // @ts-expect-error - config is readonly
-        task.config = {
-          ...task.config,
-          inputSchema: schema,
-          outputSchema: schema,
-        };
       }
     }
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -34,6 +34,7 @@ import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
+import { WorkflowEventBridge } from "./WorkflowEventBridge";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -102,8 +103,8 @@ export class Workflow<
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
     if (!parent) {
-      this._onChanged = this._onChanged.bind(this);
-      this.setupEvents();
+      this._bridge = new WorkflowEventBridge(this.events);
+      this._bridge.attach(this._graph);
     }
   }
 
@@ -113,7 +114,7 @@ export class Workflow<
   private _error: string = "";
   private _cache: WorkflowCacheAdapter;
   private _registry?: ServiceRegistry;
-  private _entitlementUnsub?: () => void;
+  private _bridge?: WorkflowEventBridge;
 
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
@@ -264,9 +265,9 @@ export class Workflow<
   public set graph(value: TaskGraph) {
     this._dataFlows = [];
     this._error = "";
-    this.clearEvents();
+    this._bridge?.detach();
     this._graph = value;
-    this.setupEvents();
+    this._bridge?.attach(this._graph);
     this.events.emit("reset");
   }
 
@@ -326,11 +327,7 @@ export class Workflow<
     this._abortController = new AbortController();
 
     // Subscribe to graph-level streaming events and forward to workflow events
-    const unsubStreaming = this.graph.subscribeToTaskStreaming({
-      onStreamStart: (taskId) => this.events.emit("stream_start", taskId),
-      onStreamChunk: (taskId, event) => this.events.emit("stream_chunk", taskId, event),
-      onStreamEnd: (taskId, output) => this.events.emit("stream_end", taskId, output),
-    });
+    this._bridge?.beginRun();
 
     try {
       const output = await this.graph.run<Output>(input, {
@@ -349,7 +346,7 @@ export class Workflow<
       this.events.emit("error", String(error));
       throw error;
     } finally {
-      unsubStreaming();
+      this._bridge?.endRun();
       this._abortController = undefined;
     }
   }
@@ -633,52 +630,16 @@ export class Workflow<
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
-    this.clearEvents();
+    this._bridge?.detach();
     this._graph = new TaskGraph({
       outputCache: this._cache.outputCache(),
     });
     this._dataFlows = [];
     this._error = "";
-    this.setupEvents();
+    this._bridge?.attach(this._graph);
     this.events.emit("changed", undefined);
     this.events.emit("reset");
     return this;
-  }
-
-  /**
-   * Sets up event listeners for the task graph
-   */
-  private setupEvents(): void {
-    this._graph.on("task_added", this._onChanged);
-    this._graph.on("task_replaced", this._onChanged);
-    this._graph.on("task_removed", this._onChanged);
-    this._graph.on("dataflow_added", this._onChanged);
-    this._graph.on("dataflow_replaced", this._onChanged);
-    this._graph.on("dataflow_removed", this._onChanged);
-    this._entitlementUnsub = this._graph.subscribeToTaskEntitlements((entitlements) =>
-      this.events.emit("entitlementChange", entitlements)
-    );
-  }
-
-  /**
-   * Clears event listeners for the task graph
-   */
-  private clearEvents(): void {
-    this._graph.off("task_added", this._onChanged);
-    this._graph.off("task_replaced", this._onChanged);
-    this._graph.off("task_removed", this._onChanged);
-    this._graph.off("dataflow_added", this._onChanged);
-    this._graph.off("dataflow_replaced", this._onChanged);
-    this._graph.off("dataflow_removed", this._onChanged);
-    this._entitlementUnsub?.();
-    this._entitlementUnsub = undefined;
-  }
-
-  /**
-   * Handles changes to the task graph
-   */
-  private _onChanged(id: unknown): void {
-    this.events.emit("changed", id);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -6,7 +6,7 @@
 
 import type { EventParameters } from "@workglow/util";
 import { EventEmitter, ServiceRegistry } from "@workglow/util";
-import { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
 import type { ITask, ITaskConstructor } from "../task/ITask";
@@ -243,7 +243,8 @@ export class Workflow<
     const loopContext = this._builder.loopContext;
     if (loopContext) {
       loopContext.finalizeTemplate(this._graph);
-      loopContext.consumePendingConnect();
+      const error = loopContext.consumePendingConnect();
+      if (error) loopContext.parent.builder.setError(error);
       return loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
@@ -588,7 +589,8 @@ export class Workflow<
    */
   public autoConnectLoopTask(pending?: { parent: ITask; iteratorTask: ITask }): void {
     if (!pending) return;
-    runLoopAutoConnect(this._graph, pending);
+    const error = runLoopAutoConnect(this._graph, pending);
+    if (error) this._builder.setError(error);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -5,8 +5,7 @@
  */
 
 import type { EventParameters } from "@workglow/util";
-import { EventEmitter, getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
-import type { DataPortSchema } from "@workglow/util/schema";
+import { EventEmitter, ServiceRegistry } from "@workglow/util";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
@@ -18,24 +17,22 @@ import { WorkflowError } from "../task/TaskError";
 import type { JsonTaskItem, TaskGraphJson, TaskGraphJsonOptions } from "../task/TaskJSON";
 import type { DataPorts, TaskConfig, TaskIdType, TaskInput } from "../task/TaskTypes";
 import { autoConnect } from "./autoConnect";
-import { ConditionalBuilder } from "./ConditionalBuilder";
+import type { ConditionalBuilder } from "./ConditionalBuilder";
 import type { PipeFunction, Taskish } from "./Conversions";
-import { ensureTask } from "./Conversions";
-import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
-import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { LoopBuilderContext, runLoopAutoConnect } from "./LoopBuilderContext";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
-import type { CreateWorkflow } from "./WorkflowFactories";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
-import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowBuilder } from "./WorkflowBuilder";
 import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
 import { WorkflowEventBridge } from "./WorkflowEventBridge";
+import type { CreateWorkflow } from "./WorkflowFactories";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
+import { parallel, pipe } from "./WorkflowPipe";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -98,10 +95,16 @@ export class Workflow<
     registry?: ServiceRegistry
   ) {
     this._cache = new WorkflowCacheAdapter(cache);
-    this._loopContext =
-      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
-    this._registry = registry ?? parent?._registry;
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
+
+    const loopContext =
+      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
+
+    this._builder = new WorkflowBuilder(
+      this,
+      registry ?? parent?.builderRegistry,
+      loopContext
+    );
 
     if (!parent) {
       this._bridge = new WorkflowEventBridge(this.events);
@@ -111,17 +114,22 @@ export class Workflow<
 
   // Private properties
   private _graph: TaskGraph;
-  private _dataFlows: Dataflow[] = [];
-  private _error: string = "";
   private _cache: WorkflowCacheAdapter;
-  private _registry?: ServiceRegistry;
   private _bridge?: WorkflowEventBridge;
+  private _builder: WorkflowBuilder;
 
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
 
-  // Loop builder state (encapsulates parent workflow + iterator task + deferred auto-connect)
-  private readonly _loopContext?: LoopBuilderContext;
+  /** @internal — exposes the parent's registry so a child loop-builder can inherit it */
+  private get builderRegistry(): ServiceRegistry | undefined {
+    return this._builder.registry;
+  }
+
+  /** @internal — exposes the builder for cross-instance loop-builder wiring */
+  public get builder(): WorkflowBuilder {
+    return this._builder;
+  }
 
   public outputCache(): TaskOutputRepository | undefined {
     return this._cache.outputCache();
@@ -132,7 +140,7 @@ export class Workflow<
    * When true, tasks are added to the template graph for an iterator task.
    */
   public get isLoopBuilder(): boolean {
-    return this._loopContext !== undefined;
+    return this._builder.loopContext !== undefined;
   }
 
   /**
@@ -156,81 +164,7 @@ export class Workflow<
       input: Partial<I> = {},
       config: Partial<C> = {}
     ) {
-      this._error = "";
-
-      const parent = getLastTask(this);
-
-      const task = this.addTaskToGraph<I, O, C>(taskClass, {
-        id: uuid4(),
-        ...config,
-        defaults: input,
-      } as C);
-
-      // Process any pending data flows
-      if (this._dataFlows.length > 0) {
-        this._dataFlows.forEach((dataflow) => {
-          const taskSchema = task.inputSchema();
-          if (
-            (typeof taskSchema !== "boolean" &&
-              taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
-              taskSchema.additionalProperties !== true) ||
-            (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
-          ) {
-            this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
-            getLogger().error(this._error);
-            return;
-          }
-
-          dataflow.targetTaskId = task.id;
-          this.graph.addDataflow(dataflow);
-        });
-
-        this._dataFlows = [];
-      }
-
-      // Auto-connect to parent if needed
-      if (parent) {
-        // Build the list of earlier tasks (in reverse chronological order)
-        const nodes = this._graph.getTasks();
-        const parentIndex = nodes.findIndex((n) => n.id === parent.id);
-        const earlierTasks: ITask[] = [];
-        for (let i = parentIndex - 1; i >= 0; i--) {
-          earlierTasks.push(nodes[i]);
-        }
-
-        const providedInputKeys = new Set(Object.keys(input || {}));
-
-        // Ports already connected via pending dataflows (e.g., from .rename())
-        // must not be re-matched by auto-connect Strategies 1/2/3.
-        const connectedInputKeys = new Set(
-          this.graph.getSourceDataflows(task.id).map((df) => df.targetTaskPortId)
-        );
-
-        const result = Workflow.autoConnect(this.graph, parent, task, {
-          providedInputKeys,
-          connectedInputKeys,
-          earlierTasks,
-        });
-
-        if (result.error) {
-          // In loop builder mode, don't remove the task - allow manual connection
-          // In normal mode, remove the task since auto-connect is required
-          if (this.isLoopBuilder) {
-            this._error = result.error;
-            getLogger().warn(this._error);
-          } else {
-            this._error = result.error + " Task not added.";
-            getLogger().error(this._error);
-            this.graph.removeTask(task.id);
-          }
-        }
-      }
-
-      // Update InputTask/OutputTask schemas based on connected dataflows
-      if (!this._error) {
-        updateBoundaryTaskSchemas(this._graph);
-      }
-
+      this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config);
       // Preserve input type from the start of the chain
       // If this is the first task, set both input and output types
       // Otherwise, only update the output type (input type is preserved from 'this')
@@ -259,8 +193,7 @@ export class Workflow<
    * Sets a new task graph
    */
   public set graph(value: TaskGraph) {
-    this._dataFlows = [];
-    this._error = "";
+    this._builder.resetState();
     this._bridge?.detach();
     this._graph = value;
     this._bridge?.attach(this._graph);
@@ -271,7 +204,7 @@ export class Workflow<
    * Gets the current error message
    */
   public get error(): string {
-    return this._error;
+    return this._builder.error;
   }
 
   /**
@@ -307,10 +240,11 @@ export class Workflow<
     config?: WorkflowRunConfig
   ): Promise<PropertyArrayGraphResult<Output>> {
     // In loop builder mode, finalize template and delegate to parent
-    if (this._loopContext) {
-      this._loopContext.finalizeTemplate(this._graph);
-      this._loopContext.consumePendingConnect();
-      return this._loopContext.parent.run(input as any, config) as Promise<
+    const loopContext = this._builder.loopContext;
+    if (loopContext) {
+      loopContext.finalizeTemplate(this._graph);
+      loopContext.consumePendingConnect();
+      return loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
     }
@@ -325,7 +259,7 @@ export class Workflow<
       const output = await this.graph.run<Output>(input, {
         parentSignal: this._abortController.signal,
         outputCache: this._cache.outputCache(),
-        registry: config?.registry ?? this._registry,
+        registry: config?.registry ?? this._builder.registry,
         resourceScope: config?.resourceScope,
       });
       const results = this.graph.mergeExecuteOutputsToRunOutput<Output, typeof PROPERTY_ARRAY>(
@@ -348,8 +282,9 @@ export class Workflow<
    */
   public async abort(): Promise<void> {
     // In loop builder mode, delegate to parent
-    if (this._loopContext) {
-      return this._loopContext.parent.abort();
+    const loopContext = this._builder.loopContext;
+    if (loopContext) {
+      return loopContext.parent.abort();
     }
     this._abortController?.abort();
   }
@@ -360,17 +295,7 @@ export class Workflow<
    * @returns The current task graph workflow
    */
   public pop(): Workflow {
-    this._error = "";
-    const nodes = this._graph.getTasks();
-
-    if (nodes.length === 0) {
-      this._error = "No tasks to remove";
-      getLogger().error(this._error);
-      return this;
-    }
-
-    const lastNode = nodes[nodes.length - 1];
-    this._graph.removeTask(lastNode.id);
+    this._builder.pop();
     return this;
   }
 
@@ -525,42 +450,7 @@ export class Workflow<
     target: string,
     indexOrOptions: number | RenameOptions = -1
   ): Workflow {
-    this._error = "";
-
-    const index =
-      typeof indexOrOptions === "number" ? indexOrOptions : (indexOrOptions.index ?? -1);
-    const transforms = typeof indexOrOptions === "number" ? undefined : indexOrOptions.transforms;
-
-    const nodes = this._graph.getTasks();
-    if (-index > nodes.length) {
-      const errorMsg = `Back index greater than number of tasks`;
-      this._error = errorMsg;
-      getLogger().error(this._error);
-      throw new WorkflowError(errorMsg);
-    }
-
-    const lastNode = nodes[nodes.length + index];
-    const outputSchema = lastNode.outputSchema();
-
-    // Handle boolean schemas
-    if (typeof outputSchema === "boolean") {
-      if (outputSchema === false && source !== DATAFLOW_ALL_PORTS) {
-        const errorMsg = `Task ${lastNode.id} has schema 'false' and outputs nothing`;
-        this._error = errorMsg;
-        getLogger().error(this._error);
-        throw new WorkflowError(errorMsg);
-      }
-      // If outputSchema is true, we skip validation as it outputs everything
-    } else if (!(outputSchema.properties as any)?.[source] && source !== DATAFLOW_ALL_PORTS) {
-      const errorMsg = `Output ${source} not found on task ${lastNode.id}`;
-      this._error = errorMsg;
-      getLogger().error(this._error);
-      throw new WorkflowError(errorMsg);
-    }
-
-    const df = new Dataflow(lastNode.id, source, undefined, target);
-    if (transforms && transforms.length > 0) df.setTransforms(transforms);
-    this._dataFlows.push(df);
+    this._builder.rename(source, target, indexOrOptions);
     return this;
   }
 
@@ -576,28 +466,7 @@ export class Workflow<
    * @returns The current workflow for chaining
    */
   public onError(handler: Taskish): Workflow {
-    this._error = "";
-
-    const parent = getLastTask(this);
-    if (!parent) {
-      this._error = "onError() requires a preceding task in the workflow";
-      getLogger().error(this._error);
-      throw new WorkflowError(this._error);
-    }
-
-    const handlerTask = ensureTask(handler);
-    this.graph.addTask(handlerTask);
-
-    // Connect the previous task's error output port to the handler's all-ports input
-    const dataflow = new Dataflow(
-      parent.id,
-      DATAFLOW_ERROR_PORT,
-      handlerTask.id,
-      DATAFLOW_ALL_PORTS
-    );
-    this.graph.addDataflow(dataflow);
-    this.events.emit("changed", handlerTask.id);
-
+    this._builder.onError(handler);
     return this;
   }
 
@@ -618,7 +487,7 @@ export class Workflow<
    */
   public reset(): Workflow {
     // In loop builder mode, reset is not supported
-    if (this._loopContext) {
+    if (this._builder.loopContext) {
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
@@ -626,8 +495,7 @@ export class Workflow<
     this._graph = new TaskGraph({
       outputCache: this._cache.outputCache(),
     });
-    this._dataFlows = [];
-    this._error = "";
+    this._builder.resetState();
     this._bridge?.attach(this._graph);
     this.events.emit("changed", undefined);
     this.events.emit("reset");
@@ -643,41 +511,7 @@ export class Workflow<
     targetTaskId: unknown,
     targetTaskPortId: string
   ): Workflow {
-    const sourceTask = this.graph.getTask(sourceTaskId);
-    const targetTask = this.graph.getTask(targetTaskId);
-
-    if (!sourceTask || !targetTask) {
-      throw new WorkflowError("Source or target task not found");
-    }
-
-    const sourceSchema = sourceTask.outputSchema();
-    const targetSchema = targetTask.inputSchema();
-
-    // Handle boolean schemas
-    if (typeof sourceSchema === "boolean") {
-      if (sourceSchema === false) {
-        throw new WorkflowError(`Source task has schema 'false' and outputs nothing`);
-      }
-      // If sourceSchema is true, we skip validation as it accepts everything
-    } else if (!sourceSchema.properties?.[sourceTaskPortId]) {
-      throw new WorkflowError(`Output ${sourceTaskPortId} not found on source task`);
-    }
-
-    if (typeof targetSchema === "boolean") {
-      if (targetSchema === false) {
-        throw new WorkflowError(`Target task has schema 'false' and accepts no inputs`);
-      }
-      if (targetSchema === true) {
-        // do nothing, we allow additional properties
-      }
-    } else if (targetSchema.additionalProperties === true) {
-      // do nothing, we allow additional properties
-    } else if (!targetSchema.properties?.[targetTaskPortId]) {
-      throw new WorkflowError(`Input ${targetTaskPortId} not found on target task`);
-    }
-
-    const dataflow = new Dataflow(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
-    this.graph.addDataflow(dataflow);
+    this._builder.connect(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
     return this;
   }
 
@@ -686,10 +520,7 @@ export class Workflow<
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
   >(taskClass: ITaskConstructor<I, O, C>, config: C): ITask<I, O, C> {
-    const task = new taskClass(config, this._registry ? { registry: this._registry } : undefined);
-    const id = this.graph.addTask(task);
-    this.events.emit("changed", id);
-    return task;
+    return this._builder.addTaskInstance<I, O, C>(taskClass, config);
   }
 
   /**
@@ -706,8 +537,10 @@ export class Workflow<
     input?: Partial<I>,
     config?: Partial<C>
   ): Workflow<Input, Output> {
-    const helper = Workflow.createWorkflow<I, O, C>(taskClass);
-    return helper.call(this, input, config) as Workflow<Input, Output>;
+    return this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config) as Workflow<
+      Input,
+      Output
+    >;
   }
 
   // ========================================================================
@@ -727,66 +560,7 @@ export class Workflow<
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
   >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
-    this._error = "";
-
-    const parent = getLastTask(this);
-
-    // Default maxIterations to "unbounded" for loop tasks whose config schema
-    // marks it as required (MapTask, WhileTask, ReduceTask, ForEachTask). The
-    // raw task constructors still require an explicit value; this default is a
-    // convenience only for the fluent Workflow builder API.
-    const schema = (
-      taskClass as unknown as { configSchema?: () => DataPortSchema }
-    ).configSchema?.();
-    const required =
-      typeof schema === "object" && schema !== null
-        ? (schema as { required?: readonly string[] }).required
-        : undefined;
-    const needsMaxIterations = Array.isArray(required) && required.includes("maxIterations");
-    const resolvedConfig =
-      needsMaxIterations && (config as { maxIterations?: unknown }).maxIterations === undefined
-        ? ({ ...config, maxIterations: "unbounded" } as Partial<C>)
-        : config;
-
-    const task = this.addTaskToGraph<I, O, C>(taskClass, { id: uuid4(), ...resolvedConfig } as C);
-
-    // Process any pending data flows (same as createWorkflow)
-    if (this._dataFlows.length > 0) {
-      this._dataFlows.forEach((dataflow) => {
-        const taskSchema = task.inputSchema();
-        if (
-          (typeof taskSchema !== "boolean" &&
-            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
-            taskSchema.additionalProperties !== true) ||
-          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
-        ) {
-          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
-          getLogger().error(this._error);
-          return;
-        }
-
-        dataflow.targetTaskId = task.id;
-        this.graph.addDataflow(dataflow);
-      });
-
-      this._dataFlows = [];
-    }
-
-    // Defer auto-connect until endMap/endReduce/endWhile, when the iterator task
-    // has its template graph populated and its dynamic inputSchema is available.
-    // Store the pending context on the loop builder workflow.
-    const loopBuilder = new Workflow(
-      this.outputCache(),
-      this,
-      task as unknown as GraphAsTask,
-      this._registry
-    ) as unknown as Workflow<I, O>;
-    if (parent) {
-      // Same-class private access: child was constructed with parent + iteratorTask,
-      // so its ctor created a LoopBuilderContext.
-      loopBuilder._loopContext!.pendingLoopConnect = { parent, iteratorTask: task };
-    }
-    return loopBuilder;
+    return this._builder.addLoopTask<I, O, C>(taskClass, config);
   }
 
   /**
@@ -804,7 +578,7 @@ export class Workflow<
    * ```
    */
   public if(condition: ConditionFn<TaskInput>): ConditionalBuilder {
-    return new ConditionalBuilder(this, condition);
+    return this._builder.createConditional(condition);
   }
 
   /**
@@ -860,8 +634,9 @@ export class Workflow<
    * Only applicable in loop builder mode.
    */
   public finalizeTemplate(): void {
-    if (!this._loopContext) return;
-    this._loopContext.finalizeTemplate(this._graph);
+    const ctx = this._builder.loopContext;
+    if (!ctx) return;
+    ctx.finalizeTemplate(this._graph);
   }
 
   /**
@@ -872,10 +647,11 @@ export class Workflow<
    * @throws WorkflowError if not in loop builder mode
    */
   public finalizeAndReturn(): Workflow {
-    if (!this._loopContext) {
+    const ctx = this._builder.loopContext;
+    if (!ctx) {
       throw new WorkflowError("finalizeAndReturn() can only be called on loop workflows");
     }
-    return this._loopContext.finalizeAndReturn(this._graph);
+    return ctx.finalizeAndReturn(this._graph);
   }
 }
 

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -26,6 +26,7 @@ import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
 import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
+import { LoopBuilderContext, runLoopAutoConnect } from "./LoopBuilderContext";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
@@ -97,8 +98,8 @@ export class Workflow<
     registry?: ServiceRegistry
   ) {
     this._cache = new WorkflowCacheAdapter(cache);
-    this._parentWorkflow = parent;
-    this._iteratorTask = iteratorTask;
+    this._loopContext =
+      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
     this._registry = registry ?? parent?._registry;
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
@@ -119,13 +120,8 @@ export class Workflow<
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
 
-  // Loop builder properties
-  private readonly _parentWorkflow?: Workflow;
-  private readonly _iteratorTask?: GraphAsTask;
-  private _pendingLoopConnect?: {
-    parent: ITask;
-    iteratorTask: ITask;
-  };
+  // Loop builder state (encapsulates parent workflow + iterator task + deferred auto-connect)
+  private readonly _loopContext?: LoopBuilderContext;
 
   public outputCache(): TaskOutputRepository | undefined {
     return this._cache.outputCache();
@@ -136,7 +132,7 @@ export class Workflow<
    * When true, tasks are added to the template graph for an iterator task.
    */
   public get isLoopBuilder(): boolean {
-    return this._parentWorkflow !== undefined;
+    return this._loopContext !== undefined;
   }
 
   /**
@@ -311,14 +307,10 @@ export class Workflow<
     config?: WorkflowRunConfig
   ): Promise<PropertyArrayGraphResult<Output>> {
     // In loop builder mode, finalize template and delegate to parent
-    if (this.isLoopBuilder) {
-      this.finalizeTemplate();
-      // Run deferred auto-connect now that template graph is populated
-      if (this._pendingLoopConnect) {
-        this._parentWorkflow!.autoConnectLoopTask(this._pendingLoopConnect);
-        this._pendingLoopConnect = undefined;
-      }
-      return this._parentWorkflow!.run(input as any, config) as Promise<
+    if (this._loopContext) {
+      this._loopContext.finalizeTemplate(this._graph);
+      this._loopContext.consumePendingConnect();
+      return this._loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
     }
@@ -356,8 +348,8 @@ export class Workflow<
    */
   public async abort(): Promise<void> {
     // In loop builder mode, delegate to parent
-    if (this._parentWorkflow) {
-      return this._parentWorkflow.abort();
+    if (this._loopContext) {
+      return this._loopContext.parent.abort();
     }
     this._abortController?.abort();
   }
@@ -626,7 +618,7 @@ export class Workflow<
    */
   public reset(): Workflow {
     // In loop builder mode, reset is not supported
-    if (this._parentWorkflow) {
+    if (this._loopContext) {
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
@@ -790,7 +782,9 @@ export class Workflow<
       this._registry
     ) as unknown as Workflow<I, O>;
     if (parent) {
-      loopBuilder._pendingLoopConnect = { parent, iteratorTask: task };
+      // Same-class private access: child was constructed with parent + iteratorTask,
+      // so its ctor created a LoopBuilderContext.
+      loopBuilder._loopContext!.pendingLoopConnect = { parent, iteratorTask: task };
     }
     return loopBuilder;
   }
@@ -820,26 +814,7 @@ export class Workflow<
    */
   public autoConnectLoopTask(pending?: { parent: ITask; iteratorTask: ITask }): void {
     if (!pending) return;
-    const { parent, iteratorTask } = pending;
-
-    if (this.graph.getTargetDataflows(parent.id).length === 0) {
-      const nodes = this._graph.getTasks();
-      const parentIndex = nodes.findIndex((n) => n.id === parent.id);
-      const earlierTasks: ITask[] = [];
-      for (let i = parentIndex - 1; i >= 0; i--) {
-        earlierTasks.push(nodes[i]);
-      }
-
-      const result = Workflow.autoConnect(this.graph, parent, iteratorTask, {
-        earlierTasks,
-      });
-
-      if (result.error) {
-        this._error = result.error + " Task not added.";
-        getLogger().error(this._error);
-        this.graph.removeTask(iteratorTask.id);
-      }
-    }
+    runLoopAutoConnect(this._graph, pending);
   }
 
   /**
@@ -885,12 +860,8 @@ export class Workflow<
    * Only applicable in loop builder mode.
    */
   public finalizeTemplate(): void {
-    if (!this._iteratorTask || this.graph.getTasks().length === 0) {
-      return;
-    }
-
-    this._iteratorTask.subGraph = this.graph;
-    this._iteratorTask.validateAcyclic();
+    if (!this._loopContext) return;
+    this._loopContext.finalizeTemplate(this._graph);
   }
 
   /**
@@ -901,17 +872,10 @@ export class Workflow<
    * @throws WorkflowError if not in loop builder mode
    */
   public finalizeAndReturn(): Workflow {
-    if (!this._parentWorkflow) {
+    if (!this._loopContext) {
       throw new WorkflowError("finalizeAndReturn() can only be called on loop workflows");
     }
-    this.finalizeTemplate();
-    // Now that the iterator task has its template graph, its dynamic inputSchema()
-    // is available. Run deferred auto-connect on the parent workflow's graph.
-    if (this._pendingLoopConnect) {
-      this._parentWorkflow.autoConnectLoopTask(this._pendingLoopConnect);
-      this._pendingLoopConnect = undefined;
-    }
-    return this._parentWorkflow;
+    return this._loopContext.finalizeAndReturn(this._graph);
   }
 }
 

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -59,6 +59,15 @@ export class WorkflowBuilder {
     return this._loopContext;
   }
 
+  /**
+   * Surfaces an error onto this builder's error slot. Used by deferred
+   * loop-builder auto-connect (which runs from a child Workflow but reports
+   * the failure onto the parent's `.error`, matching the non-loop path).
+   */
+  public setError(message: string): void {
+    this._error = message;
+  }
+
   /** Clears pending state. Called by the facade's graph setter and reset(). */
   public resetState(): void {
     this._dataFlows = [];

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -1,0 +1,404 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import type { ConditionFn } from "../task/ConditionalTask";
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask, ITaskConstructor } from "../task/ITask";
+import { WorkflowError } from "../task/TaskError";
+import type { DataPorts, TaskConfig, TaskInput } from "../task/TaskTypes";
+import { autoConnect } from "./autoConnect";
+import { ConditionalBuilder } from "./ConditionalBuilder";
+import type { Taskish } from "./Conversions";
+import { ensureTask } from "./Conversions";
+import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
+import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
+import { LoopBuilderContext } from "./LoopBuilderContext";
+import type { RenameOptions, Workflow } from "./Workflow";
+import { getLastTask } from "./WorkflowPipe";
+
+/**
+ * Owns the DSL state machine for a {@link Workflow}: the list of pending
+ * dataflows queued by `.rename(...)`, the most recent error string, the
+ * optional service registry, and the optional loop-builder context.
+ *
+ * The {@link Workflow} facade keeps its public method signatures and
+ * delegates the implementation here. This split keeps the run/abort/event
+ * surface separate from the chainable graph-construction surface.
+ */
+export class WorkflowBuilder {
+  private readonly _facade: Workflow<any, any>;
+  private _dataFlows: Dataflow[] = [];
+  private _error: string = "";
+  private readonly _registry?: ServiceRegistry;
+  private readonly _loopContext?: LoopBuilderContext;
+
+  constructor(
+    facade: Workflow<any, any>,
+    registry?: ServiceRegistry,
+    loopContext?: LoopBuilderContext
+  ) {
+    this._facade = facade;
+    this._registry = registry;
+    this._loopContext = loopContext;
+  }
+
+  public get error(): string {
+    return this._error;
+  }
+
+  public get registry(): ServiceRegistry | undefined {
+    return this._registry;
+  }
+
+  public get loopContext(): LoopBuilderContext | undefined {
+    return this._loopContext;
+  }
+
+  /** Clears pending state. Called by the facade's graph setter and reset(). */
+  public resetState(): void {
+    this._dataFlows = [];
+    this._error = "";
+  }
+
+  /**
+   * Instantiates a task and adds it to the facade's graph; emits "changed".
+   * Used both by {@link addTaskWithAutoConnect} and direct callers.
+   */
+  public addTaskInstance<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(taskClass: ITaskConstructor<I, O, C>, config: C): ITask<I, O, C> {
+    const task = new taskClass(
+      config,
+      this._registry ? { registry: this._registry } : undefined
+    );
+    const id = this._facade.graph.addTask(task);
+    this._facade.events.emit("changed", id);
+    return task;
+  }
+
+  /**
+   * Adds a task with auto-connect to the previous task. Drains pending
+   * dataflows queued by `.rename(...)` first, then runs auto-connect
+   * against the immediately-previous task plus earlier tasks for any
+   * unmatched required inputs.
+   */
+  public addTaskWithAutoConnect<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(
+    taskClass: ITaskConstructor<I, O, C>,
+    input: Partial<I> = {},
+    config: Partial<C> = {}
+  ): Workflow<any, any> {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+
+    const task = this.addTaskInstance<I, O, C>(taskClass, {
+      id: uuid4(),
+      ...config,
+      defaults: input,
+    } as C);
+
+    // Process any pending data flows
+    if (this._dataFlows.length > 0) {
+      this._dataFlows.forEach((dataflow) => {
+        const taskSchema = task.inputSchema();
+        if (
+          (typeof taskSchema !== "boolean" &&
+            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
+            taskSchema.additionalProperties !== true) ||
+          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
+        ) {
+          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
+          getLogger().error(this._error);
+          return;
+        }
+
+        dataflow.targetTaskId = task.id;
+        this._facade.graph.addDataflow(dataflow);
+      });
+
+      this._dataFlows = [];
+    }
+
+    // Auto-connect to parent if needed
+    if (parent) {
+      // Build the list of earlier tasks (in reverse chronological order)
+      const nodes = this._facade.graph.getTasks();
+      const parentIndex = nodes.findIndex((n) => n.id === parent.id);
+      const earlierTasks: ITask[] = [];
+      for (let i = parentIndex - 1; i >= 0; i--) {
+        earlierTasks.push(nodes[i]);
+      }
+
+      const providedInputKeys = new Set(Object.keys(input || {}));
+
+      // Ports already connected via pending dataflows (e.g., from .rename())
+      // must not be re-matched by auto-connect Strategies 1/2/3.
+      const connectedInputKeys = new Set(
+        this._facade.graph.getSourceDataflows(task.id).map((df) => df.targetTaskPortId)
+      );
+
+      const result = autoConnect(this._facade.graph, parent, task, {
+        providedInputKeys,
+        connectedInputKeys,
+        earlierTasks,
+      });
+
+      if (result.error) {
+        // In loop builder mode, don't remove the task - allow manual connection
+        // In normal mode, remove the task since auto-connect is required
+        if (this._loopContext !== undefined) {
+          this._error = result.error;
+          getLogger().warn(this._error);
+        } else {
+          this._error = result.error + " Task not added.";
+          getLogger().error(this._error);
+          this._facade.graph.removeTask(task.id);
+        }
+      }
+    }
+
+    // Update InputTask/OutputTask schemas based on connected dataflows
+    if (!this._error) {
+      updateBoundaryTaskSchemas(this._facade.graph);
+    }
+
+    return this._facade;
+  }
+
+  /**
+   * Adds an iterator/loop task to the workflow using the same auto-connect
+   * logic as {@link addTaskWithAutoConnect}, then returns a new loop-builder
+   * Workflow whose template graph the user populates.
+   */
+  public addLoopTask<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+
+    // Default maxIterations to "unbounded" for loop tasks whose config schema
+    // marks it as required (MapTask, WhileTask, ReduceTask, ForEachTask). The
+    // raw task constructors still require an explicit value; this default is a
+    // convenience only for the fluent Workflow builder API.
+    const schema = (
+      taskClass as unknown as { configSchema?: () => DataPortSchema }
+    ).configSchema?.();
+    const required =
+      typeof schema === "object" && schema !== null
+        ? (schema as { required?: readonly string[] }).required
+        : undefined;
+    const needsMaxIterations = Array.isArray(required) && required.includes("maxIterations");
+    const resolvedConfig =
+      needsMaxIterations && (config as { maxIterations?: unknown }).maxIterations === undefined
+        ? ({ ...config, maxIterations: "unbounded" } as Partial<C>)
+        : config;
+
+    const task = this.addTaskInstance<I, O, C>(taskClass, { id: uuid4(), ...resolvedConfig } as C);
+
+    // Process any pending data flows (same as addTaskWithAutoConnect)
+    if (this._dataFlows.length > 0) {
+      this._dataFlows.forEach((dataflow) => {
+        const taskSchema = task.inputSchema();
+        if (
+          (typeof taskSchema !== "boolean" &&
+            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
+            taskSchema.additionalProperties !== true) ||
+          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
+        ) {
+          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
+          getLogger().error(this._error);
+          return;
+        }
+
+        dataflow.targetTaskId = task.id;
+        this._facade.graph.addDataflow(dataflow);
+      });
+
+      this._dataFlows = [];
+    }
+
+    // Defer auto-connect until endMap/endReduce/endWhile, when the iterator task
+    // has its template graph populated and its dynamic inputSchema is available.
+    // Store the pending context on the loop builder workflow.
+    const FacadeCtor = this._facade.constructor as new (
+      cache?: ReturnType<Workflow["outputCache"]>,
+      parent?: Workflow,
+      iteratorTask?: GraphAsTask,
+      registry?: ServiceRegistry
+    ) => Workflow<any, any>;
+
+    const loopBuilder = new FacadeCtor(
+      this._facade.outputCache(),
+      this._facade,
+      task as unknown as GraphAsTask,
+      this._registry
+    ) as unknown as Workflow<I, O>;
+
+    if (parent) {
+      const childCtx = loopBuilder.builder.loopContext;
+      if (childCtx) {
+        childCtx.pendingLoopConnect = { parent, iteratorTask: task };
+      }
+    }
+    return loopBuilder;
+  }
+
+  /**
+   * Connects outputs to inputs between tasks. Validates source/target
+   * schemas before adding the dataflow; throws {@link WorkflowError} on
+   * mismatch.
+   */
+  public connect(
+    sourceTaskId: unknown,
+    sourceTaskPortId: string,
+    targetTaskId: unknown,
+    targetTaskPortId: string
+  ): void {
+    const sourceTask = this._facade.graph.getTask(sourceTaskId);
+    const targetTask = this._facade.graph.getTask(targetTaskId);
+
+    if (!sourceTask || !targetTask) {
+      throw new WorkflowError("Source or target task not found");
+    }
+
+    const sourceSchema = sourceTask.outputSchema();
+    const targetSchema = targetTask.inputSchema();
+
+    // Handle boolean schemas
+    if (typeof sourceSchema === "boolean") {
+      if (sourceSchema === false) {
+        throw new WorkflowError(`Source task has schema 'false' and outputs nothing`);
+      }
+      // If sourceSchema is true, we skip validation as it accepts everything
+    } else if (!sourceSchema.properties?.[sourceTaskPortId]) {
+      throw new WorkflowError(`Output ${sourceTaskPortId} not found on source task`);
+    }
+
+    if (typeof targetSchema === "boolean") {
+      if (targetSchema === false) {
+        throw new WorkflowError(`Target task has schema 'false' and accepts no inputs`);
+      }
+      if (targetSchema === true) {
+        // do nothing, we allow additional properties
+      }
+    } else if (targetSchema.additionalProperties === true) {
+      // do nothing, we allow additional properties
+    } else if (!targetSchema.properties?.[targetTaskPortId]) {
+      throw new WorkflowError(`Input ${targetTaskPortId} not found on target task`);
+    }
+
+    const dataflow = new Dataflow(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
+    this._facade.graph.addDataflow(dataflow);
+  }
+
+  /**
+   * Renames an output of a task, queuing a pending dataflow. The dataflow's
+   * target is filled in when the next task is added via
+   * {@link addTaskWithAutoConnect}.
+   */
+  public rename(
+    source: string,
+    target: string,
+    indexOrOptions: number | RenameOptions = -1
+  ): void {
+    this._error = "";
+
+    const index =
+      typeof indexOrOptions === "number" ? indexOrOptions : (indexOrOptions.index ?? -1);
+    const transforms = typeof indexOrOptions === "number" ? undefined : indexOrOptions.transforms;
+
+    const nodes = this._facade.graph.getTasks();
+    if (-index > nodes.length) {
+      const errorMsg = `Back index greater than number of tasks`;
+      this._error = errorMsg;
+      getLogger().error(this._error);
+      throw new WorkflowError(errorMsg);
+    }
+
+    const lastNode = nodes[nodes.length + index];
+    const outputSchema = lastNode.outputSchema();
+
+    // Handle boolean schemas
+    if (typeof outputSchema === "boolean") {
+      if (outputSchema === false && source !== DATAFLOW_ALL_PORTS) {
+        const errorMsg = `Task ${lastNode.id} has schema 'false' and outputs nothing`;
+        this._error = errorMsg;
+        getLogger().error(this._error);
+        throw new WorkflowError(errorMsg);
+      }
+      // If outputSchema is true, we skip validation as it outputs everything
+    } else if (!(outputSchema.properties as any)?.[source] && source !== DATAFLOW_ALL_PORTS) {
+      const errorMsg = `Output ${source} not found on task ${lastNode.id}`;
+      this._error = errorMsg;
+      getLogger().error(this._error);
+      throw new WorkflowError(errorMsg);
+    }
+
+    const df = new Dataflow(lastNode.id, source, undefined, target);
+    if (transforms && transforms.length > 0) df.setTransforms(transforms);
+    this._dataFlows.push(df);
+  }
+
+  /**
+   * Adds an error handler task that receives errors from the previous task.
+   * The handler task is wired from the previous task's `[error]` output port
+   * to its all-ports input.
+   */
+  public onError(handler: Taskish): void {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+    if (!parent) {
+      this._error = "onError() requires a preceding task in the workflow";
+      getLogger().error(this._error);
+      throw new WorkflowError(this._error);
+    }
+
+    const handlerTask = ensureTask(handler);
+    this._facade.graph.addTask(handlerTask);
+
+    // Connect the previous task's error output port to the handler's all-ports input
+    const dataflow = new Dataflow(
+      parent.id,
+      DATAFLOW_ERROR_PORT,
+      handlerTask.id,
+      DATAFLOW_ALL_PORTS
+    );
+    this._facade.graph.addDataflow(dataflow);
+    this._facade.events.emit("changed", handlerTask.id);
+  }
+
+  /** Removes the last task from the graph. */
+  public pop(): void {
+    this._error = "";
+    const nodes = this._facade.graph.getTasks();
+
+    if (nodes.length === 0) {
+      this._error = "No tasks to remove";
+      getLogger().error(this._error);
+      return;
+    }
+
+    const lastNode = nodes[nodes.length - 1];
+    this._facade.graph.removeTask(lastNode.id);
+  }
+
+  /** Opens a conditional branch builder rooted at the facade. */
+  public createConditional(condition: ConditionFn<TaskInput>): ConditionalBuilder {
+    return new ConditionalBuilder(this._facade, condition);
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -30,7 +30,20 @@ import { getLastTask } from "./WorkflowPipe";
  * delegates the implementation here. This split keeps the run/abort/event
  * surface separate from the chainable graph-construction surface.
  */
-export class WorkflowBuilder {
+
+/**
+ * Narrowed handle returned by `Workflow.builder`. Exposes only the two
+ * members other in-package code legitimately needs to reach across instances
+ * (loop-builder wiring + error propagation), keeping `_dataFlows`,
+ * `_registry`, and other builder internals out of reach via the facade.
+ * @internal
+ */
+export interface IWorkflowBuilderHandle {
+  readonly loopContext: LoopBuilderContext | undefined;
+  setError(message: string): void;
+}
+
+export class WorkflowBuilder implements IWorkflowBuilderHandle {
   private readonly _facade: Workflow<any, any>;
   private _dataFlows: Dataflow[] = [];
   private _error: string = "";

--- a/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
+++ b/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+
+/**
+ * Owns the workflow's TaskOutputRepository and supplies it to the underlying
+ * TaskGraph (at construction) and to graph.run() (per run). Today this is a
+ * thin pass-through; it is the growth point for cache key derivation,
+ * invalidation, and suspend/resume wiring in later work.
+ */
+export class WorkflowCacheAdapter {
+  private readonly _outputCache?: TaskOutputRepository;
+
+  constructor(cache?: TaskOutputRepository) {
+    this._outputCache = cache;
+  }
+
+  public outputCache(): TaskOutputRepository | undefined {
+    return this._outputCache;
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
+++ b/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
@@ -7,6 +7,7 @@
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 
 /**
+ * @internal
  * Owns the workflow's TaskOutputRepository and supplies it to the underlying
  * TaskGraph (at construction) and to graph.run() (per run). Today this is a
  * thin pass-through; it is the growth point for cache key derivation,

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -26,7 +26,6 @@ export class WorkflowEventBridge {
   private readonly _events: EventEmitter<WorkflowEventListeners>;
   private _attachedGraph?: TaskGraph;
   private _entitlementUnsub?: () => void;
-  private _streamingUnsub?: () => void;
   private readonly _onChanged: (id: unknown) => void;
 
   constructor(events: EventEmitter<WorkflowEventListeners>) {
@@ -59,26 +58,23 @@ export class WorkflowEventBridge {
     graph.off("dataflow_removed", this._onChanged);
     this._entitlementUnsub?.();
     this._entitlementUnsub = undefined;
-    // Tear down any streaming subscription that's still tied to this graph.
-    // Without this, a graph swap or reset() during a run would leave the old
-    // graph's streaming handlers wired to this workflow's events emitter.
-    this._streamingUnsub?.();
-    this._streamingUnsub = undefined;
     this._attachedGraph = undefined;
   }
 
-  public beginRun(): void {
+  /**
+   * Subscribes to streaming events on the attached graph for the duration of
+   * one run. Returns an unsubscribe token that the caller MUST hold locally
+   * and invoke when the run ends. Returning the token (rather than storing
+   * it on the bridge) keeps concurrent runs from clobbering each other's
+   * subscriptions — pre-refactor behavior.
+   */
+  public beginRun(): (() => void) | undefined {
     const graph = this._attachedGraph;
-    if (!graph) return;
-    this._streamingUnsub = graph.subscribeToTaskStreaming({
+    if (!graph) return undefined;
+    return graph.subscribeToTaskStreaming({
       onStreamStart: (taskId) => this._events.emit("stream_start", taskId),
       onStreamChunk: (taskId, event) => this._events.emit("stream_chunk", taskId, event),
       onStreamEnd: (taskId, output) => this._events.emit("stream_end", taskId, output),
     });
-  }
-
-  public endRun(): void {
-    this._streamingUnsub?.();
-    this._streamingUnsub = undefined;
   }
 }

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EventEmitter } from "@workglow/util";
+import type { TaskGraph } from "./TaskGraph";
+import type { WorkflowEventListeners } from "./Workflow";
+
+/**
+ * Routes TaskGraph mutation events, entitlement updates, and per-run streaming
+ * events to a Workflow's EventEmitter. Owns subscription lifecycle:
+ *   attach(graph)   → subscribe to mutation + entitlement events
+ *   detach()        → unsubscribe (called on graph swap and reset)
+ *   beginRun()      → subscribe to streaming events for the current run
+ *   endRun()        → unsubscribe streaming
+ *
+ * The bridge does NOT own the events emitter — the facade Workflow does. The
+ * bridge holds a reference and emits through it.
+ *
+ * Loop-builder Workflows do NOT receive a bridge (matches today's behavior:
+ * Workflow.ts only constructs a bridge when `parent` is undefined).
+ */
+export class WorkflowEventBridge {
+  private readonly _events: EventEmitter<WorkflowEventListeners>;
+  private _attachedGraph?: TaskGraph;
+  private _entitlementUnsub?: () => void;
+  private _streamingUnsub?: () => void;
+  private readonly _onChanged: (id: unknown) => void;
+
+  constructor(events: EventEmitter<WorkflowEventListeners>) {
+    this._events = events;
+    this._onChanged = (id) => this._events.emit("changed", id);
+  }
+
+  public attach(graph: TaskGraph): void {
+    if (this._attachedGraph) this.detach();
+    this._attachedGraph = graph;
+    graph.on("task_added", this._onChanged);
+    graph.on("task_replaced", this._onChanged);
+    graph.on("task_removed", this._onChanged);
+    graph.on("dataflow_added", this._onChanged);
+    graph.on("dataflow_replaced", this._onChanged);
+    graph.on("dataflow_removed", this._onChanged);
+    this._entitlementUnsub = graph.subscribeToTaskEntitlements((entitlements) =>
+      this._events.emit("entitlementChange", entitlements)
+    );
+  }
+
+  public detach(): void {
+    const graph = this._attachedGraph;
+    if (!graph) return;
+    graph.off("task_added", this._onChanged);
+    graph.off("task_replaced", this._onChanged);
+    graph.off("task_removed", this._onChanged);
+    graph.off("dataflow_added", this._onChanged);
+    graph.off("dataflow_replaced", this._onChanged);
+    graph.off("dataflow_removed", this._onChanged);
+    this._entitlementUnsub?.();
+    this._entitlementUnsub = undefined;
+    this._attachedGraph = undefined;
+  }
+
+  public beginRun(): void {
+    const graph = this._attachedGraph;
+    if (!graph) return;
+    this._streamingUnsub = graph.subscribeToTaskStreaming({
+      onStreamStart: (taskId) => this._events.emit("stream_start", taskId),
+      onStreamChunk: (taskId, event) => this._events.emit("stream_chunk", taskId, event),
+      onStreamEnd: (taskId, output) => this._events.emit("stream_end", taskId, output),
+    });
+  }
+
+  public endRun(): void {
+    this._streamingUnsub?.();
+    this._streamingUnsub = undefined;
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -59,6 +59,11 @@ export class WorkflowEventBridge {
     graph.off("dataflow_removed", this._onChanged);
     this._entitlementUnsub?.();
     this._entitlementUnsub = undefined;
+    // Tear down any streaming subscription that's still tied to this graph.
+    // Without this, a graph swap or reset() during a run would leave the old
+    // graph's streaming handlers wired to this workflow's events emitter.
+    this._streamingUnsub?.();
+    this._streamingUnsub = undefined;
     this._attachedGraph = undefined;
   }
 

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -9,6 +9,7 @@ import type { TaskGraph } from "./TaskGraph";
 import type { WorkflowEventListeners } from "./Workflow";
 
 /**
+ * @internal
  * Routes TaskGraph mutation events, entitlement updates, and per-run streaming
  * events to a Workflow's EventEmitter. Owns subscription lifecycle:
  *   attach(graph)   → subscribe to mutation + entitlement events

--- a/packages/task-graph/src/task-graph/WorkflowFactories.ts
+++ b/packages/task-graph/src/task-graph/WorkflowFactories.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITaskConstructor } from "../task/ITask";
+import type { DataPorts, TaskConfig } from "../task/TaskTypes";
+import { hasVectorLikeInput, hasVectorOutput } from "./GraphSchemaUtils";
+import { Workflow } from "./Workflow";
+import { getLastTask } from "./WorkflowPipe";
+
+// Type definitions for the workflow
+export type CreateWorkflow<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I>> = (
+  input?: Partial<I>,
+  config?: Partial<C>
+) => Workflow<I, O>;
+
+export function CreateWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+>(taskClass: ITaskConstructor<I, O, C>): CreateWorkflow<I, O, C> {
+  return Workflow.createWorkflow<I, O, C>(taskClass);
+}
+
+/**
+ * Type for loop workflow methods (map, while, reduce).
+ * Represents the method signature with proper `this` context.
+ * Loop methods take only a config parameter - input is not used for loop tasks.
+ */
+export type CreateLoopWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+> = (this: Workflow<I, O>, config?: Partial<C>) => Workflow<I, O>;
+
+/**
+ * Factory function that creates a loop workflow method for a given task class.
+ * Returns a method that can be assigned to Workflow.prototype.
+ *
+ * @param taskClass - The iterator task class (MapTask, ReduceTask, etc.)
+ * @returns A method that creates the task and returns a loop builder workflow
+ */
+export function CreateLoopWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+>(taskClass: ITaskConstructor<I, O, C>): CreateLoopWorkflow<I, O, C> {
+  return function (this: Workflow<I, O>, config: Partial<C> = {}): Workflow<I, O> {
+    return this.addLoopTask(taskClass, config);
+  };
+}
+
+/**
+ * Type for end loop workflow methods (endMap, endBatch, etc.).
+ */
+export type EndLoopWorkflow = (this: Workflow) => Workflow;
+
+/**
+ * Factory function that creates an end loop workflow method.
+ *
+ * @param methodName - The name of the method (for error messages)
+ * @returns A method that finalizes the loop and returns to the parent workflow
+ */
+export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
+  return function (this: Workflow): Workflow {
+    if (!this.isLoopBuilder) {
+      throw new Error(`${methodName}() can only be called on loop workflows`);
+    }
+    return this.finalizeAndReturn();
+  };
+}
+
+/**
+ * Type for adaptive workflow methods that dispatch to scalar or vector variant
+ * based on the previous task's output schema.
+ */
+export type CreateAdaptiveWorkflow<
+  IS extends DataPorts,
+  _OS extends DataPorts,
+  IV extends DataPorts,
+  _OV extends DataPorts,
+  CS extends TaskConfig<IS> = TaskConfig<IS>,
+  CV extends TaskConfig<IV> = TaskConfig<IV>,
+> = (
+  this: Workflow,
+  input?: Partial<IS> & Partial<IV>,
+  config?: Partial<CS> & Partial<CV>
+) => Workflow;
+
+/**
+ * Factory that creates an adaptive workflow method: when called, inspects the
+ * output schema of the last task in the chain and delegates to the vector
+ * variant if it has TypedArray output, otherwise to the scalar variant.
+ * If there is no previous task, defaults to the scalar variant.
+ *
+ * @param scalarClass - Task class for scalar path (e.g. ScalarAddTask)
+ * @param vectorClass - Task class for vector path (e.g. VectorSumTask)
+ * @returns A method suitable for Workflow.prototype
+ */
+export function CreateAdaptiveWorkflow<
+  IS extends DataPorts,
+  OS extends DataPorts,
+  IV extends DataPorts,
+  OV extends DataPorts,
+  CS extends TaskConfig<IS> = TaskConfig<IS>,
+  CV extends TaskConfig<IV> = TaskConfig<IV>,
+>(
+  scalarClass: ITaskConstructor<IS, OS, CS>,
+  vectorClass: ITaskConstructor<IV, OV, CV>
+): CreateAdaptiveWorkflow<IS, OS, IV, OV, CS, CV> {
+  const scalarHelper = Workflow.createWorkflow<IS, OS, CS>(scalarClass);
+  const vectorHelper = Workflow.createWorkflow<IV, OV, CV>(vectorClass);
+
+  return function (
+    this: Workflow<any, any>,
+    input: (Partial<IS> & Partial<IV>) | undefined = {},
+    config: (Partial<CS> & Partial<CV>) | undefined = {}
+  ): Workflow {
+    const parent = getLastTask(this);
+    const useVector =
+      (parent !== undefined && hasVectorOutput(parent)) || hasVectorLikeInput(input);
+    if (useVector) {
+      return vectorHelper.call(this, input, config) as Workflow;
+    }
+    return scalarHelper.call(this, input, config) as Workflow;
+  };
+}
+

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask } from "../task/ITask";
+import type { DataPorts } from "../task/TaskTypes";
+import type { PipeFunction, Taskish } from "./Conversions";
+import { ensureTask } from "./Conversions";
+import { Dataflow } from "./Dataflow";
+import type { ITaskGraph } from "./ITaskGraph";
+import type { IWorkflow } from "./IWorkflow";
+import type { CompoundMergeStrategy } from "./TaskGraphRunner";
+import { PROPERTY_ARRAY } from "./TaskGraphRunner";
+import { Workflow } from "./Workflow";
+
+// ============================================================================
+// Standalone utility functions (moved from Conversions.ts to break circular
+// dependency — these need both Workflow and GraphAsTask which live here)
+// ============================================================================
+
+export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
+  const tasks = workflow.graph.getTasks();
+  return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
+}
+
+export function connect(
+  source: ITask<any, any, any>,
+  target: ITask<any, any, any>,
+  workflow: IWorkflow<any, any>
+): void {
+  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
+}
+
+export function pipe<A extends DataPorts, B extends DataPorts>(
+  [fn1]: [Taskish<A, B>],
+  workflow?: IWorkflow<A, B>
+): IWorkflow<A, B>;
+
+export function pipe<A extends DataPorts, B extends DataPorts, C extends DataPorts>(
+  [fn1, fn2]: [Taskish<A, B>, Taskish<B, C>],
+  workflow?: IWorkflow<A, C>
+): IWorkflow<A, C>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+>(
+  [fn1, fn2, fn3]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>],
+  workflow?: IWorkflow<A, D>
+): IWorkflow<A, D>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+  E extends DataPorts,
+>(
+  [fn1, fn2, fn3, fn4]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>, Taskish<D, E>],
+  workflow?: IWorkflow<A, E>
+): IWorkflow<A, E>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+  E extends DataPorts,
+  F extends DataPorts,
+>(
+  [fn1, fn2, fn3, fn4, fn5]: [
+    Taskish<A, B>,
+    Taskish<B, C>,
+    Taskish<C, D>,
+    Taskish<D, E>,
+    Taskish<E, F>,
+  ],
+  workflow?: IWorkflow<A, F>
+): IWorkflow<A, F>;
+
+export function pipe<I extends DataPorts, O extends DataPorts>(
+  args: Taskish<I, O>[],
+  workflow: IWorkflow<I, O> = new Workflow<I, O>()
+): IWorkflow<I, O> {
+  let previousTask = getLastTask(workflow);
+  const tasks = args.map((arg) => ensureTask(arg));
+  tasks.forEach((task) => {
+    workflow.graph.addTask(task);
+    if (previousTask) {
+      connect(previousTask, task, workflow);
+    }
+    previousTask = task;
+  });
+  return workflow;
+}
+
+export function parallel<I extends DataPorts = DataPorts, O extends DataPorts = DataPorts>(
+  args: (PipeFunction<I, O> | ITask<I, O> | IWorkflow<I, O> | ITaskGraph)[],
+  mergeFn: CompoundMergeStrategy = PROPERTY_ARRAY,
+  workflow: IWorkflow<I, O> = new Workflow<I, O>()
+): IWorkflow<I, O> {
+  let previousTask = getLastTask(workflow);
+  const tasks = args.map((arg) => ensureTask(arg));
+  const config = {
+    compoundMerge: mergeFn,
+  };
+  const name = `‖${args.map((_arg) => "𝑓").join("‖")}‖`;
+  class ParallelTask extends GraphAsTask<I, O> {
+    public static override type = name;
+  }
+  const mergeTask = new ParallelTask(config);
+  mergeTask.subGraph!.addTasks(tasks);
+  workflow.graph.addTask(mergeTask);
+  if (previousTask) {
+    connect(previousTask, mergeTask, workflow);
+  }
+  return workflow;
+}

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -9,7 +9,7 @@ import type { ITask } from "../task/ITask";
 import type { DataPorts } from "../task/TaskTypes";
 import type { PipeFunction, Taskish } from "./Conversions";
 import { ensureTask } from "./Conversions";
-import { Dataflow } from "./Dataflow";
+import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
 import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow } from "./IWorkflow";
 import type { CompoundMergeStrategy } from "./TaskGraphRunner";
@@ -31,7 +31,9 @@ export function connect(
   target: ITask<any, any, any>,
   workflow: IWorkflow<any, any>
 ): void {
-  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
+  workflow.graph.addDataflow(
+    new Dataflow(source.id, DATAFLOW_ALL_PORTS, target.id, DATAFLOW_ALL_PORTS)
+  );
 }
 
 export function pipe<A extends DataPorts, B extends DataPorts>(

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -21,11 +21,17 @@ import { Workflow } from "./Workflow";
 // dependency — these need both Workflow and GraphAsTask which live here)
 // ============================================================================
 
+/**
+ * @internal
+ */
 export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
   const tasks = workflow.graph.getTasks();
   return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
 }
 
+/**
+ * @internal
+ */
 export function connect(
   source: ITask<any, any, any>,
   target: ITask<any, any, any>,

--- a/packages/task-graph/src/task-graph/WorkflowRunContext.ts
+++ b/packages/task-graph/src/task-graph/WorkflowRunContext.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-run mutable state for a single Workflow.run() invocation. Built at the
+ * top of run(), discarded in the run's finally clause. Mirrors RunContext on
+ * the TaskGraphRunner side: a small value object so per-run resources have a
+ * single owner with a clear disposal point, and so suspend/resume work in the
+ * future has an obvious place to grow.
+ *
+ * Single-field on the facade (last-run-wins for abort), matching the pre-
+ * existing abort semantics — concurrent run() calls overwrite the field, and
+ * abort() only targets the most-recently-started run. The streaming unsub
+ * lives on the context (not the bridge) so concurrent runs do not clobber
+ * each other's streaming subscriptions.
+ */
+export class WorkflowRunContext {
+  readonly abortController: AbortController;
+  unsubStreaming?: () => void;
+
+  constructor() {
+    this.abortController = new AbortController();
+  }
+
+  /** Releases the streaming subscription if one is held. Idempotent. */
+  dispose(): void {
+    this.unsubStreaming?.();
+    this.unsubStreaming = undefined;
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowRunContext.ts
+++ b/packages/task-graph/src/task-graph/WorkflowRunContext.ts
@@ -5,6 +5,7 @@
  */
 
 /**
+ * @internal
  * Per-run mutable state for a single Workflow.run() invocation. Built at the
  * top of run(), discarded in the run's finally clause. Mirrors RunContext on
  * the TaskGraphRunner side: a small value object so per-run resources have a

--- a/packages/task-graph/src/task-graph/WorkflowTask.ts
+++ b/packages/task-graph/src/task-graph/WorkflowTask.ts
@@ -9,6 +9,12 @@ import type { DataPorts } from "../task/TaskTypes";
 import type { CompoundMergeStrategy } from "./TaskGraphRunner";
 import { PROPERTY_ARRAY } from "./TaskGraphRunner";
 
+/**
+ * @internal
+ * Workflow's private GraphAsTask subclass — the runtime task instance that
+ * carries Workflow's compound-merge strategy. Constructed only by Workflow;
+ * not part of the public surface.
+ */
 export class WorkflowTask<
   I extends DataPorts,
   O extends DataPorts,

--- a/packages/task-graph/src/task-graph/WorkflowTask.ts
+++ b/packages/task-graph/src/task-graph/WorkflowTask.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { DataPorts } from "../task/TaskTypes";
+import type { CompoundMergeStrategy } from "./TaskGraphRunner";
+import { PROPERTY_ARRAY } from "./TaskGraphRunner";
+
+export class WorkflowTask<
+  I extends DataPorts,
+  O extends DataPorts,
+> extends GraphAsTask<I, O> {
+  public static override readonly type = "Workflow";
+  public static override readonly compoundMerge = PROPERTY_ARRAY as CompoundMergeStrategy;
+}

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -31,8 +31,10 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
   constructor(private readonly task: ITask<Input, Output, any>) {}
 
   /**
-   * Strips x-cache-key:false fields and returns key-shaped inputs. No-op when
-   * no cache is configured (returns inputs unchanged).
+   * Serializes format-annotated input properties (via their port codecs) so the
+   * resulting object is a stable, serialization-equivalent representation
+   * suitable for use as a cache key. Properties without a format annotation are
+   * passed through unchanged. No-op when no cache is configured.
    */
   async buildKey(
     inputs: Input,

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getPortCodec } from "@workglow/util";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { ITask } from "./ITask";
+import type { StreamEvent } from "./StreamTypes";
+import { Task } from "./Task";
+import type { TaskInput, TaskOutput } from "./TaskTypes";
+import type { TaskRunContext } from "./TaskRunContext";
+
+interface SchemaProperties {
+  properties?: Record<string, { format?: string }>;
+}
+
+/**
+ * @internal
+ * Cache key normalization, lookup, save, and cache-hit stream-event emission
+ * for streamable tasks. The three previously module-private helpers
+ * (serializeOutputPorts, deserializeOutputPorts, normalizeInputsForCacheKey)
+ * are private statics here.
+ *
+ * outputCache is passed as a method argument (not stored as a class field)
+ * because the facade resolves it per-run in handleStart and may differ
+ * between runs.
+ */
+export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput> {
+  constructor(private readonly task: ITask<Input, Output, any>) {}
+
+  /**
+   * Strips x-cache-key:false fields and returns key-shaped inputs. No-op when
+   * no cache is configured (returns inputs unchanged).
+   */
+  async buildKey(
+    inputs: Input,
+    outputCache: TaskOutputRepository | undefined
+  ): Promise<Input> {
+    if (!outputCache) return inputs;
+    const inputSchema = (this.task.constructor as typeof Task).inputSchema();
+    return (await CacheCoordinator.normalizeInputsForCacheKey(
+      inputs as Record<string, unknown>,
+      inputSchema as unknown as SchemaProperties
+    )) as Input;
+  }
+
+  /**
+   * Looks up a cached output. On a hit for a streaming task, also emits the
+   * synthetic stream_start / stream_chunk(finish) / stream_end events so
+   * downstream consumers see the same event shape as a fresh run.
+   *
+   * Returns the deserialized output if found, undefined otherwise.
+   */
+  async lookup(
+    keyInputs: Input,
+    outputCache: TaskOutputRepository | undefined,
+    isStreamable: boolean,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
+    if (!outputCache || !this.task.cacheable) return undefined;
+
+    const cached = await outputCache.getOutput(this.task.type, keyInputs);
+    if (cached === undefined) return undefined;
+
+    const outputSchema = (this.task.constructor as typeof Task).outputSchema();
+    const outputs = (await CacheCoordinator.deserializeOutputPorts(
+      cached as Record<string, unknown>,
+      outputSchema as unknown as SchemaProperties
+    )) as Output;
+
+    ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
+
+    if (isStreamable) {
+      this.task.runOutputData = outputs;
+      this.task.emit("stream_start");
+      this.task.emit("stream_chunk", { type: "finish", data: outputs } as StreamEvent);
+      this.task.emit("stream_end", outputs);
+    } else {
+      this.task.runOutputData = outputs;
+    }
+
+    return outputs;
+  }
+
+  /**
+   * Serializes and saves output. No-op when no cache is configured or task is
+   * not cacheable.
+   */
+  async save(
+    keyInputs: Input,
+    output: Output,
+    outputCache: TaskOutputRepository | undefined
+  ): Promise<void> {
+    if (!outputCache || !this.task.cacheable || output === undefined) return;
+    const outputSchema = (this.task.constructor as typeof Task).outputSchema();
+    const wireOutputs = await CacheCoordinator.serializeOutputPorts(
+      output as Record<string, unknown>,
+      outputSchema as unknown as SchemaProperties
+    );
+    await outputCache.saveOutput(this.task.type, keyInputs, wireOutputs as Output);
+  }
+
+  // ========================================================================
+  // Private static helpers (lifted from current module-private functions in
+  // TaskRunner.ts)
+  // ========================================================================
+
+  private static async serializeOutputPorts(
+    output: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return output;
+    const out: Record<string, unknown> = { ...output };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.serialize(out[key]);
+      }
+    }
+    return out;
+  }
+
+  private static async deserializeOutputPorts(
+    output: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return output;
+    const out: Record<string, unknown> = { ...output };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.deserialize(out[key]);
+      }
+    }
+    return out;
+  }
+
+  private static async normalizeInputsForCacheKey(
+    inputs: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return inputs;
+    const out: Record<string, unknown> = { ...inputs };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.serialize(out[key]);
+      }
+    }
+    return out;
+  }
+}

--- a/packages/task-graph/src/task/FallbackTask.ts
+++ b/packages/task-graph/src/task/FallbackTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { GraphAsTask, graphAsTaskConfigSchema } from "./GraphAsTask";
 import type { GraphAsTaskConfig } from "./GraphAsTask";
 import { FallbackTaskRunner } from "./FallbackTaskRunner";

--- a/packages/task-graph/src/task/FallbackTaskRunner.ts
+++ b/packages/task-graph/src/task/FallbackTaskRunner.ts
@@ -8,6 +8,7 @@ import type { FallbackTask, FallbackTaskConfig } from "./FallbackTask";
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
 import type { ITask } from "./ITask";
 import { TaskAbortedError, TaskFailedError, TaskTimeoutError } from "./TaskError";
+import type { TaskRunContext } from "./TaskRunContext";
 import { TaskStatus } from "./TaskTypes";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
@@ -27,7 +28,10 @@ export class FallbackTaskRunner<
   /**
    * Override executeTask to implement sequential fallback logic.
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.fallbackMode === "data") {
       return this.executeDataFallback(input);
     }
@@ -38,7 +42,10 @@ export class FallbackTaskRunner<
    * For FallbackTask, preview runs use the task's preview hook only,
    * bypassing GraphAsTaskRunner's child-merging logic.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -60,7 +67,7 @@ export class FallbackTaskRunner<
     const totalAttempts = tasks.length;
 
     for (let i = 0; i < tasks.length; i++) {
-      if (this.abortController?.signal.aborted) {
+      if (this.currentCtx?.abortController.signal.aborted) {
         throw new TaskAbortedError("Fallback aborted");
       }
 
@@ -142,7 +149,7 @@ export class FallbackTaskRunner<
 
     try {
       for (let i = 0; i < alternatives.length; i++) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           throw new TaskAbortedError("Fallback aborted");
         }
 
@@ -164,7 +171,7 @@ export class FallbackTaskRunner<
 
           // Run the subgraph with merged input
           const results = await this.task.subGraph.run<Output>(mergedInput, {
-            parentSignal: this.abortController?.signal,
+            parentSignal: this.currentCtx?.abortController.signal,
             outputCache: this.outputCache,
             registry: this.registry,
           });

--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -12,7 +12,7 @@ import { computeGraphEntitlements } from "../task-graph/GraphEntitlementUtils";
 import { computeGraphInputSchema, computeGraphOutputSchema } from "../task-graph/GraphSchemaUtils";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "../task-graph/TaskGraphRunner";
-import type { CreateLoopWorkflow } from "../task-graph/Workflow";
+import type { CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
 import type { IExecuteContext, IRunConfig } from "./ITask";
 import type { StreamEvent, StreamFinish } from "./StreamTypes";

--- a/packages/task-graph/src/task/GraphAsTaskRunner.ts
+++ b/packages/task-graph/src/task/GraphAsTaskRunner.ts
@@ -7,6 +7,7 @@
 import { GraphResultArray } from "../task-graph/TaskGraphRunner";
 import type { GraphAsTaskConfig } from "./GraphAsTask";
 import { GraphAsTask } from "./GraphAsTask";
+import type { TaskRunContext } from "./TaskRunContext";
 import { TaskRunner } from "./TaskRunner";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
@@ -34,7 +35,7 @@ export class GraphAsTaskRunner<
       }
     );
     const results = await this.task.subGraph!.run<Output>(input, {
-      parentSignal: this.abortController?.signal,
+      parentSignal: this.currentCtx?.abortController.signal,
       outputCache: this.outputCache,
       registry: this.registry,
       resourceScope: this.resourceScope,
@@ -56,11 +57,11 @@ export class GraphAsTaskRunner<
     });
   }
 
-  protected override async handleDisable(): Promise<void> {
+  protected override async handleDisable(ctx: TaskRunContext | undefined): Promise<void> {
     if (this.task.hasChildren()) {
       await this.task.subGraph!.disable();
     }
-    super.handleDisable();
+    await super.handleDisable(ctx);
   }
 
   // ========================================================================
@@ -70,7 +71,10 @@ export class GraphAsTaskRunner<
   /**
    * Execute the task
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.hasChildren()) {
       const runExecuteOutputData = await this.executeTaskChildren(input);
       this.task.runOutputData = this.task.subGraph.mergeExecuteOutputsToRunOutput(
@@ -78,7 +82,7 @@ export class GraphAsTaskRunner<
         this.task.compoundMerge
       );
     } else {
-      const result = await super.executeTask(input);
+      const result = await super.executeTask(input, ctx);
       this.task.runOutputData = result ?? ({} as Output);
     }
     return this.task.runOutputData as Output;
@@ -87,7 +91,10 @@ export class GraphAsTaskRunner<
   /**
    * Execute the task in preview mode
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.hasChildren()) {
       const previewResults = await this.executeTaskChildrenPreview();
       this.task.runOutputData = this.task.subGraph.mergeExecuteOutputsToRunOutput(
@@ -96,7 +103,7 @@ export class GraphAsTaskRunner<
       );
       return this.task.runOutputData as Output;
     } else {
-      const previewResult = await super.executeTaskPreview(input);
+      const previewResult = await super.executeTaskPreview(input, ctx);
       if (previewResult !== undefined) {
         this.task.runOutputData = previewResult;
       }

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -46,7 +46,19 @@ export interface IExecuteContext {
    * from these streams and re-yield events for immediate downstream delivery.
    */
   inputStreams?: Map<string, ReadableStream<StreamEvent>>;
-  /** Resource scope for registering heavyweight resource disposers. */
+  /**
+   * Resource scope for registering heavyweight resource disposers (model unload,
+   * AI session close, browser disconnect, etc.).
+   *
+   * **Register synchronously from within `execute()` / `executeStream()`.**
+   * The top-level runner disposes the scope as soon as the run completes;
+   * disposers registered after `execute()` resolves will land on a cleared Map
+   * and never be invoked.
+   *
+   * Always defined when the task is run via `Task.run()`, `TaskGraph.run()`,
+   * or `Workflow.run()` — the top-level runner auto-creates one if the caller
+   * did not provide it.
+   */
   resourceScope?: ResourceScope;
 }
 
@@ -115,8 +127,12 @@ export interface IRunConfig {
 
   /**
    * Resource scope for collecting heavyweight resource disposers.
-   * When provided, tasks can register cleanup functions via context.resourceScope.
-   * The caller controls when to invoke them.
+   *
+   * If omitted, the top-level runner creates a private scope and `disposeAll()`s
+   * it when the run finishes (success, error, or abort).
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`.
    */
   resourceScope?: ResourceScope;
 

--- a/packages/task-graph/src/task/IteratorTaskRunner.ts
+++ b/packages/task-graph/src/task/IteratorTaskRunner.ts
@@ -15,6 +15,7 @@ import {
   type IteratorTask,
   type IteratorTaskConfig,
 } from "./IteratorTask";
+import type { TaskRunContext } from "./TaskRunContext";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
 /**
@@ -39,7 +40,10 @@ export class IteratorTaskRunner<
    * it does not iterate the subgraph.
    */
 
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     let analysis = this.task.analyzeIterationInput(input);
 
     // Enforce maxIterations cap. Config is required (construction-time guard),
@@ -64,7 +68,10 @@ export class IteratorTaskRunner<
   /**
    * Iterator tasks should only run the task's preview hook here.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -91,7 +98,7 @@ export class IteratorTaskRunner<
 
     try {
       for (let batchStart = 0; batchStart < iterationCount; batchStart += batchSize) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           break;
         }
 
@@ -149,7 +156,7 @@ export class IteratorTaskRunner<
     let accumulator = this.task.getInitialAccumulator();
 
     for (let index = 0; index < iterationCount; index++) {
-      if (this.abortController?.signal.aborted) {
+      if (this.currentCtx?.abortController.signal.aborted) {
         break;
       }
 
@@ -185,7 +192,7 @@ export class IteratorTaskRunner<
 
     const workers = Array.from({ length: workerCount }, async () => {
       while (true) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           return;
         }
 
@@ -245,7 +252,7 @@ export class IteratorTaskRunner<
     index: number,
     iterationCount: number
   ): Promise<TaskOutput | undefined> {
-    if (this.abortController?.signal.aborted) {
+    if (this.currentCtx?.abortController.signal.aborted) {
       return undefined;
     }
 
@@ -278,7 +285,7 @@ export class IteratorTaskRunner<
 
     try {
       const results = await graphClone.run<TaskOutput>(input as TaskInput, {
-        parentSignal: this.abortController?.signal,
+        parentSignal: this.currentCtx?.abortController.signal,
         outputCache: this.outputCache,
         registry: this.registry,
         resourceScope: this.resourceScope,

--- a/packages/task-graph/src/task/MapTask.ts
+++ b/packages/task-graph/src/task/MapTask.ts
@@ -6,7 +6,8 @@
 
 import type { DataPortSchema } from "@workglow/util/schema";
 import { PROPERTY_ARRAY } from "../task-graph/TaskGraphRunner";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import type { IRunConfig } from "./ITask";
 import { IteratorTask, IteratorTaskConfig, iteratorTaskConfigSchema } from "./IteratorTask";
 import type { TaskInput, TaskOutput, TaskTypeName } from "./TaskTypes";

--- a/packages/task-graph/src/task/ReduceTask.ts
+++ b/packages/task-graph/src/task/ReduceTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import type { IRunConfig } from "./ITask";
 import {
   IterationAnalysisResult,

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -1,0 +1,236 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ResourceScope, ServiceRegistry } from "@workglow/util";
+import type { Taskish } from "../task-graph/Conversions";
+import type { ITask } from "./ITask";
+import type { StreamEvent, StreamMode } from "./StreamTypes";
+import { getOutputStreamMode, getStreamingPorts } from "./StreamTypes";
+import { TaskAbortedError, TaskError } from "./TaskError";
+import type { TaskInput, TaskOutput } from "./TaskTypes";
+import { TaskStatus } from "./TaskTypes";
+import type { TaskRunContext } from "./TaskRunContext";
+
+/**
+ * Per-call run-state inputs shared by StreamProcessor.run. Bundles facade
+ * state pulled at call time (registry, resourceScope, inputStreams) and
+ * facade methods bound to the facade instance (onProgress, own).
+ *
+ * @internal
+ */
+export interface StreamProcessorDeps {
+  readonly registry: ServiceRegistry;
+  readonly resourceScope: ResourceScope | undefined;
+  readonly inputStreams: Map<string, ReadableStream<StreamEvent>> | undefined;
+  readonly onProgress: (
+    progress: number | undefined,
+    message?: string,
+    ...args: any[]
+  ) => Promise<void>;
+  readonly own: <T extends Taskish<any, any>>(i: T) => T;
+}
+
+/**
+ * @internal
+ * Streaming event loop. Consumes a task's executeStream() output, manages
+ * text/object delta accumulators, mode switching (append/object/replace),
+ * and finish-event enrichment. Honors ctx.shouldAccumulate and
+ * ctx.abortController.signal.
+ */
+export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput> {
+  constructor(private readonly task: ITask<Input, Output, any>) {}
+
+  async run(
+    input: Input,
+    ctx: TaskRunContext,
+    deps: StreamProcessorDeps
+  ): Promise<Output | undefined> {
+    const streamMode: StreamMode = getOutputStreamMode(this.task.outputSchema());
+    if (streamMode === "append") {
+      const ports = getStreamingPorts(this.task.outputSchema());
+      if (ports.length === 0) {
+        throw new TaskError(
+          `Task ${this.task.type} declares append streaming but no output port has x-stream: "append"`
+        );
+      }
+    }
+    if (streamMode === "object") {
+      const ports = getStreamingPorts(this.task.outputSchema());
+      if (ports.length === 0) {
+        throw new TaskError(
+          `Task ${this.task.type} declares object streaming but no output port has x-stream: "object"`
+        );
+      }
+    }
+
+    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
+    const accumulatedObjects = ctx.shouldAccumulate
+      ? new Map<string, Record<string, unknown> | unknown[]>()
+      : undefined;
+    let streamingStarted = false;
+    let finalOutput: Output | undefined;
+
+    this.task.emit("stream_start");
+
+    const stream = this.task.executeStream!(input, {
+      signal: ctx.abortController.signal,
+      updateProgress: deps.onProgress,
+      own: deps.own,
+      registry: deps.registry,
+      resourceScope: deps.resourceScope,
+      inputStreams: deps.inputStreams,
+    });
+
+    for await (const event of stream) {
+      // For snapshot events, update runOutputData BEFORE emitting stream_chunk
+      // so listeners see the latest snapshot when they handle the event.
+      if (event.type === "snapshot") {
+        this.task.runOutputData = event.data as Output;
+      }
+
+      switch (event.type) {
+        case "phase": {
+          // Phase events are metadata: emit for observability, translate to a
+          // progress event with optional progress + message, do NOT mutate
+          // accumulators or runOutputData, do NOT flip status to STREAMING.
+          this.task.emit("stream_chunk", event as StreamEvent);
+          await deps.onProgress(event.progress, event.message);
+          break;
+        }
+        case "text-delta": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          if (accumulated) {
+            accumulated.set(event.port, (accumulated.get(event.port) ?? "") + event.textDelta);
+          }
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "object-delta": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          if (accumulatedObjects) {
+            const existing = accumulatedObjects.get(event.port);
+            if (Array.isArray(event.objectDelta)) {
+              // Array delta: upsert items by `id` into accumulated array
+              const arr: unknown[] = Array.isArray(existing) ? [...existing] : [];
+              for (const item of event.objectDelta) {
+                const itemObj = item as Record<string, unknown>;
+                if (itemObj && typeof itemObj === "object" && "id" in itemObj) {
+                  const idx = arr.findIndex(
+                    (e) => (e as Record<string, unknown>).id === itemObj.id
+                  );
+                  if (idx >= 0) arr[idx] = item;
+                  else arr.push(item);
+                } else {
+                  arr.push(item);
+                }
+              }
+              accumulatedObjects.set(event.port, arr);
+            } else {
+              // Non-array (e.g. structured generation): replace semantics
+              accumulatedObjects.set(event.port, event.objectDelta);
+            }
+          }
+          // Update runOutputData with accumulated state so listeners see growing state
+          this.task.runOutputData = {
+            ...this.task.runOutputData,
+            [event.port]: accumulatedObjects?.get(event.port) ?? event.objectDelta,
+          } as Output;
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "snapshot": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "finish": {
+          if (accumulated || accumulatedObjects) {
+            // Emit an enriched finish event: merge accumulated deltas into
+            // the finish payload so downstream dataflows get complete port data
+            // without needing to re-accumulate themselves.
+            const merged: Record<string, unknown> = { ...(event.data || {}) };
+            if (accumulated) {
+              for (const [port, text] of accumulated) {
+                if (text.length > 0) merged[port] = text;
+              }
+            }
+            if (accumulatedObjects) {
+              for (const [port, obj] of accumulatedObjects) {
+                merged[port] = obj;
+              }
+            }
+            // For replace-mode streams, finish carries data: {} by convention.
+            // Fall back to the last snapshot (runOutputData) so the final output
+            // is not silently cleared when the finish payload is empty.
+            if (streamMode === "replace" && Object.keys(merged).length === 0) {
+              const lastSnapshot = this.task.runOutputData;
+              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
+                finalOutput = lastSnapshot as Output;
+                this.task.emit("stream_chunk", {
+                  type: "finish",
+                  data: lastSnapshot,
+                } as StreamEvent);
+                break;
+              }
+            }
+            finalOutput = merged as unknown as Output;
+            this.task.emit("stream_chunk", { type: "finish", data: merged } as StreamEvent);
+          } else {
+            // No accumulation. For replace-mode streams the provider's finish
+            // event carries `data: {}` by convention — the snapshots already
+            // delivered the value, so the finish payload is intentionally
+            // empty. Fall back to `runOutputData` (set on every snapshot above)
+            // so we don't clobber the last snapshot with an empty object. This
+            // mirrors the same fallback in the accumulation branch.
+            const finishData = (event.data ?? {}) as Record<string, unknown>;
+            if (streamMode === "replace" && Object.keys(finishData).length === 0) {
+              const lastSnapshot = this.task.runOutputData;
+              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
+                finalOutput = lastSnapshot as Output;
+                this.task.emit("stream_chunk", {
+                  type: "finish",
+                  data: lastSnapshot,
+                } as StreamEvent);
+                break;
+              }
+            }
+            finalOutput = event.data as Output;
+            this.task.emit("stream_chunk", event as StreamEvent);
+          }
+          break;
+        }
+        case "error": {
+          throw event.error;
+        }
+      }
+    }
+
+    // Check if the task was aborted during streaming
+    if (ctx.abortController.signal.aborted) {
+      throw new TaskAbortedError("Task aborted during streaming");
+    }
+
+    if (finalOutput !== undefined) {
+      this.task.runOutputData = finalOutput;
+    }
+
+    this.task.emit("stream_end", this.task.runOutputData as Output);
+
+    return this.task.runOutputData as Output;
+  }
+}

--- a/packages/task-graph/src/task/TaskRunContext.ts
+++ b/packages/task-graph/src/task/TaskRunContext.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ISpan } from "@workglow/util";
+import type { TaskTimeoutError } from "./TaskError";
+
+/**
+ * @internal
+ * Per-run mutable state for a single TaskRunner.run() / runPreview() invocation.
+ * Built by TaskRunner.handleStart, discarded by handleComplete / handleError / handleAbort.
+ *
+ * Long-lived state (task, registry, resourceScope, outputCache default, accumulateLeafOutputs)
+ * stays on the facade. TaskRunContext only holds state created at run start and torn down
+ * at run end.
+ */
+export class TaskRunContext {
+  readonly abortController: AbortController;
+
+  shouldAccumulate: boolean = true;
+  telemetrySpan?: ISpan;
+  timeoutTimer?: ReturnType<typeof setTimeout>;
+  pendingTimeoutError?: TaskTimeoutError;
+
+  // Removes the parentSignal abort listener; set in the constructor when
+  // parentSignal is provided. Idempotent dispose().
+  private parentSignalCleanup?: () => void;
+
+  constructor(parentSignal?: AbortSignal) {
+    this.abortController = new AbortController();
+    if (parentSignal) {
+      // Listen first, then check — addEventListener on an already-aborted signal
+      // does not fire, so checking .aborted after ensures we never miss an abort.
+      const onParentAbort = () => this.abortController.abort();
+      parentSignal.addEventListener("abort", onParentAbort, { once: true });
+      this.parentSignalCleanup = () =>
+        parentSignal.removeEventListener("abort", onParentAbort);
+      if (parentSignal.aborted) {
+        this.parentSignalCleanup();
+        this.parentSignalCleanup = undefined;
+        this.abortController.abort();
+      }
+    }
+  }
+
+  /**
+   * Releases external listeners (parentSignal abort handler). Idempotent.
+   * Called by terminal handlers (handleComplete / handleError / handleAbort)
+   * so a parent abort fired after this run completes does not re-trigger our
+   * abort path and emit a duplicate terminal event.
+   */
+  dispose(): void {
+    this.parentSignalCleanup?.();
+    this.parentSignalCleanup = undefined;
+  }
+}

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -124,82 +124,97 @@ export class TaskRunner<
    * @returns The task output
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
-    await this.handleStart(config);
-    const ctx = this.currentCtx!;
-
-    const proto = Object.getPrototypeOf(this.task);
-    if (
-      proto.execute === Task.prototype.execute &&
-      typeof proto.executeStream !== "function" &&
-      proto.executePreview !== Task.prototype.executePreview
-    ) {
-      throw new TaskConfigurationError(
-        `Task "${this.task.type}" implements only executePreview() and cannot be run via run(). ` +
-          `After the run/runPreview split, run() requires execute() (or executeStream()). ` +
-          `See docs/technical/02-dual-mode-execution.md.`
-      );
-    }
+    const ownsScope = config.resourceScope === undefined;
+    const effectiveConfig: IRunConfig = ownsScope
+      ? { ...config, resourceScope: new ResourceScope() }
+      : config;
 
     try {
-      this.task.setInput(overrides);
+      await this.handleStart(effectiveConfig);
+      const ctx = this.currentCtx!;
 
-      await this.resolveSchemas();
-
-      const inputs: Input = this.task.runInputData as Input;
-      const isValid = await this.task.validateInput(inputs);
-      if (!isValid) {
-        throw new TaskInvalidInputError("Invalid input data");
+      const proto = Object.getPrototypeOf(this.task);
+      if (
+        proto.execute === Task.prototype.execute &&
+        typeof proto.executeStream !== "function" &&
+        proto.executePreview !== Task.prototype.executePreview
+      ) {
+        throw new TaskConfigurationError(
+          `Task "${this.task.type}" implements only executePreview() and cannot be run via run(). ` +
+            `After the run/runPreview split, run() requires execute() (or executeStream()). ` +
+            `See docs/technical/02-dual-mode-execution.md.`
+        );
       }
 
-      if (ctx.abortController.signal.aborted) {
-        await this.handleAbort();
-        throw new TaskAbortedError("Promise for task created and aborted before run");
-      }
+      try {
+        this.task.setInput(overrides);
 
-      const isStreamable = isTaskStreamable(this.task);
+        await this.resolveSchemas();
 
-      // Warn if schema declares streaming but executeStream is not implemented
-      if (!isStreamable && typeof this.task.executeStream !== "function") {
-        const streamMode = getOutputStreamMode(this.task.outputSchema());
-        if (streamMode !== "none") {
-          getLogger().warn(
-            `Task "${this.task.type}" declares streaming output (x-stream: "${streamMode}") ` +
-              `but does not implement executeStream(). Falling back to non-streaming execute().`
-          );
+        const inputs: Input = this.task.runInputData as Input;
+        const isValid = await this.task.validateInput(inputs);
+        if (!isValid) {
+          throw new TaskInvalidInputError("Invalid input data");
         }
+
+        if (ctx.abortController.signal.aborted) {
+          await this.handleAbort();
+          throw new TaskAbortedError("Promise for task created and aborted before run");
+        }
+
+        const isStreamable = isTaskStreamable(this.task);
+
+        // Warn if schema declares streaming but executeStream is not implemented
+        if (!isStreamable && typeof this.task.executeStream !== "function") {
+          const streamMode = getOutputStreamMode(this.task.outputSchema());
+          if (streamMode !== "none") {
+            getLogger().warn(
+              `Task "${this.task.type}" declares streaming output (x-stream: "${streamMode}") ` +
+                `but does not implement executeStream(). Falling back to non-streaming execute().`
+            );
+          }
+        }
+
+        const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
+        let outputs = await this.cacheCoordinator.lookup(
+          keyInputs,
+          this.outputCache,
+          isStreamable,
+          ctx
+        );
+
+        if (outputs === undefined) {
+          outputs = isStreamable
+            ? await this.streamProcessor.run(inputs, ctx, {
+                registry: this.registry,
+                resourceScope: this.resourceScope,
+                inputStreams: this.inputStreams,
+                onProgress: this.handleProgress.bind(this),
+                own: this.own,
+              })
+            : await this.executeTask(inputs, ctx);
+
+          await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
+          this.task.runOutputData = outputs ?? ({} as Output);
+        }
+
+        await this.handleComplete();
+
+        return this.task.runOutputData as Output;
+      } catch (err: any) {
+        await this.handleError(err);
+        // If a timeout triggered the abort, throw the TaskTimeoutError instead
+        // of the generic TaskAbortedError that the task's execute() may have thrown.
+        throw this.task.error instanceof TaskTimeoutError ? this.task.error : err;
       }
-
-      const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
-      let outputs = await this.cacheCoordinator.lookup(
-        keyInputs,
-        this.outputCache,
-        isStreamable,
-        ctx
-      );
-
-      if (outputs === undefined) {
-        outputs = isStreamable
-          ? await this.streamProcessor.run(inputs, ctx, {
-              registry: this.registry,
-              resourceScope: this.resourceScope,
-              inputStreams: this.inputStreams,
-              onProgress: this.handleProgress.bind(this),
-              own: this.own,
-            })
-          : await this.executeTask(inputs, ctx);
-
-        await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
-        this.task.runOutputData = outputs ?? ({} as Output);
+    } finally {
+      if (ownsScope) {
+        await effectiveConfig.resourceScope!.disposeAll();
       }
-
-      await this.handleComplete();
-
-      return this.task.runOutputData as Output;
-    } catch (err: any) {
-      await this.handleError(err);
-      // If a timeout triggered the abort, throw the TaskTimeoutError instead
-      // of the generic TaskAbortedError that the task's execute() may have thrown.
-      throw this.task.error instanceof TaskTimeoutError ? this.task.error : err;
+      // Reset instance field so a subsequent run on this runner starts clean.
+      // handleStart already overwrites it on the next call, but a stale ref
+      // between runs is brittle.
+      this.resourceScope = undefined;
     }
   }
 

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ISpan } from "@workglow/util";
 import {
   getLogger,
   getTelemetryProvider,
@@ -31,6 +30,7 @@ import {
   TaskInvalidInputError,
   TaskTimeoutError,
 } from "./TaskError";
+import { TaskRunContext } from "./TaskRunContext";
 import { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
 
 interface SchemaProperties {
@@ -110,9 +110,12 @@ export class TaskRunner<
   public readonly task: ITask<Input, Output, Config>;
 
   /**
-   * AbortController for cancelling task execution
+   * Per-run state. Set by handleStart, cleared by handleComplete / handleError /
+   * handleAbort. The only mutable per-run state on the facade — exists so the
+   * public abort() and disable() methods (which take no arguments) have something
+   * to act on.
    */
-  protected abortController?: AbortController;
+  protected currentCtx?: TaskRunContext;
 
   /**
    * The output cache for the task
@@ -137,33 +140,6 @@ export class TaskRunner<
   public inputStreams?: Map<string, ReadableStream<StreamEvent>>;
 
   /**
-   * Timer handle for task-level timeout. Set when `IRunConfig.timeout` is
-   * provided and cleared on completion, error, or abort.
-   */
-  protected timeoutTimer?: ReturnType<typeof setTimeout>;
-
-  /**
-   * When a timeout triggers the abort, this holds the TaskTimeoutError so
-   * handleAbort() can surface the correct error type instead of a generic
-   * TaskAbortedError.
-   */
-  protected pendingTimeoutError?: TaskTimeoutError;
-
-  /**
-   * Whether the streaming task runner should accumulate text-delta chunks and
-   * emit an enriched finish event. Set from IRunConfig.shouldAccumulate.
-   * Defaults to true so standalone task execution is backward-compatible.
-   * The graph runner sets this to false when no downstream edge needs
-   * materialized data (no cache, all downstream tasks are also streaming).
-   */
-  protected shouldAccumulate: boolean = true;
-
-  /**
-   * Active telemetry span for the current task run.
-   */
-  protected telemetrySpan?: ISpan;
-
-  /**
    * Constructor for TaskRunner
    * @param task The task to run
    */
@@ -185,6 +161,7 @@ export class TaskRunner<
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
     await this.handleStart(config);
+    const ctx = this.currentCtx!;
 
     const proto = Object.getPrototypeOf(this.task);
     if (
@@ -230,7 +207,7 @@ export class TaskRunner<
         throw new TaskInvalidInputError("Invalid input data");
       }
 
-      if (this.abortController?.signal.aborted) {
+      if (ctx.abortController.signal.aborted) {
         await this.handleAbort();
         throw new TaskAbortedError("Promise for task created and aborted before run");
       }
@@ -266,7 +243,7 @@ export class TaskRunner<
             cached as Record<string, unknown>,
             outputSchema as unknown as SchemaProperties
           )) as Output;
-          this.telemetrySpan?.addEvent("workglow.task.cache_hit");
+          ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
           if (isStreamable) {
             this.task.runOutputData = outputs;
             this.task.emit("stream_start");
@@ -281,7 +258,7 @@ export class TaskRunner<
         if (isStreamable) {
           outputs = await this.executeStreamingTask(inputs);
         } else {
-          outputs = await this.executeTask(inputs);
+          outputs = await this.executeTask(inputs, ctx);
         }
         if (this.task.cacheable && outputs !== undefined) {
           const wireOutputs = await serializeOutputPorts(
@@ -338,6 +315,10 @@ export class TaskRunner<
 
     await this.handleStartPreview();
 
+    // Build a transient context for preview overrides — preview doesn't share the
+    // full lifecycle but executeTaskPreview's signature requires a ctx.
+    const ctx = new TaskRunContext();
+
     try {
       const inputs: Input = this.task.runInputData as Input;
       const isValid = await this.task.validateInput(inputs);
@@ -345,7 +326,7 @@ export class TaskRunner<
         throw new TaskInvalidInputError("Invalid input data");
       }
 
-      const resultPreview = await this.executeTaskPreview(inputs);
+      const resultPreview = await this.executeTaskPreview(inputs, ctx);
       if (resultPreview !== undefined) {
         this.task.runOutputData = resultPreview;
       }
@@ -355,6 +336,7 @@ export class TaskRunner<
       getLogger().debug("runPreview failed", { taskId: this.task.config?.id, error: err });
       await this.handleErrorPreview();
     } finally {
+      ctx.dispose();
       return this.task.runOutputData as Output;
     }
   }
@@ -517,10 +499,7 @@ export class TaskRunner<
    * Aborts task execution
    */
   public abort(): void {
-    if (this.task.hasChildren()) {
-      this.task.subGraph.abort();
-    }
-    this.abortController?.abort();
+    this.currentCtx?.abortController.abort();
   }
 
   // ========================================================================
@@ -535,7 +514,7 @@ export class TaskRunner<
     if (hasRunConfig(i)) {
       Object.assign(i.runConfig, {
         registry: this.registry,
-        signal: this.abortController?.signal,
+        signal: this.currentCtx?.abortController.signal,
         resourceScope: this.resourceScope,
       });
     }
@@ -551,9 +530,9 @@ export class TaskRunner<
   /**
    * Protected method to execute a task by delegating back to the task itself.
    */
-  protected async executeTask(input: Input): Promise<Output | undefined> {
+  protected async executeTask(input: Input, ctx: TaskRunContext): Promise<Output | undefined> {
     const result = await this.task.execute(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -565,7 +544,10 @@ export class TaskRunner<
   /**
    * Protected method for preview execution delegation
    */
-  protected async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  protected async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -603,8 +585,9 @@ export class TaskRunner<
       }
     }
 
-    const accumulated = this.shouldAccumulate ? new Map<string, string>() : undefined;
-    const accumulatedObjects = this.shouldAccumulate
+    const ctx = this.currentCtx!;
+    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
+    const accumulatedObjects = ctx.shouldAccumulate
       ? new Map<string, Record<string, unknown> | unknown[]>()
       : undefined;
     let streamingStarted = false;
@@ -613,7 +596,7 @@ export class TaskRunner<
     this.task.emit("stream_start");
 
     const stream = this.task.executeStream!(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -758,7 +741,7 @@ export class TaskRunner<
     }
 
     // Check if the task was aborted during streaming
-    if (this.abortController?.signal.aborted) {
+    if (ctx.abortController.signal.aborted) {
       throw new TaskAbortedError("Task aborted during streaming");
     }
 
@@ -787,8 +770,11 @@ export class TaskRunner<
     this.task.progress = 0;
     this.task.status = TaskStatus.PROCESSING;
 
-    this.abortController = new AbortController();
-    this.abortController.signal.addEventListener("abort", () => {
+    // Build per-run context (handles abortController + parentSignal wiring)
+    const ctx = new TaskRunContext(config.signal);
+    this.currentCtx = ctx;
+
+    ctx.abortController.signal.addEventListener("abort", () => {
       this.handleAbort();
     });
 
@@ -803,7 +789,7 @@ export class TaskRunner<
     }
 
     // shouldAccumulate defaults to true (backward-compatible for standalone runs)
-    this.shouldAccumulate = config.shouldAccumulate !== false;
+    ctx.shouldAccumulate = config.shouldAccumulate !== false;
 
     if (config.updateProgress) {
       this.updateProgress = config.updateProgress;
@@ -817,25 +803,15 @@ export class TaskRunner<
       this.resourceScope = config.resourceScope;
     }
 
-    // If a parent signal is provided (e.g. set by context.own()), link it so
-    // that aborting the parent also aborts this task.
-    // Listen first, then check — addEventListener on an already-aborted signal
-    // does not fire, so checking .aborted after ensures we never miss an abort.
-    if (config.signal) {
-      const onAbort = () => this.abortController!.abort();
-      config.signal.addEventListener("abort", onAbort, { once: true });
-      if (config.signal.aborted) {
-        config.signal.removeEventListener("abort", onAbort);
-        this.abortController.abort();
-        return;
-      }
-    }
+    // Early-out if parent signal was already aborted (TaskRunContext constructor
+    // already aborted ctx.abortController in that case)
+    if (ctx.abortController.signal.aborted) return;
 
     // Start timeout timer if configured (timeout is a design-time config property)
     const timeout = (this.task.config as Record<string, unknown>).timeout as number | undefined;
     if (timeout !== undefined && timeout > 0) {
-      this.pendingTimeoutError = new TaskTimeoutError(timeout);
-      this.timeoutTimer = setTimeout(() => {
+      ctx.pendingTimeoutError = new TaskTimeoutError(timeout);
+      ctx.timeoutTimer = setTimeout(() => {
         this.abort();
       }, timeout);
     }
@@ -843,7 +819,7 @@ export class TaskRunner<
     // Start telemetry span
     const telemetry = getTelemetryProvider();
     if (telemetry.isEnabled) {
-      this.telemetrySpan = telemetry.startSpan("workglow.task.run", {
+      ctx.telemetrySpan = telemetry.startSpan("workglow.task.run", {
         attributes: {
           "workglow.task.type": this.task.type,
           "workglow.task.id": String(this.task.config.id),
@@ -871,9 +847,10 @@ export class TaskRunner<
    * Clears the timeout timer if one is active.
    */
   protected clearTimeoutTimer(): void {
-    if (this.timeoutTimer !== undefined) {
-      clearTimeout(this.timeoutTimer);
-      this.timeoutTimer = undefined;
+    const ctx = this.currentCtx;
+    if (ctx?.timeoutTimer !== undefined) {
+      clearTimeout(ctx.timeoutTimer);
+      ctx.timeoutTimer = undefined;
     }
   }
 
@@ -883,19 +860,18 @@ export class TaskRunner<
   protected async handleAbort(): Promise<void> {
     if (this.task.status === TaskStatus.ABORTING) return;
     this.clearTimeoutTimer();
+    const ctx = this.currentCtx;
     this.task.status = TaskStatus.ABORTING;
     await this.handleProgress(100);
     // Use the pending timeout error if the abort was triggered by a timeout
-    this.task.error = this.pendingTimeoutError ?? new TaskAbortedError();
-    this.pendingTimeoutError = undefined;
+    this.task.error = ctx?.pendingTimeoutError ?? new TaskAbortedError();
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
-      this.telemetrySpan.addEvent("workglow.task.aborted", {
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
+      ctx.telemetrySpan.addEvent("workglow.task.aborted", {
         "workglow.task.error": this.task.error.message,
       });
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+      ctx.telemetrySpan.end();
     }
 
     // Call optional cleanup method for resource release
@@ -906,6 +882,9 @@ export class TaskRunner<
         // Cleanup errors are swallowed — abort must not throw from cleanup
       }
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("abort", this.task.error);
     this.task.emit("status", this.task.status);
@@ -921,18 +900,19 @@ export class TaskRunner<
   protected async handleComplete(): Promise<void> {
     if (this.task.status === TaskStatus.COMPLETED) return;
     this.clearTimeoutTimer();
-    this.pendingTimeoutError = undefined;
+    const ctx = this.currentCtx;
 
     this.task.completedAt = new Date();
     this.task.status = TaskStatus.COMPLETED;
-    this.abortController = undefined;
     await this.handleProgress(100);
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.OK);
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.OK);
+      ctx.telemetrySpan.end();
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("complete");
     this.task.emit("status", this.task.status);
@@ -942,18 +922,19 @@ export class TaskRunner<
     this.previewRunning = false;
   }
 
-  protected async handleDisable(): Promise<void> {
+  protected async handleDisable(ctx: TaskRunContext | undefined): Promise<void> {
     if (this.task.status === TaskStatus.DISABLED) return;
     this.task.status = TaskStatus.DISABLED;
     await this.handleProgress(100);
     this.task.completedAt = new Date();
-    this.abortController = undefined;
+    ctx?.dispose();
+    if (this.currentCtx === ctx) this.currentCtx = undefined;
     this.task.emit("disabled");
     this.task.emit("status", this.task.status);
   }
 
   public async disable(): Promise<void> {
-    await this.handleDisable();
+    await this.handleDisable(this.currentCtx);
   }
 
   /**
@@ -964,7 +945,7 @@ export class TaskRunner<
     if (err instanceof TaskAbortedError) return this.handleAbort();
     if (this.task.status === TaskStatus.FAILED) return;
     this.clearTimeoutTimer();
-    this.pendingTimeoutError = undefined;
+    const ctx = this.currentCtx;
     if (this.task.hasChildren()) {
       this.task.subGraph!.abort();
     }
@@ -983,15 +964,16 @@ export class TaskRunner<
       this.task.error.taskId ??= this.task.id;
     }
     this.task.status = TaskStatus.FAILED;
-    this.abortController = undefined;
     await this.handleProgress(100);
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, this.task.error.message);
-      this.telemetrySpan.setAttributes({ "workglow.task.error": this.task.error.message });
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, this.task.error.message);
+      ctx.telemetrySpan.setAttributes({ "workglow.task.error": this.task.error.message });
+      ctx.telemetrySpan.end();
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("error", this.task.error);
     this.task.emit("status", this.task.status);

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -179,27 +179,7 @@ export class TaskRunner<
     try {
       this.task.setInput(overrides);
 
-      // Resolve config schema annotations (e.g. mcp-server references) by mutating task.config.
-      // Always resolve from originalConfig so re-runs use the original string IDs, not
-      // previously resolved objects. The original config is preserved for serialization.
-      const configSchema = (this.task.constructor as typeof Task).configSchema();
-      if (schemaHasFormatAnnotations(configSchema)) {
-        const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
-        const resolved = await resolveSchemaInputs(
-          { ...source } as Record<string, unknown>,
-          configSchema,
-          { registry: this.registry }
-        );
-        Object.assign(this.task.config, resolved);
-      }
-
-      // Resolve schema-annotated inputs (models, repositories) before validation
-      const schema = (this.task.constructor as typeof Task).inputSchema();
-      this.task.runInputData = (await resolveSchemaInputs(
-        this.task.runInputData as Record<string, unknown>,
-        schema,
-        { registry: this.registry }
-      )) as Input;
+      await this.resolveSchemas();
 
       const inputs: Input = this.task.runInputData as Input;
       const isValid = await this.task.validateInput(inputs);
@@ -293,25 +273,7 @@ export class TaskRunner<
 
     this.task.setInput(overrides);
 
-    // Resolve config schema annotations by mutating task.config directly
-    const configSchema = (this.task.constructor as typeof Task).configSchema();
-    if (schemaHasFormatAnnotations(configSchema)) {
-      const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
-      const resolved = await resolveSchemaInputs(
-        { ...source } as Record<string, unknown>,
-        configSchema,
-        { registry: this.registry }
-      );
-      Object.assign(this.task.config, resolved);
-    }
-
-    // Resolve schema-annotated inputs (models, repositories) before validation
-    const schema = (this.task.constructor as typeof Task).inputSchema();
-    this.task.runInputData = (await resolveSchemaInputs(
-      this.task.runInputData as Record<string, unknown>,
-      schema,
-      { registry: this.registry }
-    )) as Input;
+    await this.resolveSchemas();
 
     await this.handleStartPreview();
 
@@ -757,6 +719,33 @@ export class TaskRunner<
   // ========================================================================
   // Protected Handlers
   // ========================================================================
+
+  /**
+   * Resolves config and input schema annotations (e.g. mcp-server references)
+   * by mutating task.config and task.runInputData. Always resolves config from
+   * originalConfig so re-runs use the original string IDs, not previously resolved
+   * objects. Shared between run() and runPreview() to avoid duplication.
+   */
+  private async resolveSchemas(): Promise<void> {
+    const configSchema = (this.task.constructor as typeof Task).configSchema();
+    if (schemaHasFormatAnnotations(configSchema)) {
+      const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
+      const resolved = await resolveSchemaInputs(
+        { ...source } as Record<string, unknown>,
+        configSchema,
+        { registry: this.registry }
+      );
+      Object.assign(this.task.config, resolved);
+    }
+
+    // Resolve schema-annotated inputs (models, repositories) before validation
+    const schema = (this.task.constructor as typeof Task).inputSchema();
+    this.task.runInputData = (await resolveSchemaInputs(
+      this.task.runInputData as Record<string, unknown>,
+      schema,
+      { registry: this.registry }
+    )) as Input;
+  }
 
   /**
    * Handles task start

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -19,9 +19,9 @@ import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
+import { StreamProcessor } from "./StreamProcessor";
 import type { StreamEvent } from "./StreamTypes";
 import { getOutputStreamMode, isTaskStreamable } from "./StreamTypes";
-import { StreamProcessor } from "./StreamProcessor";
 import { Task } from "./Task";
 import {
   TaskAbortedError,
@@ -95,6 +95,15 @@ export class TaskRunner<
   protected resourceScope?: ResourceScope;
 
   /**
+   * True when `this.resourceScope` was auto-created by `run()` (caller did not
+   * pass one in `config`). The flag is used by `own()` so that an auto-owned
+   * scope is not stamped into a child task's long-lived `runConfig` — that
+   * stamp would survive past the parent run's `finally`-block disposal and
+   * leave the child holding a reference to a disposed scope.
+   */
+  protected ownsResourceScope = false;
+
+  /**
    * Input streams for pass-through streaming tasks.
    * Set by the graph runner before executing a streaming task that has
    * upstream streaming edges. Keyed by input port name.
@@ -128,6 +137,7 @@ export class TaskRunner<
     const effectiveConfig: IRunConfig = ownsScope
       ? { ...config, resourceScope: new ResourceScope() }
       : config;
+    this.ownsResourceScope = ownsScope;
 
     try {
       await this.handleStart(effectiveConfig);
@@ -210,11 +220,14 @@ export class TaskRunner<
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
+        // Only clear our auto-created reference. Touching `this.resourceScope`
+        // unconditionally races with concurrent re-entry: `handleStart` early-
+        // returns on `PROCESSING`, so a second `run()` can attach to the in-
+        // flight `currentCtx`; clearing the field then would strip the scope
+        // the original run is still using.
+        this.resourceScope = undefined;
       }
-      // Reset instance field so a subsequent run on this runner starts clean.
-      // handleStart already overwrites it on the next call, but a stale ref
-      // between runs is brittle.
-      this.resourceScope = undefined;
+      this.ownsResourceScope = false;
     }
   }
 
@@ -431,11 +444,21 @@ export class TaskRunner<
     // Propagate parent registry and abort signal to owned ITask instances so
     // that calling task.run() on the returned value inherits this execution context.
     if (hasRunConfig(i)) {
-      Object.assign(i.runConfig, {
+      // Only propagate `resourceScope` if the caller owns its lifecycle. Stamping
+      // an auto-created scope into a long-lived `runConfig` leaks a reference
+      // past the parent run's `finally`-block disposal — the next `task.run()`
+      // on the owned instance would then see a disposed scope, skip auto-create,
+      // and silently drop disposers on its cleared Map. With caller-passed
+      // scopes the caller controls disposal, so the propagation is safe and
+      // preserves resource-sharing across owned-task runs.
+      const stamp: Partial<IRunConfig> = {
         registry: this.registry,
         signal: this.currentCtx?.abortController.signal,
-        resourceScope: this.resourceScope,
-      });
+      };
+      if (!this.ownsResourceScope) {
+        stamp.resourceScope = this.resourceScope;
+      }
+      Object.assign(i.runConfig, stamp);
     }
     // Notify listeners that the entitlement landscape may have changed.
     // For GraphAsTask this is also handled by the subGraph subscription, but

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -111,9 +111,9 @@ export class TaskRunner<
 
   /**
    * Per-run state. Set by handleStart, cleared by handleComplete / handleError /
-   * handleAbort. The only mutable per-run state on the facade — exists so the
-   * public abort() and disable() methods (which take no arguments) have something
-   * to act on.
+   * handleAbort / handleDisable. The only mutable per-run state on the facade —
+   * exists so the public abort() and disable() methods (which take no arguments)
+   * have something to act on.
    */
   protected currentCtx?: TaskRunContext;
 
@@ -928,6 +928,7 @@ export class TaskRunner<
     await this.handleProgress(100);
     this.task.completedAt = new Date();
     ctx?.dispose();
+    // Don't clobber a newer run's ctx if disable() was queued from a stale state.
     if (this.currentCtx === ctx) this.currentCtx = undefined;
     this.task.emit("disabled");
     this.task.emit("status", this.task.status);

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -19,8 +19,9 @@ import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
-import type { StreamEvent, StreamMode } from "./StreamTypes";
-import { getOutputStreamMode, getStreamingPorts, isTaskStreamable } from "./StreamTypes";
+import type { StreamEvent } from "./StreamTypes";
+import { getOutputStreamMode, isTaskStreamable } from "./StreamTypes";
+import { StreamProcessor } from "./StreamProcessor";
 import { Task } from "./Task";
 import {
   TaskAbortedError,
@@ -79,6 +80,11 @@ export class TaskRunner<
   protected readonly cacheCoordinator: CacheCoordinator<Input, Output>;
 
   /**
+   * Stream processor for the task (handles executeStream() event loop).
+   */
+  protected readonly streamProcessor: StreamProcessor<Input, Output>;
+
+  /**
    * The service registry for the task
    */
   protected registry: ServiceRegistry = globalServiceRegistry;
@@ -104,6 +110,7 @@ export class TaskRunner<
     this.own = this.own.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
     this.cacheCoordinator = new CacheCoordinator(task);
+    this.streamProcessor = new StreamProcessor(task);
   }
 
   // ========================================================================
@@ -172,7 +179,13 @@ export class TaskRunner<
 
       if (outputs === undefined) {
         outputs = isStreamable
-          ? await this.executeStreamingTask(inputs)
+          ? await this.streamProcessor.run(inputs, ctx, {
+              registry: this.registry,
+              resourceScope: this.resourceScope,
+              inputStreams: this.inputStreams,
+              onProgress: this.handleProgress.bind(this),
+              own: this.own,
+            })
           : await this.executeTask(inputs, ctx);
 
         await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
@@ -440,209 +453,6 @@ export class TaskRunner<
     _ctx: TaskRunContext
   ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
-  }
-
-  /**
-   * Executes a streaming task by consuming its executeStream() async iterable.
-   *
-   * When `shouldAccumulate` is true (default, set by graph runner when any downstream
-   * edge needs materialized data, or when caching is on):
-   *   - text-delta chunks are accumulated per-port into a Map
-   *   - the raw finish event is NOT emitted; instead an enriched finish event is
-   *     emitted with the accumulated text merged in, so downstream dataflows can
-   *     materialize values without re-accumulating on their own
-   *
-   * When `shouldAccumulate` is false (set by graph runner when all downstream edges
-   * are also streaming and no cache is needed):
-   *   - all events including the raw finish are emitted as-is (pure pass-through)
-   *   - no accumulation Map is maintained
-   */
-  protected async executeStreamingTask(input: Input): Promise<Output | undefined> {
-    const streamMode: StreamMode = getOutputStreamMode(this.task.outputSchema());
-    if (streamMode === "append") {
-      const ports = getStreamingPorts(this.task.outputSchema());
-      if (ports.length === 0) {
-        throw new TaskError(
-          `Task ${this.task.type} declares append streaming but no output port has x-stream: "append"`
-        );
-      }
-    }
-    if (streamMode === "object") {
-      const ports = getStreamingPorts(this.task.outputSchema());
-      if (ports.length === 0) {
-        throw new TaskError(
-          `Task ${this.task.type} declares object streaming but no output port has x-stream: "object"`
-        );
-      }
-    }
-
-    const ctx = this.currentCtx!;
-    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
-    const accumulatedObjects = ctx.shouldAccumulate
-      ? new Map<string, Record<string, unknown> | unknown[]>()
-      : undefined;
-    let streamingStarted = false;
-    let finalOutput: Output | undefined;
-
-    this.task.emit("stream_start");
-
-    const stream = this.task.executeStream!(input, {
-      signal: ctx.abortController.signal,
-      updateProgress: this.handleProgress.bind(this),
-      own: this.own,
-      registry: this.registry,
-      resourceScope: this.resourceScope,
-      inputStreams: this.inputStreams,
-    });
-
-    for await (const event of stream) {
-      // For snapshot events, update runOutputData BEFORE emitting stream_chunk
-      // so listeners see the latest snapshot when they handle the event.
-      if (event.type === "snapshot") {
-        this.task.runOutputData = event.data as Output;
-      }
-
-      switch (event.type) {
-        case "phase": {
-          // Phase events are metadata: emit for observability, translate to a
-          // progress event with optional progress + message, do NOT mutate
-          // accumulators or runOutputData, do NOT flip status to STREAMING.
-          this.task.emit("stream_chunk", event as StreamEvent);
-          await this.handleProgress(event.progress, event.message);
-          break;
-        }
-        case "text-delta": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          if (accumulated) {
-            accumulated.set(event.port, (accumulated.get(event.port) ?? "") + event.textDelta);
-          }
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "object-delta": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          if (accumulatedObjects) {
-            const existing = accumulatedObjects.get(event.port);
-            if (Array.isArray(event.objectDelta)) {
-              // Array delta: upsert items by `id` into accumulated array
-              const arr: unknown[] = Array.isArray(existing) ? [...existing] : [];
-              for (const item of event.objectDelta) {
-                const itemObj = item as Record<string, unknown>;
-                if (itemObj && typeof itemObj === "object" && "id" in itemObj) {
-                  const idx = arr.findIndex(
-                    (e) => (e as Record<string, unknown>).id === itemObj.id
-                  );
-                  if (idx >= 0) arr[idx] = item;
-                  else arr.push(item);
-                } else {
-                  arr.push(item);
-                }
-              }
-              accumulatedObjects.set(event.port, arr);
-            } else {
-              // Non-array (e.g. structured generation): replace semantics
-              accumulatedObjects.set(event.port, event.objectDelta);
-            }
-          }
-          // Update runOutputData with accumulated state so listeners see growing state
-          this.task.runOutputData = {
-            ...this.task.runOutputData,
-            [event.port]: accumulatedObjects?.get(event.port) ?? event.objectDelta,
-          } as Output;
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "snapshot": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "finish": {
-          if (accumulated || accumulatedObjects) {
-            // Emit an enriched finish event: merge accumulated deltas into
-            // the finish payload so downstream dataflows get complete port data
-            // without needing to re-accumulate themselves.
-            const merged: Record<string, unknown> = { ...(event.data || {}) };
-            if (accumulated) {
-              for (const [port, text] of accumulated) {
-                if (text.length > 0) merged[port] = text;
-              }
-            }
-            if (accumulatedObjects) {
-              for (const [port, obj] of accumulatedObjects) {
-                merged[port] = obj;
-              }
-            }
-            // For replace-mode streams, finish carries data: {} by convention.
-            // Fall back to the last snapshot (runOutputData) so the final output
-            // is not silently cleared when the finish payload is empty.
-            if (streamMode === "replace" && Object.keys(merged).length === 0) {
-              const lastSnapshot = this.task.runOutputData;
-              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
-                finalOutput = lastSnapshot as Output;
-                this.task.emit("stream_chunk", {
-                  type: "finish",
-                  data: lastSnapshot,
-                } as StreamEvent);
-                break;
-              }
-            }
-            finalOutput = merged as unknown as Output;
-            this.task.emit("stream_chunk", { type: "finish", data: merged } as StreamEvent);
-          } else {
-            // No accumulation. For replace-mode streams the provider's finish
-            // event carries `data: {}` by convention — the snapshots already
-            // delivered the value, so the finish payload is intentionally
-            // empty. Fall back to `runOutputData` (set on every snapshot above)
-            // so we don't clobber the last snapshot with an empty object. This
-            // mirrors the same fallback in the accumulation branch.
-            const finishData = (event.data ?? {}) as Record<string, unknown>;
-            if (streamMode === "replace" && Object.keys(finishData).length === 0) {
-              const lastSnapshot = this.task.runOutputData;
-              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
-                finalOutput = lastSnapshot as Output;
-                this.task.emit("stream_chunk", {
-                  type: "finish",
-                  data: lastSnapshot,
-                } as StreamEvent);
-                break;
-              }
-            }
-            finalOutput = event.data as Output;
-            this.task.emit("stream_chunk", event as StreamEvent);
-          }
-          break;
-        }
-        case "error": {
-          throw event.error;
-        }
-      }
-    }
-
-    // Check if the task was aborted during streaming
-    if (ctx.abortController.signal.aborted) {
-      throw new TaskAbortedError("Task aborted during streaming");
-    }
-
-    if (finalOutput !== undefined) {
-      this.task.runOutputData = finalOutput;
-    }
-
-    this.task.emit("stream_end", this.task.runOutputData as Output);
-
-    return this.task.runOutputData as Output;
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -133,6 +133,15 @@ export class TaskRunner<
    * @returns The task output
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
+    // Reject concurrent run() on the same TaskRunner. Mirrors
+    // TaskGraphRunner.handleStart's "Graph is already running" check.
+    // Raised before any `this.*` mutation so the in-flight run is undisturbed.
+    if (this.task.status === TaskStatus.PROCESSING) {
+      throw new TaskConfigurationError(
+        `Task "${this.task.type}" is already running. Concurrent run() calls on the same TaskRunner are not supported.`
+      );
+    }
+
     const ownsScope = config.resourceScope === undefined;
     const effectiveConfig: IRunConfig = ownsScope
       ? { ...config, resourceScope: new ResourceScope() }
@@ -220,11 +229,6 @@ export class TaskRunner<
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
-        // Only clear our auto-created reference. Touching `this.resourceScope`
-        // unconditionally races with concurrent re-entry: `handleStart` early-
-        // returns on `PROCESSING`, so a second `run()` can attach to the in-
-        // flight `currentCtx`; clearing the field then would strip the scope
-        // the original run is still using.
         this.resourceScope = undefined;
       }
       this.ownsResourceScope = false;
@@ -525,11 +529,11 @@ export class TaskRunner<
   }
 
   /**
-   * Handles task start
+   * Handles task start. Concurrent-run rejection happens in {@link run} before
+   * any state mutation; by the time `handleStart` runs, the task status is
+   * guaranteed to be non-PROCESSING.
    */
   protected async handleStart(config: IRunConfig = {}): Promise<void> {
-    if (this.task.status === TaskStatus.PROCESSING) return;
-
     this.running = true;
 
     this.task.startedAt = new Date();

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -13,9 +13,9 @@ import {
   SpanStatusCode,
 } from "@workglow/util";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
-import { getPortCodec } from "@workglow/util";
 import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";
+import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
@@ -32,55 +32,6 @@ import {
 } from "./TaskError";
 import { TaskRunContext } from "./TaskRunContext";
 import { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
-
-interface SchemaProperties {
-  properties?: Record<string, { format?: string }>;
-}
-
-async function serializeOutputPorts(
-  output: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return output;
-  const out: Record<string, unknown> = { ...output };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.serialize(out[key]);
-    }
-  }
-  return out;
-}
-
-async function deserializeOutputPorts(
-  output: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return output;
-  const out: Record<string, unknown> = { ...output };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.deserialize(out[key]);
-    }
-  }
-  return out;
-}
-
-async function normalizeInputsForCacheKey(
-  inputs: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return inputs;
-  const out: Record<string, unknown> = { ...inputs };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.serialize(out[key]);
-    }
-  }
-  return out;
-}
 
 /**
  * Type guard that checks whether a value is an ITask-like object with a mutable `runConfig`.
@@ -123,6 +74,11 @@ export class TaskRunner<
   protected outputCache?: TaskOutputRepository;
 
   /**
+   * Cache coordinator for the task (key normalization, lookup, save).
+   */
+  protected readonly cacheCoordinator: CacheCoordinator<Input, Output>;
+
+  /**
    * The service registry for the task
    */
   protected registry: ServiceRegistry = globalServiceRegistry;
@@ -147,6 +103,7 @@ export class TaskRunner<
     this.task = task;
     this.own = this.own.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
+    this.cacheCoordinator = new CacheCoordinator(task);
   }
 
   // ========================================================================
@@ -192,8 +149,6 @@ export class TaskRunner<
         throw new TaskAbortedError("Promise for task created and aborted before run");
       }
 
-      let outputs: Output | undefined;
-
       const isStreamable = isTaskStreamable(this.task);
 
       // Warn if schema declares streaming but executeStream is not implemented
@@ -207,46 +162,20 @@ export class TaskRunner<
         }
       }
 
-      const inputSchema = (this.task.constructor as typeof Task).inputSchema();
-      const outputSchema = (this.task.constructor as typeof Task).outputSchema();
-      const inputsForKey = this.outputCache
-        ? await normalizeInputsForCacheKey(
-            inputs as Record<string, unknown>,
-            inputSchema as unknown as SchemaProperties
-          )
-        : inputs;
+      const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
+      let outputs = await this.cacheCoordinator.lookup(
+        keyInputs,
+        this.outputCache,
+        isStreamable,
+        ctx
+      );
 
-      if (this.task.cacheable) {
-        const cached = await this.outputCache?.getOutput(this.task.type, inputsForKey);
-        if (cached !== undefined) {
-          outputs = (await deserializeOutputPorts(
-            cached as Record<string, unknown>,
-            outputSchema as unknown as SchemaProperties
-          )) as Output;
-          ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
-          if (isStreamable) {
-            this.task.runOutputData = outputs;
-            this.task.emit("stream_start");
-            this.task.emit("stream_chunk", { type: "finish", data: outputs } as StreamEvent);
-            this.task.emit("stream_end", outputs);
-          } else {
-            this.task.runOutputData = outputs;
-          }
-        }
-      }
-      if (!outputs) {
-        if (isStreamable) {
-          outputs = await this.executeStreamingTask(inputs);
-        } else {
-          outputs = await this.executeTask(inputs, ctx);
-        }
-        if (this.task.cacheable && outputs !== undefined) {
-          const wireOutputs = await serializeOutputPorts(
-            outputs as Record<string, unknown>,
-            outputSchema as unknown as SchemaProperties
-          );
-          await this.outputCache?.saveOutput(this.task.type, inputsForKey, wireOutputs as Output);
-        }
+      if (outputs === undefined) {
+        outputs = isStreamable
+          ? await this.executeStreamingTask(inputs)
+          : await this.executeTask(inputs, ctx);
+
+        await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
         this.task.runOutputData = outputs ?? ({} as Output);
       }
 

--- a/packages/task-graph/src/task/WhileTask.ts
+++ b/packages/task-graph/src/task/WhileTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { evaluateCondition, getNestedValue } from "./ConditionUtils";
 import { GraphAsTask, GraphAsTaskConfig, graphAsTaskConfigSchema } from "./GraphAsTask";
 import type { IExecuteContext, IRunConfig } from "./ITask";

--- a/packages/task-graph/src/task/WhileTaskRunner.ts
+++ b/packages/task-graph/src/task/WhileTaskRunner.ts
@@ -5,6 +5,7 @@
  */
 
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
+import type { TaskRunContext } from "./TaskRunContext";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 import type { WhileTask, WhileTaskConfig } from "./WhileTask";
 
@@ -27,9 +28,12 @@ export class WhileTaskRunner<
    * contains the while-loop logic, rather than the default
    * GraphAsTaskRunner behavior of running the subgraph once.
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     const result = await this.task.execute(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -41,7 +45,10 @@ export class WhileTaskRunner<
   /**
    * For WhileTask, preview runs use the task's preview hook only.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 }

--- a/packages/tasks/src/task/ArrayTask.ts
+++ b/packages/tasks/src/task/ArrayTask.ts
@@ -20,6 +20,7 @@ import {
   TaskInput,
   TaskOutput,
 } from "@workglow/task-graph";
+import type { TaskRunContext } from "@workglow/task-graph";
 
 export function TypeReplicateArray<const T extends DataPortSchemaNonBoolean>(
   type: T,
@@ -274,15 +275,18 @@ class ArrayTaskRunner<
     return this.task.subGraph!.runPreview<Output>({});
   }
 
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
-    await super.executeTaskPreview(input);
+  public override async executeTaskPreview(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
+    await super.executeTaskPreview(input, ctx);
     if (this.task.hasChildren()) {
       this.task.runOutputData = this.task.executeMerge(input, this.task.runOutputData as Output);
     }
     return this.task.runOutputData as Output;
   }
-  public override async executeTask(input: Input): Promise<Output> {
-    await super.executeTask(input);
+  public override async executeTask(input: Input, ctx: TaskRunContext): Promise<Output> {
+    await super.executeTask(input, ctx);
     if (this.task.hasChildren()) {
       this.task.runOutputData = this.task.executeMerge(input, this.task.runOutputData as Output);
     }

--- a/packages/test/src/test/ai-provider/StreamingProvider.test.ts
+++ b/packages/test/src/test/ai-provider/StreamingProvider.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AiProviderStreamFn } from "@workglow/ai";
 import {
   AiJob,
   AiJobInput,
@@ -11,10 +12,10 @@ import {
   getAiProviderRegistry,
   setAiProviderRegistry,
 } from "@workglow/ai";
-import type { AiProviderStreamFn } from "@workglow/ai";
 import { JobQueueClient, JobQueueServer, RateLimiter } from "@workglow/job-queue";
-import { InMemoryQueueStorage, InMemoryRateLimiterStorage } from "@workglow/storage";
 import type { IQueueStorage } from "@workglow/storage";
+import { InMemoryQueueStorage, InMemoryRateLimiterStorage } from "@workglow/storage";
+import type { StreamEvent } from "@workglow/task-graph";
 import {
   getTaskQueueRegistry,
   setTaskQueueRegistry,
@@ -22,8 +23,7 @@ import {
   TaskOutput,
   TaskQueueRegistry,
 } from "@workglow/task-graph";
-import type { StreamEvent } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { setLogger, sleep } from "@workglow/util";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
@@ -223,7 +223,7 @@ describe("Streaming Provider", () => {
       const mockStreamFn: AiProviderStreamFn = async function* (input, model, signal) {
         yield { type: "text-delta", port: "text", textDelta: "Hello" };
         // Simulate slow streaming
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await sleep(200);
         if (signal.aborted) return;
         yield { type: "text-delta", port: "text", textDelta: " world" };
         yield { type: "finish", data: { text: "Hello world" } };

--- a/packages/test/src/test/ai/AiTaskSchemas.test.ts
+++ b/packages/test/src/test/ai/AiTaskSchemas.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, test } from "bun:test";
-import { TypeLandmark, TypePoseLandmark } from "./AiTaskSchemas";
+import { TypeLandmark, TypePoseLandmark } from "@workglow/ai";
+import { describe, expect, test } from "vitest";
 
 describe("AI task schemas", () => {
   test("exports shared landmark schemas", () => {

--- a/packages/test/src/test/ai/ImageGenerationPreviewChain.test.ts
+++ b/packages/test/src/test/ai/ImageGenerationPreviewChain.test.ts
@@ -4,18 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import type { AiProviderStreamFn, ModelConfig } from "@workglow/ai";
 import {
   AiProviderRegistry,
+  DirectExecutionStrategy,
+  getAiProviderRegistry,
   ImageGenerateTask,
   setAiProviderRegistry,
-  getAiProviderRegistry,
-  DirectExecutionStrategy,
 } from "@workglow/ai";
-import type { AiProviderStreamFn, ModelConfig } from "@workglow/ai";
-import { CpuImage, imageValueFromBuffer, type ImageValue } from "@workglow/util/media";
 import { Dataflow, Workflow } from "@workglow/task-graph";
 import { ImageGrayscaleTask } from "@workglow/tasks";
+import { sleep } from "@workglow/util";
+import { CpuImage, imageValueFromBuffer, type ImageValue } from "@workglow/util/media";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const MOCK_PROVIDER = "mock-image-provider";
 
@@ -56,7 +57,7 @@ describe("Image generation preview chain", () => {
       for (let i = 0; i < partials.length; i++) {
         yield { type: "snapshot", data: { image: partials[i] } } as any;
         while (grayPreviewSamples.length <= i) {
-          await new Promise((r) => setTimeout(r, 1));
+          await sleep(1);
         }
       }
       yield { type: "finish", data: {} } as any;

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -5,13 +5,14 @@
  */
 
 import {
-  NullLimiter,
+  CompositeLimiter,
   ConcurrencyLimiter,
   DelayLimiter,
-  CompositeLimiter,
   EvenlySpacedRateLimiter,
+  NullLimiter,
 } from "@workglow/job-queue";
-import { describe, expect, it, beforeEach } from "vitest";
+import { sleep } from "@workglow/util";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("NullLimiter", () => {
   const limiter = new NullLimiter();
@@ -98,7 +99,7 @@ describe("DelayLimiter", () => {
   it("should allow proceeding after delay expires", async () => {
     const shortDelayLimiter = new DelayLimiter(10);
     await shortDelayLimiter.recordJobStart();
-    await new Promise((r) => setTimeout(r, 20));
+    await sleep(20);
     expect(await shortDelayLimiter.canProceed()).toBe(true);
   });
 

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -59,6 +59,19 @@ class RecordingTelemetryProvider implements ITelemetryProvider {
   }
 }
 
+async function waitForCondition(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await sleep(intervalMs);
+  }
+  return predicate();
+}
+
 export interface TInput {
   readonly taskType?: string;
   readonly data?: string;
@@ -212,6 +225,7 @@ export function runGenericJobQueueTests(
 
     it("should delete completed jobs after specified time", async () => {
       const deleteAfterCompletionMs = 10;
+      const cleanupIntervalMs = 5;
 
       // Create a new server with deletion settings
       await server.stop();
@@ -222,7 +236,7 @@ export function runGenericJobQueueTests(
         limiter,
         pollIntervalMs: 1,
         deleteAfterCompletionMs,
-        cleanupIntervalMs: 5,
+        cleanupIntervalMs,
       });
       client.attach(server);
 
@@ -235,10 +249,12 @@ export function runGenericJobQueueTests(
       const jobExists = !!(await client.getJob(handle.id));
       expect(jobExists).toBe(true);
 
-      await sleep(deleteAfterCompletionMs * 3);
-
-      const deletedJobExists = !!(await client.getJob(handle.id));
-      expect(deletedJobExists).toBe(false);
+      const deleted = await waitForCondition(
+        async () => !(await client.getJob(handle.id)),
+        500,
+        cleanupIntervalMs
+      );
+      expect(deleted).toBe(true);
     });
 
     it("should not delete jobs when timing options are undefined", async () => {

--- a/packages/test/src/test/task-graph/CacheSerialization.test.ts
+++ b/packages/test/src/test/task-graph/CacheSerialization.test.ts
@@ -3,15 +3,10 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, vi, beforeEach } from "vitest";
-import {
-  Task,
-  TaskOutputRepository,
-  registerPortCodec,
-  _resetPortCodecsForTests,
-} from "@workglow/task-graph";
 import type { TaskInput, TaskOutput } from "@workglow/task-graph";
-import type { GpuImage } from "@workglow/util/media";
+import { Task, TaskOutputRepository, registerPortCodec } from "@workglow/task-graph";
+import type { ImageValue } from "@workglow/util/media";
+import { describe, expect, test, vi } from "vitest";
 
 class SpyRepo extends TaskOutputRepository {
   private readonly map = new Map<string, unknown>();
@@ -36,14 +31,10 @@ class SpyRepo extends TaskOutputRepository {
 }
 
 describe("TaskRunner cache port serialization", () => {
-  beforeEach(() => {
-    _resetPortCodecsForTests();
-  });
-
   test("output ports declaring a registered format are serialized before saveOutput", async () => {
     const serialize = vi.fn(async (v: unknown) => ({ wire: v }));
     const deserialize = vi.fn(async (v: unknown) => (v as { wire: unknown }).wire);
-    registerPortCodec("test-port", { serialize, deserialize });
+    registerPortCodec("test-port-output", { serialize, deserialize });
 
     class MyTask extends Task<
       Record<string, unknown>,
@@ -53,7 +44,7 @@ describe("TaskRunner cache port serialization", () => {
       static override outputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-output", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -69,7 +60,7 @@ describe("TaskRunner cache port serialization", () => {
   });
 
   test("cached outputs are deserialized after getOutput", async () => {
-    registerPortCodec("test-port", {
+    registerPortCodec("test-port-cache", {
       serialize: async (v: unknown) => ({ wire: v }),
       deserialize: async (v: unknown) => (v as { wire: unknown }).wire,
     });
@@ -83,7 +74,7 @@ describe("TaskRunner cache port serialization", () => {
       static override outputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-cache", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -103,7 +94,7 @@ describe("TaskRunner cache port serialization", () => {
   });
 
   test("class-instance inputs keyed identically via the registered codec", async () => {
-    registerPortCodec("test-port", {
+    registerPortCodec("test-port-input", {
       serialize: async (v: unknown) => ({ wire: (v as { reveal(): number }).reveal() }),
       deserialize: async (v: unknown) => ({
         reveal: () => (v as { wire: number }).wire,
@@ -131,7 +122,7 @@ describe("TaskRunner cache port serialization", () => {
       static override inputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-input", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -147,27 +138,18 @@ describe("TaskRunner cache port serialization", () => {
 });
 
 describe("TaskRunner cache key determinism — image codec", () => {
-  test("two GpuImages with identical pixels hit the same cache entry", async () => {
+  test("two ImageValues with identical pixels hit the same cache entry", async () => {
     await import("@workglow/util/media");
-    const { CpuImage } = await import("@workglow/util/media");
+    const { imageValueFromBuffer } = await import("@workglow/util/media");
 
     const repo = new SpyRepo();
-    const bin = {
-      data: new Uint8ClampedArray([1, 2, 3, 255]),
-      width: 1,
-      height: 1,
-      channels: 4 as const,
-    };
-    const a = CpuImage.fromRaw(bin) as unknown as GpuImage;
-    const b = CpuImage.fromRaw({
-      ...bin,
-      data: new Uint8ClampedArray([1, 2, 3, 255]),
-    }) as unknown as GpuImage;
+    const a = imageValueFromBuffer(Buffer.from([1, 2, 3, 255]), "raw-rgba", 1, 1);
+    const b = imageValueFromBuffer(Buffer.from([1, 2, 3, 255]), "raw-rgba", 1, 1);
     expect(a).not.toBe(b);
 
     let calls = 0;
     class ImgKeyTask extends Task<
-      { image: GpuImage } & Record<string, unknown>,
+      { image: ImageValue } & Record<string, unknown>,
       { x: number } & Record<string, unknown>
     > {
       static override readonly type = "ImgKeyTask";

--- a/packages/test/src/test/task-graph/InputResolver.test.ts
+++ b/packages/test/src/test/task-graph/InputResolver.test.ts
@@ -17,6 +17,7 @@ import {
   globalServiceRegistry,
   registerInputResolver,
   setLogger,
+  sleep,
 } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -477,7 +478,7 @@ describe("InputResolver", () => {
 
     test("should support async resolvers", async () => {
       registerInputResolver("async", async (id, format, registry) => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await sleep(10);
         return { asyncResolved: true, id };
       });
 

--- a/packages/test/src/test/task-graph/PortCodecRegistry.test.ts
+++ b/packages/test/src/test/task-graph/PortCodecRegistry.test.ts
@@ -3,14 +3,10 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, beforeEach } from "vitest";
-import { registerPortCodec, getPortCodec, _resetPortCodecsForTests } from "@workglow/task-graph";
+import { getPortCodec, registerPortCodec } from "@workglow/task-graph";
+import { describe, expect, test } from "vitest";
 
 describe("PortCodecRegistry", () => {
-  beforeEach(() => {
-    _resetPortCodecsForTests();
-  });
-
   test("register + get round-trip by exact format", () => {
     const codec = {
       serialize: async (v: unknown) => ({ wrapped: v }),
@@ -25,10 +21,10 @@ describe("PortCodecRegistry", () => {
       serialize: async (v: unknown) => v,
       deserialize: async (v: unknown) => v,
     };
-    registerPortCodec("image", codec);
-    expect(getPortCodec("image")).toBe(codec);
-    expect(getPortCodec("image:data-uri")).toBe(codec);
-    expect(getPortCodec("image:bitmap")).toBe(codec);
+    registerPortCodec("test-image", codec);
+    expect(getPortCodec("test-image")).toBe(codec);
+    expect(getPortCodec("test-image:data-uri")).toBe(codec);
+    expect(getPortCodec("test-image:bitmap")).toBe(codec);
   });
 
   test("unknown format returns undefined", () => {

--- a/packages/test/src/test/task-graph/ProgressEvents.test.ts
+++ b/packages/test/src/test/task-graph/ProgressEvents.test.ts
@@ -6,6 +6,7 @@
 
 import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { Task, TaskAbortedError, TaskStatus } from "@workglow/task-graph";
+import { sleep } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -111,7 +112,7 @@ describe("Progress events: terminal-100 tick", () => {
       if (progress !== undefined) events.push(progress);
     });
     const runPromise = task.run();
-    await new Promise((r) => setTimeout(r, 10));
+    await sleep(10);
     await task.runner.abort();
     await expect(runPromise).rejects.toThrow();
     expect(events).toContain(100);

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -323,3 +323,39 @@ describe("TaskRunner.run auto-ownership", () => {
     expect(disposed).toEqual(["bare"]);
   });
 });
+
+describe("ResourceScope `await using` integration", () => {
+  it("runner does not dispose; block-scoped `await using` does", async () => {
+    const disposed: string[] = [];
+
+    class UsingScopeTask extends Task<{}, {}> {
+      static override readonly type = "UsingScopeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("using:t1", async () => {
+          disposed.push("t1");
+        });
+        return {};
+      }
+    }
+
+    {
+      await using scope = new ResourceScope();
+      const graph = new TaskGraph();
+      graph.addTask(new UsingScopeTask({ id: "t1" }));
+      await graph.run({}, { resourceScope: scope });
+
+      // Inside the block: runner did NOT dispose. Scope still holds the disposer.
+      expect(scope.size).toBeGreaterThan(0);
+      expect(disposed).toEqual([]);
+    }
+
+    // Block exits → `await using` invokes [Symbol.asyncDispose] → disposeAll runs.
+    expect(disposed).toEqual(["t1"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -359,3 +359,45 @@ describe("ResourceScope `await using` integration", () => {
     expect(disposed).toEqual(["t1"]);
   });
 });
+
+describe("ResourceScope nested-run forwarding under auto-ownership", () => {
+  it("GraphAsTask: outermost runner disposes exactly once", async () => {
+    const disposeCalls: string[] = [];
+
+    class CountingDisposerTask extends Task<{ tag: string }, { tag: string }> {
+      static override readonly type = "CountingDisposerTask";
+      static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { tag: { type: "string", default: "default" } },
+        } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { tag: { type: "string" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(
+        input: { tag: string },
+        ctx: IExecuteContext
+      ): Promise<{ tag: string }> {
+        ctx.resourceScope?.register(`count:${input.tag}`, async () => {
+          disposeCalls.push(input.tag);
+        });
+        return { tag: input.tag };
+      }
+    }
+
+    // Outer graph contains an inner Workflow-as-task, which contains the disposer-registering task.
+    const inner = new Workflow();
+    inner.addTask(CountingDisposerTask, { tag: "nested" });
+    const outer = new TaskGraph();
+    outer.addTask(inner.toTask());
+
+    await outer.run({ tag: "nested" });
+
+    // Disposer must fire exactly once — not once per nested level.
+    expect(disposeCalls).toEqual(["nested"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -167,3 +167,66 @@ describe("ResourceScope AI pattern", () => {
     expect(unloaded).toEqual(["test-model"]);
   });
 });
+
+describe("TaskRunner.run auto-ownership", () => {
+  it("auto-creates and disposes a ResourceScope when none is passed", async () => {
+    const disposed: string[] = [];
+
+    class AutoDisposeTask extends Task<{}, { ok: boolean }> {
+      static override readonly type = "AutoDisposeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{ ok: boolean }> {
+        ctx.resourceScope?.register("auto:bare", async () => {
+          disposed.push("bare");
+        });
+        return { ok: true };
+      }
+    }
+
+    const task = new AutoDisposeTask({ id: "t1" });
+    const result = await task.run({}, {});
+
+    expect(result).toEqual({ ok: true });
+    // Disposal awaited before run() resolves — so the side effect is visible here.
+    expect(disposed).toEqual(["bare"]);
+  });
+
+  it("does not dispose a caller-passed ResourceScope", async () => {
+    const disposed: string[] = [];
+
+    class CallerOwnsTask extends Task<{}, {}> {
+      static override readonly type = "CallerOwnsTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("caller:bare", async () => {
+          disposed.push("bare");
+        });
+        return {};
+      }
+    }
+
+    const scope = new ResourceScope();
+    const task = new CallerOwnsTask({ id: "t1" });
+    await task.run({}, { resourceScope: scope });
+
+    // Runner did NOT dispose — caller still owns the disposer.
+    expect(disposed).toEqual([]);
+    expect(scope.has("caller:bare")).toBe(true);
+
+    await scope.disposeAll();
+    expect(disposed).toEqual(["bare"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -360,6 +360,76 @@ describe("ResourceScope `await using` integration", () => {
   });
 });
 
+describe("ResourceScope auto-ownership failure paths", () => {
+  it("disposes auto-scope when run is aborted via parentSignal", async () => {
+    const events: string[] = [];
+
+    class HangingResourceTask extends Task<{}, {}> {
+      static override readonly type = "HangingResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("abort:t1", async () => {
+          events.push("disposed");
+        });
+        // Wait for abort
+        await new Promise<void>((resolve, reject) => {
+          ctx.signal.addEventListener("abort", () => reject(new Error("aborted")));
+        });
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new HangingResourceTask({ id: "t1" }));
+    graph.on("abort", () => events.push("abort-event"));
+
+    const ctrl = new AbortController();
+    const runPromise = graph.run({}, { parentSignal: ctrl.signal });
+    // Give the task a tick to register its disposer.
+    await new Promise((r) => setTimeout(r, 10));
+    ctrl.abort();
+
+    await expect(runPromise).rejects.toThrow();
+
+    // Both the abort event and the disposer fired.
+    expect(events).toContain("abort-event");
+    expect(events).toContain("disposed");
+    // Abort event before disposal (handleAbort is awaited in the epilogue).
+    expect(events.indexOf("abort-event")).toBeLessThan(events.indexOf("disposed"));
+  });
+
+  it("resets this.resourceScope even when handleStart rejects (maxTasks)", async () => {
+    class TrivialTask extends Task<{}, {}> {
+      static override readonly type = "TrivialTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(): Promise<{}> {
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new TrivialTask({ id: "a" }));
+    graph.addTask(new TrivialTask({ id: "b" }));
+
+    // maxTasks: 1 forces handleStart to throw before any task runs.
+    await expect(graph.run({}, { maxTasks: 1 })).rejects.toThrow();
+
+    // Subsequent run with no maxTasks should succeed — the previous run's
+    // auto-scope did not leak into the runner instance.
+    await graph.run();
+  });
+});
+
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -363,6 +363,7 @@ describe("ResourceScope `await using` integration", () => {
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];
+    const capturedScopes: ResourceScope[] = [];
 
     class CountingDisposerTask extends Task<{ tag: string }, { tag: string }> {
       static override readonly type = "CountingDisposerTask";
@@ -382,6 +383,7 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
         input: { tag: string },
         ctx: IExecuteContext
       ): Promise<{ tag: string }> {
+        if (ctx.resourceScope) capturedScopes.push(ctx.resourceScope);
         ctx.resourceScope?.register(`count:${input.tag}`, async () => {
           disposeCalls.push(input.tag);
         });
@@ -399,5 +401,58 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
 
     // Disposer must fire exactly once — not once per nested level.
     expect(disposeCalls).toEqual(["nested"]);
+    // All task executions must see the same scope identity (correct forwarding).
+    expect(new Set(capturedScopes).size).toBe(1);
+  });
+
+  it("MapTask iteration: scope persists across iterations, disposes once at end", async () => {
+    const disposeCalls: string[] = [];
+    const capturedScopes: ResourceScope[] = [];
+
+    class IteratingDisposerTask extends Task<{ item: number }, { item: number }> {
+      static override readonly type = "IteratingDisposerTask";
+      static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { item: { type: "number" } },
+          required: ["item"],
+          additionalProperties: true,
+        } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { item: { type: "number" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(
+        input: { item: number },
+        ctx: IExecuteContext
+      ): Promise<{ item: number }> {
+        if (ctx.resourceScope) capturedScopes.push(ctx.resourceScope);
+        // Same key across all 3 iterations. With one shared scope (correct
+        // forwarding), first-registration-wins keeps only the first; with
+        // per-iteration scopes (broken forwarding), each iteration's scope
+        // gets its own copy and disposes at iteration end → 3 entries.
+        ctx.resourceScope?.register("model:shared", async () => {
+          disposeCalls.push("disposed");
+        });
+        return { item: input.item };
+      }
+    }
+
+    const workflow = new Workflow();
+    workflow
+      .map({ maxIterations: "unbounded", concurrencyLimit: 1 })
+      .addTask(IteratingDisposerTask)
+      .endMap();
+
+    await workflow.run({ item: [1, 2, 3] });
+
+    // First-registration-wins held → exactly one disposer fired.
+    expect(disposeCalls).toEqual(["disposed"]);
+    // All 3 iterations saw the same scope identity → forwarding works.
+    expect(capturedScopes).toHaveLength(3);
+    expect(new Set(capturedScopes).size).toBe(1);
   });
 });

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -231,6 +231,36 @@ describe("TaskGraphRunner.runGraph auto-ownership", () => {
   });
 });
 
+describe("TaskGraphRunner terminal-event ordering", () => {
+  it("emits 'error' event before auto-disposal fires", async () => {
+    const events: string[] = [];
+
+    class FailingResourceTask extends Task<{}, {}> {
+      static override readonly type = "FailingResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("order:failing", async () => {
+          events.push("disposed");
+        });
+        throw new Error("intentional failure");
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new FailingResourceTask({ id: "t1" }));
+    graph.on("error", () => events.push("error-event"));
+
+    await expect(graph.run()).rejects.toThrow("intentional failure");
+
+    expect(events).toEqual(["error-event", "disposed"]);
+  });
+});
+
 describe("TaskRunner.run auto-ownership", () => {
   it("auto-creates and disposes a ResourceScope when none is passed", async () => {
     const disposed: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "vitest";
-import { ResourceScope } from "@workglow/util";
 import { IExecuteContext, Task, TaskGraph, Workflow } from "@workglow/task-graph";
+import { ResourceScope } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
 
 // A task that registers a disposer on the resource scope
 class ResourceAcquiringTask extends Task<{ name: string }, { name: string }> {
@@ -363,6 +363,10 @@ describe("ResourceScope `await using` integration", () => {
 describe("ResourceScope auto-ownership failure paths", () => {
   it("disposes auto-scope when run is aborted via parentSignal", async () => {
     const events: string[] = [];
+    let registered: () => void;
+    const registeredPromise = new Promise<void>((r) => {
+      registered = r;
+    });
 
     class HangingResourceTask extends Task<{}, {}> {
       static override readonly type = "HangingResourceTask";
@@ -376,8 +380,11 @@ describe("ResourceScope auto-ownership failure paths", () => {
         ctx.resourceScope?.register("abort:t1", async () => {
           events.push("disposed");
         });
-        // Wait for abort
-        await new Promise<void>((resolve, reject) => {
+        // Signal that registration is complete — replaces a wall-clock sleep
+        // so the abort fires deterministically AFTER the disposer is in the Map,
+        // regardless of how busy the test runner is.
+        registered();
+        await new Promise<void>((_resolve, reject) => {
           ctx.signal.addEventListener("abort", () => reject(new Error("aborted")));
         });
         return {};
@@ -390,8 +397,7 @@ describe("ResourceScope auto-ownership failure paths", () => {
 
     const ctrl = new AbortController();
     const runPromise = graph.run({}, { parentSignal: ctrl.signal });
-    // Give the task a tick to register its disposer.
-    await new Promise((r) => setTimeout(r, 10));
+    await registeredPromise;
     ctrl.abort();
 
     await expect(runPromise).rejects.toThrow();
@@ -559,5 +565,116 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
     // All 3 iterations saw the same scope identity → forwarding works.
     expect(capturedScopes).toHaveLength(3);
     expect(new Set(capturedScopes).size).toBe(1);
+  });
+});
+
+describe("ResourceScope auto-ownership does not leak through context.own()", () => {
+  it("auto-owned scope is not stamped into owned tasks' runConfig", async () => {
+    const disposed: string[] = [];
+
+    class ChildResourceTask extends Task<{}, {}> {
+      static override readonly type = "ChildResourceTaskOwn";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("child:resource", async () => {
+          disposed.push("child");
+        });
+        return {};
+      }
+    }
+
+    let ownedChild: ChildResourceTask | undefined;
+
+    class ParentTask extends Task<{}, {}> {
+      static override readonly type = "ParentOwnTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        // Just adopt — don't run it. We want to inspect the stamped runConfig.
+        ownedChild = ctx.own(new ChildResourceTask({ id: "child" }));
+        return {};
+      }
+    }
+
+    const parent = new ParentTask({ id: "parent" });
+    await parent.run();
+
+    // Parent's auto-scope was disposed in `finally`. The owned child must NOT
+    // hold a reference to that disposed scope — otherwise its next `task.run()`
+    // would skip auto-create and silently drop disposers on a cleared Map.
+    expect(ownedChild).toBeDefined();
+    expect(ownedChild!.runConfig?.resourceScope).toBeUndefined();
+
+    // Running the orphaned child should still work end-to-end: it auto-creates
+    // its own fresh scope and disposes it cleanly.
+    await ownedChild!.run();
+    expect(disposed).toEqual(["child"]);
+  });
+
+  it("caller-passed scope IS still propagated through own() (preserves resource sharing)", async () => {
+    const disposed: string[] = [];
+    const callerScope = new ResourceScope();
+
+    class ChildSharedTask extends Task<{}, {}> {
+      static override readonly type = "ChildSharedTaskOwn";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("shared:resource", async () => {
+          disposed.push("shared");
+        });
+        return {};
+      }
+    }
+
+    let ownedChild: ChildSharedTask | undefined;
+
+    class ParentSharedTask extends Task<{}, {}> {
+      static override readonly type = "ParentSharedOwnTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ownedChild = ctx.own(new ChildSharedTask({ id: "child" }));
+        // Run the owned child synchronously inside the parent run. The child
+        // pulls `resourceScope` from its (just-stamped) runConfig — so its
+        // disposer must land on the caller's scope, not on a per-child
+        // auto-scope that would be disposed when the child returns.
+        await ownedChild.run();
+        return {};
+      }
+    }
+
+    const parent = new ParentSharedTask({ id: "parent" });
+    await parent.run({}, { resourceScope: callerScope });
+
+    // Caller-passed scope IS propagated — owned child's runConfig points at it
+    // so that a follow-up `task.run()` on the child shares the same scope and
+    // benefits from first-registration-wins / shared-model semantics.
+    expect(ownedChild).toBeDefined();
+    expect(ownedChild!.runConfig?.resourceScope).toBe(callerScope);
+    // The child's disposer landed on the caller's scope, not a per-run scope.
+    expect(callerScope.has("shared:resource")).toBe(true);
+
+    // Caller still owns disposal — runner did not dispose at parent's exit.
+    expect(disposed).toEqual([]);
+    await callerScope.disposeAll();
+    expect(disposed).toEqual(["shared"]);
   });
 });

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -168,6 +168,69 @@ describe("ResourceScope AI pattern", () => {
   });
 });
 
+describe("TaskGraphRunner.runGraph auto-ownership", () => {
+  it("auto-creates and disposes a ResourceScope when none is passed", async () => {
+    const disposed: string[] = [];
+
+    class GraphAutoDisposeTask extends Task<{}, { name: string }> {
+      static override readonly type = "GraphAutoDisposeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { name: { type: "string" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{ name: string }> {
+        ctx.resourceScope?.register("auto:graph", async () => {
+          disposed.push("graph");
+        });
+        return { name: "ok" };
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new GraphAutoDisposeTask({ id: "t1" }));
+    await graph.run();
+
+    // Auto-disposal awaited before graph.run() resolves.
+    expect(disposed).toEqual(["graph"]);
+  });
+
+  it("does not dispose a caller-passed ResourceScope", async () => {
+    const disposed: string[] = [];
+
+    class CallerOwnsGraphTask extends Task<{}, {}> {
+      static override readonly type = "CallerOwnsGraphTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("caller:graph", async () => {
+          disposed.push("graph");
+        });
+        return {};
+      }
+    }
+
+    const scope = new ResourceScope();
+    const graph = new TaskGraph();
+    graph.addTask(new CallerOwnsGraphTask({ id: "t1" }));
+    await graph.run({}, { resourceScope: scope });
+
+    expect(disposed).toEqual([]);
+    expect(scope.has("caller:graph")).toBe(true);
+
+    await scope.disposeAll();
+    expect(disposed).toEqual(["graph"]);
+  });
+});
+
 describe("TaskRunner.run auto-ownership", () => {
   it("auto-creates and disposes a ResourceScope when none is passed", async () => {
     const disposed: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -430,6 +430,41 @@ describe("ResourceScope auto-ownership failure paths", () => {
   });
 });
 
+describe("runPreview does not auto-create a ResourceScope", () => {
+  it("runGraphPreview leaves resourceScope undefined and does not call disposers", async () => {
+    const previewSawScope: boolean[] = [];
+
+    class PreviewResourceTask extends Task<{}, {}> {
+      static override readonly type = "PreviewResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("preview:t1", async () => {});
+        return {};
+      }
+      // Note: IExecutePreviewContext = Pick<IExecuteContext, "own"> — no resourceScope.
+      // The point of this test is that runPreview() does not throw and does not
+      // attempt to auto-create or thread a scope.
+      override async executePreview(): Promise<{}> {
+        // Can't observe ctx.resourceScope because IExecutePreviewContext excludes it.
+        // Record that executePreview ran at all (scope tracking is done externally).
+        previewSawScope.push(false); // always false: preview context has no resourceScope
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new PreviewResourceTask({ id: "t1" }));
+    await graph.runPreview();
+
+    expect(previewSawScope).toEqual([false]);
+  });
+});
+
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];

--- a/packages/test/src/test/task-graph/RunPreviewStream.test.ts
+++ b/packages/test/src/test/task-graph/RunPreviewStream.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "vitest";
 import { Dataflow, Task, Workflow, type StreamEvent } from "@workglow/task-graph";
+import { sleep } from "@workglow/util";
+import { describe, expect, it } from "vitest";
 
 class SyntheticStreamSource extends Task<{ trigger: number }, { value: number }> {
   public static override type = "SyntheticStreamSource";
@@ -27,7 +28,7 @@ class SyntheticStreamSource extends Task<{ trigger: number }, { value: number }>
   async *executeStream(): AsyncIterable<StreamEvent<{ value: number }>> {
     for (let i = 1; i <= 3; i++) {
       yield { type: "snapshot", data: { value: i } };
-      await new Promise((r) => setTimeout(r, 5));
+      await sleep(5);
     }
     yield { type: "finish", data: {} as { value: number } };
   }

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -1194,7 +1194,7 @@ describe("Workflow — refactor regression net", () => {
     it("onError adds a handler task wired to the error port", () => {
       const w = new Workflow();
       w.addTask(NumberTask, { input: 1 });
-      w.onError(NumberTask);
+      w.onError(new NumberTask({}));
       expect(w.graph.getTasks()).toHaveLength(2);
       const errorEdges = w.graph
         .getDataflows()
@@ -1258,7 +1258,7 @@ describe("Workflow — refactor regression net", () => {
       class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
         static override type = "SlowAbortTask";
         static override category = "Test";
-        async execute(
+        override async execute(
           input: { input: number },
           _config?: unknown,
           signal?: AbortSignal

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -8,10 +8,12 @@ import {
   computeGraphInputSchema,
   CreateWorkflow,
   hasVectorOutput,
+  MapTask,
   PROPERTY_ARRAY,
   Task,
   TaskConfig,
   TaskError,
+  TaskGraph,
   Workflow,
   WorkflowError,
 } from "@workglow/task-graph";
@@ -1178,6 +1180,170 @@ describe("Workflow", () => {
         const result = await workflow.run({ input: "hello" }, { registry });
         expect(result).toEqual({ output: "processed-hello" });
       });
+    });
+  });
+});
+
+// ============================================================================
+// Refactor regression net — gap coverage for the Workflow decomposition.
+// Pairs with: builder/docs/superpowers/specs/2026-05-02-decompose-workflow-design.md
+// ============================================================================
+
+describe("Workflow — refactor regression net", () => {
+  describe("onError handler wiring (spec #2)", () => {
+    it("onError adds a handler task wired to the error port", () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      w.onError(NumberTask);
+      expect(w.graph.getTasks()).toHaveLength(2);
+      const errorEdges = w.graph
+        .getDataflows()
+        .filter((df) => df.sourceTaskPortId === "[error]");
+      expect(errorEdges.length).toBe(1);
+    });
+  });
+
+  describe("loop-builder lifecycle (spec #3)", () => {
+    it("addLoopTask returns a child workflow that adds the iterator to the parent graph", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      expect(inner).not.toBe(w);
+      expect(w.graph.getTasks()).toHaveLength(1);
+      expect(w.graph.getTasks()[0].type).toBe("MapTask");
+    });
+
+    it("child reset throws WorkflowError", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      expect(() => inner.reset()).toThrow(WorkflowError);
+    });
+
+    it("finalizeAndReturn promotes the child template into the iterator subGraph and returns parent", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      inner.addTask(NumberTask, { input: 1 });
+      const back = inner.finalizeAndReturn();
+      expect(back).toBe(w);
+      const iter = w.graph.getTasks()[0] as { subGraph?: unknown };
+      expect(iter.subGraph).toBeDefined();
+    });
+  });
+
+  describe("conditional smoke (spec #4)", () => {
+    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks", () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      w.if((input: { output?: number }) => (input.output ?? 0) > 0)
+        .then(NumberToStringTask)
+        .else(NumberToStringTask)
+        .endIf();
+      const types = w.graph.getTasks().map((t) => t.type);
+      expect(types).toContain("ConditionalTask");
+      expect(types.filter((t) => t === "NumberToStringTask")).toHaveLength(2);
+    });
+  });
+
+  describe("run & abort event ordering (spec #5)", () => {
+    it("run() emits start then complete in order", async () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      const events: string[] = [];
+      w.on("start", () => events.push("start"));
+      w.on("complete", () => events.push("complete"));
+      await w.run();
+      expect(events).toEqual(["start", "complete"]);
+    });
+
+    it("abort() during run causes run to reject and emits error", async () => {
+      class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
+        static override type = "SlowAbortTask";
+        static override category = "Test";
+        async execute(
+          input: { input: number },
+          _config?: unknown,
+          signal?: AbortSignal
+        ): Promise<{ output: number }> {
+          await new Promise((_resolve, reject) => {
+            if (signal) {
+              signal.addEventListener("abort", () => reject(new Error("aborted")));
+            }
+          });
+          return { output: input.input };
+        }
+      }
+
+      const w = new Workflow();
+      w.addTask(SlowAbortTask, { input: 1 });
+      const errors: string[] = [];
+      w.on("error", (msg) => errors.push(msg));
+
+      const runPromise = w.run();
+      setTimeout(() => void w.abort(), 10);
+      await expect(runPromise).rejects.toBeDefined();
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("event lifecycle on graph swap (spec #6)", () => {
+    it("setting workflow.graph emits reset; subsequent addTask emits changed", () => {
+      const w = new Workflow();
+      const events: string[] = [];
+      w.on("reset", () => events.push("reset"));
+      w.on("changed", () => events.push("changed"));
+
+      w.graph = new TaskGraph();
+      expect(events).toContain("reset");
+
+      const beforeChangedCount = events.filter((e) => e === "changed").length;
+      w.addTask(NumberTask, { input: 1 });
+      const afterChangedCount = events.filter((e) => e === "changed").length;
+      expect(afterChangedCount).toBeGreaterThan(beforeChangedCount);
+    });
+  });
+
+  describe("entitlement bridge (spec #8)", () => {
+    it("workflow.events exposes entitlementChange listener slot", () => {
+      const w = new Workflow();
+      let listenerError: unknown;
+      try {
+        w.on("entitlementChange", () => {
+          /* listener body is irrelevant — we only test that subscription succeeds */
+        });
+      } catch (e) {
+        listenerError = e;
+      }
+      expect(listenerError).toBeUndefined();
+      // Trigger any graph mutation; subscription must not throw.
+      w.addTask(NumberTask, { input: 1 });
+      expect(w.error).toBe("");
+    });
+  });
+
+  describe("external-consumer invariants (spec #11)", () => {
+    it("Workflow remains a class with a mutable prototype", () => {
+      // The augmentation pattern used by builder JoinTask/SplitTask depends on
+      // Workflow.prototype being mutable. The existing file already exercises
+      // this via Workflow.prototype.testSimple = CreateWorkflow(...). Here we
+      // assert the contract explicitly so a future change that breaks the
+      // pattern (e.g. converting Workflow to a type alias) trips this test.
+      const helper = CreateWorkflow(NumberTask);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Workflow.prototype as any).PrototypeAugmentTest = helper;
+      const w = new Workflow();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (w as any).PrototypeAugmentTest({ input: 1 });
+      expect(w.graph.getTasks()).toHaveLength(1);
+      expect(w.graph.getTasks()[0].type).toBe("NumberTask");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (Workflow.prototype as any).PrototypeAugmentTest;
+    });
+
+    it("workflow.events identity is stable across the lifetime of the instance", () => {
+      const w = new Workflow();
+      const e1 = w.events;
+      w.addTask(NumberTask, { input: 1 });
+      const e2 = w.events;
+      expect(e1).toBe(e2);
     });
   });
 });

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -8,15 +8,20 @@ import {
   computeGraphInputSchema,
   CreateWorkflow,
   hasVectorOutput,
+  IExecuteContext,
   MapTask,
   PROPERTY_ARRAY,
+  StreamEvent,
   Task,
   TaskConfig,
+  TaskEntitlements,
   TaskError,
   TaskGraph,
+  TaskIdType,
   Workflow,
   WorkflowError,
 } from "@workglow/task-graph";
+import { DataPortSchema } from "@workglow/util/schema";
 import {
   InputTask,
   OutputTask,
@@ -1190,6 +1195,43 @@ describe("Workflow", () => {
 // Pairs with: builder/docs/superpowers/specs/2026-05-02-decompose-workflow-design.md
 // ============================================================================
 
+type StreamRelayInput = { prompt: string };
+type StreamRelayOutput = { text: string };
+
+class StreamRelayTask extends Task<StreamRelayInput, StreamRelayOutput> {
+  public static override type = "StreamRelayTask";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "test" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: StreamRelayInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<StreamRelayOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "hello" };
+    yield { type: "text-delta", port: "text", textDelta: " world" };
+    yield { type: "finish", data: { text: "hello world" } };
+  }
+
+  override async execute(_input: StreamRelayInput): Promise<StreamRelayOutput | undefined> {
+    return { text: "hello world" };
+  }
+}
+
 describe("Workflow — refactor regression net", () => {
   describe("onError handler wiring (spec #2)", () => {
     it("onError adds a handler task wired to the error port", () => {
@@ -1301,21 +1343,65 @@ describe("Workflow — refactor regression net", () => {
     });
   });
 
-  describe("entitlement bridge (spec #8 — listener slot only)", () => {
-    // NOTE: this only verifies the subscription wiring does not throw. Actual
-    // propagation from graph→workflow is NOT yet asserted here — that gap will
-    // be filled when WorkflowEventBridge lands (migration step 7). Until then
-    // a regression that drops the entitlement subscription entirely would not
-    // be caught by this test alone.
-    it("workflow.events accepts entitlementChange subscription without throwing", () => {
+  describe("entitlement bridge propagation (spec #8)", () => {
+    it("entitlementChange propagates from graph mutations through to workflow.events", () => {
       const w = new Workflow();
-      expect(() =>
-        w.on("entitlementChange", () => {
-          /* no-op */
-        })
-      ).not.toThrow();
-      // Mutating the graph after subscribing must not throw either.
-      expect(() => w.addTask(NumberTask, { input: 1 })).not.toThrow();
+      const fires: TaskEntitlements[] = [];
+      w.on("entitlementChange", (entitlements) => fires.push(entitlements));
+      const before = fires.length;
+      w.addTask(NumberTask, { input: 1 });
+      // task_added on the graph must produce at least one entitlementChange
+      // emission on workflow.events. Pre-refactor behavior was via the
+      // subscribeToTaskEntitlements wiring inside Workflow; post-refactor
+      // it routes through WorkflowEventBridge.attach.
+      expect(fires.length).toBeGreaterThan(before);
+    });
+  });
+
+  describe("streaming relay (spec #7)", () => {
+    it("graph stream_start/stream_chunk/stream_end propagate to workflow.events during run", async () => {
+      const w = new Workflow();
+      w.addTask(StreamRelayTask, { prompt: "hi" });
+
+      const startIds: TaskIdType[] = [];
+      const chunks: { taskId: TaskIdType; event: StreamEvent }[] = [];
+      const ends: { taskId: TaskIdType; output: Record<string, unknown> }[] = [];
+      w.on("stream_start", (taskId) => startIds.push(taskId));
+      w.on("stream_chunk", (taskId, event) => chunks.push({ taskId, event }));
+      w.on("stream_end", (taskId, output) => ends.push({ taskId, output }));
+
+      await w.run({ prompt: "hi" });
+
+      expect(startIds.length).toBeGreaterThanOrEqual(1);
+      const textDeltas = chunks.filter((c) => c.event.type === "text-delta");
+      expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+      expect(ends.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("streaming subscription is released after run completes (no leak via bridge field)", async () => {
+      // Pre-refactor `unsubStreaming` was a local in run(); post-refactor the
+      // bridge.beginRun() RETURNS the unsub and run() holds it locally too.
+      // This test verifies that nothing on the bridge keeps a stale unsub
+      // between runs (the I-1 fix from PR review).
+      const w = new Workflow();
+      w.addTask(StreamRelayTask, { prompt: "first" });
+      const chunksRun1: StreamEvent[] = [];
+      const off1 = (event: StreamEvent) => chunksRun1.push(event);
+      w.on("stream_chunk", (_id, event) => off1(event));
+      await w.run({ prompt: "first" });
+
+      const countAfterRun1 = chunksRun1.length;
+      // No second listener subscription needed — same instance.
+      // After run1 completes its streaming subscription must be torn down so
+      // no further chunks are received from the prior subscription. Triggering
+      // a second run reuses the bridge cleanly.
+      w.reset();
+      w.addTask(StreamRelayTask, { prompt: "second" });
+      await w.run({ prompt: "second" });
+      // chunksRun1 captures from BOTH runs (we never unsubscribed off1), so
+      // count must increase. The test would fail if the bridge had silently
+      // dropped subscriptions or double-bound them.
+      expect(chunksRun1.length).toBeGreaterThan(countAfterRun1);
     });
   });
 

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LongRunningTask,
   NumberTask,
   NumberToStringTask,
   StringTask,
@@ -1224,22 +1225,31 @@ describe("Workflow — refactor regression net", () => {
       inner.addTask(NumberTask, { input: 1 });
       const back = inner.finalizeAndReturn();
       expect(back).toBe(w);
-      const iter = w.graph.getTasks()[0] as { subGraph?: unknown };
+      const iter = w.graph.getTasks()[0] as { subGraph?: TaskGraph };
       expect(iter.subGraph).toBeDefined();
+      // Pin contents so an empty-graph regression in finalizeTemplate trips here.
+      expect(iter.subGraph!.getTasks()).toHaveLength(1);
     });
   });
 
   describe("conditional smoke (spec #4)", () => {
-    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks", () => {
+    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks with both branches wired", () => {
       const w = new Workflow();
       w.addTask(NumberTask, { input: 1 });
       w.if((input: { output?: number }) => (input.output ?? 0) > 0)
         .then(NumberToStringTask)
         .else(NumberToStringTask)
         .endIf();
-      const types = w.graph.getTasks().map((t) => t.type);
+      const tasks = w.graph.getTasks();
+      const types = tasks.map((t) => t.type);
       expect(types).toContain("ConditionalTask");
       expect(types.filter((t) => t === "NumberToStringTask")).toHaveLength(2);
+
+      const conditional = tasks.find((t) => t.type === "ConditionalTask")!;
+      const branchEdges = w.graph
+        .getDataflows()
+        .filter((df) => df.sourceTaskId === conditional.id);
+      expect(branchEdges.map((df) => df.sourceTaskPortId).sort()).toEqual(["else", "then"]);
     });
   });
 
@@ -1254,33 +1264,16 @@ describe("Workflow — refactor regression net", () => {
       expect(events).toEqual(["start", "complete"]);
     });
 
-    it("abort() during run causes run to reject and emits error", async () => {
-      class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
-        static override type = "SlowAbortTask";
-        static override category = "Test";
-        override async execute(
-          input: { input: number },
-          _config?: unknown,
-          signal?: AbortSignal
-        ): Promise<{ output: number }> {
-          await new Promise((_resolve, reject) => {
-            if (signal) {
-              signal.addEventListener("abort", () => reject(new Error("aborted")));
-            }
-          });
-          return { output: input.input };
-        }
-      }
-
+    it("abort() during run causes run to reject and emits error exactly once", async () => {
       const w = new Workflow();
-      w.addTask(SlowAbortTask, { input: 1 });
+      w.addTask(LongRunningTask, {});
       const errors: string[] = [];
       w.on("error", (msg) => errors.push(msg));
 
       const runPromise = w.run();
       setTimeout(() => void w.abort(), 10);
       await expect(runPromise).rejects.toBeDefined();
-      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors).toHaveLength(1);
     });
   });
 
@@ -1297,25 +1290,32 @@ describe("Workflow — refactor regression net", () => {
       const beforeChangedCount = events.filter((e) => e === "changed").length;
       w.addTask(NumberTask, { input: 1 });
       const afterChangedCount = events.filter((e) => e === "changed").length;
-      expect(afterChangedCount).toBeGreaterThan(beforeChangedCount);
+      // addTask emits "changed" multiple times today (once directly on the
+      // facade, once via the bridge's task_added subscription). The exact
+      // count is implementation-defined; we pin lower and upper bounds. A
+      // bridge double-subscription regression after the WorkflowEventBridge
+      // extraction (migration step 7) would push the delta past 4.
+      const delta = afterChangedCount - beforeChangedCount;
+      expect(delta).toBeGreaterThanOrEqual(1);
+      expect(delta).toBeLessThanOrEqual(4);
     });
   });
 
-  describe("entitlement bridge (spec #8)", () => {
-    it("workflow.events exposes entitlementChange listener slot", () => {
+  describe("entitlement bridge (spec #8 — listener slot only)", () => {
+    // NOTE: this only verifies the subscription wiring does not throw. Actual
+    // propagation from graph→workflow is NOT yet asserted here — that gap will
+    // be filled when WorkflowEventBridge lands (migration step 7). Until then
+    // a regression that drops the entitlement subscription entirely would not
+    // be caught by this test alone.
+    it("workflow.events accepts entitlementChange subscription without throwing", () => {
       const w = new Workflow();
-      let listenerError: unknown;
-      try {
+      expect(() =>
         w.on("entitlementChange", () => {
-          /* listener body is irrelevant — we only test that subscription succeeds */
-        });
-      } catch (e) {
-        listenerError = e;
-      }
-      expect(listenerError).toBeUndefined();
-      // Trigger any graph mutation; subscription must not throw.
-      w.addTask(NumberTask, { input: 1 });
-      expect(w.error).toBe("");
+          /* no-op */
+        })
+      ).not.toThrow();
+      // Mutating the graph after subscribing must not throw either.
+      expect(() => w.addTask(NumberTask, { input: 1 })).not.toThrow();
     });
   });
 

--- a/packages/test/src/test/task-graph/Workflow.transforms.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.transforms.test.ts
@@ -19,11 +19,11 @@ describe("Workflow .rename accepts { transforms }", () => {
       transforms: [{ id: "uppercase" }],
     });
 
-    // rename pushes a pending Dataflow onto Workflow._dataFlows (no target
-    // yet). Inspect it via the private field through a cast — this is a
-    // behavioural test only.
+    // rename pushes a pending Dataflow onto WorkflowBuilder._dataFlows (no
+    // target yet). Inspect it via the private field through a cast — this is
+    // a behavioural test only.
     const pendingDataflows = (
-      w as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
     )._dataFlows;
     expect(pendingDataflows).toHaveLength(1);
     expect(pendingDataflows[0].getTransforms().map((t) => t.id)).toEqual(["uppercase"]);
@@ -32,8 +32,9 @@ describe("Workflow .rename accepts { transforms }", () => {
   it(".rename(source, target, index) (numeric) still works without options", () => {
     const w = new Workflow();
     w.addTask(TestSimpleTask).rename("output", "input", -1);
-    const pending = (w as unknown as { _dataFlows: { getTransforms(): readonly unknown[] }[] })
-      ._dataFlows;
+    const pending = (
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly unknown[] }[] }
+    )._dataFlows;
     expect(pending).toHaveLength(1);
     expect(pending[0].getTransforms()).toHaveLength(0);
   });
@@ -45,7 +46,7 @@ describe("Workflow .rename accepts { transforms }", () => {
       transforms: [{ id: "uppercase" }, { id: "lowercase" }],
     });
     const pending = (
-      w as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
     )._dataFlows;
     expect(pending[0].getTransforms().map((t) => t.id)).toEqual(["uppercase", "lowercase"]);
   });

--- a/packages/test/src/test/task-graph/runner-internals.test.ts
+++ b/packages/test/src/test/task-graph/runner-internals.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Dataflow,
+  EdgeMaterializer,
+  RunContext,
+  RunScheduler,
+  StreamPump,
+  Task,
+  TaskGraph,
+  TaskGraphRunner,
+  TaskRegistry,
+  TaskStatus,
+} from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Tiny test tasks — kept local so they don't pollute the shared TestTasks set.
+// ---------------------------------------------------------------------------
+
+class RunnerInternalsSourceTask extends Task<{ value: string }, { value: string }> {
+  public static override readonly type = "RunnerInternals_Source";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Source";
+  public static override readonly description = "Source";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  override async execute(input: { value: string }): Promise<{ value: string }> {
+    return { value: input.value };
+  }
+}
+
+class RunnerInternalsSinkTask extends Task<{ value: string }, { result: string }> {
+  public static override readonly type = "RunnerInternals_Sink";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Sink";
+  public static override readonly description = "Sink";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  override async execute(input: { value: string }): Promise<{ result: string }> {
+    return { result: input.value };
+  }
+}
+
+beforeEach(() => {
+  TaskRegistry.registerTask(RunnerInternalsSourceTask);
+  TaskRegistry.registerTask(RunnerInternalsSinkTask);
+});
+
+// ---------------------------------------------------------------------------
+// EdgeMaterializer
+// ---------------------------------------------------------------------------
+
+describe("EdgeMaterializer", () => {
+  it("copyInputFromEdgesToNode reads from one upstream edge", async () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+    graph.addDataflow(new Dataflow(a.id, "value", b.id, "value"));
+
+    const runner = new TaskGraphRunner(graph);
+    const em = new EdgeMaterializer(graph, runner);
+
+    // Push a's output to its outgoing edge, then materialize b's input.
+    await em.pushOutputFromNodeToEdges(a, { value: "hello" });
+    em.copyInputFromEdgesToNode(b);
+
+    expect(b.runInputData.value).toBe("hello");
+  });
+
+  it("pushErrorOutputToEdges sets error edge COMPLETED + sibling edge DISABLED", () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const errSink = new RunnerInternalsSinkTask({ id: "err" });
+    const normalSink = new RunnerInternalsSinkTask({ id: "ok" });
+    graph.addTask(a);
+    graph.addTask(errSink);
+    graph.addTask(normalSink);
+
+    graph.addDataflow(new Dataflow(a.id, "[error]", errSink.id, "value"));
+    graph.addDataflow(new Dataflow(a.id, "value", normalSink.id, "value"));
+
+    const runner = new TaskGraphRunner(graph);
+    const em = new EdgeMaterializer(graph, runner);
+    em.pushErrorOutputToEdges(a);
+
+    const errDf = graph.getDataflows().find((d) => d.sourceTaskPortId === "[error]")!;
+    const normalDf = graph.getDataflows().find((d) => d.sourceTaskPortId === "value")!;
+    expect(errDf.status).toBe(TaskStatus.COMPLETED);
+    expect(normalDf.status).toBe(TaskStatus.DISABLED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RunScheduler
+// ---------------------------------------------------------------------------
+
+describe("RunScheduler", () => {
+  it("propagateDisabledStatus cascades through a 3-node chain", () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    const c = new RunnerInternalsSinkTask({ id: "c" });
+    graph.addTask(a);
+    graph.addTask(b);
+    graph.addTask(c);
+    const dfAB = new Dataflow(a.id, "value", b.id, "value");
+    graph.addDataflow(dfAB);
+    graph.addDataflow(new Dataflow(b.id, "result", c.id, "value"));
+
+    // Simulate `a` being disabled: status flipped + outgoing edge marked DISABLED.
+    // (In production this is done by pushStatusFromNodeToEdges; here we set it
+    // directly so the test is hermetic to that helper.)
+    a.status = TaskStatus.DISABLED;
+    dfAB.setStatus(TaskStatus.DISABLED);
+
+    const runner = new TaskGraphRunner(graph);
+    const ctx = new RunContext();
+    // processScheduler is protected; bracket access keeps the seam testable.
+    const rs = new RunScheduler(graph, (runner as any).processScheduler, runner);
+    rs.propagateDisabledStatus(ctx);
+
+    expect(b.status).toBe(TaskStatus.DISABLED);
+    expect(c.status).toBe(TaskStatus.DISABLED);
+  });
+
+  it("handleProgress averages across two contributing tasks", async () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+
+    a.progress = 60;
+    b.progress = 40;
+
+    const runner = new TaskGraphRunner(graph);
+    const ctx = new RunContext();
+    const rs = new RunScheduler(graph, (runner as any).processScheduler, runner);
+
+    let captured: number | undefined;
+    graph.subscribe("graph_progress", (p) => {
+      captured = p;
+    });
+
+    await rs.handleProgress(ctx, a, undefined);
+    expect(captured).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StreamPump
+// ---------------------------------------------------------------------------
+
+describe("StreamPump", () => {
+  it("taskNeedsAccumulation returns true when output cache is active", () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+    graph.addDataflow(new Dataflow(a.id, "value", b.id, "value"));
+
+    const runner = new TaskGraphRunner(graph);
+    const em = new EdgeMaterializer(graph, runner);
+    const sp = new StreamPump(graph, (runner as any).processScheduler, em);
+
+    // Bracket access bypasses TS visibility — taskNeedsAccumulation is `private`.
+    // Two-arg branch: when outputCache is truthy, accumulation is required regardless of edges.
+    const fakeOutputCache = {} as any;
+    expect((sp as any).taskNeedsAccumulation(a, fakeOutputCache, false)).toBe(true);
+
+    // Inverse smoke: with a non-streaming chain and no outputCache, no accumulation is needed.
+    expect((sp as any).taskNeedsAccumulation(a, undefined, false)).toBe(false);
+  });
+
+  it("prepareStreamingInputs tees upstream stream into task.runner.inputStreams", () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+    graph.addDataflow(new Dataflow(a.id, "value", b.id, "value"));
+    const df = graph.getDataflows()[0];
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: "text-delta", text: "hi" } as any);
+        controller.close();
+      },
+    });
+    df.setStream(stream as any);
+
+    const runner = new TaskGraphRunner(graph);
+    const em = new EdgeMaterializer(graph, runner);
+    const sp = new StreamPump(graph, (runner as any).processScheduler, em);
+    sp.prepareStreamingInputs(b);
+
+    expect(b.runner.inputStreams).toBeDefined();
+    expect(b.runner.inputStreams!.has("value")).toBe(true);
+    expect(df.stream).toBeDefined();
+    expect(df.stream).not.toBe(stream); // tee replaced the original
+  });
+});

--- a/packages/test/src/test/task-graph/taskrunner-internals.test.ts
+++ b/packages/test/src/test/task-graph/taskrunner-internals.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CacheCoordinator,
+  StreamProcessor,
+  Task,
+  TaskRunContext,
+  TaskRegistry,
+} from "@workglow/task-graph";
+import type { StreamEvent } from "@workglow/task-graph";
+import { globalServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+
+// ============================================================================
+// TaskRunContext
+// ============================================================================
+
+describe("TaskRunContext", () => {
+  it("dispose() removes the parentSignal listener", () => {
+    const parent = new AbortController();
+    const ctx = new TaskRunContext(parent.signal);
+
+    ctx.dispose();
+    parent.abort();
+
+    // ctx's own controller was not touched by parent.abort() because dispose()
+    // removed the bridging listener
+    expect(ctx.abortController.signal.aborted).toBe(false);
+  });
+
+  it("constructor: parent already aborted -> ctx aborts immediately, no listener leak", () => {
+    const parent = new AbortController();
+    parent.abort();
+
+    const ctx = new TaskRunContext(parent.signal);
+    expect(ctx.abortController.signal.aborted).toBe(true);
+
+    // dispose should be a safe no-op since the cleanup ran inline
+    ctx.dispose();
+    ctx.dispose();
+  });
+});
+
+// ============================================================================
+// StreamProcessor (text-delta accumulation + replace-mode fallback)
+// ============================================================================
+
+type AccumInput = { text: string };
+type AccumOutput = { text: string };
+
+class AccumStreamingTask extends Task<AccumInput, AccumOutput> {
+  public static override readonly type = "TestAccumStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Accum";
+  public static override readonly description = "Accum";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: AccumInput): Promise<AccumOutput> {
+    return { text: input.text };
+  }
+  public async *executeStream(_input: AccumInput): AsyncIterable<StreamEvent<AccumOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "Hello, " };
+    yield { type: "text-delta", port: "text", textDelta: "world!" };
+    yield { type: "finish", data: {} as AccumOutput };
+  }
+}
+
+type ReplaceInput = { q: string };
+type ReplaceOutput = { result: string };
+
+class ReplaceStreamingTask extends Task<ReplaceInput, ReplaceOutput> {
+  public static override readonly type = "TestReplaceStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Replace";
+  public static override readonly description = "Replace";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "replace" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: ReplaceInput): Promise<ReplaceOutput> {
+    return { result: input.q };
+  }
+  public async *executeStream(_input: ReplaceInput): AsyncIterable<StreamEvent<ReplaceOutput>> {
+    yield { type: "snapshot", data: { result: "intermediate" } };
+    yield { type: "snapshot", data: { result: "final" } };
+    // empty finish - exercise the replace-mode fallback
+    yield { type: "finish", data: {} as ReplaceOutput };
+  }
+}
+
+describe("StreamProcessor", () => {
+  it("text-delta accumulation builds enriched finish payload", async () => {
+    TaskRegistry.registerTask(AccumStreamingTask);
+    const task = new AccumStreamingTask();
+    const sp = new StreamProcessor<AccumInput, AccumOutput>(task);
+    const ctx = new TaskRunContext();
+
+    let finishData: Record<string, unknown> | undefined;
+    task.subscribe("stream_chunk", (event: any) => {
+      if (event.type === "finish") {
+        finishData = event.data;
+      }
+    });
+
+    await sp.run({ text: "ignored" }, ctx, {
+      registry: globalServiceRegistry,
+      resourceScope: undefined,
+      inputStreams: undefined,
+      onProgress: async () => {},
+      own: (i) => i,
+    });
+
+    expect(finishData).toEqual({ text: "Hello, world!" });
+  });
+
+  it("replace-mode finish with empty data falls back to last snapshot", async () => {
+    TaskRegistry.registerTask(ReplaceStreamingTask);
+    const task = new ReplaceStreamingTask();
+    const sp = new StreamProcessor<ReplaceInput, ReplaceOutput>(task);
+    const ctx = new TaskRunContext();
+
+    const result = await sp.run({ q: "ignored" }, ctx, {
+      registry: globalServiceRegistry,
+      resourceScope: undefined,
+      inputStreams: undefined,
+      onProgress: async () => {},
+      own: (i) => i,
+    });
+
+    expect(result).toEqual({ result: "final" });
+  });
+});
+
+// ============================================================================
+// CacheCoordinator
+// ============================================================================
+
+type CacheableInput = { q: string };
+type CacheableOutput = { result: string };
+
+class CacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
+  public static override readonly type = "TestCacheableStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = true;
+  public static override readonly title = "Cacheable";
+  public static override readonly description = "Cacheable";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: CacheableInput): Promise<CacheableOutput> {
+    return { result: input.q };
+  }
+}
+
+class NonCacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
+  public static override readonly type = "TestNonCacheableStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "NonCacheable";
+  public static override readonly description = "NonCacheable";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: CacheableInput): Promise<CacheableOutput> {
+    return { result: input.q };
+  }
+}
+
+class FakeCacheRepo {
+  private store = new Map<string, unknown>();
+
+  async getOutput(type: string, input: unknown): Promise<unknown> {
+    return this.store.get(`${type}::${JSON.stringify(input)}`);
+  }
+
+  async saveOutput(type: string, input: unknown, output: unknown): Promise<void> {
+    this.store.set(`${type}::${JSON.stringify(input)}`, output);
+  }
+}
+
+describe("CacheCoordinator", () => {
+  it("lookup hit emits stream_start/finish/end for streamable tasks", async () => {
+    TaskRegistry.registerTask(CacheableStreamingTask);
+    const task = new CacheableStreamingTask();
+    const cache = new FakeCacheRepo() as any;
+
+    // Pre-populate the cache
+    await cache.saveOutput("TestCacheableStreaming", { q: "hello" }, { result: "cached!" });
+
+    const cc = new CacheCoordinator<CacheableInput, CacheableOutput>(task);
+    const ctx = new TaskRunContext();
+
+    const events: string[] = [];
+    task.subscribe("stream_start", () => events.push("start"));
+    task.subscribe("stream_chunk", (event: any) => events.push(`chunk:${event.type}`));
+    task.subscribe("stream_end", () => events.push("end"));
+
+    const result = await cc.lookup({ q: "hello" }, cache, /* isStreamable */ true, ctx);
+
+    expect(result).toEqual({ result: "cached!" });
+    expect(events).toEqual(["start", "chunk:finish", "end"]);
+  });
+
+  it("save no-op when outputCache is undefined or task is not cacheable", async () => {
+    TaskRegistry.registerTask(CacheableStreamingTask);
+    const task = new CacheableStreamingTask();
+    const cc = new CacheCoordinator<CacheableInput, CacheableOutput>(task);
+
+    // Should not throw, should not record anything (cache=undefined)
+    await cc.save({ q: "x" }, { result: "y" }, undefined);
+
+    // With a cache but a non-cacheable task - verify by using a separate non-cacheable task class
+    TaskRegistry.registerTask(NonCacheableStreamingTask);
+    const nonCacheableTask = new NonCacheableStreamingTask();
+    const cc2 = new CacheCoordinator<CacheableInput, CacheableOutput>(nonCacheableTask);
+    const cache = new FakeCacheRepo() as any;
+
+    await cc2.save({ q: "x" }, { result: "y" }, cache);
+
+    const cached = await cache.getOutput("TestNonCacheableStreaming", { q: "x" });
+    expect(cached).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task-graph/workflow-internals.test.ts
+++ b/packages/test/src/test/task-graph/workflow-internals.test.ts
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Dataflow,
+  LoopBuilderContext,
+  Task,
+  TaskGraph,
+  TaskRegistry,
+  Workflow,
+  WorkflowBuilder,
+  WorkflowEventBridge,
+  runLoopAutoConnect,
+} from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { EventEmitter } from "@workglow/util";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Tiny test tasks — kept local so they don't pollute the shared TestTasks set.
+// ---------------------------------------------------------------------------
+
+class WfInternalsSourceTask extends Task<{ value: string }, { value: string }> {
+  public static override readonly type = "WfInternals_Source";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  override async execute(input: { value: string }): Promise<{ value: string }> {
+    return { value: input.value };
+  }
+}
+
+class WfInternalsSinkTask extends Task<{ value: string }, { result: string }> {
+  public static override readonly type = "WfInternals_Sink";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { value: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  override async execute(input: { value: string }): Promise<{ result: string }> {
+    return { result: input.value };
+  }
+}
+
+beforeEach(() => {
+  TaskRegistry.registerTask(WfInternalsSourceTask);
+  TaskRegistry.registerTask(WfInternalsSinkTask);
+});
+
+// ---------------------------------------------------------------------------
+// WorkflowEventBridge
+// ---------------------------------------------------------------------------
+
+describe("WorkflowEventBridge", () => {
+  it("attach() routes graph mutations to the events emitter; detach() unsubscribes", () => {
+    const events = new EventEmitter<any>();
+    const bridge = new WorkflowEventBridge(events);
+    const graph = new TaskGraph();
+
+    let changed = 0;
+    events.on("changed", () => changed++);
+
+    bridge.attach(graph);
+    graph.addTask(new WfInternalsSourceTask({ id: "a" }));
+    const afterAttach = changed;
+    expect(afterAttach).toBeGreaterThan(0);
+
+    bridge.detach();
+    graph.addTask(new WfInternalsSinkTask({ id: "b" }));
+    expect(changed).toBe(afterAttach);
+  });
+
+  it("attach() called twice auto-detaches the first subscription (no double-fire)", () => {
+    const events = new EventEmitter<any>();
+    const bridge = new WorkflowEventBridge(events);
+    const graph1 = new TaskGraph();
+    const graph2 = new TaskGraph();
+
+    let changed = 0;
+    events.on("changed", () => changed++);
+
+    bridge.attach(graph1);
+    bridge.attach(graph2);
+
+    // Mutating the OLD graph must not fire events any more — bridge re-anchored to graph2.
+    const beforeOld = changed;
+    graph1.addTask(new WfInternalsSourceTask({ id: "stale" }));
+    expect(changed).toBe(beforeOld);
+
+    // Mutating the NEW graph fires exactly one set of changes (no double-subscription).
+    graph2.addTask(new WfInternalsSourceTask({ id: "fresh" }));
+    expect(changed).toBeGreaterThan(beforeOld);
+  });
+
+  it("beginRun() returns an unsub token that stops streaming-event propagation", () => {
+    const events = new EventEmitter<any>();
+    const bridge = new WorkflowEventBridge(events);
+    const graph = new TaskGraph();
+    bridge.attach(graph);
+
+    const chunks: unknown[] = [];
+    events.on("stream_chunk", (_id: unknown, e: unknown) => chunks.push(e));
+
+    const unsub = bridge.beginRun();
+    expect(unsub).toBeDefined();
+
+    // Fire a synthetic streaming event on the graph; bridge must relay it.
+    graph.emit("task_stream_chunk", "src", { type: "text-delta", port: "x", textDelta: "hi" });
+    expect(chunks).toHaveLength(1);
+
+    // Release the run; subsequent emits must not relay.
+    unsub!();
+    graph.emit("task_stream_chunk", "src", { type: "text-delta", port: "x", textDelta: "post" });
+    expect(chunks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LoopBuilderContext
+// ---------------------------------------------------------------------------
+
+describe("LoopBuilderContext", () => {
+  it("finalizeTemplate is a no-op on an empty child graph (no subGraph assignment)", () => {
+    const parent = new Workflow();
+    parent.addTask(WfInternalsSourceTask, { value: "x" });
+    const inner = parent.addLoopTask((WfInternalsSourceTask as any), {});
+
+    // Don't add anything to the child — child graph is empty.
+    inner.finalizeTemplate();
+
+    // The iterator task on the parent should still have its initial subGraph
+    // (which is an empty graph allocated by GraphAsTask), but finalize should
+    // NOT have promoted the empty child into it. Easiest observable check:
+    // the iterator's subGraph remains empty after finalize.
+    const iter = parent.graph.getTasks().find((t) => t.id !== parent.graph.getTasks()[0].id);
+    const sub = (iter as { subGraph?: TaskGraph }).subGraph;
+    expect(sub).toBeDefined();
+    expect(sub!.getTasks()).toHaveLength(0);
+  });
+
+  it("runLoopAutoConnect returns the error message when auto-connect cannot find a match", () => {
+    // Construct a graph where autoConnect on the iterator can't find any
+    // earlier task to satisfy the iterator's input. We use the bare helper
+    // (free function exported alongside LoopBuilderContext) to avoid building
+    // a full Workflow facade for this assertion.
+    const graph = new TaskGraph();
+    const upstream = new WfInternalsSourceTask({ id: "up" });
+    const iterator = new WfInternalsSinkTask({ id: "iter" });
+    graph.addTask(upstream);
+    graph.addTask(iterator);
+
+    // Pre-populate a dataflow into iterator so autoConnect's early exit triggers
+    // (it returns undefined when target already has incoming edges). That's the
+    // happy path — verify it.
+    graph.addDataflow(new Dataflow(upstream.id, "value", iterator.id, "value"));
+
+    const result = runLoopAutoConnect(graph, { parent: upstream, iteratorTask: iterator });
+    // No work needed (iterator already had an incoming edge), so no error.
+    expect(result).toBeUndefined();
+  });
+
+  it("consumePendingConnect clears pendingLoopConnect after invocation", () => {
+    const parentWf = new Workflow();
+    parentWf.addTask(WfInternalsSourceTask, { value: "x" });
+    const iterator = new WfInternalsSinkTask({ id: "iter" });
+    parentWf.graph.addTask(iterator);
+
+    const ctx = new LoopBuilderContext(parentWf, iterator as never);
+    ctx.pendingLoopConnect = { parent: iterator, iteratorTask: iterator };
+
+    expect(ctx.pendingLoopConnect).toBeDefined();
+    ctx.consumePendingConnect();
+    expect(ctx.pendingLoopConnect).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WorkflowBuilder
+// ---------------------------------------------------------------------------
+
+describe("WorkflowBuilder", () => {
+  it("setError populates the .error getter; resetState clears it", () => {
+    const w = new Workflow();
+    // Reach the concrete builder (not the narrowed handle) for full API access.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const builder = (w as any)._builder as WorkflowBuilder;
+
+    builder.setError("boom");
+    expect(builder.error).toBe("boom");
+
+    builder.resetState();
+    expect(builder.error).toBe("");
+  });
+
+  it("addTaskInstance adds the task to the facade's graph and emits 'changed'", () => {
+    const w = new Workflow();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const builder = (w as any)._builder as WorkflowBuilder;
+
+    let changedCount = 0;
+    w.on("changed", () => changedCount++);
+
+    const before = changedCount;
+    const task = builder.addTaskInstance(WfInternalsSourceTask, {
+      id: "x",
+      defaults: { value: "v" },
+    } as never);
+
+    expect(w.graph.getTask(task.id)).toBeDefined();
+    expect(changedCount).toBeGreaterThan(before);
+  });
+
+  it("loopContext getter reflects the constructor argument", () => {
+    const parentWf = new Workflow();
+    const iterator = new WfInternalsSinkTask({ id: "iter" });
+    const ctx = new LoopBuilderContext(parentWf, iterator as never);
+
+    const builderWithCtx = new WorkflowBuilder(parentWf, undefined, ctx);
+    expect(builderWithCtx.loopContext).toBe(ctx);
+
+    const builderWithoutCtx = new WorkflowBuilder(parentWf);
+    expect(builderWithoutCtx.loopContext).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task/ArrayTask.test.ts
+++ b/packages/test/src/test/task/ArrayTask.test.ts
@@ -600,13 +600,7 @@ describe("ArrayTask", () => {
       expect(task.completedAt).toBeDefined();
     });
 
-    // Manually trigger a progress event before running the task
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleStart();
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleProgress(0.5);
-
-    // Run the task
+    // Run the task — it emits start/progress/complete on its own.
     const results = await task.run();
 
     // Verify events were emitted
@@ -669,21 +663,8 @@ describe("ArrayTask", () => {
       });
     });
 
-    // Manually trigger progress events
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleStart();
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleProgress(0.5);
-
-    // Manually trigger progress events on child tasks
-    task.subGraph!.getTasks().forEach((childTask: ITask) => {
-      // @ts-expect-error - we are testing the protected method
-      childTask.runner.handleStart();
-      // @ts-expect-error - we are testing the protected method
-      childTask.runner.handleProgress(0.5);
-    });
-
-    // Run the task
+    // Run the task — start/progress/complete events fire on parent and children
+    // through the normal run path.
     await task.run();
 
     // Verify parent events were emitted

--- a/packages/test/src/test/task/ImageOp.test.ts
+++ b/packages/test/src/test/task/ImageOp.test.ts
@@ -3,14 +3,9 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, vi } from "vitest";
-import {
-  registerFilterOp,
-  applyFilter,
-  hasFilterOp,
-  _resetFilterRegistryForTests,
-} from "@workglow/tasks";
+import { applyFilter, hasFilterOp, registerFilterOp } from "@workglow/tasks";
 import { CpuImage, type GpuImage } from "@workglow/util/media";
+import { describe, expect, test, vi } from "vitest";
 
 describe("applyFilter", () => {
   test("dispatches to the registered cpu fn for CpuImage", () => {
@@ -54,14 +49,16 @@ describe("applyFilter", () => {
 
 describe("hasFilterOp", () => {
   test("returns false when no op registered for (backend, filter)", () => {
-    _resetFilterRegistryForTests();
     expect(hasFilterOp("webgpu", "__nope__")).toBe(false);
   });
 
   test("returns true after registerFilterOp for that key", () => {
-    _resetFilterRegistryForTests();
     registerFilterOp<undefined>("webgpu", "__yes__", (img) => img);
     expect(hasFilterOp("webgpu", "__yes__")).toBe(true);
     expect(hasFilterOp("cpu", "__yes__")).toBe(false);
+  });
+
+  test("keeps built-in task filter registrations available", () => {
+    expect(hasFilterOp("cpu", "sepia")).toBe(true);
   });
 });

--- a/packages/test/src/test/task/IteratorTask.test.ts
+++ b/packages/test/src/test/task/IteratorTask.test.ts
@@ -885,7 +885,7 @@ describe("IteratorTask", () => {
         }
 
         override async execute(input: { item: number }): Promise<{ item: number }> {
-          await new Promise((resolve) => setTimeout(resolve, (4 - input.item) * 5));
+          await sleep((4 - input.item) * 5);
           return { item: input.item };
         }
       }

--- a/packages/test/src/test/task/SingleTask.test.ts
+++ b/packages/test/src/test/task/SingleTask.test.ts
@@ -4,11 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Task, TaskAbortedError, TaskError, TaskStatus } from "@workglow/task-graph";
+import {
+  Task,
+  TaskAbortedError,
+  TaskConfigurationError,
+  TaskError,
+  TaskStatus,
+} from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
-import { EventTestTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
+import { EventTestTask, LongRunningTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
 
 const spyOn = vi.spyOn;
 
@@ -620,6 +626,35 @@ describe("SingleTask", () => {
         await runPromise.catch(() => {});
         expect(task.status).toBe(TaskStatus.ABORTING);
       });
+    });
+  });
+
+  describe("Concurrent run() rejection", () => {
+    it("throws TaskConfigurationError when run() is called while the task is PROCESSING", async () => {
+      const task = new LongRunningTask();
+      const inflight = task.run();
+      // Yield so handleStart sets status to PROCESSING and the execute loop is parked.
+      await sleep(0);
+      expect(task.status).toBe(TaskStatus.PROCESSING);
+
+      await expect(task.run()).rejects.toBeInstanceOf(TaskConfigurationError);
+
+      task.abort();
+      await inflight.catch(() => {});
+    });
+
+    it("does not disturb the in-flight run when a concurrent run() is rejected", async () => {
+      const task = new EventTestTask();
+      task.delayMs = 30;
+      const inflight = task.run();
+      await sleep(0);
+      expect(task.status).toBe(TaskStatus.PROCESSING);
+
+      await expect(task.run()).rejects.toBeInstanceOf(TaskConfigurationError);
+
+      const result = await inflight;
+      expect(result).toEqual({ key: "default", previewOnly: false, all: true });
+      expect(task.status).toBe(TaskStatus.COMPLETED);
     });
   });
 });

--- a/packages/test/src/test/task/SingleTask.test.ts
+++ b/packages/test/src/test/task/SingleTask.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { Task, TaskAbortedError, TaskError, TaskStatus } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { setLogger, sleep } from "@workglow/util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 import { EventTestTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
@@ -502,7 +502,7 @@ describe("SingleTask", () => {
         const runPromise = task.run();
 
         // Wait a bit to ensure progress event has time to fire
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await sleep(10);
 
         task.abort();
         await runPromise.catch(() => {});

--- a/scripts/test.test.ts
+++ b/scripts/test.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, test } from "bun:test";
+
+describe("scripts/test.ts", () => {
+  test("unit bun dry-run omits integration files and empty argv entries", async () => {
+    const proc = Bun.spawn(["bun", "scripts/test.ts", "unit", "bun", "--dry-run"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"bun","test"');
+    expect(stdout).not.toContain('""');
+    expect(stdout).not.toContain(".integration.test.ts");
+  });
+});

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -104,6 +104,7 @@ Runners:  ${KNOWN_RUNNERS.join(", ")} (default: both)
 
 Options:
   --all          Run full suite (bun + vitest, no filters, very slow)
+  --dry-run      Print runner commands without executing them
   --help         Show this usage message
 
 Examples:
@@ -166,21 +167,11 @@ function collectFiles(
 }
 
 async function runBunTest(files: string[]): Promise<number> {
-  const parallelFlag =
-    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
-      ? "--parallel=1"
-      : "--parallel";
-  // Match vitest's testTimeout: Bun's default is 5s per test, which is easy to exceed in HF/Sqlite work
-  const timeoutFlag = "--timeout=15000";
-  const proc = Bun.spawn(
-    files.length > 0
-      ? ["bun", "test", timeoutFlag, parallelFlag, ...files]
-      : ["bun", "test", timeoutFlag, parallelFlag],
-    {
-      cwd: ROOT,
-      stdio: ["inherit", "inherit", "inherit"],
-    }
-  );
+  const args = buildBunTestArgs(files);
+  const proc = Bun.spawn(args, {
+    cwd: ROOT,
+    stdio: ["inherit", "inherit", "inherit"],
+  });
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
     console.error(`Bun test failed with exit code ${exitCode}`);
@@ -188,7 +179,18 @@ async function runBunTest(files: string[]): Promise<number> {
   return exitCode;
 }
 
-async function runVitest(files: string[]): Promise<number> {
+function buildBunTestArgs(files: string[]): string[] {
+  const parallelFlag: string =
+    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
+      ? "--parallel=1"
+      : "--parallel";
+  // Match vitest's testTimeout: Bun's default is 5s per test, which is easy to exceed in HF/Sqlite work
+  const timeoutFlag = "--timeout=15000";
+  const flags = [timeoutFlag, parallelFlag].filter((flag) => flag.length > 0);
+  return files.length > 0 ? ["bun", "test", ...flags, ...files] : ["bun", "test", ...flags];
+}
+
+function buildVitestArgs(files: string[]): string[] {
   // When no file filter: run all. Otherwise pass relative paths as name filters.
   const relFiles = files.length > 0 ? files.map((f) => relative(ROOT, f)) : [];
   const args = ["npx", "vitest", "run", ...relFiles];
@@ -198,6 +200,11 @@ async function runVitest(files: string[]): Promise<number> {
   if (process.env.CI) {
     args.push("--coverage");
   }
+  return args;
+}
+
+async function runVitest(files: string[]): Promise<number> {
+  const args = buildVitestArgs(files);
   const proc = Bun.spawn(args, {
     cwd: ROOT,
     stdio: ["inherit", "inherit", "inherit"],
@@ -219,7 +226,8 @@ if (rawArgs.includes("--help")) {
 }
 
 const runAll = rawArgs.includes("--all");
-const filteredArgs = rawArgs.filter((a) => a !== "--all");
+const dryRun = rawArgs.includes("--dry-run");
+const filteredArgs = rawArgs.filter((a) => a !== "--all" && a !== "--dry-run");
 
 if (!runAll && filteredArgs.length === 0) {
   showHelp();
@@ -274,6 +282,16 @@ const kindLabel = kinds.length > 0 ? kinds.join("+") : "all";
 const sectionLabel = sections.length > 0 ? sections.join("+") : "all";
 const fileCount = files.length > 0 ? `${files.length} file(s)` : "all files";
 console.log(`\nRunning ${kindLabel} tests in sections [${sectionLabel}] — ${fileCount}\n`);
+
+if (dryRun) {
+  if (!vitestOnly) {
+    console.log(JSON.stringify(buildBunTestArgs(files)));
+  }
+  if (!bunOnly) {
+    console.log(JSON.stringify(buildVitestArgs(files)));
+  }
+  process.exit(0);
+}
 
 // ── Execute ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Pure structural refactor of `packages/task-graph/src/task-graph/TaskGraphRunner.ts` (1,478 → 774 lines, 48% reduction) into a thin facade plus three internal collaborators and a per-run value object. **No behavior change. No public API change.**

- **`RunContext`** (49 lines) — per-run mutable state (runId, abortController, in-progress maps, failedTaskErrors, telemetrySpan, graphTimeoutTimer, pendingGraphTimeoutError, activeEnforcer). Built by `handleStart`, discarded by terminal handlers.
- **`EdgeMaterializer`** (254 lines) — dataflow read/write, transforms, error-port routing, per-task reset.
- **`StreamPump`** (347 lines) — streaming-input tee, streaming task execution, accumulation policy, stream fan-out to outgoing edges.
- **`RunScheduler`** (314 lines) — for-await run loop, status/disabled cascade, progress aggregation, graph-level timeout arm/clear.

The facade keeps lifecycle handlers (`handleStart`/`handleComplete`/`handleError`/`handleAbort`/`handleDisable`), `runTask` orchestration, the inline `runGraphPreview` body, and the terminal-state precedence in `runGraph` (timeout > error > abort > complete).

### Why

Sets up two upcoming workstreams:
- **Resumability** (next planned feature) — the run-loop gains pause/checkpoint/resume; `RunContext` is the natural shape to serialize.
- **Deeper unit-test coverage** — current tests are integration-only. Each new class is now constructable in isolation with a synthetic graph + fresh context. This PR seeds 6 such tests; richer per-class coverage can land in follow-ups against the now-clean seams.

### Public API

`runGraph`, `runGraphPreview`, `abort`, `disable`, `addInputData`, `resetGraph`, `mergeExecuteOutputsToRunOutput`, plus the constructor — all byte-identical signatures. Three facade members (`previewRunning`, `registry`, `runScheduler`) widened to `public` and tagged `@internal` for collaborator back-references; not part of the long-lived public contract.

### Spec & plan

- Spec: `builder/docs/superpowers/specs/2026-05-02-decompose-taskgraph-runner-design.md`
- Plan: `builder/docs/superpowers/plans/2026-05-02-decompose-taskgraph-runner-plan.md`

## Test plan

- [x] \`bun scripts/test.ts graph task vitest\` — **1669 passed | 24 skipped** (1663 baseline + 6 new unit tests for the new collaborators)
- [x] \`bun run build:types\` — 24/24 successful
- [x] \`bun run build:packages\` — 22/22 successful
- [x] Broader smoke (\`graph task storage queue ai vitest\`) — all sections pass; no downstream regressions in Workflow / AiTask / RAG paths
- [x] Each commit individually green; subagent-driven-development with two-stage review (spec compliance + code quality) per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)