### PR TITLE
Add stopTimeoutMs configuration to HFTransformersBinding tests

### DIFF
--- a/packages/test/src/test/ai-provider/HFTransformersBinding.test.ts
+++ b/packages/test/src/test/ai-provider/HFTransformersBinding.test.ts
@@ -89,6 +89,7 @@ describe("HFTransformersBinding", () => {
           queueName: HF_TRANSFORMERS_ONNX_CPU,
           limiter: new ConcurrencyLimiter(1),
           pollIntervalMs: 1,
+          stopTimeoutMs: 0,
         }
       );
 
@@ -160,6 +161,7 @@ describe("HFTransformersBinding", () => {
           queueName: HF_TRANSFORMERS_ONNX_CPU,
           limiter,
           pollIntervalMs: 1,
+          stopTimeoutMs: 0,
         }
       );
 


### PR DESCRIPTION
## Summary
Updated HFTransformersBinding test cases to include the `stopTimeoutMs` configuration parameter when instantiating the binding.

## Changes
- Added `stopTimeoutMs: 0` to the HFTransformersBinding configuration in two test cases
  - First test case: basic initialization test (line 92)
  - Second test case: concurrency limiter test (line 164)

## Details
The `stopTimeoutMs` parameter is now explicitly set to `0` in both test scenarios. This ensures the tests are using the complete configuration interface and allows for immediate shutdown behavior during testing without waiting for timeout periods.

https://claude.ai/code/session_01K6ckagMk5WiC667s6Fh5dE