### PR TITLE
refactor(task-graph): decompose TaskRunner (1019→730 lines)

### DIFF
--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -37,6 +37,7 @@ export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
 export * from "./task/CacheCoordinator";
+export * from "./task/StreamProcessor";
 export * from "./task/TaskRunContext";
 export * from "./task";
 

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -36,6 +36,7 @@ export * from "./task-graph/TransformTypes";
 export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
+export * from "./task/TaskRunContext";
 export * from "./task";
 
 export * from "./storage/TaskGraphRepository";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -36,6 +36,7 @@ export * from "./task-graph/TransformTypes";
 export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
+export * from "./task/CacheCoordinator";
 export * from "./task/TaskRunContext";
 export * from "./task";
 

--- a/packages/task-graph/src/task-graph/Dataflow.ts
+++ b/packages/task-graph/src/task-graph/Dataflow.ts
@@ -110,7 +110,7 @@ export class Dataflow {
    * Consumes the active stream to completion and materializes the value.
    *
    * Accumulation of text-delta chunks is the responsibility of the **source
-   * task** (via TaskRunner.executeStreamingTask when shouldAccumulate=true).
+   * task** (via StreamProcessor when shouldAccumulate=true).
    * When accumulation is needed the source task emits an enriched finish event
    * that carries the fully-assembled port data. All downstream edges share that
    * enriched event through tee'd ReadableStreams, so no edge needs to

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -31,8 +31,10 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
   constructor(private readonly task: ITask<Input, Output, any>) {}
 
   /**
-   * Strips x-cache-key:false fields and returns key-shaped inputs. No-op when
-   * no cache is configured (returns inputs unchanged).
+   * Serializes format-annotated input properties (via their port codecs) so the
+   * resulting object is a stable, serialization-equivalent representation
+   * suitable for use as a cache key. Properties without a format annotation are
+   * passed through unchanged. No-op when no cache is configured.
    */
   async buildKey(
     inputs: Input,

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getPortCodec } from "@workglow/util";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+import type { ITask } from "./ITask";
+import type { StreamEvent } from "./StreamTypes";
+import { Task } from "./Task";
+import type { TaskInput, TaskOutput } from "./TaskTypes";
+import type { TaskRunContext } from "./TaskRunContext";
+
+interface SchemaProperties {
+  properties?: Record<string, { format?: string }>;
+}
+
+/**
+ * @internal
+ * Cache key normalization, lookup, save, and cache-hit stream-event emission
+ * for streamable tasks. The three previously module-private helpers
+ * (serializeOutputPorts, deserializeOutputPorts, normalizeInputsForCacheKey)
+ * are private statics here.
+ *
+ * outputCache is passed as a method argument (not stored as a class field)
+ * because the facade resolves it per-run in handleStart and may differ
+ * between runs.
+ */
+export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput> {
+  constructor(private readonly task: ITask<Input, Output, any>) {}
+
+  /**
+   * Strips x-cache-key:false fields and returns key-shaped inputs. No-op when
+   * no cache is configured (returns inputs unchanged).
+   */
+  async buildKey(
+    inputs: Input,
+    outputCache: TaskOutputRepository | undefined
+  ): Promise<Input> {
+    if (!outputCache) return inputs;
+    const inputSchema = (this.task.constructor as typeof Task).inputSchema();
+    return (await CacheCoordinator.normalizeInputsForCacheKey(
+      inputs as Record<string, unknown>,
+      inputSchema as unknown as SchemaProperties
+    )) as Input;
+  }
+
+  /**
+   * Looks up a cached output. On a hit for a streaming task, also emits the
+   * synthetic stream_start / stream_chunk(finish) / stream_end events so
+   * downstream consumers see the same event shape as a fresh run.
+   *
+   * Returns the deserialized output if found, undefined otherwise.
+   */
+  async lookup(
+    keyInputs: Input,
+    outputCache: TaskOutputRepository | undefined,
+    isStreamable: boolean,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
+    if (!outputCache || !this.task.cacheable) return undefined;
+
+    const cached = await outputCache.getOutput(this.task.type, keyInputs);
+    if (cached === undefined) return undefined;
+
+    const outputSchema = (this.task.constructor as typeof Task).outputSchema();
+    const outputs = (await CacheCoordinator.deserializeOutputPorts(
+      cached as Record<string, unknown>,
+      outputSchema as unknown as SchemaProperties
+    )) as Output;
+
+    ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
+
+    if (isStreamable) {
+      this.task.runOutputData = outputs;
+      this.task.emit("stream_start");
+      this.task.emit("stream_chunk", { type: "finish", data: outputs } as StreamEvent);
+      this.task.emit("stream_end", outputs);
+    } else {
+      this.task.runOutputData = outputs;
+    }
+
+    return outputs;
+  }
+
+  /**
+   * Serializes and saves output. No-op when no cache is configured or task is
+   * not cacheable.
+   */
+  async save(
+    keyInputs: Input,
+    output: Output,
+    outputCache: TaskOutputRepository | undefined
+  ): Promise<void> {
+    if (!outputCache || !this.task.cacheable || output === undefined) return;
+    const outputSchema = (this.task.constructor as typeof Task).outputSchema();
+    const wireOutputs = await CacheCoordinator.serializeOutputPorts(
+      output as Record<string, unknown>,
+      outputSchema as unknown as SchemaProperties
+    );
+    await outputCache.saveOutput(this.task.type, keyInputs, wireOutputs as Output);
+  }
+
+  // ========================================================================
+  // Private static helpers (lifted from current module-private functions in
+  // TaskRunner.ts)
+  // ========================================================================
+
+  private static async serializeOutputPorts(
+    output: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return output;
+    const out: Record<string, unknown> = { ...output };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.serialize(out[key]);
+      }
+    }
+    return out;
+  }
+
+  private static async deserializeOutputPorts(
+    output: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return output;
+    const out: Record<string, unknown> = { ...output };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.deserialize(out[key]);
+      }
+    }
+    return out;
+  }
+
+  private static async normalizeInputsForCacheKey(
+    inputs: Record<string, unknown>,
+    schema: SchemaProperties
+  ): Promise<Record<string, unknown>> {
+    if (!schema?.properties) return inputs;
+    const out: Record<string, unknown> = { ...inputs };
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const codec = prop.format ? getPortCodec(prop.format) : undefined;
+      if (codec && out[key] !== undefined) {
+        out[key] = await codec.serialize(out[key]);
+      }
+    }
+    return out;
+  }
+}

--- a/packages/task-graph/src/task/FallbackTaskRunner.ts
+++ b/packages/task-graph/src/task/FallbackTaskRunner.ts
@@ -8,6 +8,7 @@ import type { FallbackTask, FallbackTaskConfig } from "./FallbackTask";
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
 import type { ITask } from "./ITask";
 import { TaskAbortedError, TaskFailedError, TaskTimeoutError } from "./TaskError";
+import type { TaskRunContext } from "./TaskRunContext";
 import { TaskStatus } from "./TaskTypes";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
@@ -27,7 +28,10 @@ export class FallbackTaskRunner<
   /**
    * Override executeTask to implement sequential fallback logic.
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.fallbackMode === "data") {
       return this.executeDataFallback(input);
     }
@@ -38,7 +42,10 @@ export class FallbackTaskRunner<
    * For FallbackTask, preview runs use the task's preview hook only,
    * bypassing GraphAsTaskRunner's child-merging logic.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -60,7 +67,7 @@ export class FallbackTaskRunner<
     const totalAttempts = tasks.length;
 
     for (let i = 0; i < tasks.length; i++) {
-      if (this.abortController?.signal.aborted) {
+      if (this.currentCtx?.abortController.signal.aborted) {
         throw new TaskAbortedError("Fallback aborted");
       }
 
@@ -142,7 +149,7 @@ export class FallbackTaskRunner<
 
     try {
       for (let i = 0; i < alternatives.length; i++) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           throw new TaskAbortedError("Fallback aborted");
         }
 
@@ -164,7 +171,7 @@ export class FallbackTaskRunner<
 
           // Run the subgraph with merged input
           const results = await this.task.subGraph.run<Output>(mergedInput, {
-            parentSignal: this.abortController?.signal,
+            parentSignal: this.currentCtx?.abortController.signal,
             outputCache: this.outputCache,
             registry: this.registry,
           });

--- a/packages/task-graph/src/task/GraphAsTaskRunner.ts
+++ b/packages/task-graph/src/task/GraphAsTaskRunner.ts
@@ -7,6 +7,7 @@
 import { GraphResultArray } from "../task-graph/TaskGraphRunner";
 import type { GraphAsTaskConfig } from "./GraphAsTask";
 import { GraphAsTask } from "./GraphAsTask";
+import type { TaskRunContext } from "./TaskRunContext";
 import { TaskRunner } from "./TaskRunner";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
@@ -34,7 +35,7 @@ export class GraphAsTaskRunner<
       }
     );
     const results = await this.task.subGraph!.run<Output>(input, {
-      parentSignal: this.abortController?.signal,
+      parentSignal: this.currentCtx?.abortController.signal,
       outputCache: this.outputCache,
       registry: this.registry,
       resourceScope: this.resourceScope,
@@ -56,11 +57,11 @@ export class GraphAsTaskRunner<
     });
   }
 
-  protected override async handleDisable(): Promise<void> {
+  protected override async handleDisable(ctx: TaskRunContext | undefined): Promise<void> {
     if (this.task.hasChildren()) {
       await this.task.subGraph!.disable();
     }
-    super.handleDisable();
+    await super.handleDisable(ctx);
   }
 
   // ========================================================================
@@ -70,7 +71,10 @@ export class GraphAsTaskRunner<
   /**
    * Execute the task
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.hasChildren()) {
       const runExecuteOutputData = await this.executeTaskChildren(input);
       this.task.runOutputData = this.task.subGraph.mergeExecuteOutputsToRunOutput(
@@ -78,7 +82,7 @@ export class GraphAsTaskRunner<
         this.task.compoundMerge
       );
     } else {
-      const result = await super.executeTask(input);
+      const result = await super.executeTask(input, ctx);
       this.task.runOutputData = result ?? ({} as Output);
     }
     return this.task.runOutputData as Output;
@@ -87,7 +91,10 @@ export class GraphAsTaskRunner<
   /**
    * Execute the task in preview mode
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     if (this.task.hasChildren()) {
       const previewResults = await this.executeTaskChildrenPreview();
       this.task.runOutputData = this.task.subGraph.mergeExecuteOutputsToRunOutput(
@@ -96,7 +103,7 @@ export class GraphAsTaskRunner<
       );
       return this.task.runOutputData as Output;
     } else {
-      const previewResult = await super.executeTaskPreview(input);
+      const previewResult = await super.executeTaskPreview(input, ctx);
       if (previewResult !== undefined) {
         this.task.runOutputData = previewResult;
       }

--- a/packages/task-graph/src/task/IteratorTaskRunner.ts
+++ b/packages/task-graph/src/task/IteratorTaskRunner.ts
@@ -15,6 +15,7 @@ import {
   type IteratorTask,
   type IteratorTaskConfig,
 } from "./IteratorTask";
+import type { TaskRunContext } from "./TaskRunContext";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 
 /**
@@ -39,7 +40,10 @@ export class IteratorTaskRunner<
    * it does not iterate the subgraph.
    */
 
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     let analysis = this.task.analyzeIterationInput(input);
 
     // Enforce maxIterations cap. Config is required (construction-time guard),
@@ -64,7 +68,10 @@ export class IteratorTaskRunner<
   /**
    * Iterator tasks should only run the task's preview hook here.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -91,7 +98,7 @@ export class IteratorTaskRunner<
 
     try {
       for (let batchStart = 0; batchStart < iterationCount; batchStart += batchSize) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           break;
         }
 
@@ -149,7 +156,7 @@ export class IteratorTaskRunner<
     let accumulator = this.task.getInitialAccumulator();
 
     for (let index = 0; index < iterationCount; index++) {
-      if (this.abortController?.signal.aborted) {
+      if (this.currentCtx?.abortController.signal.aborted) {
         break;
       }
 
@@ -185,7 +192,7 @@ export class IteratorTaskRunner<
 
     const workers = Array.from({ length: workerCount }, async () => {
       while (true) {
-        if (this.abortController?.signal.aborted) {
+        if (this.currentCtx?.abortController.signal.aborted) {
           return;
         }
 
@@ -245,7 +252,7 @@ export class IteratorTaskRunner<
     index: number,
     iterationCount: number
   ): Promise<TaskOutput | undefined> {
-    if (this.abortController?.signal.aborted) {
+    if (this.currentCtx?.abortController.signal.aborted) {
       return undefined;
     }
 
@@ -278,7 +285,7 @@ export class IteratorTaskRunner<
 
     try {
       const results = await graphClone.run<TaskOutput>(input as TaskInput, {
-        parentSignal: this.abortController?.signal,
+        parentSignal: this.currentCtx?.abortController.signal,
         outputCache: this.outputCache,
         registry: this.registry,
         resourceScope: this.resourceScope,

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -1,0 +1,236 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ResourceScope, ServiceRegistry } from "@workglow/util";
+import type { Taskish } from "../task-graph/Conversions";
+import type { ITask } from "./ITask";
+import type { StreamEvent, StreamMode } from "./StreamTypes";
+import { getOutputStreamMode, getStreamingPorts } from "./StreamTypes";
+import { TaskAbortedError, TaskError } from "./TaskError";
+import type { TaskInput, TaskOutput } from "./TaskTypes";
+import { TaskStatus } from "./TaskTypes";
+import type { TaskRunContext } from "./TaskRunContext";
+
+/**
+ * Per-call run-state inputs shared by StreamProcessor.run. Bundles facade
+ * state pulled at call time (registry, resourceScope, inputStreams) and
+ * facade methods bound to the facade instance (onProgress, own).
+ *
+ * @internal
+ */
+export interface StreamProcessorDeps {
+  readonly registry: ServiceRegistry;
+  readonly resourceScope: ResourceScope | undefined;
+  readonly inputStreams: Map<string, ReadableStream<StreamEvent>> | undefined;
+  readonly onProgress: (
+    progress: number | undefined,
+    message?: string,
+    ...args: any[]
+  ) => Promise<void>;
+  readonly own: <T extends Taskish<any, any>>(i: T) => T;
+}
+
+/**
+ * @internal
+ * Streaming event loop. Consumes a task's executeStream() output, manages
+ * text/object delta accumulators, mode switching (append/object/replace),
+ * and finish-event enrichment. Honors ctx.shouldAccumulate and
+ * ctx.abortController.signal.
+ */
+export class StreamProcessor<Input extends TaskInput, Output extends TaskOutput> {
+  constructor(private readonly task: ITask<Input, Output, any>) {}
+
+  async run(
+    input: Input,
+    ctx: TaskRunContext,
+    deps: StreamProcessorDeps
+  ): Promise<Output | undefined> {
+    const streamMode: StreamMode = getOutputStreamMode(this.task.outputSchema());
+    if (streamMode === "append") {
+      const ports = getStreamingPorts(this.task.outputSchema());
+      if (ports.length === 0) {
+        throw new TaskError(
+          `Task ${this.task.type} declares append streaming but no output port has x-stream: "append"`
+        );
+      }
+    }
+    if (streamMode === "object") {
+      const ports = getStreamingPorts(this.task.outputSchema());
+      if (ports.length === 0) {
+        throw new TaskError(
+          `Task ${this.task.type} declares object streaming but no output port has x-stream: "object"`
+        );
+      }
+    }
+
+    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
+    const accumulatedObjects = ctx.shouldAccumulate
+      ? new Map<string, Record<string, unknown> | unknown[]>()
+      : undefined;
+    let streamingStarted = false;
+    let finalOutput: Output | undefined;
+
+    this.task.emit("stream_start");
+
+    const stream = this.task.executeStream!(input, {
+      signal: ctx.abortController.signal,
+      updateProgress: deps.onProgress,
+      own: deps.own,
+      registry: deps.registry,
+      resourceScope: deps.resourceScope,
+      inputStreams: deps.inputStreams,
+    });
+
+    for await (const event of stream) {
+      // For snapshot events, update runOutputData BEFORE emitting stream_chunk
+      // so listeners see the latest snapshot when they handle the event.
+      if (event.type === "snapshot") {
+        this.task.runOutputData = event.data as Output;
+      }
+
+      switch (event.type) {
+        case "phase": {
+          // Phase events are metadata: emit for observability, translate to a
+          // progress event with optional progress + message, do NOT mutate
+          // accumulators or runOutputData, do NOT flip status to STREAMING.
+          this.task.emit("stream_chunk", event as StreamEvent);
+          await deps.onProgress(event.progress, event.message);
+          break;
+        }
+        case "text-delta": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          if (accumulated) {
+            accumulated.set(event.port, (accumulated.get(event.port) ?? "") + event.textDelta);
+          }
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "object-delta": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          if (accumulatedObjects) {
+            const existing = accumulatedObjects.get(event.port);
+            if (Array.isArray(event.objectDelta)) {
+              // Array delta: upsert items by `id` into accumulated array
+              const arr: unknown[] = Array.isArray(existing) ? [...existing] : [];
+              for (const item of event.objectDelta) {
+                const itemObj = item as Record<string, unknown>;
+                if (itemObj && typeof itemObj === "object" && "id" in itemObj) {
+                  const idx = arr.findIndex(
+                    (e) => (e as Record<string, unknown>).id === itemObj.id
+                  );
+                  if (idx >= 0) arr[idx] = item;
+                  else arr.push(item);
+                } else {
+                  arr.push(item);
+                }
+              }
+              accumulatedObjects.set(event.port, arr);
+            } else {
+              // Non-array (e.g. structured generation): replace semantics
+              accumulatedObjects.set(event.port, event.objectDelta);
+            }
+          }
+          // Update runOutputData with accumulated state so listeners see growing state
+          this.task.runOutputData = {
+            ...this.task.runOutputData,
+            [event.port]: accumulatedObjects?.get(event.port) ?? event.objectDelta,
+          } as Output;
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "snapshot": {
+          if (!streamingStarted) {
+            streamingStarted = true;
+            this.task.status = TaskStatus.STREAMING;
+            this.task.emit("status", this.task.status);
+          }
+          this.task.emit("stream_chunk", event as StreamEvent);
+          break;
+        }
+        case "finish": {
+          if (accumulated || accumulatedObjects) {
+            // Emit an enriched finish event: merge accumulated deltas into
+            // the finish payload so downstream dataflows get complete port data
+            // without needing to re-accumulate themselves.
+            const merged: Record<string, unknown> = { ...(event.data || {}) };
+            if (accumulated) {
+              for (const [port, text] of accumulated) {
+                if (text.length > 0) merged[port] = text;
+              }
+            }
+            if (accumulatedObjects) {
+              for (const [port, obj] of accumulatedObjects) {
+                merged[port] = obj;
+              }
+            }
+            // For replace-mode streams, finish carries data: {} by convention.
+            // Fall back to the last snapshot (runOutputData) so the final output
+            // is not silently cleared when the finish payload is empty.
+            if (streamMode === "replace" && Object.keys(merged).length === 0) {
+              const lastSnapshot = this.task.runOutputData;
+              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
+                finalOutput = lastSnapshot as Output;
+                this.task.emit("stream_chunk", {
+                  type: "finish",
+                  data: lastSnapshot,
+                } as StreamEvent);
+                break;
+              }
+            }
+            finalOutput = merged as unknown as Output;
+            this.task.emit("stream_chunk", { type: "finish", data: merged } as StreamEvent);
+          } else {
+            // No accumulation. For replace-mode streams the provider's finish
+            // event carries `data: {}` by convention — the snapshots already
+            // delivered the value, so the finish payload is intentionally
+            // empty. Fall back to `runOutputData` (set on every snapshot above)
+            // so we don't clobber the last snapshot with an empty object. This
+            // mirrors the same fallback in the accumulation branch.
+            const finishData = (event.data ?? {}) as Record<string, unknown>;
+            if (streamMode === "replace" && Object.keys(finishData).length === 0) {
+              const lastSnapshot = this.task.runOutputData;
+              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
+                finalOutput = lastSnapshot as Output;
+                this.task.emit("stream_chunk", {
+                  type: "finish",
+                  data: lastSnapshot,
+                } as StreamEvent);
+                break;
+              }
+            }
+            finalOutput = event.data as Output;
+            this.task.emit("stream_chunk", event as StreamEvent);
+          }
+          break;
+        }
+        case "error": {
+          throw event.error;
+        }
+      }
+    }
+
+    // Check if the task was aborted during streaming
+    if (ctx.abortController.signal.aborted) {
+      throw new TaskAbortedError("Task aborted during streaming");
+    }
+
+    if (finalOutput !== undefined) {
+      this.task.runOutputData = finalOutput;
+    }
+
+    this.task.emit("stream_end", this.task.runOutputData as Output);
+
+    return this.task.runOutputData as Output;
+  }
+}

--- a/packages/task-graph/src/task/TaskRunContext.ts
+++ b/packages/task-graph/src/task/TaskRunContext.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ISpan } from "@workglow/util";
+import type { TaskTimeoutError } from "./TaskError";
+
+/**
+ * @internal
+ * Per-run mutable state for a single TaskRunner.run() / runPreview() invocation.
+ * Built by TaskRunner.handleStart, discarded by handleComplete / handleError / handleAbort.
+ *
+ * Long-lived state (task, registry, resourceScope, outputCache default, accumulateLeafOutputs)
+ * stays on the facade. TaskRunContext only holds state created at run start and torn down
+ * at run end.
+ */
+export class TaskRunContext {
+  readonly abortController: AbortController;
+
+  shouldAccumulate: boolean = true;
+  telemetrySpan?: ISpan;
+  timeoutTimer?: ReturnType<typeof setTimeout>;
+  pendingTimeoutError?: TaskTimeoutError;
+
+  // Removes the parentSignal abort listener; set in the constructor when
+  // parentSignal is provided. Idempotent dispose().
+  private parentSignalCleanup?: () => void;
+
+  constructor(parentSignal?: AbortSignal) {
+    this.abortController = new AbortController();
+    if (parentSignal) {
+      // Listen first, then check — addEventListener on an already-aborted signal
+      // does not fire, so checking .aborted after ensures we never miss an abort.
+      const onParentAbort = () => this.abortController.abort();
+      parentSignal.addEventListener("abort", onParentAbort, { once: true });
+      this.parentSignalCleanup = () =>
+        parentSignal.removeEventListener("abort", onParentAbort);
+      if (parentSignal.aborted) {
+        this.parentSignalCleanup();
+        this.parentSignalCleanup = undefined;
+        this.abortController.abort();
+      }
+    }
+  }
+
+  /**
+   * Releases external listeners (parentSignal abort handler). Idempotent.
+   * Called by terminal handlers (handleComplete / handleError / handleAbort)
+   * so a parent abort fired after this run completes does not re-trigger our
+   * abort path and emit a duplicate terminal event.
+   */
+  dispose(): void {
+    this.parentSignalCleanup?.();
+    this.parentSignalCleanup = undefined;
+  }
+}

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ISpan } from "@workglow/util";
 import {
   getLogger,
   getTelemetryProvider,
@@ -31,6 +30,7 @@ import {
   TaskInvalidInputError,
   TaskTimeoutError,
 } from "./TaskError";
+import { TaskRunContext } from "./TaskRunContext";
 import { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
 
 interface SchemaProperties {
@@ -110,9 +110,12 @@ export class TaskRunner<
   public readonly task: ITask<Input, Output, Config>;
 
   /**
-   * AbortController for cancelling task execution
+   * Per-run state. Set by handleStart, cleared by handleComplete / handleError /
+   * handleAbort. The only mutable per-run state on the facade — exists so the
+   * public abort() and disable() methods (which take no arguments) have something
+   * to act on.
    */
-  protected abortController?: AbortController;
+  protected currentCtx?: TaskRunContext;
 
   /**
    * The output cache for the task
@@ -137,33 +140,6 @@ export class TaskRunner<
   public inputStreams?: Map<string, ReadableStream<StreamEvent>>;
 
   /**
-   * Timer handle for task-level timeout. Set when `IRunConfig.timeout` is
-   * provided and cleared on completion, error, or abort.
-   */
-  protected timeoutTimer?: ReturnType<typeof setTimeout>;
-
-  /**
-   * When a timeout triggers the abort, this holds the TaskTimeoutError so
-   * handleAbort() can surface the correct error type instead of a generic
-   * TaskAbortedError.
-   */
-  protected pendingTimeoutError?: TaskTimeoutError;
-
-  /**
-   * Whether the streaming task runner should accumulate text-delta chunks and
-   * emit an enriched finish event. Set from IRunConfig.shouldAccumulate.
-   * Defaults to true so standalone task execution is backward-compatible.
-   * The graph runner sets this to false when no downstream edge needs
-   * materialized data (no cache, all downstream tasks are also streaming).
-   */
-  protected shouldAccumulate: boolean = true;
-
-  /**
-   * Active telemetry span for the current task run.
-   */
-  protected telemetrySpan?: ISpan;
-
-  /**
    * Constructor for TaskRunner
    * @param task The task to run
    */
@@ -185,6 +161,7 @@ export class TaskRunner<
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
     await this.handleStart(config);
+    const ctx = this.currentCtx!;
 
     const proto = Object.getPrototypeOf(this.task);
     if (
@@ -230,7 +207,7 @@ export class TaskRunner<
         throw new TaskInvalidInputError("Invalid input data");
       }
 
-      if (this.abortController?.signal.aborted) {
+      if (ctx.abortController.signal.aborted) {
         await this.handleAbort();
         throw new TaskAbortedError("Promise for task created and aborted before run");
       }
@@ -266,7 +243,7 @@ export class TaskRunner<
             cached as Record<string, unknown>,
             outputSchema as unknown as SchemaProperties
           )) as Output;
-          this.telemetrySpan?.addEvent("workglow.task.cache_hit");
+          ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
           if (isStreamable) {
             this.task.runOutputData = outputs;
             this.task.emit("stream_start");
@@ -281,7 +258,7 @@ export class TaskRunner<
         if (isStreamable) {
           outputs = await this.executeStreamingTask(inputs);
         } else {
-          outputs = await this.executeTask(inputs);
+          outputs = await this.executeTask(inputs, ctx);
         }
         if (this.task.cacheable && outputs !== undefined) {
           const wireOutputs = await serializeOutputPorts(
@@ -338,6 +315,10 @@ export class TaskRunner<
 
     await this.handleStartPreview();
 
+    // Build a transient context for preview overrides — preview doesn't share the
+    // full lifecycle but executeTaskPreview's signature requires a ctx.
+    const ctx = new TaskRunContext();
+
     try {
       const inputs: Input = this.task.runInputData as Input;
       const isValid = await this.task.validateInput(inputs);
@@ -345,7 +326,7 @@ export class TaskRunner<
         throw new TaskInvalidInputError("Invalid input data");
       }
 
-      const resultPreview = await this.executeTaskPreview(inputs);
+      const resultPreview = await this.executeTaskPreview(inputs, ctx);
       if (resultPreview !== undefined) {
         this.task.runOutputData = resultPreview;
       }
@@ -355,6 +336,7 @@ export class TaskRunner<
       getLogger().debug("runPreview failed", { taskId: this.task.config?.id, error: err });
       await this.handleErrorPreview();
     } finally {
+      ctx.dispose();
       return this.task.runOutputData as Output;
     }
   }
@@ -517,10 +499,7 @@ export class TaskRunner<
    * Aborts task execution
    */
   public abort(): void {
-    if (this.task.hasChildren()) {
-      this.task.subGraph.abort();
-    }
-    this.abortController?.abort();
+    this.currentCtx?.abortController.abort();
   }
 
   // ========================================================================
@@ -535,7 +514,7 @@ export class TaskRunner<
     if (hasRunConfig(i)) {
       Object.assign(i.runConfig, {
         registry: this.registry,
-        signal: this.abortController?.signal,
+        signal: this.currentCtx?.abortController.signal,
         resourceScope: this.resourceScope,
       });
     }
@@ -551,9 +530,9 @@ export class TaskRunner<
   /**
    * Protected method to execute a task by delegating back to the task itself.
    */
-  protected async executeTask(input: Input): Promise<Output | undefined> {
+  protected async executeTask(input: Input, ctx: TaskRunContext): Promise<Output | undefined> {
     const result = await this.task.execute(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -565,7 +544,10 @@ export class TaskRunner<
   /**
    * Protected method for preview execution delegation
    */
-  protected async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  protected async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 
@@ -603,8 +585,9 @@ export class TaskRunner<
       }
     }
 
-    const accumulated = this.shouldAccumulate ? new Map<string, string>() : undefined;
-    const accumulatedObjects = this.shouldAccumulate
+    const ctx = this.currentCtx!;
+    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
+    const accumulatedObjects = ctx.shouldAccumulate
       ? new Map<string, Record<string, unknown> | unknown[]>()
       : undefined;
     let streamingStarted = false;
@@ -613,7 +596,7 @@ export class TaskRunner<
     this.task.emit("stream_start");
 
     const stream = this.task.executeStream!(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -758,7 +741,7 @@ export class TaskRunner<
     }
 
     // Check if the task was aborted during streaming
-    if (this.abortController?.signal.aborted) {
+    if (ctx.abortController.signal.aborted) {
       throw new TaskAbortedError("Task aborted during streaming");
     }
 
@@ -787,8 +770,11 @@ export class TaskRunner<
     this.task.progress = 0;
     this.task.status = TaskStatus.PROCESSING;
 
-    this.abortController = new AbortController();
-    this.abortController.signal.addEventListener("abort", () => {
+    // Build per-run context (handles abortController + parentSignal wiring)
+    const ctx = new TaskRunContext(config.signal);
+    this.currentCtx = ctx;
+
+    ctx.abortController.signal.addEventListener("abort", () => {
       this.handleAbort();
     });
 
@@ -803,7 +789,7 @@ export class TaskRunner<
     }
 
     // shouldAccumulate defaults to true (backward-compatible for standalone runs)
-    this.shouldAccumulate = config.shouldAccumulate !== false;
+    ctx.shouldAccumulate = config.shouldAccumulate !== false;
 
     if (config.updateProgress) {
       this.updateProgress = config.updateProgress;
@@ -817,25 +803,15 @@ export class TaskRunner<
       this.resourceScope = config.resourceScope;
     }
 
-    // If a parent signal is provided (e.g. set by context.own()), link it so
-    // that aborting the parent also aborts this task.
-    // Listen first, then check — addEventListener on an already-aborted signal
-    // does not fire, so checking .aborted after ensures we never miss an abort.
-    if (config.signal) {
-      const onAbort = () => this.abortController!.abort();
-      config.signal.addEventListener("abort", onAbort, { once: true });
-      if (config.signal.aborted) {
-        config.signal.removeEventListener("abort", onAbort);
-        this.abortController.abort();
-        return;
-      }
-    }
+    // Early-out if parent signal was already aborted (TaskRunContext constructor
+    // already aborted ctx.abortController in that case)
+    if (ctx.abortController.signal.aborted) return;
 
     // Start timeout timer if configured (timeout is a design-time config property)
     const timeout = (this.task.config as Record<string, unknown>).timeout as number | undefined;
     if (timeout !== undefined && timeout > 0) {
-      this.pendingTimeoutError = new TaskTimeoutError(timeout);
-      this.timeoutTimer = setTimeout(() => {
+      ctx.pendingTimeoutError = new TaskTimeoutError(timeout);
+      ctx.timeoutTimer = setTimeout(() => {
         this.abort();
       }, timeout);
     }
@@ -843,7 +819,7 @@ export class TaskRunner<
     // Start telemetry span
     const telemetry = getTelemetryProvider();
     if (telemetry.isEnabled) {
-      this.telemetrySpan = telemetry.startSpan("workglow.task.run", {
+      ctx.telemetrySpan = telemetry.startSpan("workglow.task.run", {
         attributes: {
           "workglow.task.type": this.task.type,
           "workglow.task.id": String(this.task.config.id),
@@ -871,9 +847,10 @@ export class TaskRunner<
    * Clears the timeout timer if one is active.
    */
   protected clearTimeoutTimer(): void {
-    if (this.timeoutTimer !== undefined) {
-      clearTimeout(this.timeoutTimer);
-      this.timeoutTimer = undefined;
+    const ctx = this.currentCtx;
+    if (ctx?.timeoutTimer !== undefined) {
+      clearTimeout(ctx.timeoutTimer);
+      ctx.timeoutTimer = undefined;
     }
   }
 
@@ -883,19 +860,18 @@ export class TaskRunner<
   protected async handleAbort(): Promise<void> {
     if (this.task.status === TaskStatus.ABORTING) return;
     this.clearTimeoutTimer();
+    const ctx = this.currentCtx;
     this.task.status = TaskStatus.ABORTING;
     await this.handleProgress(100);
     // Use the pending timeout error if the abort was triggered by a timeout
-    this.task.error = this.pendingTimeoutError ?? new TaskAbortedError();
-    this.pendingTimeoutError = undefined;
+    this.task.error = ctx?.pendingTimeoutError ?? new TaskAbortedError();
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
-      this.telemetrySpan.addEvent("workglow.task.aborted", {
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, "aborted");
+      ctx.telemetrySpan.addEvent("workglow.task.aborted", {
         "workglow.task.error": this.task.error.message,
       });
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+      ctx.telemetrySpan.end();
     }
 
     // Call optional cleanup method for resource release
@@ -906,6 +882,9 @@ export class TaskRunner<
         // Cleanup errors are swallowed — abort must not throw from cleanup
       }
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("abort", this.task.error);
     this.task.emit("status", this.task.status);
@@ -921,18 +900,19 @@ export class TaskRunner<
   protected async handleComplete(): Promise<void> {
     if (this.task.status === TaskStatus.COMPLETED) return;
     this.clearTimeoutTimer();
-    this.pendingTimeoutError = undefined;
+    const ctx = this.currentCtx;
 
     this.task.completedAt = new Date();
     this.task.status = TaskStatus.COMPLETED;
-    this.abortController = undefined;
     await this.handleProgress(100);
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.OK);
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.OK);
+      ctx.telemetrySpan.end();
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("complete");
     this.task.emit("status", this.task.status);
@@ -942,18 +922,19 @@ export class TaskRunner<
     this.previewRunning = false;
   }
 
-  protected async handleDisable(): Promise<void> {
+  protected async handleDisable(ctx: TaskRunContext | undefined): Promise<void> {
     if (this.task.status === TaskStatus.DISABLED) return;
     this.task.status = TaskStatus.DISABLED;
     await this.handleProgress(100);
     this.task.completedAt = new Date();
-    this.abortController = undefined;
+    ctx?.dispose();
+    if (this.currentCtx === ctx) this.currentCtx = undefined;
     this.task.emit("disabled");
     this.task.emit("status", this.task.status);
   }
 
   public async disable(): Promise<void> {
-    await this.handleDisable();
+    await this.handleDisable(this.currentCtx);
   }
 
   /**
@@ -964,7 +945,7 @@ export class TaskRunner<
     if (err instanceof TaskAbortedError) return this.handleAbort();
     if (this.task.status === TaskStatus.FAILED) return;
     this.clearTimeoutTimer();
-    this.pendingTimeoutError = undefined;
+    const ctx = this.currentCtx;
     if (this.task.hasChildren()) {
       this.task.subGraph!.abort();
     }
@@ -983,15 +964,16 @@ export class TaskRunner<
       this.task.error.taskId ??= this.task.id;
     }
     this.task.status = TaskStatus.FAILED;
-    this.abortController = undefined;
     await this.handleProgress(100);
 
-    if (this.telemetrySpan) {
-      this.telemetrySpan.setStatus(SpanStatusCode.ERROR, this.task.error.message);
-      this.telemetrySpan.setAttributes({ "workglow.task.error": this.task.error.message });
-      this.telemetrySpan.end();
-      this.telemetrySpan = undefined;
+    if (ctx?.telemetrySpan) {
+      ctx.telemetrySpan.setStatus(SpanStatusCode.ERROR, this.task.error.message);
+      ctx.telemetrySpan.setAttributes({ "workglow.task.error": this.task.error.message });
+      ctx.telemetrySpan.end();
     }
+
+    ctx?.dispose();
+    this.currentCtx = undefined;
 
     this.task.emit("error", this.task.error);
     this.task.emit("status", this.task.status);

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -179,27 +179,7 @@ export class TaskRunner<
     try {
       this.task.setInput(overrides);
 
-      // Resolve config schema annotations (e.g. mcp-server references) by mutating task.config.
-      // Always resolve from originalConfig so re-runs use the original string IDs, not
-      // previously resolved objects. The original config is preserved for serialization.
-      const configSchema = (this.task.constructor as typeof Task).configSchema();
-      if (schemaHasFormatAnnotations(configSchema)) {
-        const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
-        const resolved = await resolveSchemaInputs(
-          { ...source } as Record<string, unknown>,
-          configSchema,
-          { registry: this.registry }
-        );
-        Object.assign(this.task.config, resolved);
-      }
-
-      // Resolve schema-annotated inputs (models, repositories) before validation
-      const schema = (this.task.constructor as typeof Task).inputSchema();
-      this.task.runInputData = (await resolveSchemaInputs(
-        this.task.runInputData as Record<string, unknown>,
-        schema,
-        { registry: this.registry }
-      )) as Input;
+      await this.resolveSchemas();
 
       const inputs: Input = this.task.runInputData as Input;
       const isValid = await this.task.validateInput(inputs);
@@ -293,25 +273,7 @@ export class TaskRunner<
 
     this.task.setInput(overrides);
 
-    // Resolve config schema annotations by mutating task.config directly
-    const configSchema = (this.task.constructor as typeof Task).configSchema();
-    if (schemaHasFormatAnnotations(configSchema)) {
-      const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
-      const resolved = await resolveSchemaInputs(
-        { ...source } as Record<string, unknown>,
-        configSchema,
-        { registry: this.registry }
-      );
-      Object.assign(this.task.config, resolved);
-    }
-
-    // Resolve schema-annotated inputs (models, repositories) before validation
-    const schema = (this.task.constructor as typeof Task).inputSchema();
-    this.task.runInputData = (await resolveSchemaInputs(
-      this.task.runInputData as Record<string, unknown>,
-      schema,
-      { registry: this.registry }
-    )) as Input;
+    await this.resolveSchemas();
 
     await this.handleStartPreview();
 
@@ -757,6 +719,33 @@ export class TaskRunner<
   // ========================================================================
   // Protected Handlers
   // ========================================================================
+
+  /**
+   * Resolves config and input schema annotations (e.g. mcp-server references)
+   * by mutating task.config and task.runInputData. Always resolves config from
+   * originalConfig so re-runs use the original string IDs, not previously resolved
+   * objects. Shared between run() and runPreview() to avoid duplication.
+   */
+  private async resolveSchemas(): Promise<void> {
+    const configSchema = (this.task.constructor as typeof Task).configSchema();
+    if (schemaHasFormatAnnotations(configSchema)) {
+      const source = (this.task as unknown as Task).originalConfig ?? this.task.config;
+      const resolved = await resolveSchemaInputs(
+        { ...source } as Record<string, unknown>,
+        configSchema,
+        { registry: this.registry }
+      );
+      Object.assign(this.task.config, resolved);
+    }
+
+    // Resolve schema-annotated inputs (models, repositories) before validation
+    const schema = (this.task.constructor as typeof Task).inputSchema();
+    this.task.runInputData = (await resolveSchemaInputs(
+      this.task.runInputData as Record<string, unknown>,
+      schema,
+      { registry: this.registry }
+    )) as Input;
+  }
 
   /**
    * Handles task start

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -111,9 +111,9 @@ export class TaskRunner<
 
   /**
    * Per-run state. Set by handleStart, cleared by handleComplete / handleError /
-   * handleAbort. The only mutable per-run state on the facade — exists so the
-   * public abort() and disable() methods (which take no arguments) have something
-   * to act on.
+   * handleAbort / handleDisable. The only mutable per-run state on the facade —
+   * exists so the public abort() and disable() methods (which take no arguments)
+   * have something to act on.
    */
   protected currentCtx?: TaskRunContext;
 
@@ -928,6 +928,7 @@ export class TaskRunner<
     await this.handleProgress(100);
     this.task.completedAt = new Date();
     ctx?.dispose();
+    // Don't clobber a newer run's ctx if disable() was queued from a stale state.
     if (this.currentCtx === ctx) this.currentCtx = undefined;
     this.task.emit("disabled");
     this.task.emit("status", this.task.status);

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -19,8 +19,9 @@ import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
-import type { StreamEvent, StreamMode } from "./StreamTypes";
-import { getOutputStreamMode, getStreamingPorts, isTaskStreamable } from "./StreamTypes";
+import type { StreamEvent } from "./StreamTypes";
+import { getOutputStreamMode, isTaskStreamable } from "./StreamTypes";
+import { StreamProcessor } from "./StreamProcessor";
 import { Task } from "./Task";
 import {
   TaskAbortedError,
@@ -79,6 +80,11 @@ export class TaskRunner<
   protected readonly cacheCoordinator: CacheCoordinator<Input, Output>;
 
   /**
+   * Stream processor for the task (handles executeStream() event loop).
+   */
+  protected readonly streamProcessor: StreamProcessor<Input, Output>;
+
+  /**
    * The service registry for the task
    */
   protected registry: ServiceRegistry = globalServiceRegistry;
@@ -104,6 +110,7 @@ export class TaskRunner<
     this.own = this.own.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
     this.cacheCoordinator = new CacheCoordinator(task);
+    this.streamProcessor = new StreamProcessor(task);
   }
 
   // ========================================================================
@@ -172,7 +179,13 @@ export class TaskRunner<
 
       if (outputs === undefined) {
         outputs = isStreamable
-          ? await this.executeStreamingTask(inputs)
+          ? await this.streamProcessor.run(inputs, ctx, {
+              registry: this.registry,
+              resourceScope: this.resourceScope,
+              inputStreams: this.inputStreams,
+              onProgress: this.handleProgress.bind(this),
+              own: this.own,
+            })
           : await this.executeTask(inputs, ctx);
 
         await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
@@ -440,209 +453,6 @@ export class TaskRunner<
     _ctx: TaskRunContext
   ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
-  }
-
-  /**
-   * Executes a streaming task by consuming its executeStream() async iterable.
-   *
-   * When `shouldAccumulate` is true (default, set by graph runner when any downstream
-   * edge needs materialized data, or when caching is on):
-   *   - text-delta chunks are accumulated per-port into a Map
-   *   - the raw finish event is NOT emitted; instead an enriched finish event is
-   *     emitted with the accumulated text merged in, so downstream dataflows can
-   *     materialize values without re-accumulating on their own
-   *
-   * When `shouldAccumulate` is false (set by graph runner when all downstream edges
-   * are also streaming and no cache is needed):
-   *   - all events including the raw finish are emitted as-is (pure pass-through)
-   *   - no accumulation Map is maintained
-   */
-  protected async executeStreamingTask(input: Input): Promise<Output | undefined> {
-    const streamMode: StreamMode = getOutputStreamMode(this.task.outputSchema());
-    if (streamMode === "append") {
-      const ports = getStreamingPorts(this.task.outputSchema());
-      if (ports.length === 0) {
-        throw new TaskError(
-          `Task ${this.task.type} declares append streaming but no output port has x-stream: "append"`
-        );
-      }
-    }
-    if (streamMode === "object") {
-      const ports = getStreamingPorts(this.task.outputSchema());
-      if (ports.length === 0) {
-        throw new TaskError(
-          `Task ${this.task.type} declares object streaming but no output port has x-stream: "object"`
-        );
-      }
-    }
-
-    const ctx = this.currentCtx!;
-    const accumulated = ctx.shouldAccumulate ? new Map<string, string>() : undefined;
-    const accumulatedObjects = ctx.shouldAccumulate
-      ? new Map<string, Record<string, unknown> | unknown[]>()
-      : undefined;
-    let streamingStarted = false;
-    let finalOutput: Output | undefined;
-
-    this.task.emit("stream_start");
-
-    const stream = this.task.executeStream!(input, {
-      signal: ctx.abortController.signal,
-      updateProgress: this.handleProgress.bind(this),
-      own: this.own,
-      registry: this.registry,
-      resourceScope: this.resourceScope,
-      inputStreams: this.inputStreams,
-    });
-
-    for await (const event of stream) {
-      // For snapshot events, update runOutputData BEFORE emitting stream_chunk
-      // so listeners see the latest snapshot when they handle the event.
-      if (event.type === "snapshot") {
-        this.task.runOutputData = event.data as Output;
-      }
-
-      switch (event.type) {
-        case "phase": {
-          // Phase events are metadata: emit for observability, translate to a
-          // progress event with optional progress + message, do NOT mutate
-          // accumulators or runOutputData, do NOT flip status to STREAMING.
-          this.task.emit("stream_chunk", event as StreamEvent);
-          await this.handleProgress(event.progress, event.message);
-          break;
-        }
-        case "text-delta": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          if (accumulated) {
-            accumulated.set(event.port, (accumulated.get(event.port) ?? "") + event.textDelta);
-          }
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "object-delta": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          if (accumulatedObjects) {
-            const existing = accumulatedObjects.get(event.port);
-            if (Array.isArray(event.objectDelta)) {
-              // Array delta: upsert items by `id` into accumulated array
-              const arr: unknown[] = Array.isArray(existing) ? [...existing] : [];
-              for (const item of event.objectDelta) {
-                const itemObj = item as Record<string, unknown>;
-                if (itemObj && typeof itemObj === "object" && "id" in itemObj) {
-                  const idx = arr.findIndex(
-                    (e) => (e as Record<string, unknown>).id === itemObj.id
-                  );
-                  if (idx >= 0) arr[idx] = item;
-                  else arr.push(item);
-                } else {
-                  arr.push(item);
-                }
-              }
-              accumulatedObjects.set(event.port, arr);
-            } else {
-              // Non-array (e.g. structured generation): replace semantics
-              accumulatedObjects.set(event.port, event.objectDelta);
-            }
-          }
-          // Update runOutputData with accumulated state so listeners see growing state
-          this.task.runOutputData = {
-            ...this.task.runOutputData,
-            [event.port]: accumulatedObjects?.get(event.port) ?? event.objectDelta,
-          } as Output;
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "snapshot": {
-          if (!streamingStarted) {
-            streamingStarted = true;
-            this.task.status = TaskStatus.STREAMING;
-            this.task.emit("status", this.task.status);
-          }
-          this.task.emit("stream_chunk", event as StreamEvent);
-          break;
-        }
-        case "finish": {
-          if (accumulated || accumulatedObjects) {
-            // Emit an enriched finish event: merge accumulated deltas into
-            // the finish payload so downstream dataflows get complete port data
-            // without needing to re-accumulate themselves.
-            const merged: Record<string, unknown> = { ...(event.data || {}) };
-            if (accumulated) {
-              for (const [port, text] of accumulated) {
-                if (text.length > 0) merged[port] = text;
-              }
-            }
-            if (accumulatedObjects) {
-              for (const [port, obj] of accumulatedObjects) {
-                merged[port] = obj;
-              }
-            }
-            // For replace-mode streams, finish carries data: {} by convention.
-            // Fall back to the last snapshot (runOutputData) so the final output
-            // is not silently cleared when the finish payload is empty.
-            if (streamMode === "replace" && Object.keys(merged).length === 0) {
-              const lastSnapshot = this.task.runOutputData;
-              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
-                finalOutput = lastSnapshot as Output;
-                this.task.emit("stream_chunk", {
-                  type: "finish",
-                  data: lastSnapshot,
-                } as StreamEvent);
-                break;
-              }
-            }
-            finalOutput = merged as unknown as Output;
-            this.task.emit("stream_chunk", { type: "finish", data: merged } as StreamEvent);
-          } else {
-            // No accumulation. For replace-mode streams the provider's finish
-            // event carries `data: {}` by convention — the snapshots already
-            // delivered the value, so the finish payload is intentionally
-            // empty. Fall back to `runOutputData` (set on every snapshot above)
-            // so we don't clobber the last snapshot with an empty object. This
-            // mirrors the same fallback in the accumulation branch.
-            const finishData = (event.data ?? {}) as Record<string, unknown>;
-            if (streamMode === "replace" && Object.keys(finishData).length === 0) {
-              const lastSnapshot = this.task.runOutputData;
-              if (lastSnapshot && Object.keys(lastSnapshot).length > 0) {
-                finalOutput = lastSnapshot as Output;
-                this.task.emit("stream_chunk", {
-                  type: "finish",
-                  data: lastSnapshot,
-                } as StreamEvent);
-                break;
-              }
-            }
-            finalOutput = event.data as Output;
-            this.task.emit("stream_chunk", event as StreamEvent);
-          }
-          break;
-        }
-        case "error": {
-          throw event.error;
-        }
-      }
-    }
-
-    // Check if the task was aborted during streaming
-    if (ctx.abortController.signal.aborted) {
-      throw new TaskAbortedError("Task aborted during streaming");
-    }
-
-    if (finalOutput !== undefined) {
-      this.task.runOutputData = finalOutput;
-    }
-
-    this.task.emit("stream_end", this.task.runOutputData as Output);
-
-    return this.task.runOutputData as Output;
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -13,9 +13,9 @@ import {
   SpanStatusCode,
 } from "@workglow/util";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
-import { getPortCodec } from "@workglow/util";
 import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";
+import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
@@ -32,55 +32,6 @@ import {
 } from "./TaskError";
 import { TaskRunContext } from "./TaskRunContext";
 import { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
-
-interface SchemaProperties {
-  properties?: Record<string, { format?: string }>;
-}
-
-async function serializeOutputPorts(
-  output: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return output;
-  const out: Record<string, unknown> = { ...output };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.serialize(out[key]);
-    }
-  }
-  return out;
-}
-
-async function deserializeOutputPorts(
-  output: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return output;
-  const out: Record<string, unknown> = { ...output };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.deserialize(out[key]);
-    }
-  }
-  return out;
-}
-
-async function normalizeInputsForCacheKey(
-  inputs: Record<string, unknown>,
-  schema: SchemaProperties
-): Promise<Record<string, unknown>> {
-  if (!schema?.properties) return inputs;
-  const out: Record<string, unknown> = { ...inputs };
-  for (const [key, prop] of Object.entries(schema.properties)) {
-    const codec = prop.format ? getPortCodec(prop.format) : undefined;
-    if (codec && out[key] !== undefined) {
-      out[key] = await codec.serialize(out[key]);
-    }
-  }
-  return out;
-}
 
 /**
  * Type guard that checks whether a value is an ITask-like object with a mutable `runConfig`.
@@ -123,6 +74,11 @@ export class TaskRunner<
   protected outputCache?: TaskOutputRepository;
 
   /**
+   * Cache coordinator for the task (key normalization, lookup, save).
+   */
+  protected readonly cacheCoordinator: CacheCoordinator<Input, Output>;
+
+  /**
    * The service registry for the task
    */
   protected registry: ServiceRegistry = globalServiceRegistry;
@@ -147,6 +103,7 @@ export class TaskRunner<
     this.task = task;
     this.own = this.own.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
+    this.cacheCoordinator = new CacheCoordinator(task);
   }
 
   // ========================================================================
@@ -192,8 +149,6 @@ export class TaskRunner<
         throw new TaskAbortedError("Promise for task created and aborted before run");
       }
 
-      let outputs: Output | undefined;
-
       const isStreamable = isTaskStreamable(this.task);
 
       // Warn if schema declares streaming but executeStream is not implemented
@@ -207,46 +162,20 @@ export class TaskRunner<
         }
       }
 
-      const inputSchema = (this.task.constructor as typeof Task).inputSchema();
-      const outputSchema = (this.task.constructor as typeof Task).outputSchema();
-      const inputsForKey = this.outputCache
-        ? await normalizeInputsForCacheKey(
-            inputs as Record<string, unknown>,
-            inputSchema as unknown as SchemaProperties
-          )
-        : inputs;
+      const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
+      let outputs = await this.cacheCoordinator.lookup(
+        keyInputs,
+        this.outputCache,
+        isStreamable,
+        ctx
+      );
 
-      if (this.task.cacheable) {
-        const cached = await this.outputCache?.getOutput(this.task.type, inputsForKey);
-        if (cached !== undefined) {
-          outputs = (await deserializeOutputPorts(
-            cached as Record<string, unknown>,
-            outputSchema as unknown as SchemaProperties
-          )) as Output;
-          ctx.telemetrySpan?.addEvent("workglow.task.cache_hit");
-          if (isStreamable) {
-            this.task.runOutputData = outputs;
-            this.task.emit("stream_start");
-            this.task.emit("stream_chunk", { type: "finish", data: outputs } as StreamEvent);
-            this.task.emit("stream_end", outputs);
-          } else {
-            this.task.runOutputData = outputs;
-          }
-        }
-      }
-      if (!outputs) {
-        if (isStreamable) {
-          outputs = await this.executeStreamingTask(inputs);
-        } else {
-          outputs = await this.executeTask(inputs, ctx);
-        }
-        if (this.task.cacheable && outputs !== undefined) {
-          const wireOutputs = await serializeOutputPorts(
-            outputs as Record<string, unknown>,
-            outputSchema as unknown as SchemaProperties
-          );
-          await this.outputCache?.saveOutput(this.task.type, inputsForKey, wireOutputs as Output);
-        }
+      if (outputs === undefined) {
+        outputs = isStreamable
+          ? await this.executeStreamingTask(inputs)
+          : await this.executeTask(inputs, ctx);
+
+        await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
         this.task.runOutputData = outputs ?? ({} as Output);
       }
 

--- a/packages/task-graph/src/task/WhileTaskRunner.ts
+++ b/packages/task-graph/src/task/WhileTaskRunner.ts
@@ -5,6 +5,7 @@
  */
 
 import { GraphAsTaskRunner } from "./GraphAsTaskRunner";
+import type { TaskRunContext } from "./TaskRunContext";
 import type { TaskInput, TaskOutput } from "./TaskTypes";
 import type { WhileTask, WhileTaskConfig } from "./WhileTask";
 
@@ -27,9 +28,12 @@ export class WhileTaskRunner<
    * contains the while-loop logic, rather than the default
    * GraphAsTaskRunner behavior of running the subgraph once.
    */
-  protected override async executeTask(input: Input): Promise<Output | undefined> {
+  protected override async executeTask(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     const result = await this.task.execute(input, {
-      signal: this.abortController!.signal,
+      signal: ctx.abortController.signal,
       updateProgress: this.handleProgress.bind(this),
       own: this.own,
       registry: this.registry,
@@ -41,7 +45,10 @@ export class WhileTaskRunner<
   /**
    * For WhileTask, preview runs use the task's preview hook only.
    */
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
+  public override async executeTaskPreview(
+    input: Input,
+    _ctx: TaskRunContext
+  ): Promise<Output | undefined> {
     return this.task.executePreview?.(input, { own: this.own });
   }
 }

--- a/packages/tasks/src/task/ArrayTask.ts
+++ b/packages/tasks/src/task/ArrayTask.ts
@@ -20,6 +20,7 @@ import {
   TaskInput,
   TaskOutput,
 } from "@workglow/task-graph";
+import type { TaskRunContext } from "@workglow/task-graph";
 
 export function TypeReplicateArray<const T extends DataPortSchemaNonBoolean>(
   type: T,
@@ -274,15 +275,18 @@ class ArrayTaskRunner<
     return this.task.subGraph!.runPreview<Output>({});
   }
 
-  public override async executeTaskPreview(input: Input): Promise<Output | undefined> {
-    await super.executeTaskPreview(input);
+  public override async executeTaskPreview(
+    input: Input,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
+    await super.executeTaskPreview(input, ctx);
     if (this.task.hasChildren()) {
       this.task.runOutputData = this.task.executeMerge(input, this.task.runOutputData as Output);
     }
     return this.task.runOutputData as Output;
   }
-  public override async executeTask(input: Input): Promise<Output> {
-    await super.executeTask(input);
+  public override async executeTask(input: Input, ctx: TaskRunContext): Promise<Output> {
+    await super.executeTask(input, ctx);
     if (this.task.hasChildren()) {
       this.task.runOutputData = this.task.executeMerge(input, this.task.runOutputData as Output);
     }

--- a/packages/test/src/test/task-graph/taskrunner-internals.test.ts
+++ b/packages/test/src/test/task-graph/taskrunner-internals.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CacheCoordinator,
+  StreamProcessor,
+  Task,
+  TaskRunContext,
+  TaskRegistry,
+} from "@workglow/task-graph";
+import type { StreamEvent } from "@workglow/task-graph";
+import { globalServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+
+// ============================================================================
+// TaskRunContext
+// ============================================================================
+
+describe("TaskRunContext", () => {
+  it("dispose() removes the parentSignal listener", () => {
+    const parent = new AbortController();
+    const ctx = new TaskRunContext(parent.signal);
+
+    ctx.dispose();
+    parent.abort();
+
+    // ctx's own controller was not touched by parent.abort() because dispose()
+    // removed the bridging listener
+    expect(ctx.abortController.signal.aborted).toBe(false);
+  });
+
+  it("constructor: parent already aborted -> ctx aborts immediately, no listener leak", () => {
+    const parent = new AbortController();
+    parent.abort();
+
+    const ctx = new TaskRunContext(parent.signal);
+    expect(ctx.abortController.signal.aborted).toBe(true);
+
+    // dispose should be a safe no-op since the cleanup ran inline
+    ctx.dispose();
+    ctx.dispose();
+  });
+});
+
+// ============================================================================
+// StreamProcessor (text-delta accumulation + replace-mode fallback)
+// ============================================================================
+
+type AccumInput = { text: string };
+type AccumOutput = { text: string };
+
+class AccumStreamingTask extends Task<AccumInput, AccumOutput> {
+  public static override readonly type = "TestAccumStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Accum";
+  public static override readonly description = "Accum";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: AccumInput): Promise<AccumOutput> {
+    return { text: input.text };
+  }
+  public async *executeStream(_input: AccumInput): AsyncIterable<StreamEvent<AccumOutput>> {
+    yield { type: "text-delta", port: "text", textDelta: "Hello, " };
+    yield { type: "text-delta", port: "text", textDelta: "world!" };
+    yield { type: "finish", data: {} as AccumOutput };
+  }
+}
+
+type ReplaceInput = { q: string };
+type ReplaceOutput = { result: string };
+
+class ReplaceStreamingTask extends Task<ReplaceInput, ReplaceOutput> {
+  public static override readonly type = "TestReplaceStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "Replace";
+  public static override readonly description = "Replace";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "replace" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: ReplaceInput): Promise<ReplaceOutput> {
+    return { result: input.q };
+  }
+  public async *executeStream(_input: ReplaceInput): AsyncIterable<StreamEvent<ReplaceOutput>> {
+    yield { type: "snapshot", data: { result: "intermediate" } };
+    yield { type: "snapshot", data: { result: "final" } };
+    // empty finish - exercise the replace-mode fallback
+    yield { type: "finish", data: {} as ReplaceOutput };
+  }
+}
+
+describe("StreamProcessor", () => {
+  it("text-delta accumulation builds enriched finish payload", async () => {
+    TaskRegistry.registerTask(AccumStreamingTask);
+    const task = new AccumStreamingTask();
+    const sp = new StreamProcessor<AccumInput, AccumOutput>(task);
+    const ctx = new TaskRunContext();
+
+    let finishData: Record<string, unknown> | undefined;
+    task.subscribe("stream_chunk", (event: any) => {
+      if (event.type === "finish") {
+        finishData = event.data;
+      }
+    });
+
+    await sp.run({ text: "ignored" }, ctx, {
+      registry: globalServiceRegistry,
+      resourceScope: undefined,
+      inputStreams: undefined,
+      onProgress: async () => {},
+      own: (i) => i,
+    });
+
+    expect(finishData).toEqual({ text: "Hello, world!" });
+  });
+
+  it("replace-mode finish with empty data falls back to last snapshot", async () => {
+    TaskRegistry.registerTask(ReplaceStreamingTask);
+    const task = new ReplaceStreamingTask();
+    const sp = new StreamProcessor<ReplaceInput, ReplaceOutput>(task);
+    const ctx = new TaskRunContext();
+
+    const result = await sp.run({ q: "ignored" }, ctx, {
+      registry: globalServiceRegistry,
+      resourceScope: undefined,
+      inputStreams: undefined,
+      onProgress: async () => {},
+      own: (i) => i,
+    });
+
+    expect(result).toEqual({ result: "final" });
+  });
+});
+
+// ============================================================================
+// CacheCoordinator
+// ============================================================================
+
+type CacheableInput = { q: string };
+type CacheableOutput = { result: string };
+
+class CacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
+  public static override readonly type = "TestCacheableStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = true;
+  public static override readonly title = "Cacheable";
+  public static override readonly description = "Cacheable";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: CacheableInput): Promise<CacheableOutput> {
+    return { result: input.q };
+  }
+}
+
+class NonCacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
+  public static override readonly type = "TestNonCacheableStreaming";
+  public static override readonly category = "Test";
+  public static override readonly cacheable = false;
+  public static override readonly title = "NonCacheable";
+  public static override readonly description = "NonCacheable";
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { q: { type: "string" } },
+    } as const satisfies DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { result: { type: "string", "x-stream": "append" } },
+    } as const satisfies DataPortSchema;
+  }
+  public override async execute(input: CacheableInput): Promise<CacheableOutput> {
+    return { result: input.q };
+  }
+}
+
+class FakeCacheRepo {
+  private store = new Map<string, unknown>();
+
+  async getOutput(type: string, input: unknown): Promise<unknown> {
+    return this.store.get(`${type}::${JSON.stringify(input)}`);
+  }
+
+  async saveOutput(type: string, input: unknown, output: unknown): Promise<void> {
+    this.store.set(`${type}::${JSON.stringify(input)}`, output);
+  }
+}
+
+describe("CacheCoordinator", () => {
+  it("lookup hit emits stream_start/finish/end for streamable tasks", async () => {
+    TaskRegistry.registerTask(CacheableStreamingTask);
+    const task = new CacheableStreamingTask();
+    const cache = new FakeCacheRepo() as any;
+
+    // Pre-populate the cache
+    await cache.saveOutput("TestCacheableStreaming", { q: "hello" }, { result: "cached!" });
+
+    const cc = new CacheCoordinator<CacheableInput, CacheableOutput>(task);
+    const ctx = new TaskRunContext();
+
+    const events: string[] = [];
+    task.subscribe("stream_start", () => events.push("start"));
+    task.subscribe("stream_chunk", (event: any) => events.push(`chunk:${event.type}`));
+    task.subscribe("stream_end", () => events.push("end"));
+
+    const result = await cc.lookup({ q: "hello" }, cache, /* isStreamable */ true, ctx);
+
+    expect(result).toEqual({ result: "cached!" });
+    expect(events).toEqual(["start", "chunk:finish", "end"]);
+  });
+
+  it("save no-op when outputCache is undefined or task is not cacheable", async () => {
+    TaskRegistry.registerTask(CacheableStreamingTask);
+    const task = new CacheableStreamingTask();
+    const cc = new CacheCoordinator<CacheableInput, CacheableOutput>(task);
+
+    // Should not throw, should not record anything (cache=undefined)
+    await cc.save({ q: "x" }, { result: "y" }, undefined);
+
+    // With a cache but a non-cacheable task - verify by using a separate non-cacheable task class
+    TaskRegistry.registerTask(NonCacheableStreamingTask);
+    const nonCacheableTask = new NonCacheableStreamingTask();
+    const cc2 = new CacheCoordinator<CacheableInput, CacheableOutput>(nonCacheableTask);
+    const cache = new FakeCacheRepo() as any;
+
+    await cc2.save({ q: "x" }, { result: "y" }, cache);
+
+    const cached = await cache.getOutput("TestNonCacheableStreaming", { q: "x" });
+    expect(cached).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Pure structural refactor of `packages/task-graph/src/task/TaskRunner.ts` (1,019 → 730 lines, ~28% reduction) into a thin facade plus three internal collaborators. Sibling refactor to PR #447 (TaskGraphRunner decomposition) — same facade + per-run-context + collaborators pattern, applied to the per-task lifecycle.

**Stacked on PR #447** — base branch is \`refactor-taskgraph-runner\`. Merge PR #447 first, then this rebases naturally onto main.

- **\`TaskRunContext\`** (58 lines) — per-run mutable state (abortController, shouldAccumulate, telemetrySpan, timeoutTimer, pendingTimeoutError) + parentSignal lifetime via \`dispose()\`. Built by \`handleStart\`, discarded by terminal handlers.
- **\`CacheCoordinator\`** (154 lines) — cache key normalization, lookup, save, cache-hit fake-stream emission. The 3 previously module-private helpers (serializeOutputPorts, deserializeOutputPorts, normalizeInputsForCacheKey) become private statics here.
- **\`StreamProcessor\`** (236 lines) — the 185-line streaming event loop lifted verbatim. Takes \`(input, ctx, deps)\`; deps bundle facade-mutable state (registry, resourceScope, inputStreams, onProgress, own).

The facade keeps lifecycle handlers (handleStart/Complete/Error/Abort/Disable/Progress), \`run\`/\`runPreview\`/\`runPreviewStream\`/\`abort\`/\`disable\` public methods, the \`executeTask\`/\`executeTaskPreview\`/\`handleDisable\` override slots, and the new private \`resolveSchemas()\` (deduped from \`run\` + \`runPreview\`).

### Override-signature change (the one intentional API change)

The 3 subclass-overridable hooks gain a \`ctx\` parameter:
- \`executeTask(input, ctx)\` — was \`executeTask(input)\`
- \`executeTaskPreview(input, ctx)\` — was \`executeTaskPreview(input)\`
- \`handleDisable(ctx | undefined)\` — was \`handleDisable()\`

All 5 subclasses across both packages updated atomically in one commit:
- \`@workglow/task-graph\`: GraphAsTaskRunner, IteratorTaskRunner, WhileTaskRunner, FallbackTaskRunner
- \`@workglow/tasks\`: ArrayTaskRunner

### Why

Sibling refactor to TaskGraphRunner. Sets up clean unit-testing seams (this PR seeds 6); per-task resumability becomes tractable in the same way per-graph resumability does. Both refactors converge on the same facade + per-run-context + collaborators pattern, applied at their respective lifecycle scope.

### Public API

\`run\`, \`runPreview\`, \`runPreviewStream\`, \`abort\`, \`disable\`, plus the constructor — all byte-identical signatures. The 3 override slots' new \`ctx\` parameter is the only intentional change.

### Spec & plan

- Spec: \`builder/docs/superpowers/specs/2026-05-02-decompose-taskrunner-design.md\`
- Plan: \`builder/docs/superpowers/plans/2026-05-02-decompose-taskrunner-plan.md\`

## Test plan

- [x] \`bun scripts/test.ts graph task vitest\` — **1675 passed | 24 skipped** (1669 baseline + 6 new unit tests for TaskRunContext / StreamProcessor / CacheCoordinator)
- [x] \`bun run build:types\` — 24/24 successful
- [x] \`bun run build:packages\` — 22/22 successful
- [x] Broader smoke (\`graph task storage queue ai vitest\`) — **2,672 passed | 50 skipped**; no regressions in Workflow / AiTask / streaming / RAG paths
- [x] Each commit individually green; subagent-driven-development with two-stage review (spec + code quality) per task

🤖 Generated with [Claude Code](https://claude.com/claude-code)