### PR TITLE
refactor(task-graph): decompose Workflow into focused units

### DIFF
--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -19,6 +19,7 @@ export * from "./task-graph/Conversions";
 export * from "./task-graph/GraphToWorkflowCode";
 export * from "./task-graph/IWorkflow";
 export * from "./task-graph/Workflow";
+export * from "./task-graph/WorkflowFactories";
 export * from "./task-graph/WorkflowPipe";
 
 export * from "./task-graph/TransformRegistry";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -19,6 +19,7 @@ export * from "./task-graph/Conversions";
 export * from "./task-graph/GraphToWorkflowCode";
 export * from "./task-graph/IWorkflow";
 export * from "./task-graph/Workflow";
+export * from "./task-graph/WorkflowPipe";
 
 export * from "./task-graph/TransformRegistry";
 export * from "./task-graph/TransformTypes";

--- a/packages/task-graph/src/task-graph/GraphSchemaUtils.ts
+++ b/packages/task-graph/src/task-graph/GraphSchemaUtils.ts
@@ -5,7 +5,9 @@
  */
 
 import { uuid4 } from "@workglow/util";
-import type { DataPortSchema } from "@workglow/util/schema";
+import type { DataPortSchema, JsonSchema } from "@workglow/util/schema";
+import type { ITask } from "../task/ITask";
+import { Task } from "../task/Task";
 import type {
   DataflowJson,
   JsonTaskItem,
@@ -499,4 +501,186 @@ export function addBoundaryNodesToDependencyJson(
   }
 
   return [...prependItems, ...items, ...appendItems];
+}
+
+const TYPED_ARRAY_FORMAT_PREFIX = "TypedArray";
+
+/**
+ * Returns true if the given JSON schema (or any nested schema) has a format
+ * string starting with "TypedArray" (e.g. "TypedArray" or "TypedArray:Float32Array").
+ * Walks oneOf/anyOf wrappers and array items.
+ */
+function schemaHasTypedArrayFormat(schema: JsonSchema): boolean {
+  if (typeof schema === "boolean") return false;
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return false;
+
+  const s = schema as Record<string, unknown>;
+  if (typeof s.format === "string" && s.format.startsWith(TYPED_ARRAY_FORMAT_PREFIX)) {
+    return true;
+  }
+
+  const checkUnion = (schemas: unknown): boolean => {
+    if (!Array.isArray(schemas)) return false;
+    return schemas.some((sub) => schemaHasTypedArrayFormat(sub as JsonSchema));
+  };
+  if (checkUnion(s.oneOf) || checkUnion(s.anyOf)) return true;
+
+  const items = s.items;
+  if (items && typeof items === "object" && !Array.isArray(items)) {
+    if (schemaHasTypedArrayFormat(items as JsonSchema)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the task's output schema has any port with TypedArray format.
+ * Used by adaptive workflow methods to choose scalar vs vector task variant.
+ */
+export function hasVectorOutput(task: ITask): boolean {
+  const outputSchema = task.outputSchema();
+  if (typeof outputSchema === "boolean" || !outputSchema?.properties) return false;
+  return Object.values(outputSchema.properties).some((prop) =>
+    schemaHasTypedArrayFormat(prop as JsonSchema)
+  );
+}
+
+/**
+ * Returns true if the input object looks like vector task input: has a "vectors"
+ * property that is an array with at least one TypedArray element. Used by
+ * adaptive workflow methods so that e.g. sum({ vectors: [new Float32Array(...)] })
+ * chooses the vector variant even with no previous task.
+ */
+export function hasVectorLikeInput(input: unknown): boolean {
+  if (!input || typeof input !== "object") return false;
+  const v = (input as Record<string, unknown>).vectors;
+  return (
+    Array.isArray(v) &&
+    v.length > 0 &&
+    typeof v[0] === "object" &&
+    v[0] !== null &&
+    ArrayBuffer.isView(v[0])
+  );
+}
+
+/**
+ * Updates InputTask/OutputTask config schemas based on their connected dataflows.
+ * InputTask schema reflects its outgoing dataflow targets' input schemas.
+ * OutputTask schema reflects its incoming dataflow sources' output schemas.
+ */
+export function updateBoundaryTaskSchemas(graph: TaskGraph): void {
+  const tasks = graph.getTasks();
+
+  for (const task of tasks) {
+    if (task.type === "InputTask") {
+      // If the schema is marked as fully manual (x-ui-manual at schema level),
+      // skip edge-based regeneration — the user explicitly defined this schema.
+      const existingConfig = (task as ITask).config;
+      const existingSchema = existingConfig?.inputSchema ?? existingConfig?.outputSchema;
+      if (
+        existingSchema &&
+        typeof existingSchema === "object" &&
+        (existingSchema as Record<string, unknown>)["x-ui-manual"] === true
+      ) {
+        continue;
+      }
+
+      const outgoing = graph.getTargetDataflows(task.id);
+      if (outgoing.length === 0) continue;
+
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
+
+      for (const df of outgoing) {
+        const targetTask = graph.getTask(df.targetTaskId);
+        if (!targetTask) continue;
+        const targetSchema = targetTask.inputSchema();
+        if (typeof targetSchema === "boolean") continue;
+        const prop = (targetSchema.properties as any)?.[df.targetTaskPortId];
+        if (prop && typeof prop !== "boolean") {
+          properties[df.sourceTaskPortId] = prop;
+          if (targetSchema.required?.includes(df.targetTaskPortId)) {
+            if (!required.includes(df.sourceTaskPortId)) {
+              required.push(df.sourceTaskPortId);
+            }
+          }
+        }
+      }
+
+      const schema = {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      } as DataPortSchema;
+
+      // @ts-expect-error - config is readonly
+      task.config = {
+        ...task.config,
+        inputSchema: schema,
+        outputSchema: schema,
+      };
+    }
+
+    if (task.type === "OutputTask") {
+      const incoming = graph.getSourceDataflows(task.id);
+      if (incoming.length === 0) continue;
+
+      const properties: Record<string, any> = {};
+      const required: string[] = [];
+
+      for (const df of incoming) {
+        const sourceTask = graph.getTask(df.sourceTaskId);
+        if (!sourceTask) continue;
+        const sourceSchema = sourceTask.outputSchema();
+        if (typeof sourceSchema === "boolean") continue;
+        let prop = (sourceSchema.properties as any)?.[df.sourceTaskPortId];
+        let propRequired = sourceSchema.required?.includes(df.sourceTaskPortId) ?? false;
+
+        // For passthrough tasks with additionalProperties (e.g. DebugLogTask),
+        // the port won't appear in the static output schema. Trace back through
+        // the passthrough task's own incoming dataflows to find the actual schema.
+        if (
+          !prop &&
+          sourceSchema.additionalProperties === true &&
+          (sourceTask.constructor as typeof Task).passthroughInputsToOutputs === true
+        ) {
+          const upstreamDfs = graph.getSourceDataflows(sourceTask.id);
+          for (const udf of upstreamDfs) {
+            if (udf.targetTaskPortId !== df.sourceTaskPortId) continue;
+            const upstreamTask = graph.getTask(udf.sourceTaskId);
+            if (!upstreamTask) continue;
+            const upstreamSchema = upstreamTask.outputSchema();
+            if (typeof upstreamSchema === "boolean") continue;
+            prop = (upstreamSchema.properties as any)?.[udf.sourceTaskPortId];
+            if (prop) {
+              propRequired = upstreamSchema.required?.includes(udf.sourceTaskPortId) ?? false;
+              break;
+            }
+          }
+        }
+
+        if (prop && typeof prop !== "boolean") {
+          properties[df.targetTaskPortId] = prop;
+          if (propRequired && !required.includes(df.targetTaskPortId)) {
+            required.push(df.targetTaskPortId);
+          }
+        }
+      }
+
+      const schema = {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      } as DataPortSchema;
+
+      // @ts-expect-error - config is readonly
+      task.config = {
+        ...task.config,
+        inputSchema: schema,
+        outputSchema: schema,
+      };
+    }
+  }
 }

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+import type { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask } from "../task/ITask";
+import { autoConnect } from "./autoConnect";
+import type { TaskGraph } from "./TaskGraph";
+import type { Workflow } from "./Workflow";
+
+export interface PendingLoopConnect {
+  readonly parent: ITask;
+  readonly iteratorTask: ITask;
+}
+
+/**
+ * Runs deferred auto-connect for a loop iterator task on the parent
+ * workflow's graph. Extracted as a free function so it can be invoked
+ * from both {@link LoopBuilderContext.autoConnectLoopTask} and from
+ * the parent {@link Workflow}'s public delegate method (the parent is
+ * not itself in loop-builder mode and has no context of its own).
+ */
+export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopConnect): void {
+  const { parent, iteratorTask } = pending;
+  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return;
+
+  const nodes = parentGraph.getTasks();
+  const parentIndex = nodes.findIndex((n) => n.id === parent.id);
+  const earlierTasks: ITask[] = [];
+  for (let i = parentIndex - 1; i >= 0; i--) {
+    earlierTasks.push(nodes[i]);
+  }
+
+  const result = autoConnect(parentGraph, parent, iteratorTask, { earlierTasks });
+  if (result.error) {
+    getLogger().error(result.error + " Task not added.");
+    parentGraph.removeTask(iteratorTask.id);
+  }
+}
+
+/**
+ * Holds the parent <-> child relationship for a Workflow operating in
+ * loop-builder mode (created by parent.addLoopTask). Owns deferred
+ * auto-connect state. Has no events, no DSL.
+ */
+export class LoopBuilderContext {
+  public readonly parent: Workflow;
+  public readonly iteratorTask: GraphAsTask;
+  public pendingLoopConnect?: PendingLoopConnect;
+
+  constructor(parent: Workflow, iteratorTask: GraphAsTask) {
+    this.parent = parent;
+    this.iteratorTask = iteratorTask;
+  }
+
+  /**
+   * Promotes a populated child template graph into the iterator task's
+   * subGraph. No-op on empty graphs.
+   */
+  public finalizeTemplate(childGraph: TaskGraph): void {
+    if (childGraph.getTasks().length === 0) return;
+    this.iteratorTask.subGraph = childGraph;
+    this.iteratorTask.validateAcyclic();
+  }
+
+  /** Runs auto-connect for the pending loop connect (if any), then clears it. */
+  public consumePendingConnect(): void {
+    const pending = this.pendingLoopConnect;
+    if (!pending) return;
+    runLoopAutoConnect(this.parent.graph, pending);
+    this.pendingLoopConnect = undefined;
+  }
+
+  /** Finalizes the template and returns the parent workflow. */
+  public finalizeAndReturn(childGraph: TaskGraph): Workflow {
+    this.finalizeTemplate(childGraph);
+    this.consumePendingConnect();
+    return this.parent;
+  }
+}

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -19,13 +19,21 @@ export interface PendingLoopConnect {
 /**
  * Runs deferred auto-connect for a loop iterator task on the parent
  * workflow's graph. Extracted as a free function so it can be invoked
- * from both {@link LoopBuilderContext.autoConnectLoopTask} and from
+ * from both {@link LoopBuilderContext.consumePendingConnect} and from
  * the parent {@link Workflow}'s public delegate method (the parent is
  * not itself in loop-builder mode and has no context of its own).
+ *
+ * Returns the error message if auto-connect failed, otherwise undefined.
+ * On failure the iterator task is removed from the parent graph; the
+ * caller is responsible for surfacing the error onto the parent
+ * workflow's `.error` (matches the non-loop auto-connect path).
  */
-export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopConnect): void {
+export function runLoopAutoConnect(
+  parentGraph: TaskGraph,
+  pending: PendingLoopConnect
+): string | undefined {
   const { parent, iteratorTask } = pending;
-  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return;
+  if (parentGraph.getTargetDataflows(parent.id).length !== 0) return undefined;
 
   const nodes = parentGraph.getTasks();
   const parentIndex = nodes.findIndex((n) => n.id === parent.id);
@@ -36,9 +44,12 @@ export function runLoopAutoConnect(parentGraph: TaskGraph, pending: PendingLoopC
 
   const result = autoConnect(parentGraph, parent, iteratorTask, { earlierTasks });
   if (result.error) {
-    getLogger().error(result.error + " Task not added.");
+    const message = result.error + " Task not added.";
+    getLogger().error(message);
     parentGraph.removeTask(iteratorTask.id);
+    return message;
   }
+  return undefined;
 }
 
 /**
@@ -66,18 +77,28 @@ export class LoopBuilderContext {
     this.iteratorTask.validateAcyclic();
   }
 
-  /** Runs auto-connect for the pending loop connect (if any), then clears it. */
-  public consumePendingConnect(): void {
+  /**
+   * Runs auto-connect for the pending loop connect (if any), then clears it.
+   * Returns the error message if auto-connect failed, otherwise undefined,
+   * so the caller can propagate the failure to the parent workflow's `.error`.
+   */
+  public consumePendingConnect(): string | undefined {
     const pending = this.pendingLoopConnect;
-    if (!pending) return;
-    runLoopAutoConnect(this.parent.graph, pending);
+    if (!pending) return undefined;
+    const error = runLoopAutoConnect(this.parent.graph, pending);
     this.pendingLoopConnect = undefined;
+    return error;
   }
 
-  /** Finalizes the template and returns the parent workflow. */
+  /**
+   * Finalizes the template and returns the parent workflow. Any deferred
+   * auto-connect error is surfaced onto the parent's `.error` to match the
+   * non-loop auto-connect path.
+   */
   public finalizeAndReturn(childGraph: TaskGraph): Workflow {
     this.finalizeTemplate(childGraph);
-    this.consumePendingConnect();
+    const error = this.consumePendingConnect();
+    if (error) this.parent.builder.setError(error);
     return this.parent;
   }
 }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -33,6 +33,7 @@ import type { ITransformStep } from "./TransformTypes";
 import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
 export interface RenameOptions {
@@ -66,11 +67,6 @@ export type WorkflowEventParameters<Event extends WorkflowEvents> = EventParamet
   WorkflowEventListeners,
   Event
 >;
-
-class WorkflowTask<I extends DataPorts, O extends DataPorts> extends GraphAsTask<I, O> {
-  public static override readonly type = "Workflow";
-  public static override readonly compoundMerge = PROPERTY_ARRAY as CompoundMergeStrategy;
-}
 
 /**
  * Class for building and managing a task graph

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -33,6 +33,7 @@ import type { ITransformStep } from "./TransformTypes";
 import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -94,11 +95,11 @@ export class Workflow<
     iteratorTask?: GraphAsTask,
     registry?: ServiceRegistry
   ) {
-    this._outputCache = cache;
+    this._cache = new WorkflowCacheAdapter(cache);
     this._parentWorkflow = parent;
     this._iteratorTask = iteratorTask;
     this._registry = registry ?? parent?._registry;
-    this._graph = new TaskGraph({ outputCache: this._outputCache });
+    this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
     if (!parent) {
       this._onChanged = this._onChanged.bind(this);
@@ -110,7 +111,7 @@ export class Workflow<
   private _graph: TaskGraph;
   private _dataFlows: Dataflow[] = [];
   private _error: string = "";
-  private _outputCache?: TaskOutputRepository;
+  private _cache: WorkflowCacheAdapter;
   private _registry?: ServiceRegistry;
   private _entitlementUnsub?: () => void;
 
@@ -126,7 +127,7 @@ export class Workflow<
   };
 
   public outputCache(): TaskOutputRepository | undefined {
-    return this._outputCache;
+    return this._cache.outputCache();
   }
 
   /**
@@ -334,7 +335,7 @@ export class Workflow<
     try {
       const output = await this.graph.run<Output>(input, {
         parentSignal: this._abortController.signal,
-        outputCache: this._outputCache,
+        outputCache: this._cache.outputCache(),
         registry: config?.registry ?? this._registry,
         resourceScope: config?.resourceScope,
       });
@@ -634,7 +635,7 @@ export class Workflow<
 
     this.clearEvents();
     this._graph = new TaskGraph({
-      outputCache: this._outputCache,
+      outputCache: this._cache.outputCache(),
     });
     this._dataFlows = [];
     this._error = "";

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -29,95 +29,12 @@ import {
   hasVectorOutput,
   updateBoundaryTaskSchemas,
 } from "./GraphSchemaUtils";
-import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
-
-// ============================================================================
-// Standalone utility functions (moved from Conversions.ts to break circular
-// dependency — these need both Workflow and GraphAsTask which live here)
-// ============================================================================
-
-export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
-  const tasks = workflow.graph.getTasks();
-  return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
-}
-
-export function connect(
-  source: ITask<any, any, any>,
-  target: ITask<any, any, any>,
-  workflow: IWorkflow<any, any>
-): void {
-  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
-}
-
-export function pipe<A extends DataPorts, B extends DataPorts>(
-  [fn1]: [Taskish<A, B>],
-  workflow?: IWorkflow<A, B>
-): IWorkflow<A, B>;
-
-export function pipe<A extends DataPorts, B extends DataPorts, C extends DataPorts>(
-  [fn1, fn2]: [Taskish<A, B>, Taskish<B, C>],
-  workflow?: IWorkflow<A, C>
-): IWorkflow<A, C>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
->(
-  [fn1, fn2, fn3]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>],
-  workflow?: IWorkflow<A, D>
-): IWorkflow<A, D>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
-  E extends DataPorts,
->(
-  [fn1, fn2, fn3, fn4]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>, Taskish<D, E>],
-  workflow?: IWorkflow<A, E>
-): IWorkflow<A, E>;
-
-export function pipe<
-  A extends DataPorts,
-  B extends DataPorts,
-  C extends DataPorts,
-  D extends DataPorts,
-  E extends DataPorts,
-  F extends DataPorts,
->(
-  [fn1, fn2, fn3, fn4, fn5]: [
-    Taskish<A, B>,
-    Taskish<B, C>,
-    Taskish<C, D>,
-    Taskish<D, E>,
-    Taskish<E, F>,
-  ],
-  workflow?: IWorkflow<A, F>
-): IWorkflow<A, F>;
-
-export function pipe<I extends DataPorts, O extends DataPorts>(
-  args: Taskish<I, O>[],
-  workflow: IWorkflow<I, O> = new Workflow<I, O>()
-): IWorkflow<I, O> {
-  let previousTask = getLastTask(workflow);
-  const tasks = args.map((arg) => ensureTask(arg));
-  tasks.forEach((task) => {
-    workflow.graph.addTask(task);
-    if (previousTask) {
-      connect(previousTask, task, workflow);
-    }
-    previousTask = task;
-  });
-  return workflow;
-}
+import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 
 /** Options accepted by {@link Workflow.rename}. */
 export interface RenameOptions {
@@ -125,29 +42,6 @@ export interface RenameOptions {
   readonly index?: number;
   /** Transform chain applied to the dataflow edge this rename creates. */
   readonly transforms?: ReadonlyArray<ITransformStep>;
-}
-
-export function parallel<I extends DataPorts = DataPorts, O extends DataPorts = DataPorts>(
-  args: (PipeFunction<I, O> | ITask<I, O> | IWorkflow<I, O> | ITaskGraph)[],
-  mergeFn: CompoundMergeStrategy = PROPERTY_ARRAY,
-  workflow: IWorkflow<I, O> = new Workflow<I, O>()
-): IWorkflow<I, O> {
-  let previousTask = getLastTask(workflow);
-  const tasks = args.map((arg) => ensureTask(arg));
-  const config = {
-    compoundMerge: mergeFn,
-  };
-  const name = `‖${args.map((_arg) => "𝑓").join("‖")}‖`;
-  class ParallelTask extends GraphAsTask<I, O> {
-    public static override type = name;
-  }
-  const mergeTask = new ParallelTask(config);
-  mergeTask.subGraph!.addTasks(tasks);
-  workflow.graph.addTask(mergeTask);
-  if (previousTask) {
-    connect(previousTask, mergeTask, workflow);
-  }
-  return workflow;
 }
 
 // Type definitions for the workflow

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -253,8 +253,10 @@ export class Workflow<
     this.events.emit("start");
     this._abortController = new AbortController();
 
-    // Subscribe to graph-level streaming events and forward to workflow events
-    this._bridge?.beginRun();
+    // Subscribe to graph-level streaming events and forward to workflow events.
+    // The unsub token is held LOCAL to this run so concurrent run() calls don't
+    // clobber each other's streaming subscriptions.
+    const unsubStreaming = this._bridge?.beginRun();
 
     try {
       const output = await this.graph.run<Output>(input, {
@@ -273,7 +275,7 @@ export class Workflow<
       this.events.emit("error", String(error));
       throw error;
     } finally {
-      this._bridge?.endRun();
+      unsubStreaming?.();
       this._abortController = undefined;
     }
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -24,16 +24,14 @@ import { ensureTask } from "./Conversions";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
-import {
-  hasVectorLikeInput,
-  hasVectorOutput,
-  updateBoundaryTaskSchemas,
-} from "./GraphSchemaUtils";
+import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
+import type { CreateWorkflow } from "./WorkflowFactories";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -42,124 +40,6 @@ export interface RenameOptions {
   readonly index?: number;
   /** Transform chain applied to the dataflow edge this rename creates. */
   readonly transforms?: ReadonlyArray<ITransformStep>;
-}
-
-// Type definitions for the workflow
-export type CreateWorkflow<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I>> = (
-  input?: Partial<I>,
-  config?: Partial<C>
-) => Workflow<I, O>;
-
-export function CreateWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
->(taskClass: ITaskConstructor<I, O, C>): CreateWorkflow<I, O, C> {
-  return Workflow.createWorkflow<I, O, C>(taskClass);
-}
-
-/**
- * Type for loop workflow methods (map, while, reduce).
- * Represents the method signature with proper `this` context.
- * Loop methods take only a config parameter - input is not used for loop tasks.
- */
-export type CreateLoopWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
-> = (this: Workflow<I, O>, config?: Partial<C>) => Workflow<I, O>;
-
-/**
- * Factory function that creates a loop workflow method for a given task class.
- * Returns a method that can be assigned to Workflow.prototype.
- *
- * @param taskClass - The iterator task class (MapTask, ReduceTask, etc.)
- * @returns A method that creates the task and returns a loop builder workflow
- */
-export function CreateLoopWorkflow<
-  I extends DataPorts,
-  O extends DataPorts,
-  C extends TaskConfig<I> = TaskConfig<I>,
->(taskClass: ITaskConstructor<I, O, C>): CreateLoopWorkflow<I, O, C> {
-  return function (this: Workflow<I, O>, config: Partial<C> = {}): Workflow<I, O> {
-    return this.addLoopTask(taskClass, config);
-  };
-}
-
-/**
- * Type for end loop workflow methods (endMap, endBatch, etc.).
- */
-export type EndLoopWorkflow = (this: Workflow) => Workflow;
-
-/**
- * Factory function that creates an end loop workflow method.
- *
- * @param methodName - The name of the method (for error messages)
- * @returns A method that finalizes the loop and returns to the parent workflow
- */
-export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
-  return function (this: Workflow): Workflow {
-    if (!this.isLoopBuilder) {
-      throw new Error(`${methodName}() can only be called on loop workflows`);
-    }
-    return this.finalizeAndReturn();
-  };
-}
-
-/**
- * Type for adaptive workflow methods that dispatch to scalar or vector variant
- * based on the previous task's output schema.
- */
-export type CreateAdaptiveWorkflow<
-  IS extends DataPorts,
-  _OS extends DataPorts,
-  IV extends DataPorts,
-  _OV extends DataPorts,
-  CS extends TaskConfig<IS> = TaskConfig<IS>,
-  CV extends TaskConfig<IV> = TaskConfig<IV>,
-> = (
-  this: Workflow,
-  input?: Partial<IS> & Partial<IV>,
-  config?: Partial<CS> & Partial<CV>
-) => Workflow;
-
-/**
- * Factory that creates an adaptive workflow method: when called, inspects the
- * output schema of the last task in the chain and delegates to the vector
- * variant if it has TypedArray output, otherwise to the scalar variant.
- * If there is no previous task, defaults to the scalar variant.
- *
- * @param scalarClass - Task class for scalar path (e.g. ScalarAddTask)
- * @param vectorClass - Task class for vector path (e.g. VectorSumTask)
- * @returns A method suitable for Workflow.prototype
- */
-export function CreateAdaptiveWorkflow<
-  IS extends DataPorts,
-  OS extends DataPorts,
-  IV extends DataPorts,
-  OV extends DataPorts,
-  CS extends TaskConfig<IS> = TaskConfig<IS>,
-  CV extends TaskConfig<IV> = TaskConfig<IV>,
->(
-  scalarClass: ITaskConstructor<IS, OS, CS>,
-  vectorClass: ITaskConstructor<IV, OV, CV>
-): CreateAdaptiveWorkflow<IS, OS, IV, OV, CS, CV> {
-  const scalarHelper = Workflow.createWorkflow<IS, OS, CS>(scalarClass);
-  const vectorHelper = Workflow.createWorkflow<IV, OV, CV>(vectorClass);
-
-  return function (
-    this: Workflow<any, any>,
-    input: (Partial<IS> & Partial<IV>) | undefined = {},
-    config: (Partial<CS> & Partial<CV>) | undefined = {}
-  ): Workflow {
-    const parent = getLastTask(this);
-    const useVector =
-      (parent !== undefined && hasVectorOutput(parent)) || hasVectorLikeInput(input);
-    if (useVector) {
-      return vectorHelper.call(this, input, config) as Workflow;
-    }
-    return scalarHelper.call(this, input, config) as Workflow;
-  };
 }
 
 // Event types
@@ -1077,8 +957,10 @@ export class Workflow<
   }
 }
 
-// Module augmentation prototype assignments — placed here (not in GraphAsTask.ts)
-// so that Workflow is fully defined before assignment. GraphAsTask is already
-// imported at the top of this file, so it's safe to reference here.
+// Module augmentation prototype assignments — placed here (not in WorkflowFactories.ts)
+// so they run after the Workflow class declaration. Static imports in ESM are
+// hoisted and evaluated depth-first, so a side-effect tail import would run
+// before the class binding initializes. Inline assignments here are safe because
+// the class is already fully initialized by this point.
 Workflow.prototype.group = CreateLoopWorkflow(GraphAsTask);
 Workflow.prototype.endGroup = CreateEndLoopWorkflow("endGroup");

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -7,7 +7,6 @@
 import type { EventParameters } from "@workglow/util";
 import { EventEmitter, getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
-import { JsonSchema } from "@workglow/util/schema";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
@@ -25,6 +24,11 @@ import { ensureTask } from "./Conversions";
 import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
+import {
+  hasVectorLikeInput,
+  hasVectorOutput,
+  updateBoundaryTaskSchemas,
+} from "./GraphSchemaUtils";
 import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { TaskGraph } from "./TaskGraph";
@@ -206,66 +210,6 @@ export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
     }
     return this.finalizeAndReturn();
   };
-}
-
-const TYPED_ARRAY_FORMAT_PREFIX = "TypedArray";
-
-/**
- * Returns true if the given JSON schema (or any nested schema) has a format
- * string starting with "TypedArray" (e.g. "TypedArray" or "TypedArray:Float32Array").
- * Walks oneOf/anyOf wrappers and array items.
- */
-function schemaHasTypedArrayFormat(schema: JsonSchema): boolean {
-  if (typeof schema === "boolean") return false;
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return false;
-
-  const s = schema as Record<string, unknown>;
-  if (typeof s.format === "string" && s.format.startsWith(TYPED_ARRAY_FORMAT_PREFIX)) {
-    return true;
-  }
-
-  const checkUnion = (schemas: unknown): boolean => {
-    if (!Array.isArray(schemas)) return false;
-    return schemas.some((sub) => schemaHasTypedArrayFormat(sub as JsonSchema));
-  };
-  if (checkUnion(s.oneOf) || checkUnion(s.anyOf)) return true;
-
-  const items = s.items;
-  if (items && typeof items === "object" && !Array.isArray(items)) {
-    if (schemaHasTypedArrayFormat(items as JsonSchema)) return true;
-  }
-
-  return false;
-}
-
-/**
- * Returns true if the task's output schema has any port with TypedArray format.
- * Used by adaptive workflow methods to choose scalar vs vector task variant.
- */
-export function hasVectorOutput(task: ITask): boolean {
-  const outputSchema = task.outputSchema();
-  if (typeof outputSchema === "boolean" || !outputSchema?.properties) return false;
-  return Object.values(outputSchema.properties).some((prop) =>
-    schemaHasTypedArrayFormat(prop as JsonSchema)
-  );
-}
-
-/**
- * Returns true if the input object looks like vector task input: has a "vectors"
- * property that is an array with at least one TypedArray element. Used by
- * adaptive workflow methods so that e.g. sum({ vectors: [new Float32Array(...)] })
- * chooses the vector variant even with no previous task.
- */
-export function hasVectorLikeInput(input: unknown): boolean {
-  if (!input || typeof input !== "object") return false;
-  const v = (input as Record<string, unknown>).vectors;
-  return (
-    Array.isArray(v) &&
-    v.length > 0 &&
-    typeof v[0] === "object" &&
-    v[0] !== null &&
-    ArrayBuffer.isView(v[0])
-  );
 }
 
 /**
@@ -516,7 +460,7 @@ export class Workflow<
 
       // Update InputTask/OutputTask schemas based on connected dataflows
       if (!this._error) {
-        Workflow.updateBoundaryTaskSchemas(this._graph);
+        updateBoundaryTaskSchemas(this._graph);
       }
 
       // Preserve input type from the start of the chain
@@ -1162,128 +1106,6 @@ export class Workflow<
         this._error = result.error + " Task not added.";
         getLogger().error(this._error);
         this.graph.removeTask(iteratorTask.id);
-      }
-    }
-  }
-
-  /**
-   * Updates InputTask/OutputTask config schemas based on their connected dataflows.
-   * InputTask schema reflects its outgoing dataflow targets' input schemas.
-   * OutputTask schema reflects its incoming dataflow sources' output schemas.
-   */
-  private static updateBoundaryTaskSchemas(graph: TaskGraph): void {
-    const tasks = graph.getTasks();
-
-    for (const task of tasks) {
-      if (task.type === "InputTask") {
-        // If the schema is marked as fully manual (x-ui-manual at schema level),
-        // skip edge-based regeneration — the user explicitly defined this schema.
-        const existingConfig = (task as ITask).config;
-        const existingSchema = existingConfig?.inputSchema ?? existingConfig?.outputSchema;
-        if (
-          existingSchema &&
-          typeof existingSchema === "object" &&
-          (existingSchema as Record<string, unknown>)["x-ui-manual"] === true
-        ) {
-          continue;
-        }
-
-        const outgoing = graph.getTargetDataflows(task.id);
-        if (outgoing.length === 0) continue;
-
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
-
-        for (const df of outgoing) {
-          const targetTask = graph.getTask(df.targetTaskId);
-          if (!targetTask) continue;
-          const targetSchema = targetTask.inputSchema();
-          if (typeof targetSchema === "boolean") continue;
-          const prop = (targetSchema.properties as any)?.[df.targetTaskPortId];
-          if (prop && typeof prop !== "boolean") {
-            properties[df.sourceTaskPortId] = prop;
-            if (targetSchema.required?.includes(df.targetTaskPortId)) {
-              if (!required.includes(df.sourceTaskPortId)) {
-                required.push(df.sourceTaskPortId);
-              }
-            }
-          }
-        }
-
-        const schema = {
-          type: "object",
-          properties,
-          ...(required.length > 0 ? { required } : {}),
-          additionalProperties: false,
-        } as DataPortSchema;
-
-        // @ts-expect-error - config is readonly
-        task.config = {
-          ...task.config,
-          inputSchema: schema,
-          outputSchema: schema,
-        };
-      }
-
-      if (task.type === "OutputTask") {
-        const incoming = graph.getSourceDataflows(task.id);
-        if (incoming.length === 0) continue;
-
-        const properties: Record<string, any> = {};
-        const required: string[] = [];
-
-        for (const df of incoming) {
-          const sourceTask = graph.getTask(df.sourceTaskId);
-          if (!sourceTask) continue;
-          const sourceSchema = sourceTask.outputSchema();
-          if (typeof sourceSchema === "boolean") continue;
-          let prop = (sourceSchema.properties as any)?.[df.sourceTaskPortId];
-          let propRequired = sourceSchema.required?.includes(df.sourceTaskPortId) ?? false;
-
-          // For passthrough tasks with additionalProperties (e.g. DebugLogTask),
-          // the port won't appear in the static output schema. Trace back through
-          // the passthrough task's own incoming dataflows to find the actual schema.
-          if (
-            !prop &&
-            sourceSchema.additionalProperties === true &&
-            (sourceTask.constructor as typeof Task).passthroughInputsToOutputs === true
-          ) {
-            const upstreamDfs = graph.getSourceDataflows(sourceTask.id);
-            for (const udf of upstreamDfs) {
-              if (udf.targetTaskPortId !== df.sourceTaskPortId) continue;
-              const upstreamTask = graph.getTask(udf.sourceTaskId);
-              if (!upstreamTask) continue;
-              const upstreamSchema = upstreamTask.outputSchema();
-              if (typeof upstreamSchema === "boolean") continue;
-              prop = (upstreamSchema.properties as any)?.[udf.sourceTaskPortId];
-              if (prop) {
-                propRequired = upstreamSchema.required?.includes(udf.sourceTaskPortId) ?? false;
-                break;
-              }
-            }
-          }
-
-          if (prop && typeof prop !== "boolean") {
-            properties[df.targetTaskPortId] = prop;
-            if (propRequired && !required.includes(df.targetTaskPortId)) {
-              required.push(df.targetTaskPortId);
-            }
-          }
-        }
-
-        const schema = {
-          type: "object",
-          properties,
-          ...(required.length > 0 ? { required } : {}),
-          additionalProperties: false,
-        } as DataPortSchema;
-
-        // @ts-expect-error - config is readonly
-        task.config = {
-          ...task.config,
-          inputSchema: schema,
-          outputSchema: schema,
-        };
       }
     }
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -34,6 +34,7 @@ import type { CreateWorkflow } from "./WorkflowFactories";
 import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
 import { getLastTask, parallel, pipe } from "./WorkflowPipe";
 import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
+import { WorkflowEventBridge } from "./WorkflowEventBridge";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -102,8 +103,8 @@ export class Workflow<
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
     if (!parent) {
-      this._onChanged = this._onChanged.bind(this);
-      this.setupEvents();
+      this._bridge = new WorkflowEventBridge(this.events);
+      this._bridge.attach(this._graph);
     }
   }
 
@@ -113,7 +114,7 @@ export class Workflow<
   private _error: string = "";
   private _cache: WorkflowCacheAdapter;
   private _registry?: ServiceRegistry;
-  private _entitlementUnsub?: () => void;
+  private _bridge?: WorkflowEventBridge;
 
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
@@ -264,9 +265,9 @@ export class Workflow<
   public set graph(value: TaskGraph) {
     this._dataFlows = [];
     this._error = "";
-    this.clearEvents();
+    this._bridge?.detach();
     this._graph = value;
-    this.setupEvents();
+    this._bridge?.attach(this._graph);
     this.events.emit("reset");
   }
 
@@ -326,11 +327,7 @@ export class Workflow<
     this._abortController = new AbortController();
 
     // Subscribe to graph-level streaming events and forward to workflow events
-    const unsubStreaming = this.graph.subscribeToTaskStreaming({
-      onStreamStart: (taskId) => this.events.emit("stream_start", taskId),
-      onStreamChunk: (taskId, event) => this.events.emit("stream_chunk", taskId, event),
-      onStreamEnd: (taskId, output) => this.events.emit("stream_end", taskId, output),
-    });
+    this._bridge?.beginRun();
 
     try {
       const output = await this.graph.run<Output>(input, {
@@ -349,7 +346,7 @@ export class Workflow<
       this.events.emit("error", String(error));
       throw error;
     } finally {
-      unsubStreaming();
+      this._bridge?.endRun();
       this._abortController = undefined;
     }
   }
@@ -633,52 +630,16 @@ export class Workflow<
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
-    this.clearEvents();
+    this._bridge?.detach();
     this._graph = new TaskGraph({
       outputCache: this._cache.outputCache(),
     });
     this._dataFlows = [];
     this._error = "";
-    this.setupEvents();
+    this._bridge?.attach(this._graph);
     this.events.emit("changed", undefined);
     this.events.emit("reset");
     return this;
-  }
-
-  /**
-   * Sets up event listeners for the task graph
-   */
-  private setupEvents(): void {
-    this._graph.on("task_added", this._onChanged);
-    this._graph.on("task_replaced", this._onChanged);
-    this._graph.on("task_removed", this._onChanged);
-    this._graph.on("dataflow_added", this._onChanged);
-    this._graph.on("dataflow_replaced", this._onChanged);
-    this._graph.on("dataflow_removed", this._onChanged);
-    this._entitlementUnsub = this._graph.subscribeToTaskEntitlements((entitlements) =>
-      this.events.emit("entitlementChange", entitlements)
-    );
-  }
-
-  /**
-   * Clears event listeners for the task graph
-   */
-  private clearEvents(): void {
-    this._graph.off("task_added", this._onChanged);
-    this._graph.off("task_replaced", this._onChanged);
-    this._graph.off("task_removed", this._onChanged);
-    this._graph.off("dataflow_added", this._onChanged);
-    this._graph.off("dataflow_replaced", this._onChanged);
-    this._graph.off("dataflow_removed", this._onChanged);
-    this._entitlementUnsub?.();
-    this._entitlementUnsub = undefined;
-  }
-
-  /**
-   * Handles changes to the task graph
-   */
-  private _onChanged(id: unknown): void {
-    this.events.emit("changed", id);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -6,7 +6,7 @@
 
 import type { EventParameters } from "@workglow/util";
 import { EventEmitter, ServiceRegistry } from "@workglow/util";
-import { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
 import type { ITask, ITaskConstructor } from "../task/ITask";
@@ -243,7 +243,8 @@ export class Workflow<
     const loopContext = this._builder.loopContext;
     if (loopContext) {
       loopContext.finalizeTemplate(this._graph);
-      loopContext.consumePendingConnect();
+      const error = loopContext.consumePendingConnect();
+      if (error) loopContext.parent.builder.setError(error);
       return loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
@@ -588,7 +589,8 @@ export class Workflow<
    */
   public autoConnectLoopTask(pending?: { parent: ITask; iteratorTask: ITask }): void {
     if (!pending) return;
-    runLoopAutoConnect(this._graph, pending);
+    const error = runLoopAutoConnect(this._graph, pending);
+    if (error) this._builder.setError(error);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -5,8 +5,7 @@
  */
 
 import type { EventParameters } from "@workglow/util";
-import { EventEmitter, getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
-import type { DataPortSchema } from "@workglow/util/schema";
+import { EventEmitter, ServiceRegistry } from "@workglow/util";
 import { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
@@ -18,24 +17,22 @@ import { WorkflowError } from "../task/TaskError";
 import type { JsonTaskItem, TaskGraphJson, TaskGraphJsonOptions } from "../task/TaskJSON";
 import type { DataPorts, TaskConfig, TaskIdType, TaskInput } from "../task/TaskTypes";
 import { autoConnect } from "./autoConnect";
-import { ConditionalBuilder } from "./ConditionalBuilder";
+import type { ConditionalBuilder } from "./ConditionalBuilder";
 import type { PipeFunction, Taskish } from "./Conversions";
-import { ensureTask } from "./Conversions";
-import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
 import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
-import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
 import { LoopBuilderContext, runLoopAutoConnect } from "./LoopBuilderContext";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
 import type { ITransformStep } from "./TransformTypes";
-import type { CreateWorkflow } from "./WorkflowFactories";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
-import { getLastTask, parallel, pipe } from "./WorkflowPipe";
+import { WorkflowBuilder } from "./WorkflowBuilder";
 import { WorkflowCacheAdapter } from "./WorkflowCacheAdapter";
 import { WorkflowEventBridge } from "./WorkflowEventBridge";
+import type { CreateWorkflow } from "./WorkflowFactories";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "./WorkflowFactories";
+import { parallel, pipe } from "./WorkflowPipe";
 import { WorkflowTask } from "./WorkflowTask";
 
 /** Options accepted by {@link Workflow.rename}. */
@@ -98,10 +95,16 @@ export class Workflow<
     registry?: ServiceRegistry
   ) {
     this._cache = new WorkflowCacheAdapter(cache);
-    this._loopContext =
-      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
-    this._registry = registry ?? parent?._registry;
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
+
+    const loopContext =
+      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
+
+    this._builder = new WorkflowBuilder(
+      this,
+      registry ?? parent?.builderRegistry,
+      loopContext
+    );
 
     if (!parent) {
       this._bridge = new WorkflowEventBridge(this.events);
@@ -111,17 +114,22 @@ export class Workflow<
 
   // Private properties
   private _graph: TaskGraph;
-  private _dataFlows: Dataflow[] = [];
-  private _error: string = "";
   private _cache: WorkflowCacheAdapter;
-  private _registry?: ServiceRegistry;
   private _bridge?: WorkflowEventBridge;
+  private _builder: WorkflowBuilder;
 
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
 
-  // Loop builder state (encapsulates parent workflow + iterator task + deferred auto-connect)
-  private readonly _loopContext?: LoopBuilderContext;
+  /** @internal — exposes the parent's registry so a child loop-builder can inherit it */
+  private get builderRegistry(): ServiceRegistry | undefined {
+    return this._builder.registry;
+  }
+
+  /** @internal — exposes the builder for cross-instance loop-builder wiring */
+  public get builder(): WorkflowBuilder {
+    return this._builder;
+  }
 
   public outputCache(): TaskOutputRepository | undefined {
     return this._cache.outputCache();
@@ -132,7 +140,7 @@ export class Workflow<
    * When true, tasks are added to the template graph for an iterator task.
    */
   public get isLoopBuilder(): boolean {
-    return this._loopContext !== undefined;
+    return this._builder.loopContext !== undefined;
   }
 
   /**
@@ -156,81 +164,7 @@ export class Workflow<
       input: Partial<I> = {},
       config: Partial<C> = {}
     ) {
-      this._error = "";
-
-      const parent = getLastTask(this);
-
-      const task = this.addTaskToGraph<I, O, C>(taskClass, {
-        id: uuid4(),
-        ...config,
-        defaults: input,
-      } as C);
-
-      // Process any pending data flows
-      if (this._dataFlows.length > 0) {
-        this._dataFlows.forEach((dataflow) => {
-          const taskSchema = task.inputSchema();
-          if (
-            (typeof taskSchema !== "boolean" &&
-              taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
-              taskSchema.additionalProperties !== true) ||
-            (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
-          ) {
-            this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
-            getLogger().error(this._error);
-            return;
-          }
-
-          dataflow.targetTaskId = task.id;
-          this.graph.addDataflow(dataflow);
-        });
-
-        this._dataFlows = [];
-      }
-
-      // Auto-connect to parent if needed
-      if (parent) {
-        // Build the list of earlier tasks (in reverse chronological order)
-        const nodes = this._graph.getTasks();
-        const parentIndex = nodes.findIndex((n) => n.id === parent.id);
-        const earlierTasks: ITask[] = [];
-        for (let i = parentIndex - 1; i >= 0; i--) {
-          earlierTasks.push(nodes[i]);
-        }
-
-        const providedInputKeys = new Set(Object.keys(input || {}));
-
-        // Ports already connected via pending dataflows (e.g., from .rename())
-        // must not be re-matched by auto-connect Strategies 1/2/3.
-        const connectedInputKeys = new Set(
-          this.graph.getSourceDataflows(task.id).map((df) => df.targetTaskPortId)
-        );
-
-        const result = Workflow.autoConnect(this.graph, parent, task, {
-          providedInputKeys,
-          connectedInputKeys,
-          earlierTasks,
-        });
-
-        if (result.error) {
-          // In loop builder mode, don't remove the task - allow manual connection
-          // In normal mode, remove the task since auto-connect is required
-          if (this.isLoopBuilder) {
-            this._error = result.error;
-            getLogger().warn(this._error);
-          } else {
-            this._error = result.error + " Task not added.";
-            getLogger().error(this._error);
-            this.graph.removeTask(task.id);
-          }
-        }
-      }
-
-      // Update InputTask/OutputTask schemas based on connected dataflows
-      if (!this._error) {
-        updateBoundaryTaskSchemas(this._graph);
-      }
-
+      this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config);
       // Preserve input type from the start of the chain
       // If this is the first task, set both input and output types
       // Otherwise, only update the output type (input type is preserved from 'this')
@@ -259,8 +193,7 @@ export class Workflow<
    * Sets a new task graph
    */
   public set graph(value: TaskGraph) {
-    this._dataFlows = [];
-    this._error = "";
+    this._builder.resetState();
     this._bridge?.detach();
     this._graph = value;
     this._bridge?.attach(this._graph);
@@ -271,7 +204,7 @@ export class Workflow<
    * Gets the current error message
    */
   public get error(): string {
-    return this._error;
+    return this._builder.error;
   }
 
   /**
@@ -307,10 +240,11 @@ export class Workflow<
     config?: WorkflowRunConfig
   ): Promise<PropertyArrayGraphResult<Output>> {
     // In loop builder mode, finalize template and delegate to parent
-    if (this._loopContext) {
-      this._loopContext.finalizeTemplate(this._graph);
-      this._loopContext.consumePendingConnect();
-      return this._loopContext.parent.run(input as any, config) as Promise<
+    const loopContext = this._builder.loopContext;
+    if (loopContext) {
+      loopContext.finalizeTemplate(this._graph);
+      loopContext.consumePendingConnect();
+      return loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
     }
@@ -325,7 +259,7 @@ export class Workflow<
       const output = await this.graph.run<Output>(input, {
         parentSignal: this._abortController.signal,
         outputCache: this._cache.outputCache(),
-        registry: config?.registry ?? this._registry,
+        registry: config?.registry ?? this._builder.registry,
         resourceScope: config?.resourceScope,
       });
       const results = this.graph.mergeExecuteOutputsToRunOutput<Output, typeof PROPERTY_ARRAY>(
@@ -348,8 +282,9 @@ export class Workflow<
    */
   public async abort(): Promise<void> {
     // In loop builder mode, delegate to parent
-    if (this._loopContext) {
-      return this._loopContext.parent.abort();
+    const loopContext = this._builder.loopContext;
+    if (loopContext) {
+      return loopContext.parent.abort();
     }
     this._abortController?.abort();
   }
@@ -360,17 +295,7 @@ export class Workflow<
    * @returns The current task graph workflow
    */
   public pop(): Workflow {
-    this._error = "";
-    const nodes = this._graph.getTasks();
-
-    if (nodes.length === 0) {
-      this._error = "No tasks to remove";
-      getLogger().error(this._error);
-      return this;
-    }
-
-    const lastNode = nodes[nodes.length - 1];
-    this._graph.removeTask(lastNode.id);
+    this._builder.pop();
     return this;
   }
 
@@ -525,42 +450,7 @@ export class Workflow<
     target: string,
     indexOrOptions: number | RenameOptions = -1
   ): Workflow {
-    this._error = "";
-
-    const index =
-      typeof indexOrOptions === "number" ? indexOrOptions : (indexOrOptions.index ?? -1);
-    const transforms = typeof indexOrOptions === "number" ? undefined : indexOrOptions.transforms;
-
-    const nodes = this._graph.getTasks();
-    if (-index > nodes.length) {
-      const errorMsg = `Back index greater than number of tasks`;
-      this._error = errorMsg;
-      getLogger().error(this._error);
-      throw new WorkflowError(errorMsg);
-    }
-
-    const lastNode = nodes[nodes.length + index];
-    const outputSchema = lastNode.outputSchema();
-
-    // Handle boolean schemas
-    if (typeof outputSchema === "boolean") {
-      if (outputSchema === false && source !== DATAFLOW_ALL_PORTS) {
-        const errorMsg = `Task ${lastNode.id} has schema 'false' and outputs nothing`;
-        this._error = errorMsg;
-        getLogger().error(this._error);
-        throw new WorkflowError(errorMsg);
-      }
-      // If outputSchema is true, we skip validation as it outputs everything
-    } else if (!(outputSchema.properties as any)?.[source] && source !== DATAFLOW_ALL_PORTS) {
-      const errorMsg = `Output ${source} not found on task ${lastNode.id}`;
-      this._error = errorMsg;
-      getLogger().error(this._error);
-      throw new WorkflowError(errorMsg);
-    }
-
-    const df = new Dataflow(lastNode.id, source, undefined, target);
-    if (transforms && transforms.length > 0) df.setTransforms(transforms);
-    this._dataFlows.push(df);
+    this._builder.rename(source, target, indexOrOptions);
     return this;
   }
 
@@ -576,28 +466,7 @@ export class Workflow<
    * @returns The current workflow for chaining
    */
   public onError(handler: Taskish): Workflow {
-    this._error = "";
-
-    const parent = getLastTask(this);
-    if (!parent) {
-      this._error = "onError() requires a preceding task in the workflow";
-      getLogger().error(this._error);
-      throw new WorkflowError(this._error);
-    }
-
-    const handlerTask = ensureTask(handler);
-    this.graph.addTask(handlerTask);
-
-    // Connect the previous task's error output port to the handler's all-ports input
-    const dataflow = new Dataflow(
-      parent.id,
-      DATAFLOW_ERROR_PORT,
-      handlerTask.id,
-      DATAFLOW_ALL_PORTS
-    );
-    this.graph.addDataflow(dataflow);
-    this.events.emit("changed", handlerTask.id);
-
+    this._builder.onError(handler);
     return this;
   }
 
@@ -618,7 +487,7 @@ export class Workflow<
    */
   public reset(): Workflow {
     // In loop builder mode, reset is not supported
-    if (this._loopContext) {
+    if (this._builder.loopContext) {
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
@@ -626,8 +495,7 @@ export class Workflow<
     this._graph = new TaskGraph({
       outputCache: this._cache.outputCache(),
     });
-    this._dataFlows = [];
-    this._error = "";
+    this._builder.resetState();
     this._bridge?.attach(this._graph);
     this.events.emit("changed", undefined);
     this.events.emit("reset");
@@ -643,41 +511,7 @@ export class Workflow<
     targetTaskId: unknown,
     targetTaskPortId: string
   ): Workflow {
-    const sourceTask = this.graph.getTask(sourceTaskId);
-    const targetTask = this.graph.getTask(targetTaskId);
-
-    if (!sourceTask || !targetTask) {
-      throw new WorkflowError("Source or target task not found");
-    }
-
-    const sourceSchema = sourceTask.outputSchema();
-    const targetSchema = targetTask.inputSchema();
-
-    // Handle boolean schemas
-    if (typeof sourceSchema === "boolean") {
-      if (sourceSchema === false) {
-        throw new WorkflowError(`Source task has schema 'false' and outputs nothing`);
-      }
-      // If sourceSchema is true, we skip validation as it accepts everything
-    } else if (!sourceSchema.properties?.[sourceTaskPortId]) {
-      throw new WorkflowError(`Output ${sourceTaskPortId} not found on source task`);
-    }
-
-    if (typeof targetSchema === "boolean") {
-      if (targetSchema === false) {
-        throw new WorkflowError(`Target task has schema 'false' and accepts no inputs`);
-      }
-      if (targetSchema === true) {
-        // do nothing, we allow additional properties
-      }
-    } else if (targetSchema.additionalProperties === true) {
-      // do nothing, we allow additional properties
-    } else if (!targetSchema.properties?.[targetTaskPortId]) {
-      throw new WorkflowError(`Input ${targetTaskPortId} not found on target task`);
-    }
-
-    const dataflow = new Dataflow(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
-    this.graph.addDataflow(dataflow);
+    this._builder.connect(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
     return this;
   }
 
@@ -686,10 +520,7 @@ export class Workflow<
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
   >(taskClass: ITaskConstructor<I, O, C>, config: C): ITask<I, O, C> {
-    const task = new taskClass(config, this._registry ? { registry: this._registry } : undefined);
-    const id = this.graph.addTask(task);
-    this.events.emit("changed", id);
-    return task;
+    return this._builder.addTaskInstance<I, O, C>(taskClass, config);
   }
 
   /**
@@ -706,8 +537,10 @@ export class Workflow<
     input?: Partial<I>,
     config?: Partial<C>
   ): Workflow<Input, Output> {
-    const helper = Workflow.createWorkflow<I, O, C>(taskClass);
-    return helper.call(this, input, config) as Workflow<Input, Output>;
+    return this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config) as Workflow<
+      Input,
+      Output
+    >;
   }
 
   // ========================================================================
@@ -727,66 +560,7 @@ export class Workflow<
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
   >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
-    this._error = "";
-
-    const parent = getLastTask(this);
-
-    // Default maxIterations to "unbounded" for loop tasks whose config schema
-    // marks it as required (MapTask, WhileTask, ReduceTask, ForEachTask). The
-    // raw task constructors still require an explicit value; this default is a
-    // convenience only for the fluent Workflow builder API.
-    const schema = (
-      taskClass as unknown as { configSchema?: () => DataPortSchema }
-    ).configSchema?.();
-    const required =
-      typeof schema === "object" && schema !== null
-        ? (schema as { required?: readonly string[] }).required
-        : undefined;
-    const needsMaxIterations = Array.isArray(required) && required.includes("maxIterations");
-    const resolvedConfig =
-      needsMaxIterations && (config as { maxIterations?: unknown }).maxIterations === undefined
-        ? ({ ...config, maxIterations: "unbounded" } as Partial<C>)
-        : config;
-
-    const task = this.addTaskToGraph<I, O, C>(taskClass, { id: uuid4(), ...resolvedConfig } as C);
-
-    // Process any pending data flows (same as createWorkflow)
-    if (this._dataFlows.length > 0) {
-      this._dataFlows.forEach((dataflow) => {
-        const taskSchema = task.inputSchema();
-        if (
-          (typeof taskSchema !== "boolean" &&
-            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
-            taskSchema.additionalProperties !== true) ||
-          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
-        ) {
-          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
-          getLogger().error(this._error);
-          return;
-        }
-
-        dataflow.targetTaskId = task.id;
-        this.graph.addDataflow(dataflow);
-      });
-
-      this._dataFlows = [];
-    }
-
-    // Defer auto-connect until endMap/endReduce/endWhile, when the iterator task
-    // has its template graph populated and its dynamic inputSchema is available.
-    // Store the pending context on the loop builder workflow.
-    const loopBuilder = new Workflow(
-      this.outputCache(),
-      this,
-      task as unknown as GraphAsTask,
-      this._registry
-    ) as unknown as Workflow<I, O>;
-    if (parent) {
-      // Same-class private access: child was constructed with parent + iteratorTask,
-      // so its ctor created a LoopBuilderContext.
-      loopBuilder._loopContext!.pendingLoopConnect = { parent, iteratorTask: task };
-    }
-    return loopBuilder;
+    return this._builder.addLoopTask<I, O, C>(taskClass, config);
   }
 
   /**
@@ -804,7 +578,7 @@ export class Workflow<
    * ```
    */
   public if(condition: ConditionFn<TaskInput>): ConditionalBuilder {
-    return new ConditionalBuilder(this, condition);
+    return this._builder.createConditional(condition);
   }
 
   /**
@@ -860,8 +634,9 @@ export class Workflow<
    * Only applicable in loop builder mode.
    */
   public finalizeTemplate(): void {
-    if (!this._loopContext) return;
-    this._loopContext.finalizeTemplate(this._graph);
+    const ctx = this._builder.loopContext;
+    if (!ctx) return;
+    ctx.finalizeTemplate(this._graph);
   }
 
   /**
@@ -872,10 +647,11 @@ export class Workflow<
    * @throws WorkflowError if not in loop builder mode
    */
   public finalizeAndReturn(): Workflow {
-    if (!this._loopContext) {
+    const ctx = this._builder.loopContext;
+    if (!ctx) {
       throw new WorkflowError("finalizeAndReturn() can only be called on loop workflows");
     }
-    return this._loopContext.finalizeAndReturn(this._graph);
+    return ctx.finalizeAndReturn(this._graph);
   }
 }
 

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -26,6 +26,7 @@ import type { GraphEntitlementOptions } from "./GraphEntitlementUtils";
 import { computeGraphEntitlements } from "./GraphEntitlementUtils";
 import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
 import type { IWorkflow, WorkflowRunConfig } from "./IWorkflow";
+import { LoopBuilderContext, runLoopAutoConnect } from "./LoopBuilderContext";
 import { TaskGraph } from "./TaskGraph";
 import type { PropertyArrayGraphResult } from "./TaskGraphRunner";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "./TaskGraphRunner";
@@ -97,8 +98,8 @@ export class Workflow<
     registry?: ServiceRegistry
   ) {
     this._cache = new WorkflowCacheAdapter(cache);
-    this._parentWorkflow = parent;
-    this._iteratorTask = iteratorTask;
+    this._loopContext =
+      parent && iteratorTask ? new LoopBuilderContext(parent, iteratorTask) : undefined;
     this._registry = registry ?? parent?._registry;
     this._graph = new TaskGraph({ outputCache: this._cache.outputCache() });
 
@@ -119,13 +120,8 @@ export class Workflow<
   // Abort controller for cancelling task execution
   private _abortController?: AbortController;
 
-  // Loop builder properties
-  private readonly _parentWorkflow?: Workflow;
-  private readonly _iteratorTask?: GraphAsTask;
-  private _pendingLoopConnect?: {
-    parent: ITask;
-    iteratorTask: ITask;
-  };
+  // Loop builder state (encapsulates parent workflow + iterator task + deferred auto-connect)
+  private readonly _loopContext?: LoopBuilderContext;
 
   public outputCache(): TaskOutputRepository | undefined {
     return this._cache.outputCache();
@@ -136,7 +132,7 @@ export class Workflow<
    * When true, tasks are added to the template graph for an iterator task.
    */
   public get isLoopBuilder(): boolean {
-    return this._parentWorkflow !== undefined;
+    return this._loopContext !== undefined;
   }
 
   /**
@@ -311,14 +307,10 @@ export class Workflow<
     config?: WorkflowRunConfig
   ): Promise<PropertyArrayGraphResult<Output>> {
     // In loop builder mode, finalize template and delegate to parent
-    if (this.isLoopBuilder) {
-      this.finalizeTemplate();
-      // Run deferred auto-connect now that template graph is populated
-      if (this._pendingLoopConnect) {
-        this._parentWorkflow!.autoConnectLoopTask(this._pendingLoopConnect);
-        this._pendingLoopConnect = undefined;
-      }
-      return this._parentWorkflow!.run(input as any, config) as Promise<
+    if (this._loopContext) {
+      this._loopContext.finalizeTemplate(this._graph);
+      this._loopContext.consumePendingConnect();
+      return this._loopContext.parent.run(input as any, config) as Promise<
         PropertyArrayGraphResult<Output>
       >;
     }
@@ -356,8 +348,8 @@ export class Workflow<
    */
   public async abort(): Promise<void> {
     // In loop builder mode, delegate to parent
-    if (this._parentWorkflow) {
-      return this._parentWorkflow.abort();
+    if (this._loopContext) {
+      return this._loopContext.parent.abort();
     }
     this._abortController?.abort();
   }
@@ -626,7 +618,7 @@ export class Workflow<
    */
   public reset(): Workflow {
     // In loop builder mode, reset is not supported
-    if (this._parentWorkflow) {
+    if (this._loopContext) {
       throw new WorkflowError("Cannot reset a loop workflow. Call reset() on the parent workflow.");
     }
 
@@ -790,7 +782,9 @@ export class Workflow<
       this._registry
     ) as unknown as Workflow<I, O>;
     if (parent) {
-      loopBuilder._pendingLoopConnect = { parent, iteratorTask: task };
+      // Same-class private access: child was constructed with parent + iteratorTask,
+      // so its ctor created a LoopBuilderContext.
+      loopBuilder._loopContext!.pendingLoopConnect = { parent, iteratorTask: task };
     }
     return loopBuilder;
   }
@@ -820,26 +814,7 @@ export class Workflow<
    */
   public autoConnectLoopTask(pending?: { parent: ITask; iteratorTask: ITask }): void {
     if (!pending) return;
-    const { parent, iteratorTask } = pending;
-
-    if (this.graph.getTargetDataflows(parent.id).length === 0) {
-      const nodes = this._graph.getTasks();
-      const parentIndex = nodes.findIndex((n) => n.id === parent.id);
-      const earlierTasks: ITask[] = [];
-      for (let i = parentIndex - 1; i >= 0; i--) {
-        earlierTasks.push(nodes[i]);
-      }
-
-      const result = Workflow.autoConnect(this.graph, parent, iteratorTask, {
-        earlierTasks,
-      });
-
-      if (result.error) {
-        this._error = result.error + " Task not added.";
-        getLogger().error(this._error);
-        this.graph.removeTask(iteratorTask.id);
-      }
-    }
+    runLoopAutoConnect(this._graph, pending);
   }
 
   /**
@@ -885,12 +860,8 @@ export class Workflow<
    * Only applicable in loop builder mode.
    */
   public finalizeTemplate(): void {
-    if (!this._iteratorTask || this.graph.getTasks().length === 0) {
-      return;
-    }
-
-    this._iteratorTask.subGraph = this.graph;
-    this._iteratorTask.validateAcyclic();
+    if (!this._loopContext) return;
+    this._loopContext.finalizeTemplate(this._graph);
   }
 
   /**
@@ -901,17 +872,10 @@ export class Workflow<
    * @throws WorkflowError if not in loop builder mode
    */
   public finalizeAndReturn(): Workflow {
-    if (!this._parentWorkflow) {
+    if (!this._loopContext) {
       throw new WorkflowError("finalizeAndReturn() can only be called on loop workflows");
     }
-    this.finalizeTemplate();
-    // Now that the iterator task has its template graph, its dynamic inputSchema()
-    // is available. Run deferred auto-connect on the parent workflow's graph.
-    if (this._pendingLoopConnect) {
-      this._parentWorkflow.autoConnectLoopTask(this._pendingLoopConnect);
-      this._pendingLoopConnect = undefined;
-    }
-    return this._parentWorkflow;
+    return this._loopContext.finalizeAndReturn(this._graph);
   }
 }
 

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -59,6 +59,15 @@ export class WorkflowBuilder {
     return this._loopContext;
   }
 
+  /**
+   * Surfaces an error onto this builder's error slot. Used by deferred
+   * loop-builder auto-connect (which runs from a child Workflow but reports
+   * the failure onto the parent's `.error`, matching the non-loop path).
+   */
+  public setError(message: string): void {
+    this._error = message;
+  }
+
   /** Clears pending state. Called by the facade's graph setter and reset(). */
   public resetState(): void {
     this._dataFlows = [];

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -1,0 +1,404 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import type { ConditionFn } from "../task/ConditionalTask";
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask, ITaskConstructor } from "../task/ITask";
+import { WorkflowError } from "../task/TaskError";
+import type { DataPorts, TaskConfig, TaskInput } from "../task/TaskTypes";
+import { autoConnect } from "./autoConnect";
+import { ConditionalBuilder } from "./ConditionalBuilder";
+import type { Taskish } from "./Conversions";
+import { ensureTask } from "./Conversions";
+import { Dataflow, DATAFLOW_ALL_PORTS, DATAFLOW_ERROR_PORT } from "./Dataflow";
+import { updateBoundaryTaskSchemas } from "./GraphSchemaUtils";
+import { LoopBuilderContext } from "./LoopBuilderContext";
+import type { RenameOptions, Workflow } from "./Workflow";
+import { getLastTask } from "./WorkflowPipe";
+
+/**
+ * Owns the DSL state machine for a {@link Workflow}: the list of pending
+ * dataflows queued by `.rename(...)`, the most recent error string, the
+ * optional service registry, and the optional loop-builder context.
+ *
+ * The {@link Workflow} facade keeps its public method signatures and
+ * delegates the implementation here. This split keeps the run/abort/event
+ * surface separate from the chainable graph-construction surface.
+ */
+export class WorkflowBuilder {
+  private readonly _facade: Workflow<any, any>;
+  private _dataFlows: Dataflow[] = [];
+  private _error: string = "";
+  private readonly _registry?: ServiceRegistry;
+  private readonly _loopContext?: LoopBuilderContext;
+
+  constructor(
+    facade: Workflow<any, any>,
+    registry?: ServiceRegistry,
+    loopContext?: LoopBuilderContext
+  ) {
+    this._facade = facade;
+    this._registry = registry;
+    this._loopContext = loopContext;
+  }
+
+  public get error(): string {
+    return this._error;
+  }
+
+  public get registry(): ServiceRegistry | undefined {
+    return this._registry;
+  }
+
+  public get loopContext(): LoopBuilderContext | undefined {
+    return this._loopContext;
+  }
+
+  /** Clears pending state. Called by the facade's graph setter and reset(). */
+  public resetState(): void {
+    this._dataFlows = [];
+    this._error = "";
+  }
+
+  /**
+   * Instantiates a task and adds it to the facade's graph; emits "changed".
+   * Used both by {@link addTaskWithAutoConnect} and direct callers.
+   */
+  public addTaskInstance<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(taskClass: ITaskConstructor<I, O, C>, config: C): ITask<I, O, C> {
+    const task = new taskClass(
+      config,
+      this._registry ? { registry: this._registry } : undefined
+    );
+    const id = this._facade.graph.addTask(task);
+    this._facade.events.emit("changed", id);
+    return task;
+  }
+
+  /**
+   * Adds a task with auto-connect to the previous task. Drains pending
+   * dataflows queued by `.rename(...)` first, then runs auto-connect
+   * against the immediately-previous task plus earlier tasks for any
+   * unmatched required inputs.
+   */
+  public addTaskWithAutoConnect<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(
+    taskClass: ITaskConstructor<I, O, C>,
+    input: Partial<I> = {},
+    config: Partial<C> = {}
+  ): Workflow<any, any> {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+
+    const task = this.addTaskInstance<I, O, C>(taskClass, {
+      id: uuid4(),
+      ...config,
+      defaults: input,
+    } as C);
+
+    // Process any pending data flows
+    if (this._dataFlows.length > 0) {
+      this._dataFlows.forEach((dataflow) => {
+        const taskSchema = task.inputSchema();
+        if (
+          (typeof taskSchema !== "boolean" &&
+            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
+            taskSchema.additionalProperties !== true) ||
+          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
+        ) {
+          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
+          getLogger().error(this._error);
+          return;
+        }
+
+        dataflow.targetTaskId = task.id;
+        this._facade.graph.addDataflow(dataflow);
+      });
+
+      this._dataFlows = [];
+    }
+
+    // Auto-connect to parent if needed
+    if (parent) {
+      // Build the list of earlier tasks (in reverse chronological order)
+      const nodes = this._facade.graph.getTasks();
+      const parentIndex = nodes.findIndex((n) => n.id === parent.id);
+      const earlierTasks: ITask[] = [];
+      for (let i = parentIndex - 1; i >= 0; i--) {
+        earlierTasks.push(nodes[i]);
+      }
+
+      const providedInputKeys = new Set(Object.keys(input || {}));
+
+      // Ports already connected via pending dataflows (e.g., from .rename())
+      // must not be re-matched by auto-connect Strategies 1/2/3.
+      const connectedInputKeys = new Set(
+        this._facade.graph.getSourceDataflows(task.id).map((df) => df.targetTaskPortId)
+      );
+
+      const result = autoConnect(this._facade.graph, parent, task, {
+        providedInputKeys,
+        connectedInputKeys,
+        earlierTasks,
+      });
+
+      if (result.error) {
+        // In loop builder mode, don't remove the task - allow manual connection
+        // In normal mode, remove the task since auto-connect is required
+        if (this._loopContext !== undefined) {
+          this._error = result.error;
+          getLogger().warn(this._error);
+        } else {
+          this._error = result.error + " Task not added.";
+          getLogger().error(this._error);
+          this._facade.graph.removeTask(task.id);
+        }
+      }
+    }
+
+    // Update InputTask/OutputTask schemas based on connected dataflows
+    if (!this._error) {
+      updateBoundaryTaskSchemas(this._facade.graph);
+    }
+
+    return this._facade;
+  }
+
+  /**
+   * Adds an iterator/loop task to the workflow using the same auto-connect
+   * logic as {@link addTaskWithAutoConnect}, then returns a new loop-builder
+   * Workflow whose template graph the user populates.
+   */
+  public addLoopTask<
+    I extends DataPorts,
+    O extends DataPorts,
+    C extends TaskConfig<I> = TaskConfig<I>,
+  >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+
+    // Default maxIterations to "unbounded" for loop tasks whose config schema
+    // marks it as required (MapTask, WhileTask, ReduceTask, ForEachTask). The
+    // raw task constructors still require an explicit value; this default is a
+    // convenience only for the fluent Workflow builder API.
+    const schema = (
+      taskClass as unknown as { configSchema?: () => DataPortSchema }
+    ).configSchema?.();
+    const required =
+      typeof schema === "object" && schema !== null
+        ? (schema as { required?: readonly string[] }).required
+        : undefined;
+    const needsMaxIterations = Array.isArray(required) && required.includes("maxIterations");
+    const resolvedConfig =
+      needsMaxIterations && (config as { maxIterations?: unknown }).maxIterations === undefined
+        ? ({ ...config, maxIterations: "unbounded" } as Partial<C>)
+        : config;
+
+    const task = this.addTaskInstance<I, O, C>(taskClass, { id: uuid4(), ...resolvedConfig } as C);
+
+    // Process any pending data flows (same as addTaskWithAutoConnect)
+    if (this._dataFlows.length > 0) {
+      this._dataFlows.forEach((dataflow) => {
+        const taskSchema = task.inputSchema();
+        if (
+          (typeof taskSchema !== "boolean" &&
+            taskSchema.properties?.[dataflow.targetTaskPortId] === undefined &&
+            taskSchema.additionalProperties !== true) ||
+          (taskSchema === true && dataflow.targetTaskPortId !== DATAFLOW_ALL_PORTS)
+        ) {
+          this._error = `Input ${dataflow.targetTaskPortId} not found on task ${task.id}`;
+          getLogger().error(this._error);
+          return;
+        }
+
+        dataflow.targetTaskId = task.id;
+        this._facade.graph.addDataflow(dataflow);
+      });
+
+      this._dataFlows = [];
+    }
+
+    // Defer auto-connect until endMap/endReduce/endWhile, when the iterator task
+    // has its template graph populated and its dynamic inputSchema is available.
+    // Store the pending context on the loop builder workflow.
+    const FacadeCtor = this._facade.constructor as new (
+      cache?: ReturnType<Workflow["outputCache"]>,
+      parent?: Workflow,
+      iteratorTask?: GraphAsTask,
+      registry?: ServiceRegistry
+    ) => Workflow<any, any>;
+
+    const loopBuilder = new FacadeCtor(
+      this._facade.outputCache(),
+      this._facade,
+      task as unknown as GraphAsTask,
+      this._registry
+    ) as unknown as Workflow<I, O>;
+
+    if (parent) {
+      const childCtx = loopBuilder.builder.loopContext;
+      if (childCtx) {
+        childCtx.pendingLoopConnect = { parent, iteratorTask: task };
+      }
+    }
+    return loopBuilder;
+  }
+
+  /**
+   * Connects outputs to inputs between tasks. Validates source/target
+   * schemas before adding the dataflow; throws {@link WorkflowError} on
+   * mismatch.
+   */
+  public connect(
+    sourceTaskId: unknown,
+    sourceTaskPortId: string,
+    targetTaskId: unknown,
+    targetTaskPortId: string
+  ): void {
+    const sourceTask = this._facade.graph.getTask(sourceTaskId);
+    const targetTask = this._facade.graph.getTask(targetTaskId);
+
+    if (!sourceTask || !targetTask) {
+      throw new WorkflowError("Source or target task not found");
+    }
+
+    const sourceSchema = sourceTask.outputSchema();
+    const targetSchema = targetTask.inputSchema();
+
+    // Handle boolean schemas
+    if (typeof sourceSchema === "boolean") {
+      if (sourceSchema === false) {
+        throw new WorkflowError(`Source task has schema 'false' and outputs nothing`);
+      }
+      // If sourceSchema is true, we skip validation as it accepts everything
+    } else if (!sourceSchema.properties?.[sourceTaskPortId]) {
+      throw new WorkflowError(`Output ${sourceTaskPortId} not found on source task`);
+    }
+
+    if (typeof targetSchema === "boolean") {
+      if (targetSchema === false) {
+        throw new WorkflowError(`Target task has schema 'false' and accepts no inputs`);
+      }
+      if (targetSchema === true) {
+        // do nothing, we allow additional properties
+      }
+    } else if (targetSchema.additionalProperties === true) {
+      // do nothing, we allow additional properties
+    } else if (!targetSchema.properties?.[targetTaskPortId]) {
+      throw new WorkflowError(`Input ${targetTaskPortId} not found on target task`);
+    }
+
+    const dataflow = new Dataflow(sourceTaskId, sourceTaskPortId, targetTaskId, targetTaskPortId);
+    this._facade.graph.addDataflow(dataflow);
+  }
+
+  /**
+   * Renames an output of a task, queuing a pending dataflow. The dataflow's
+   * target is filled in when the next task is added via
+   * {@link addTaskWithAutoConnect}.
+   */
+  public rename(
+    source: string,
+    target: string,
+    indexOrOptions: number | RenameOptions = -1
+  ): void {
+    this._error = "";
+
+    const index =
+      typeof indexOrOptions === "number" ? indexOrOptions : (indexOrOptions.index ?? -1);
+    const transforms = typeof indexOrOptions === "number" ? undefined : indexOrOptions.transforms;
+
+    const nodes = this._facade.graph.getTasks();
+    if (-index > nodes.length) {
+      const errorMsg = `Back index greater than number of tasks`;
+      this._error = errorMsg;
+      getLogger().error(this._error);
+      throw new WorkflowError(errorMsg);
+    }
+
+    const lastNode = nodes[nodes.length + index];
+    const outputSchema = lastNode.outputSchema();
+
+    // Handle boolean schemas
+    if (typeof outputSchema === "boolean") {
+      if (outputSchema === false && source !== DATAFLOW_ALL_PORTS) {
+        const errorMsg = `Task ${lastNode.id} has schema 'false' and outputs nothing`;
+        this._error = errorMsg;
+        getLogger().error(this._error);
+        throw new WorkflowError(errorMsg);
+      }
+      // If outputSchema is true, we skip validation as it outputs everything
+    } else if (!(outputSchema.properties as any)?.[source] && source !== DATAFLOW_ALL_PORTS) {
+      const errorMsg = `Output ${source} not found on task ${lastNode.id}`;
+      this._error = errorMsg;
+      getLogger().error(this._error);
+      throw new WorkflowError(errorMsg);
+    }
+
+    const df = new Dataflow(lastNode.id, source, undefined, target);
+    if (transforms && transforms.length > 0) df.setTransforms(transforms);
+    this._dataFlows.push(df);
+  }
+
+  /**
+   * Adds an error handler task that receives errors from the previous task.
+   * The handler task is wired from the previous task's `[error]` output port
+   * to its all-ports input.
+   */
+  public onError(handler: Taskish): void {
+    this._error = "";
+
+    const parent = getLastTask(this._facade);
+    if (!parent) {
+      this._error = "onError() requires a preceding task in the workflow";
+      getLogger().error(this._error);
+      throw new WorkflowError(this._error);
+    }
+
+    const handlerTask = ensureTask(handler);
+    this._facade.graph.addTask(handlerTask);
+
+    // Connect the previous task's error output port to the handler's all-ports input
+    const dataflow = new Dataflow(
+      parent.id,
+      DATAFLOW_ERROR_PORT,
+      handlerTask.id,
+      DATAFLOW_ALL_PORTS
+    );
+    this._facade.graph.addDataflow(dataflow);
+    this._facade.events.emit("changed", handlerTask.id);
+  }
+
+  /** Removes the last task from the graph. */
+  public pop(): void {
+    this._error = "";
+    const nodes = this._facade.graph.getTasks();
+
+    if (nodes.length === 0) {
+      this._error = "No tasks to remove";
+      getLogger().error(this._error);
+      return;
+    }
+
+    const lastNode = nodes[nodes.length - 1];
+    this._facade.graph.removeTask(lastNode.id);
+  }
+
+  /** Opens a conditional branch builder rooted at the facade. */
+  public createConditional(condition: ConditionFn<TaskInput>): ConditionalBuilder {
+    return new ConditionalBuilder(this._facade, condition);
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
+++ b/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+
+/**
+ * Owns the workflow's TaskOutputRepository and supplies it to the underlying
+ * TaskGraph (at construction) and to graph.run() (per run). Today this is a
+ * thin pass-through; it is the growth point for cache key derivation,
+ * invalidation, and suspend/resume wiring in later work.
+ */
+export class WorkflowCacheAdapter {
+  private readonly _outputCache?: TaskOutputRepository;
+
+  constructor(cache?: TaskOutputRepository) {
+    this._outputCache = cache;
+  }
+
+  public outputCache(): TaskOutputRepository | undefined {
+    return this._outputCache;
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -26,7 +26,6 @@ export class WorkflowEventBridge {
   private readonly _events: EventEmitter<WorkflowEventListeners>;
   private _attachedGraph?: TaskGraph;
   private _entitlementUnsub?: () => void;
-  private _streamingUnsub?: () => void;
   private readonly _onChanged: (id: unknown) => void;
 
   constructor(events: EventEmitter<WorkflowEventListeners>) {
@@ -59,26 +58,23 @@ export class WorkflowEventBridge {
     graph.off("dataflow_removed", this._onChanged);
     this._entitlementUnsub?.();
     this._entitlementUnsub = undefined;
-    // Tear down any streaming subscription that's still tied to this graph.
-    // Without this, a graph swap or reset() during a run would leave the old
-    // graph's streaming handlers wired to this workflow's events emitter.
-    this._streamingUnsub?.();
-    this._streamingUnsub = undefined;
     this._attachedGraph = undefined;
   }
 
-  public beginRun(): void {
+  /**
+   * Subscribes to streaming events on the attached graph for the duration of
+   * one run. Returns an unsubscribe token that the caller MUST hold locally
+   * and invoke when the run ends. Returning the token (rather than storing
+   * it on the bridge) keeps concurrent runs from clobbering each other's
+   * subscriptions — pre-refactor behavior.
+   */
+  public beginRun(): (() => void) | undefined {
     const graph = this._attachedGraph;
-    if (!graph) return;
-    this._streamingUnsub = graph.subscribeToTaskStreaming({
+    if (!graph) return undefined;
+    return graph.subscribeToTaskStreaming({
       onStreamStart: (taskId) => this._events.emit("stream_start", taskId),
       onStreamChunk: (taskId, event) => this._events.emit("stream_chunk", taskId, event),
       onStreamEnd: (taskId, output) => this._events.emit("stream_end", taskId, output),
     });
-  }
-
-  public endRun(): void {
-    this._streamingUnsub?.();
-    this._streamingUnsub = undefined;
   }
 }

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EventEmitter } from "@workglow/util";
+import type { TaskGraph } from "./TaskGraph";
+import type { WorkflowEventListeners } from "./Workflow";
+
+/**
+ * Routes TaskGraph mutation events, entitlement updates, and per-run streaming
+ * events to a Workflow's EventEmitter. Owns subscription lifecycle:
+ *   attach(graph)   → subscribe to mutation + entitlement events
+ *   detach()        → unsubscribe (called on graph swap and reset)
+ *   beginRun()      → subscribe to streaming events for the current run
+ *   endRun()        → unsubscribe streaming
+ *
+ * The bridge does NOT own the events emitter — the facade Workflow does. The
+ * bridge holds a reference and emits through it.
+ *
+ * Loop-builder Workflows do NOT receive a bridge (matches today's behavior:
+ * Workflow.ts only constructs a bridge when `parent` is undefined).
+ */
+export class WorkflowEventBridge {
+  private readonly _events: EventEmitter<WorkflowEventListeners>;
+  private _attachedGraph?: TaskGraph;
+  private _entitlementUnsub?: () => void;
+  private _streamingUnsub?: () => void;
+  private readonly _onChanged: (id: unknown) => void;
+
+  constructor(events: EventEmitter<WorkflowEventListeners>) {
+    this._events = events;
+    this._onChanged = (id) => this._events.emit("changed", id);
+  }
+
+  public attach(graph: TaskGraph): void {
+    if (this._attachedGraph) this.detach();
+    this._attachedGraph = graph;
+    graph.on("task_added", this._onChanged);
+    graph.on("task_replaced", this._onChanged);
+    graph.on("task_removed", this._onChanged);
+    graph.on("dataflow_added", this._onChanged);
+    graph.on("dataflow_replaced", this._onChanged);
+    graph.on("dataflow_removed", this._onChanged);
+    this._entitlementUnsub = graph.subscribeToTaskEntitlements((entitlements) =>
+      this._events.emit("entitlementChange", entitlements)
+    );
+  }
+
+  public detach(): void {
+    const graph = this._attachedGraph;
+    if (!graph) return;
+    graph.off("task_added", this._onChanged);
+    graph.off("task_replaced", this._onChanged);
+    graph.off("task_removed", this._onChanged);
+    graph.off("dataflow_added", this._onChanged);
+    graph.off("dataflow_replaced", this._onChanged);
+    graph.off("dataflow_removed", this._onChanged);
+    this._entitlementUnsub?.();
+    this._entitlementUnsub = undefined;
+    this._attachedGraph = undefined;
+  }
+
+  public beginRun(): void {
+    const graph = this._attachedGraph;
+    if (!graph) return;
+    this._streamingUnsub = graph.subscribeToTaskStreaming({
+      onStreamStart: (taskId) => this._events.emit("stream_start", taskId),
+      onStreamChunk: (taskId, event) => this._events.emit("stream_chunk", taskId, event),
+      onStreamEnd: (taskId, output) => this._events.emit("stream_end", taskId, output),
+    });
+  }
+
+  public endRun(): void {
+    this._streamingUnsub?.();
+    this._streamingUnsub = undefined;
+  }
+}

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -59,6 +59,11 @@ export class WorkflowEventBridge {
     graph.off("dataflow_removed", this._onChanged);
     this._entitlementUnsub?.();
     this._entitlementUnsub = undefined;
+    // Tear down any streaming subscription that's still tied to this graph.
+    // Without this, a graph swap or reset() during a run would leave the old
+    // graph's streaming handlers wired to this workflow's events emitter.
+    this._streamingUnsub?.();
+    this._streamingUnsub = undefined;
     this._attachedGraph = undefined;
   }
 

--- a/packages/task-graph/src/task-graph/WorkflowFactories.ts
+++ b/packages/task-graph/src/task-graph/WorkflowFactories.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITaskConstructor } from "../task/ITask";
+import type { DataPorts, TaskConfig } from "../task/TaskTypes";
+import { hasVectorLikeInput, hasVectorOutput } from "./GraphSchemaUtils";
+import { Workflow } from "./Workflow";
+import { getLastTask } from "./WorkflowPipe";
+
+// Type definitions for the workflow
+export type CreateWorkflow<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I>> = (
+  input?: Partial<I>,
+  config?: Partial<C>
+) => Workflow<I, O>;
+
+export function CreateWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+>(taskClass: ITaskConstructor<I, O, C>): CreateWorkflow<I, O, C> {
+  return Workflow.createWorkflow<I, O, C>(taskClass);
+}
+
+/**
+ * Type for loop workflow methods (map, while, reduce).
+ * Represents the method signature with proper `this` context.
+ * Loop methods take only a config parameter - input is not used for loop tasks.
+ */
+export type CreateLoopWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+> = (this: Workflow<I, O>, config?: Partial<C>) => Workflow<I, O>;
+
+/**
+ * Factory function that creates a loop workflow method for a given task class.
+ * Returns a method that can be assigned to Workflow.prototype.
+ *
+ * @param taskClass - The iterator task class (MapTask, ReduceTask, etc.)
+ * @returns A method that creates the task and returns a loop builder workflow
+ */
+export function CreateLoopWorkflow<
+  I extends DataPorts,
+  O extends DataPorts,
+  C extends TaskConfig<I> = TaskConfig<I>,
+>(taskClass: ITaskConstructor<I, O, C>): CreateLoopWorkflow<I, O, C> {
+  return function (this: Workflow<I, O>, config: Partial<C> = {}): Workflow<I, O> {
+    return this.addLoopTask(taskClass, config);
+  };
+}
+
+/**
+ * Type for end loop workflow methods (endMap, endBatch, etc.).
+ */
+export type EndLoopWorkflow = (this: Workflow) => Workflow;
+
+/**
+ * Factory function that creates an end loop workflow method.
+ *
+ * @param methodName - The name of the method (for error messages)
+ * @returns A method that finalizes the loop and returns to the parent workflow
+ */
+export function CreateEndLoopWorkflow(methodName: string): EndLoopWorkflow {
+  return function (this: Workflow): Workflow {
+    if (!this.isLoopBuilder) {
+      throw new Error(`${methodName}() can only be called on loop workflows`);
+    }
+    return this.finalizeAndReturn();
+  };
+}
+
+/**
+ * Type for adaptive workflow methods that dispatch to scalar or vector variant
+ * based on the previous task's output schema.
+ */
+export type CreateAdaptiveWorkflow<
+  IS extends DataPorts,
+  _OS extends DataPorts,
+  IV extends DataPorts,
+  _OV extends DataPorts,
+  CS extends TaskConfig<IS> = TaskConfig<IS>,
+  CV extends TaskConfig<IV> = TaskConfig<IV>,
+> = (
+  this: Workflow,
+  input?: Partial<IS> & Partial<IV>,
+  config?: Partial<CS> & Partial<CV>
+) => Workflow;
+
+/**
+ * Factory that creates an adaptive workflow method: when called, inspects the
+ * output schema of the last task in the chain and delegates to the vector
+ * variant if it has TypedArray output, otherwise to the scalar variant.
+ * If there is no previous task, defaults to the scalar variant.
+ *
+ * @param scalarClass - Task class for scalar path (e.g. ScalarAddTask)
+ * @param vectorClass - Task class for vector path (e.g. VectorSumTask)
+ * @returns A method suitable for Workflow.prototype
+ */
+export function CreateAdaptiveWorkflow<
+  IS extends DataPorts,
+  OS extends DataPorts,
+  IV extends DataPorts,
+  OV extends DataPorts,
+  CS extends TaskConfig<IS> = TaskConfig<IS>,
+  CV extends TaskConfig<IV> = TaskConfig<IV>,
+>(
+  scalarClass: ITaskConstructor<IS, OS, CS>,
+  vectorClass: ITaskConstructor<IV, OV, CV>
+): CreateAdaptiveWorkflow<IS, OS, IV, OV, CS, CV> {
+  const scalarHelper = Workflow.createWorkflow<IS, OS, CS>(scalarClass);
+  const vectorHelper = Workflow.createWorkflow<IV, OV, CV>(vectorClass);
+
+  return function (
+    this: Workflow<any, any>,
+    input: (Partial<IS> & Partial<IV>) | undefined = {},
+    config: (Partial<CS> & Partial<CV>) | undefined = {}
+  ): Workflow {
+    const parent = getLastTask(this);
+    const useVector =
+      (parent !== undefined && hasVectorOutput(parent)) || hasVectorLikeInput(input);
+    if (useVector) {
+      return vectorHelper.call(this, input, config) as Workflow;
+    }
+    return scalarHelper.call(this, input, config) as Workflow;
+  };
+}
+

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { ITask } from "../task/ITask";
+import type { DataPorts } from "../task/TaskTypes";
+import type { PipeFunction, Taskish } from "./Conversions";
+import { ensureTask } from "./Conversions";
+import { Dataflow } from "./Dataflow";
+import type { ITaskGraph } from "./ITaskGraph";
+import type { IWorkflow } from "./IWorkflow";
+import type { CompoundMergeStrategy } from "./TaskGraphRunner";
+import { PROPERTY_ARRAY } from "./TaskGraphRunner";
+import { Workflow } from "./Workflow";
+
+// ============================================================================
+// Standalone utility functions (moved from Conversions.ts to break circular
+// dependency — these need both Workflow and GraphAsTask which live here)
+// ============================================================================
+
+export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
+  const tasks = workflow.graph.getTasks();
+  return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
+}
+
+export function connect(
+  source: ITask<any, any, any>,
+  target: ITask<any, any, any>,
+  workflow: IWorkflow<any, any>
+): void {
+  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
+}
+
+export function pipe<A extends DataPorts, B extends DataPorts>(
+  [fn1]: [Taskish<A, B>],
+  workflow?: IWorkflow<A, B>
+): IWorkflow<A, B>;
+
+export function pipe<A extends DataPorts, B extends DataPorts, C extends DataPorts>(
+  [fn1, fn2]: [Taskish<A, B>, Taskish<B, C>],
+  workflow?: IWorkflow<A, C>
+): IWorkflow<A, C>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+>(
+  [fn1, fn2, fn3]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>],
+  workflow?: IWorkflow<A, D>
+): IWorkflow<A, D>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+  E extends DataPorts,
+>(
+  [fn1, fn2, fn3, fn4]: [Taskish<A, B>, Taskish<B, C>, Taskish<C, D>, Taskish<D, E>],
+  workflow?: IWorkflow<A, E>
+): IWorkflow<A, E>;
+
+export function pipe<
+  A extends DataPorts,
+  B extends DataPorts,
+  C extends DataPorts,
+  D extends DataPorts,
+  E extends DataPorts,
+  F extends DataPorts,
+>(
+  [fn1, fn2, fn3, fn4, fn5]: [
+    Taskish<A, B>,
+    Taskish<B, C>,
+    Taskish<C, D>,
+    Taskish<D, E>,
+    Taskish<E, F>,
+  ],
+  workflow?: IWorkflow<A, F>
+): IWorkflow<A, F>;
+
+export function pipe<I extends DataPorts, O extends DataPorts>(
+  args: Taskish<I, O>[],
+  workflow: IWorkflow<I, O> = new Workflow<I, O>()
+): IWorkflow<I, O> {
+  let previousTask = getLastTask(workflow);
+  const tasks = args.map((arg) => ensureTask(arg));
+  tasks.forEach((task) => {
+    workflow.graph.addTask(task);
+    if (previousTask) {
+      connect(previousTask, task, workflow);
+    }
+    previousTask = task;
+  });
+  return workflow;
+}
+
+export function parallel<I extends DataPorts = DataPorts, O extends DataPorts = DataPorts>(
+  args: (PipeFunction<I, O> | ITask<I, O> | IWorkflow<I, O> | ITaskGraph)[],
+  mergeFn: CompoundMergeStrategy = PROPERTY_ARRAY,
+  workflow: IWorkflow<I, O> = new Workflow<I, O>()
+): IWorkflow<I, O> {
+  let previousTask = getLastTask(workflow);
+  const tasks = args.map((arg) => ensureTask(arg));
+  const config = {
+    compoundMerge: mergeFn,
+  };
+  const name = `‖${args.map((_arg) => "𝑓").join("‖")}‖`;
+  class ParallelTask extends GraphAsTask<I, O> {
+    public static override type = name;
+  }
+  const mergeTask = new ParallelTask(config);
+  mergeTask.subGraph!.addTasks(tasks);
+  workflow.graph.addTask(mergeTask);
+  if (previousTask) {
+    connect(previousTask, mergeTask, workflow);
+  }
+  return workflow;
+}

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -9,7 +9,7 @@ import type { ITask } from "../task/ITask";
 import type { DataPorts } from "../task/TaskTypes";
 import type { PipeFunction, Taskish } from "./Conversions";
 import { ensureTask } from "./Conversions";
-import { Dataflow } from "./Dataflow";
+import { Dataflow, DATAFLOW_ALL_PORTS } from "./Dataflow";
 import type { ITaskGraph } from "./ITaskGraph";
 import type { IWorkflow } from "./IWorkflow";
 import type { CompoundMergeStrategy } from "./TaskGraphRunner";
@@ -31,7 +31,9 @@ export function connect(
   target: ITask<any, any, any>,
   workflow: IWorkflow<any, any>
 ): void {
-  workflow.graph.addDataflow(new Dataflow(source.id, "*", target.id, "*"));
+  workflow.graph.addDataflow(
+    new Dataflow(source.id, DATAFLOW_ALL_PORTS, target.id, DATAFLOW_ALL_PORTS)
+  );
 }
 
 export function pipe<A extends DataPorts, B extends DataPorts>(

--- a/packages/task-graph/src/task-graph/WorkflowTask.ts
+++ b/packages/task-graph/src/task-graph/WorkflowTask.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphAsTask } from "../task/GraphAsTask";
+import type { DataPorts } from "../task/TaskTypes";
+import type { CompoundMergeStrategy } from "./TaskGraphRunner";
+import { PROPERTY_ARRAY } from "./TaskGraphRunner";
+
+export class WorkflowTask<
+  I extends DataPorts,
+  O extends DataPorts,
+> extends GraphAsTask<I, O> {
+  public static override readonly type = "Workflow";
+  public static override readonly compoundMerge = PROPERTY_ARRAY as CompoundMergeStrategy;
+}

--- a/packages/task-graph/src/task/FallbackTask.ts
+++ b/packages/task-graph/src/task/FallbackTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { GraphAsTask, graphAsTaskConfigSchema } from "./GraphAsTask";
 import type { GraphAsTaskConfig } from "./GraphAsTask";
 import { FallbackTaskRunner } from "./FallbackTaskRunner";

--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -12,7 +12,7 @@ import { computeGraphEntitlements } from "../task-graph/GraphEntitlementUtils";
 import { computeGraphInputSchema, computeGraphOutputSchema } from "../task-graph/GraphSchemaUtils";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import { CompoundMergeStrategy, PROPERTY_ARRAY } from "../task-graph/TaskGraphRunner";
-import type { CreateLoopWorkflow } from "../task-graph/Workflow";
+import type { CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
 import type { IExecuteContext, IRunConfig } from "./ITask";
 import type { StreamEvent, StreamFinish } from "./StreamTypes";

--- a/packages/task-graph/src/task/MapTask.ts
+++ b/packages/task-graph/src/task/MapTask.ts
@@ -6,7 +6,8 @@
 
 import type { DataPortSchema } from "@workglow/util/schema";
 import { PROPERTY_ARRAY } from "../task-graph/TaskGraphRunner";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import type { IRunConfig } from "./ITask";
 import { IteratorTask, IteratorTaskConfig, iteratorTaskConfigSchema } from "./IteratorTask";
 import type { TaskInput, TaskOutput, TaskTypeName } from "./TaskTypes";

--- a/packages/task-graph/src/task/ReduceTask.ts
+++ b/packages/task-graph/src/task/ReduceTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import type { IRunConfig } from "./ITask";
 import {
   IterationAnalysisResult,

--- a/packages/task-graph/src/task/WhileTask.ts
+++ b/packages/task-graph/src/task/WhileTask.ts
@@ -5,7 +5,8 @@
  */
 
 import type { DataPortSchema } from "@workglow/util/schema";
-import { CreateEndLoopWorkflow, CreateLoopWorkflow, Workflow } from "../task-graph/Workflow";
+import { Workflow } from "../task-graph/Workflow";
+import { CreateEndLoopWorkflow, CreateLoopWorkflow } from "../task-graph/WorkflowFactories";
 import { evaluateCondition, getNestedValue } from "./ConditionUtils";
 import { GraphAsTask, GraphAsTaskConfig, graphAsTaskConfigSchema } from "./GraphAsTask";
 import type { IExecuteContext, IRunConfig } from "./ITask";

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -1194,7 +1194,7 @@ describe("Workflow — refactor regression net", () => {
     it("onError adds a handler task wired to the error port", () => {
       const w = new Workflow();
       w.addTask(NumberTask, { input: 1 });
-      w.onError(NumberTask);
+      w.onError(new NumberTask({}));
       expect(w.graph.getTasks()).toHaveLength(2);
       const errorEdges = w.graph
         .getDataflows()
@@ -1258,7 +1258,7 @@ describe("Workflow — refactor regression net", () => {
       class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
         static override type = "SlowAbortTask";
         static override category = "Test";
-        async execute(
+        override async execute(
           input: { input: number },
           _config?: unknown,
           signal?: AbortSignal

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -8,10 +8,12 @@ import {
   computeGraphInputSchema,
   CreateWorkflow,
   hasVectorOutput,
+  MapTask,
   PROPERTY_ARRAY,
   Task,
   TaskConfig,
   TaskError,
+  TaskGraph,
   Workflow,
   WorkflowError,
 } from "@workglow/task-graph";
@@ -1178,6 +1180,170 @@ describe("Workflow", () => {
         const result = await workflow.run({ input: "hello" }, { registry });
         expect(result).toEqual({ output: "processed-hello" });
       });
+    });
+  });
+});
+
+// ============================================================================
+// Refactor regression net — gap coverage for the Workflow decomposition.
+// Pairs with: builder/docs/superpowers/specs/2026-05-02-decompose-workflow-design.md
+// ============================================================================
+
+describe("Workflow — refactor regression net", () => {
+  describe("onError handler wiring (spec #2)", () => {
+    it("onError adds a handler task wired to the error port", () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      w.onError(NumberTask);
+      expect(w.graph.getTasks()).toHaveLength(2);
+      const errorEdges = w.graph
+        .getDataflows()
+        .filter((df) => df.sourceTaskPortId === "[error]");
+      expect(errorEdges.length).toBe(1);
+    });
+  });
+
+  describe("loop-builder lifecycle (spec #3)", () => {
+    it("addLoopTask returns a child workflow that adds the iterator to the parent graph", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      expect(inner).not.toBe(w);
+      expect(w.graph.getTasks()).toHaveLength(1);
+      expect(w.graph.getTasks()[0].type).toBe("MapTask");
+    });
+
+    it("child reset throws WorkflowError", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      expect(() => inner.reset()).toThrow(WorkflowError);
+    });
+
+    it("finalizeAndReturn promotes the child template into the iterator subGraph and returns parent", () => {
+      const w = new Workflow();
+      const inner = w.addLoopTask(MapTask, {});
+      inner.addTask(NumberTask, { input: 1 });
+      const back = inner.finalizeAndReturn();
+      expect(back).toBe(w);
+      const iter = w.graph.getTasks()[0] as { subGraph?: unknown };
+      expect(iter.subGraph).toBeDefined();
+    });
+  });
+
+  describe("conditional smoke (spec #4)", () => {
+    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks", () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      w.if((input: { output?: number }) => (input.output ?? 0) > 0)
+        .then(NumberToStringTask)
+        .else(NumberToStringTask)
+        .endIf();
+      const types = w.graph.getTasks().map((t) => t.type);
+      expect(types).toContain("ConditionalTask");
+      expect(types.filter((t) => t === "NumberToStringTask")).toHaveLength(2);
+    });
+  });
+
+  describe("run & abort event ordering (spec #5)", () => {
+    it("run() emits start then complete in order", async () => {
+      const w = new Workflow();
+      w.addTask(NumberTask, { input: 1 });
+      const events: string[] = [];
+      w.on("start", () => events.push("start"));
+      w.on("complete", () => events.push("complete"));
+      await w.run();
+      expect(events).toEqual(["start", "complete"]);
+    });
+
+    it("abort() during run causes run to reject and emits error", async () => {
+      class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
+        static override type = "SlowAbortTask";
+        static override category = "Test";
+        async execute(
+          input: { input: number },
+          _config?: unknown,
+          signal?: AbortSignal
+        ): Promise<{ output: number }> {
+          await new Promise((_resolve, reject) => {
+            if (signal) {
+              signal.addEventListener("abort", () => reject(new Error("aborted")));
+            }
+          });
+          return { output: input.input };
+        }
+      }
+
+      const w = new Workflow();
+      w.addTask(SlowAbortTask, { input: 1 });
+      const errors: string[] = [];
+      w.on("error", (msg) => errors.push(msg));
+
+      const runPromise = w.run();
+      setTimeout(() => void w.abort(), 10);
+      await expect(runPromise).rejects.toBeDefined();
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("event lifecycle on graph swap (spec #6)", () => {
+    it("setting workflow.graph emits reset; subsequent addTask emits changed", () => {
+      const w = new Workflow();
+      const events: string[] = [];
+      w.on("reset", () => events.push("reset"));
+      w.on("changed", () => events.push("changed"));
+
+      w.graph = new TaskGraph();
+      expect(events).toContain("reset");
+
+      const beforeChangedCount = events.filter((e) => e === "changed").length;
+      w.addTask(NumberTask, { input: 1 });
+      const afterChangedCount = events.filter((e) => e === "changed").length;
+      expect(afterChangedCount).toBeGreaterThan(beforeChangedCount);
+    });
+  });
+
+  describe("entitlement bridge (spec #8)", () => {
+    it("workflow.events exposes entitlementChange listener slot", () => {
+      const w = new Workflow();
+      let listenerError: unknown;
+      try {
+        w.on("entitlementChange", () => {
+          /* listener body is irrelevant — we only test that subscription succeeds */
+        });
+      } catch (e) {
+        listenerError = e;
+      }
+      expect(listenerError).toBeUndefined();
+      // Trigger any graph mutation; subscription must not throw.
+      w.addTask(NumberTask, { input: 1 });
+      expect(w.error).toBe("");
+    });
+  });
+
+  describe("external-consumer invariants (spec #11)", () => {
+    it("Workflow remains a class with a mutable prototype", () => {
+      // The augmentation pattern used by builder JoinTask/SplitTask depends on
+      // Workflow.prototype being mutable. The existing file already exercises
+      // this via Workflow.prototype.testSimple = CreateWorkflow(...). Here we
+      // assert the contract explicitly so a future change that breaks the
+      // pattern (e.g. converting Workflow to a type alias) trips this test.
+      const helper = CreateWorkflow(NumberTask);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Workflow.prototype as any).PrototypeAugmentTest = helper;
+      const w = new Workflow();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (w as any).PrototypeAugmentTest({ input: 1 });
+      expect(w.graph.getTasks()).toHaveLength(1);
+      expect(w.graph.getTasks()[0].type).toBe("NumberTask");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (Workflow.prototype as any).PrototypeAugmentTest;
+    });
+
+    it("workflow.events identity is stable across the lifetime of the instance", () => {
+      const w = new Workflow();
+      const e1 = w.events;
+      w.addTask(NumberTask, { input: 1 });
+      const e2 = w.events;
+      expect(e1).toBe(e2);
     });
   });
 });

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -8,15 +8,20 @@ import {
   computeGraphInputSchema,
   CreateWorkflow,
   hasVectorOutput,
+  IExecuteContext,
   MapTask,
   PROPERTY_ARRAY,
+  StreamEvent,
   Task,
   TaskConfig,
+  TaskEntitlements,
   TaskError,
   TaskGraph,
+  TaskIdType,
   Workflow,
   WorkflowError,
 } from "@workglow/task-graph";
+import { DataPortSchema } from "@workglow/util/schema";
 import {
   InputTask,
   OutputTask,
@@ -1190,6 +1195,43 @@ describe("Workflow", () => {
 // Pairs with: builder/docs/superpowers/specs/2026-05-02-decompose-workflow-design.md
 // ============================================================================
 
+type StreamRelayInput = { prompt: string };
+type StreamRelayOutput = { text: string };
+
+class StreamRelayTask extends Task<StreamRelayInput, StreamRelayOutput> {
+  public static override type = "StreamRelayTask";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { prompt: { type: "string", default: "test" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  async *executeStream(
+    _input: StreamRelayInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<StreamRelayOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "hello" };
+    yield { type: "text-delta", port: "text", textDelta: " world" };
+    yield { type: "finish", data: { text: "hello world" } };
+  }
+
+  override async execute(_input: StreamRelayInput): Promise<StreamRelayOutput | undefined> {
+    return { text: "hello world" };
+  }
+}
+
 describe("Workflow — refactor regression net", () => {
   describe("onError handler wiring (spec #2)", () => {
     it("onError adds a handler task wired to the error port", () => {
@@ -1301,21 +1343,65 @@ describe("Workflow — refactor regression net", () => {
     });
   });
 
-  describe("entitlement bridge (spec #8 — listener slot only)", () => {
-    // NOTE: this only verifies the subscription wiring does not throw. Actual
-    // propagation from graph→workflow is NOT yet asserted here — that gap will
-    // be filled when WorkflowEventBridge lands (migration step 7). Until then
-    // a regression that drops the entitlement subscription entirely would not
-    // be caught by this test alone.
-    it("workflow.events accepts entitlementChange subscription without throwing", () => {
+  describe("entitlement bridge propagation (spec #8)", () => {
+    it("entitlementChange propagates from graph mutations through to workflow.events", () => {
       const w = new Workflow();
-      expect(() =>
-        w.on("entitlementChange", () => {
-          /* no-op */
-        })
-      ).not.toThrow();
-      // Mutating the graph after subscribing must not throw either.
-      expect(() => w.addTask(NumberTask, { input: 1 })).not.toThrow();
+      const fires: TaskEntitlements[] = [];
+      w.on("entitlementChange", (entitlements) => fires.push(entitlements));
+      const before = fires.length;
+      w.addTask(NumberTask, { input: 1 });
+      // task_added on the graph must produce at least one entitlementChange
+      // emission on workflow.events. Pre-refactor behavior was via the
+      // subscribeToTaskEntitlements wiring inside Workflow; post-refactor
+      // it routes through WorkflowEventBridge.attach.
+      expect(fires.length).toBeGreaterThan(before);
+    });
+  });
+
+  describe("streaming relay (spec #7)", () => {
+    it("graph stream_start/stream_chunk/stream_end propagate to workflow.events during run", async () => {
+      const w = new Workflow();
+      w.addTask(StreamRelayTask, { prompt: "hi" });
+
+      const startIds: TaskIdType[] = [];
+      const chunks: { taskId: TaskIdType; event: StreamEvent }[] = [];
+      const ends: { taskId: TaskIdType; output: Record<string, unknown> }[] = [];
+      w.on("stream_start", (taskId) => startIds.push(taskId));
+      w.on("stream_chunk", (taskId, event) => chunks.push({ taskId, event }));
+      w.on("stream_end", (taskId, output) => ends.push({ taskId, output }));
+
+      await w.run({ prompt: "hi" });
+
+      expect(startIds.length).toBeGreaterThanOrEqual(1);
+      const textDeltas = chunks.filter((c) => c.event.type === "text-delta");
+      expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+      expect(ends.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("streaming subscription is released after run completes (no leak via bridge field)", async () => {
+      // Pre-refactor `unsubStreaming` was a local in run(); post-refactor the
+      // bridge.beginRun() RETURNS the unsub and run() holds it locally too.
+      // This test verifies that nothing on the bridge keeps a stale unsub
+      // between runs (the I-1 fix from PR review).
+      const w = new Workflow();
+      w.addTask(StreamRelayTask, { prompt: "first" });
+      const chunksRun1: StreamEvent[] = [];
+      const off1 = (event: StreamEvent) => chunksRun1.push(event);
+      w.on("stream_chunk", (_id, event) => off1(event));
+      await w.run({ prompt: "first" });
+
+      const countAfterRun1 = chunksRun1.length;
+      // No second listener subscription needed — same instance.
+      // After run1 completes its streaming subscription must be torn down so
+      // no further chunks are received from the prior subscription. Triggering
+      // a second run reuses the bridge cleanly.
+      w.reset();
+      w.addTask(StreamRelayTask, { prompt: "second" });
+      await w.run({ prompt: "second" });
+      // chunksRun1 captures from BOTH runs (we never unsubscribed off1), so
+      // count must increase. The test would fail if the bridge had silently
+      // dropped subscriptions or double-bound them.
+      expect(chunksRun1.length).toBeGreaterThan(countAfterRun1);
     });
   });
 

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LongRunningTask,
   NumberTask,
   NumberToStringTask,
   StringTask,
@@ -1224,22 +1225,31 @@ describe("Workflow — refactor regression net", () => {
       inner.addTask(NumberTask, { input: 1 });
       const back = inner.finalizeAndReturn();
       expect(back).toBe(w);
-      const iter = w.graph.getTasks()[0] as { subGraph?: unknown };
+      const iter = w.graph.getTasks()[0] as { subGraph?: TaskGraph };
       expect(iter.subGraph).toBeDefined();
+      // Pin contents so an empty-graph regression in finalizeTemplate trips here.
+      expect(iter.subGraph!.getTasks()).toHaveLength(1);
     });
   });
 
   describe("conditional smoke (spec #4)", () => {
-    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks", () => {
+    it("if/then/else/endIf adds a ConditionalTask plus two branch tasks with both branches wired", () => {
       const w = new Workflow();
       w.addTask(NumberTask, { input: 1 });
       w.if((input: { output?: number }) => (input.output ?? 0) > 0)
         .then(NumberToStringTask)
         .else(NumberToStringTask)
         .endIf();
-      const types = w.graph.getTasks().map((t) => t.type);
+      const tasks = w.graph.getTasks();
+      const types = tasks.map((t) => t.type);
       expect(types).toContain("ConditionalTask");
       expect(types.filter((t) => t === "NumberToStringTask")).toHaveLength(2);
+
+      const conditional = tasks.find((t) => t.type === "ConditionalTask")!;
+      const branchEdges = w.graph
+        .getDataflows()
+        .filter((df) => df.sourceTaskId === conditional.id);
+      expect(branchEdges.map((df) => df.sourceTaskPortId).sort()).toEqual(["else", "then"]);
     });
   });
 
@@ -1254,33 +1264,16 @@ describe("Workflow — refactor regression net", () => {
       expect(events).toEqual(["start", "complete"]);
     });
 
-    it("abort() during run causes run to reject and emits error", async () => {
-      class SlowAbortTask extends Task<{ input: number }, { output: number }, TaskConfig> {
-        static override type = "SlowAbortTask";
-        static override category = "Test";
-        override async execute(
-          input: { input: number },
-          _config?: unknown,
-          signal?: AbortSignal
-        ): Promise<{ output: number }> {
-          await new Promise((_resolve, reject) => {
-            if (signal) {
-              signal.addEventListener("abort", () => reject(new Error("aborted")));
-            }
-          });
-          return { output: input.input };
-        }
-      }
-
+    it("abort() during run causes run to reject and emits error exactly once", async () => {
       const w = new Workflow();
-      w.addTask(SlowAbortTask, { input: 1 });
+      w.addTask(LongRunningTask, {});
       const errors: string[] = [];
       w.on("error", (msg) => errors.push(msg));
 
       const runPromise = w.run();
       setTimeout(() => void w.abort(), 10);
       await expect(runPromise).rejects.toBeDefined();
-      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors).toHaveLength(1);
     });
   });
 
@@ -1297,25 +1290,32 @@ describe("Workflow — refactor regression net", () => {
       const beforeChangedCount = events.filter((e) => e === "changed").length;
       w.addTask(NumberTask, { input: 1 });
       const afterChangedCount = events.filter((e) => e === "changed").length;
-      expect(afterChangedCount).toBeGreaterThan(beforeChangedCount);
+      // addTask emits "changed" multiple times today (once directly on the
+      // facade, once via the bridge's task_added subscription). The exact
+      // count is implementation-defined; we pin lower and upper bounds. A
+      // bridge double-subscription regression after the WorkflowEventBridge
+      // extraction (migration step 7) would push the delta past 4.
+      const delta = afterChangedCount - beforeChangedCount;
+      expect(delta).toBeGreaterThanOrEqual(1);
+      expect(delta).toBeLessThanOrEqual(4);
     });
   });
 
-  describe("entitlement bridge (spec #8)", () => {
-    it("workflow.events exposes entitlementChange listener slot", () => {
+  describe("entitlement bridge (spec #8 — listener slot only)", () => {
+    // NOTE: this only verifies the subscription wiring does not throw. Actual
+    // propagation from graph→workflow is NOT yet asserted here — that gap will
+    // be filled when WorkflowEventBridge lands (migration step 7). Until then
+    // a regression that drops the entitlement subscription entirely would not
+    // be caught by this test alone.
+    it("workflow.events accepts entitlementChange subscription without throwing", () => {
       const w = new Workflow();
-      let listenerError: unknown;
-      try {
+      expect(() =>
         w.on("entitlementChange", () => {
-          /* listener body is irrelevant — we only test that subscription succeeds */
-        });
-      } catch (e) {
-        listenerError = e;
-      }
-      expect(listenerError).toBeUndefined();
-      // Trigger any graph mutation; subscription must not throw.
-      w.addTask(NumberTask, { input: 1 });
-      expect(w.error).toBe("");
+          /* no-op */
+        })
+      ).not.toThrow();
+      // Mutating the graph after subscribing must not throw either.
+      expect(() => w.addTask(NumberTask, { input: 1 })).not.toThrow();
     });
   });
 

--- a/packages/test/src/test/task-graph/Workflow.transforms.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.transforms.test.ts
@@ -19,11 +19,11 @@ describe("Workflow .rename accepts { transforms }", () => {
       transforms: [{ id: "uppercase" }],
     });
 
-    // rename pushes a pending Dataflow onto Workflow._dataFlows (no target
-    // yet). Inspect it via the private field through a cast — this is a
-    // behavioural test only.
+    // rename pushes a pending Dataflow onto WorkflowBuilder._dataFlows (no
+    // target yet). Inspect it via the private field through a cast — this is
+    // a behavioural test only.
     const pendingDataflows = (
-      w as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
     )._dataFlows;
     expect(pendingDataflows).toHaveLength(1);
     expect(pendingDataflows[0].getTransforms().map((t) => t.id)).toEqual(["uppercase"]);
@@ -32,8 +32,9 @@ describe("Workflow .rename accepts { transforms }", () => {
   it(".rename(source, target, index) (numeric) still works without options", () => {
     const w = new Workflow();
     w.addTask(TestSimpleTask).rename("output", "input", -1);
-    const pending = (w as unknown as { _dataFlows: { getTransforms(): readonly unknown[] }[] })
-      ._dataFlows;
+    const pending = (
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly unknown[] }[] }
+    )._dataFlows;
     expect(pending).toHaveLength(1);
     expect(pending[0].getTransforms()).toHaveLength(0);
   });
@@ -45,7 +46,7 @@ describe("Workflow .rename accepts { transforms }", () => {
       transforms: [{ id: "uppercase" }, { id: "lowercase" }],
     });
     const pending = (
-      w as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
+      w.builder as unknown as { _dataFlows: { getTransforms(): readonly { id: string }[] }[] }
     )._dataFlows;
     expect(pending[0].getTransforms().map((t) => t.id)).toEqual(["uppercase", "lowercase"]);
   });


### PR DESCRIPTION
## Summary

Pure structural refactor of `packages/task-graph/src/task-graph/Workflow.ts`. **No behavior change. No public-API change.** The 1,368-line file is split into a thin facade plus seven focused sibling modules.

- `Workflow.ts`: **1,368 → 664 lines** (−51%)
- Public API of `Workflow` is unchanged: same constructor, same methods, same events, same statics
- `common.ts` diff is additive-only (two new `export *` lines)

### Why

Prep work for two upcoming workstreams:

1. **Cache + suspend/resume on running graphs.** `WorkflowCacheAdapter` is a thin pass-through today and the natural growth point for cache key derivation, invalidation, and suspend/resume hooks.
2. **Better testing.** `Workflow` had no co-located tests in `packages/task-graph/src/task-graph/__tests__/` and only indirect coverage in `packages/test/`. The regression net added in this branch (appended to `packages/test/src/test/task-graph/Workflow.test.ts`) explicitly locks in observable behavior for: onError wiring, loop-builder lifecycle, conditional smoke, run/abort event ordering, graph-swap detach/attach, entitlementChange subscription, mutable-prototype invariant, and events-field identity.

### File layout (all in `packages/task-graph/src/task-graph/`)

| File | Lines | Owns |
|------|-------|------|
| `Workflow.ts` | 664 | Facade — `_graph`, `_abortController`, `events`, composed units; public API |
| `WorkflowBuilder.ts` (new) | 404 | DSL state machine — `_dataFlows`, `_error`, `_registry`, `_loopContext`, plus `addTaskWithAutoConnect`, `addLoopTask`, `connect`, `rename`, `onError`, `pop`, `createConditional` |
| `WorkflowFactories.ts` (new) | 130 | `Create*Workflow` factories. `group`/`endGroup` proto assignments stay inline in `Workflow.ts` (see "ES module gotcha" below) |
| `WorkflowPipe.ts` (new) | 123 | Module-level `pipe`/`parallel`/`getLastTask`/`connect` |
| `LoopBuilderContext.ts` (new) | 83 | Loop-builder mode value object + `finalizeTemplate`/`finalizeAndReturn`/`consumePendingConnect` |
| `WorkflowEventBridge.ts` (new) | 79 | `attach`/`detach`/`beginRun`/`endRun` for graph→events relay |
| `WorkflowCacheAdapter.ts` (new) | 25 | `_outputCache` field + `outputCache()` accessor; growth point for cache/suspend/resume |
| `WorkflowTask.ts` (new) | 18 | Private `WorkflowTask extends GraphAsTask` (used only by `Workflow#toTask()`) |

Schema helpers (`schemaHasTypedArrayFormat`, `hasVectorOutput`, `hasVectorLikeInput`, `TYPED_ARRAY_FORMAT_PREFIX`, `updateBoundaryTaskSchemas`) moved into existing `GraphSchemaUtils.ts`.

### External-consumer invariants preserved

- `Workflow` remains a class with a mutable prototype (verified by regression test).
- `CreateWorkflow` type and function still exported from `@workglow/task-graph`.
- Zero-arg `new Workflow()` constructor still works.
- `workflow.graph = newGraph` setter detaches old subscriptions and attaches to the new graph (verified).
- `workflow.events` reference identity is stable across the lifetime of the instance (verified).
- Builder repo's prototype-augmentation pattern (`Workflow.prototype.Join = CreateWorkflow(JoinTask)` in `JoinTask.ts`/`SplitTask.ts`) continues to work.

### ES module gotcha (planning lesson)

The original spec proposed moving the `Workflow.prototype.group / endGroup` proto assignments into `WorkflowFactories.ts` and adding a tail side-effect import to `Workflow.ts`. **This doesn't work** — ES static imports are hoisted before any class declaration evaluates, so the factories module observes `Workflow` as `undefined`. The proto assignments stay inline in `Workflow.ts` after the class declaration; `Workflow.ts` imports the factory functions (not their side effects) from `WorkflowFactories.ts`. Internal consumers (`MapTask`, `WhileTask`, `ReduceTask`, `FallbackTask`) updated to import factories from the new location.

### Spec & plan

- Spec: `builder/docs/superpowers/specs/2026-05-02-decompose-workflow-design.md`
- Plan: `builder/docs/superpowers/plans/2026-05-02-decompose-workflow.md`

## Test plan

- [x] `bun run build:types` — 24/24 packages green
- [x] `Workflow.test.ts` regression net — 86/86 (75 existing + 11 new)
- [x] `packages/test/src/test/task-graph/` — 498/498 across 31 files
- [x] `packages/test/src/test/task/` — 1,128/1,128 across 72 files
- [x] Full suite — 3,694/3,800 (2 pre-existing AI-provider integration flakes unrelated to this branch)
- [x] `git diff main -- packages/task-graph/src/common.ts` shows only additive `export *` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
