### PR TITLE
feat(task-graph): ResourceScope auto-ownership at top-level runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - run: bun run build
       - name: Upload build artifacts
@@ -47,7 +47,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -67,7 +67,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -91,7 +91,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -115,7 +115,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -135,7 +135,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -155,7 +155,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -179,7 +179,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -207,7 +207,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -239,7 +239,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -271,7 +271,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -299,7 +299,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -327,7 +327,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -365,7 +365,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.12
       - run: bun i
       - name: Download Vitest coverage fragments
         run: mkdir -p coverage-parts
@@ -416,9 +416,22 @@ jobs:
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: [test-bun-unit, test-vitest-unit, test-bun-integration, test-vitest-integration, test-bun-rag, test-vitest-rag, test-bun-ai-provider-hft, test-bun-ai-provider-llamacpp, test-bun-ai-provider-api, test-vitest-ai-provider-hft, test-vitest-ai-provider-llamacpp, test-vitest-ai-provider-api]
+    needs:
+      [
+        test-bun-unit,
+        test-vitest-unit,
+        test-bun-integration,
+        test-vitest-integration,
+        test-bun-rag,
+        test-vitest-rag,
+        test-bun-ai-provider-hft,
+        test-bun-ai-provider-llamacpp,
+        test-bun-ai-provider-api,
+        test-vitest-ai-provider-hft,
+        test-vitest-ai-provider-llamacpp,
+        test-vitest-ai-provider-api,
+      ]
     steps:
       - uses: geekyeggo/delete-artifact@v6
         with:
           name: build-output
-

--- a/docs/technical/01-task-graph-dag-engine.md
+++ b/docs/technical/01-task-graph-dag-engine.md
@@ -325,6 +325,22 @@ Long-lived state from `config` (`registry`, `outputCache`, `resourceScope`, `acc
 
 **Mnemonic:** `TaskGraphRunConfig` is what the caller asks for; `RunContext` is what the runner is doing right now.
 
+#### `resourceScope` ownership
+
+`resourceScope` is special: the runner sets `this.resourceScope` from
+`config.resourceScope` when present, but if the caller did not provide one,
+`runGraph` allocates a private `ResourceScope` and `disposeAll()`s it in a
+`finally` block when the run terminates (success, error, or abort). Casual
+callers get automatic cleanup of heavyweight resources (model unload, AI
+session close, browser disconnect) with no ceremony. Caller-passed scopes are
+never touched by the runner — expert callers retain full lifecycle control.
+
+The same auto-ownership pattern applies to `TaskRunner.run` for the bare-task
+path. Nested runs (`GraphAsTask`, `IteratorTask`, `runTask`, `subGraph.run`)
+always forward `this.resourceScope`, which is defined post-`handleStart`, so
+child runners observe a "caller-passed" scope and never own it. Disposal
+happens exactly once, at the top of the call stack.
+
 ---
 
 ## Execution Flow

--- a/packages/task-graph/src/task-graph/IWorkflow.ts
+++ b/packages/task-graph/src/task-graph/IWorkflow.ts
@@ -12,7 +12,17 @@ import { GraphResult, PROPERTY_ARRAY } from "./TaskGraphRunner";
 export interface WorkflowRunConfig {
   /** Optional service registry to use for this workflow run */
   readonly registry?: ServiceRegistry;
-  /** Resource scope for collecting heavyweight resource disposers. */
+  /**
+   * Resource scope for collecting heavyweight resource disposers during the
+   * workflow run.
+   *
+   * If omitted, the underlying graph runner creates a private scope and
+   * disposes it when the run finishes — automatic cleanup for casual callers.
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`. Use this to share resources (e.g., a loaded AI model) across
+   * multiple runs, then dispose at app shutdown.
+   */
   readonly resourceScope?: ResourceScope;
 }
 

--- a/packages/task-graph/src/task-graph/LoopBuilderContext.ts
+++ b/packages/task-graph/src/task-graph/LoopBuilderContext.ts
@@ -11,12 +11,16 @@ import { autoConnect } from "./autoConnect";
 import type { TaskGraph } from "./TaskGraph";
 import type { Workflow } from "./Workflow";
 
+/**
+ * @internal
+ */
 export interface PendingLoopConnect {
   readonly parent: ITask;
   readonly iteratorTask: ITask;
 }
 
 /**
+ * @internal
  * Runs deferred auto-connect for a loop iterator task on the parent
  * workflow's graph. Extracted as a free function so it can be invoked
  * from both {@link LoopBuilderContext.consumePendingConnect} and from
@@ -53,6 +57,7 @@ export function runLoopAutoConnect(
 }
 
 /**
+ * @internal
  * Holds the parent <-> child relationship for a Workflow operating in
  * loop-builder mode (created by parent.addLoopTask). Owns deferred
  * auto-connect state. Has no events, no DSL.

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -69,8 +69,16 @@ export interface TaskGraphRunConfig {
    */
   enforceEntitlements?: boolean;
   /**
-   * Resource scope for collecting heavyweight resource disposers during graph execution.
-   * Threaded to all tasks via IExecuteContext. The caller controls disposal.
+   * Resource scope for collecting heavyweight resource disposers during graph
+   * execution. Threaded to all tasks via IExecuteContext.
+   *
+   * If omitted, the top-level runner creates a private scope and `disposeAll()`s
+   * it when the run finishes (success, error, or abort) — automatic cleanup for
+   * casual callers.
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`. Use this to share resources (e.g., a loaded AI model) across
+   * multiple runs, then dispose at app shutdown.
    */
   resourceScope?: ResourceScope;
 }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -234,11 +234,11 @@ export class TaskGraphRunner {
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
+        // Only clear our auto-created reference. Caller-passed scopes keep the
+        // caller's lifecycle; `handleStart` overwrites the field on the next
+        // run anyway via `effectiveConfig`.
+        this.resourceScope = undefined;
       }
-      // Reset instance field so a subsequent run on this runner starts clean.
-      // handleStart already overwrites it on the next call, but a stale ref
-      // between runs is brittle.
-      this.resourceScope = undefined;
     }
   }
 

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -220,7 +220,7 @@ export class TaskGraphRunner {
       }
       if (ctx.failedTaskErrors.size > 0) {
         const latestError = ctx.failedTaskErrors.values().next().value!;
-        this.handleError(latestError);
+        await this.handleError(latestError);
         throw latestError;
       }
       if (ctx.abortController.signal.aborted) {

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -188,43 +188,58 @@ export class TaskGraphRunner {
     input: TaskInput = {} as TaskInput,
     config?: TaskGraphRunConfig
   ): Promise<GraphResultArray<ExecuteOutput>> {
-    await this.handleStart(config);
+    const ownsScope = config?.resourceScope === undefined;
+    const effectiveConfig: TaskGraphRunConfig = ownsScope
+      ? { ...config, resourceScope: new ResourceScope() }
+      : config!;
 
-    // Capture ctx locally — terminal handlers (handleAbort/Error/Complete)
-    // clear this.currentCtx, but the abort signal listener may invoke
-    // handleAbort while runGraph's loop or epilogue is still running.
-    // The local reference keeps per-run state readable until runGraph returns.
-    const ctx = this.currentCtx!;
+    try {
+      await this.handleStart(effectiveConfig);
 
-    const results = await this.runScheduler.runLoop<ExecuteOutput>(
-      input,
-      config,
-      ctx,
-      this.edgeMaterializer
-    );
+      // Capture ctx locally — terminal handlers (handleAbort/Error/Complete)
+      // clear this.currentCtx, but the abort signal listener may invoke
+      // handleAbort while runGraph's loop or epilogue is still running.
+      // The local reference keeps per-run state readable until runGraph returns.
+      const ctx = this.currentCtx!;
 
-    // Check graph-level timeout first — it is the root cause when tasks fail due
-    // to the graph abort signal, and should take precedence over any task-level
-    // TaskAbortedError that was placed in failedTaskErrors as a consequence.
-    // Capture pendingGraphTimeoutError BEFORE calling handleAbort, which clears currentCtx.
-    const pendingTimeout = ctx.pendingGraphTimeoutError;
-    if (pendingTimeout) {
-      await this.handleAbort();
-      throw pendingTimeout;
+      const results = await this.runScheduler.runLoop<ExecuteOutput>(
+        input,
+        effectiveConfig,
+        ctx,
+        this.edgeMaterializer
+      );
+
+      // Check graph-level timeout first — it is the root cause when tasks fail due
+      // to the graph abort signal, and should take precedence over any task-level
+      // TaskAbortedError that was placed in failedTaskErrors as a consequence.
+      // Capture pendingGraphTimeoutError BEFORE calling handleAbort, which clears currentCtx.
+      const pendingTimeout = ctx.pendingGraphTimeoutError;
+      if (pendingTimeout) {
+        await this.handleAbort();
+        throw pendingTimeout;
+      }
+      if (ctx.failedTaskErrors.size > 0) {
+        const latestError = ctx.failedTaskErrors.values().next().value!;
+        this.handleError(latestError);
+        throw latestError;
+      }
+      if (ctx.abortController.signal.aborted) {
+        await this.handleAbort();
+        throw new TaskAbortedError();
+      }
+
+      await this.handleComplete();
+
+      return this.filterLeafResults(results);
+    } finally {
+      if (ownsScope) {
+        await effectiveConfig.resourceScope!.disposeAll();
+      }
+      // Reset instance field so a subsequent run on this runner starts clean.
+      // handleStart already overwrites it on the next call, but a stale ref
+      // between runs is brittle.
+      this.resourceScope = undefined;
     }
-    if (ctx.failedTaskErrors.size > 0) {
-      const latestError = ctx.failedTaskErrors.values().next().value!;
-      this.handleError(latestError);
-      throw latestError;
-    }
-    if (ctx.abortController.signal.aborted) {
-      await this.handleAbort();
-      throw new TaskAbortedError();
-    }
-
-    await this.handleComplete();
-
-    return this.filterLeafResults(results);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
+++ b/packages/task-graph/src/task-graph/WorkflowCacheAdapter.ts
@@ -7,6 +7,7 @@
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 
 /**
+ * @internal
  * Owns the workflow's TaskOutputRepository and supplies it to the underlying
  * TaskGraph (at construction) and to graph.run() (per run). Today this is a
  * thin pass-through; it is the growth point for cache key derivation,

--- a/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
+++ b/packages/task-graph/src/task-graph/WorkflowEventBridge.ts
@@ -9,6 +9,7 @@ import type { TaskGraph } from "./TaskGraph";
 import type { WorkflowEventListeners } from "./Workflow";
 
 /**
+ * @internal
  * Routes TaskGraph mutation events, entitlement updates, and per-run streaming
  * events to a Workflow's EventEmitter. Owns subscription lifecycle:
  *   attach(graph)   → subscribe to mutation + entitlement events

--- a/packages/task-graph/src/task-graph/WorkflowPipe.ts
+++ b/packages/task-graph/src/task-graph/WorkflowPipe.ts
@@ -21,11 +21,17 @@ import { Workflow } from "./Workflow";
 // dependency — these need both Workflow and GraphAsTask which live here)
 // ============================================================================
 
+/**
+ * @internal
+ */
 export function getLastTask(workflow: IWorkflow): ITask<any, any, any> | undefined {
   const tasks = workflow.graph.getTasks();
   return tasks.length > 0 ? tasks[tasks.length - 1] : undefined;
 }
 
+/**
+ * @internal
+ */
 export function connect(
   source: ITask<any, any, any>,
   target: ITask<any, any, any>,

--- a/packages/task-graph/src/task-graph/WorkflowRunContext.ts
+++ b/packages/task-graph/src/task-graph/WorkflowRunContext.ts
@@ -5,6 +5,7 @@
  */
 
 /**
+ * @internal
  * Per-run mutable state for a single Workflow.run() invocation. Built at the
  * top of run(), discarded in the run's finally clause. Mirrors RunContext on
  * the TaskGraphRunner side: a small value object so per-run resources have a

--- a/packages/task-graph/src/task-graph/WorkflowTask.ts
+++ b/packages/task-graph/src/task-graph/WorkflowTask.ts
@@ -9,6 +9,12 @@ import type { DataPorts } from "../task/TaskTypes";
 import type { CompoundMergeStrategy } from "./TaskGraphRunner";
 import { PROPERTY_ARRAY } from "./TaskGraphRunner";
 
+/**
+ * @internal
+ * Workflow's private GraphAsTask subclass — the runtime task instance that
+ * carries Workflow's compound-merge strategy. Constructed only by Workflow;
+ * not part of the public surface.
+ */
 export class WorkflowTask<
   I extends DataPorts,
   O extends DataPorts,

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -46,7 +46,19 @@ export interface IExecuteContext {
    * from these streams and re-yield events for immediate downstream delivery.
    */
   inputStreams?: Map<string, ReadableStream<StreamEvent>>;
-  /** Resource scope for registering heavyweight resource disposers. */
+  /**
+   * Resource scope for registering heavyweight resource disposers (model unload,
+   * AI session close, browser disconnect, etc.).
+   *
+   * **Register synchronously from within `execute()` / `executeStream()`.**
+   * The top-level runner disposes the scope as soon as the run completes;
+   * disposers registered after `execute()` resolves will land on a cleared Map
+   * and never be invoked.
+   *
+   * Always defined when the task is run via `Task.run()`, `TaskGraph.run()`,
+   * or `Workflow.run()` — the top-level runner auto-creates one if the caller
+   * did not provide it.
+   */
   resourceScope?: ResourceScope;
 }
 
@@ -115,8 +127,12 @@ export interface IRunConfig {
 
   /**
    * Resource scope for collecting heavyweight resource disposers.
-   * When provided, tasks can register cleanup functions via context.resourceScope.
-   * The caller controls when to invoke them.
+   *
+   * If omitted, the top-level runner creates a private scope and `disposeAll()`s
+   * it when the run finishes (success, error, or abort).
+   *
+   * If provided, the caller owns the lifecycle; the runner never calls
+   * `disposeAll`.
    */
   resourceScope?: ResourceScope;
 

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -124,82 +124,97 @@ export class TaskRunner<
    * @returns The task output
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
-    await this.handleStart(config);
-    const ctx = this.currentCtx!;
-
-    const proto = Object.getPrototypeOf(this.task);
-    if (
-      proto.execute === Task.prototype.execute &&
-      typeof proto.executeStream !== "function" &&
-      proto.executePreview !== Task.prototype.executePreview
-    ) {
-      throw new TaskConfigurationError(
-        `Task "${this.task.type}" implements only executePreview() and cannot be run via run(). ` +
-          `After the run/runPreview split, run() requires execute() (or executeStream()). ` +
-          `See docs/technical/02-dual-mode-execution.md.`
-      );
-    }
+    const ownsScope = config.resourceScope === undefined;
+    const effectiveConfig: IRunConfig = ownsScope
+      ? { ...config, resourceScope: new ResourceScope() }
+      : config;
 
     try {
-      this.task.setInput(overrides);
+      await this.handleStart(effectiveConfig);
+      const ctx = this.currentCtx!;
 
-      await this.resolveSchemas();
-
-      const inputs: Input = this.task.runInputData as Input;
-      const isValid = await this.task.validateInput(inputs);
-      if (!isValid) {
-        throw new TaskInvalidInputError("Invalid input data");
+      const proto = Object.getPrototypeOf(this.task);
+      if (
+        proto.execute === Task.prototype.execute &&
+        typeof proto.executeStream !== "function" &&
+        proto.executePreview !== Task.prototype.executePreview
+      ) {
+        throw new TaskConfigurationError(
+          `Task "${this.task.type}" implements only executePreview() and cannot be run via run(). ` +
+            `After the run/runPreview split, run() requires execute() (or executeStream()). ` +
+            `See docs/technical/02-dual-mode-execution.md.`
+        );
       }
 
-      if (ctx.abortController.signal.aborted) {
-        await this.handleAbort();
-        throw new TaskAbortedError("Promise for task created and aborted before run");
-      }
+      try {
+        this.task.setInput(overrides);
 
-      const isStreamable = isTaskStreamable(this.task);
+        await this.resolveSchemas();
 
-      // Warn if schema declares streaming but executeStream is not implemented
-      if (!isStreamable && typeof this.task.executeStream !== "function") {
-        const streamMode = getOutputStreamMode(this.task.outputSchema());
-        if (streamMode !== "none") {
-          getLogger().warn(
-            `Task "${this.task.type}" declares streaming output (x-stream: "${streamMode}") ` +
-              `but does not implement executeStream(). Falling back to non-streaming execute().`
-          );
+        const inputs: Input = this.task.runInputData as Input;
+        const isValid = await this.task.validateInput(inputs);
+        if (!isValid) {
+          throw new TaskInvalidInputError("Invalid input data");
         }
+
+        if (ctx.abortController.signal.aborted) {
+          await this.handleAbort();
+          throw new TaskAbortedError("Promise for task created and aborted before run");
+        }
+
+        const isStreamable = isTaskStreamable(this.task);
+
+        // Warn if schema declares streaming but executeStream is not implemented
+        if (!isStreamable && typeof this.task.executeStream !== "function") {
+          const streamMode = getOutputStreamMode(this.task.outputSchema());
+          if (streamMode !== "none") {
+            getLogger().warn(
+              `Task "${this.task.type}" declares streaming output (x-stream: "${streamMode}") ` +
+                `but does not implement executeStream(). Falling back to non-streaming execute().`
+            );
+          }
+        }
+
+        const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
+        let outputs = await this.cacheCoordinator.lookup(
+          keyInputs,
+          this.outputCache,
+          isStreamable,
+          ctx
+        );
+
+        if (outputs === undefined) {
+          outputs = isStreamable
+            ? await this.streamProcessor.run(inputs, ctx, {
+                registry: this.registry,
+                resourceScope: this.resourceScope,
+                inputStreams: this.inputStreams,
+                onProgress: this.handleProgress.bind(this),
+                own: this.own,
+              })
+            : await this.executeTask(inputs, ctx);
+
+          await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
+          this.task.runOutputData = outputs ?? ({} as Output);
+        }
+
+        await this.handleComplete();
+
+        return this.task.runOutputData as Output;
+      } catch (err: any) {
+        await this.handleError(err);
+        // If a timeout triggered the abort, throw the TaskTimeoutError instead
+        // of the generic TaskAbortedError that the task's execute() may have thrown.
+        throw this.task.error instanceof TaskTimeoutError ? this.task.error : err;
       }
-
-      const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
-      let outputs = await this.cacheCoordinator.lookup(
-        keyInputs,
-        this.outputCache,
-        isStreamable,
-        ctx
-      );
-
-      if (outputs === undefined) {
-        outputs = isStreamable
-          ? await this.streamProcessor.run(inputs, ctx, {
-              registry: this.registry,
-              resourceScope: this.resourceScope,
-              inputStreams: this.inputStreams,
-              onProgress: this.handleProgress.bind(this),
-              own: this.own,
-            })
-          : await this.executeTask(inputs, ctx);
-
-        await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
-        this.task.runOutputData = outputs ?? ({} as Output);
+    } finally {
+      if (ownsScope) {
+        await effectiveConfig.resourceScope!.disposeAll();
       }
-
-      await this.handleComplete();
-
-      return this.task.runOutputData as Output;
-    } catch (err: any) {
-      await this.handleError(err);
-      // If a timeout triggered the abort, throw the TaskTimeoutError instead
-      // of the generic TaskAbortedError that the task's execute() may have thrown.
-      throw this.task.error instanceof TaskTimeoutError ? this.task.error : err;
+      // Reset instance field so a subsequent run on this runner starts clean.
+      // handleStart already overwrites it on the next call, but a stale ref
+      // between runs is brittle.
+      this.resourceScope = undefined;
     }
   }
 

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -19,9 +19,9 @@ import { CacheCoordinator } from "./CacheCoordinator";
 import { resolveSchemaInputs, schemaHasFormatAnnotations } from "./InputResolver";
 import type { IRunConfig, ITask } from "./ITask";
 import { ITaskRunner } from "./ITaskRunner";
+import { StreamProcessor } from "./StreamProcessor";
 import type { StreamEvent } from "./StreamTypes";
 import { getOutputStreamMode, isTaskStreamable } from "./StreamTypes";
-import { StreamProcessor } from "./StreamProcessor";
 import { Task } from "./Task";
 import {
   TaskAbortedError,
@@ -95,6 +95,15 @@ export class TaskRunner<
   protected resourceScope?: ResourceScope;
 
   /**
+   * True when `this.resourceScope` was auto-created by `run()` (caller did not
+   * pass one in `config`). The flag is used by `own()` so that an auto-owned
+   * scope is not stamped into a child task's long-lived `runConfig` — that
+   * stamp would survive past the parent run's `finally`-block disposal and
+   * leave the child holding a reference to a disposed scope.
+   */
+  protected ownsResourceScope = false;
+
+  /**
    * Input streams for pass-through streaming tasks.
    * Set by the graph runner before executing a streaming task that has
    * upstream streaming edges. Keyed by input port name.
@@ -128,6 +137,7 @@ export class TaskRunner<
     const effectiveConfig: IRunConfig = ownsScope
       ? { ...config, resourceScope: new ResourceScope() }
       : config;
+    this.ownsResourceScope = ownsScope;
 
     try {
       await this.handleStart(effectiveConfig);
@@ -210,11 +220,14 @@ export class TaskRunner<
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
+        // Only clear our auto-created reference. Touching `this.resourceScope`
+        // unconditionally races with concurrent re-entry: `handleStart` early-
+        // returns on `PROCESSING`, so a second `run()` can attach to the in-
+        // flight `currentCtx`; clearing the field then would strip the scope
+        // the original run is still using.
+        this.resourceScope = undefined;
       }
-      // Reset instance field so a subsequent run on this runner starts clean.
-      // handleStart already overwrites it on the next call, but a stale ref
-      // between runs is brittle.
-      this.resourceScope = undefined;
+      this.ownsResourceScope = false;
     }
   }
 
@@ -431,11 +444,21 @@ export class TaskRunner<
     // Propagate parent registry and abort signal to owned ITask instances so
     // that calling task.run() on the returned value inherits this execution context.
     if (hasRunConfig(i)) {
-      Object.assign(i.runConfig, {
+      // Only propagate `resourceScope` if the caller owns its lifecycle. Stamping
+      // an auto-created scope into a long-lived `runConfig` leaks a reference
+      // past the parent run's `finally`-block disposal — the next `task.run()`
+      // on the owned instance would then see a disposed scope, skip auto-create,
+      // and silently drop disposers on its cleared Map. With caller-passed
+      // scopes the caller controls disposal, so the propagation is safe and
+      // preserves resource-sharing across owned-task runs.
+      const stamp: Partial<IRunConfig> = {
         registry: this.registry,
         signal: this.currentCtx?.abortController.signal,
-        resourceScope: this.resourceScope,
-      });
+      };
+      if (!this.ownsResourceScope) {
+        stamp.resourceScope = this.resourceScope;
+      }
+      Object.assign(i.runConfig, stamp);
     }
     // Notify listeners that the entitlement landscape may have changed.
     // For GraphAsTask this is also handled by the subGraph subscription, but

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -133,6 +133,15 @@ export class TaskRunner<
    * @returns The task output
    */
   async run(overrides: Partial<Input> = {}, config: IRunConfig = {}): Promise<Output> {
+    // Reject concurrent run() on the same TaskRunner. Mirrors
+    // TaskGraphRunner.handleStart's "Graph is already running" check.
+    // Raised before any `this.*` mutation so the in-flight run is undisturbed.
+    if (this.task.status === TaskStatus.PROCESSING) {
+      throw new TaskConfigurationError(
+        `Task "${this.task.type}" is already running. Concurrent run() calls on the same TaskRunner are not supported.`
+      );
+    }
+
     const ownsScope = config.resourceScope === undefined;
     const effectiveConfig: IRunConfig = ownsScope
       ? { ...config, resourceScope: new ResourceScope() }
@@ -220,11 +229,6 @@ export class TaskRunner<
     } finally {
       if (ownsScope) {
         await effectiveConfig.resourceScope!.disposeAll();
-        // Only clear our auto-created reference. Touching `this.resourceScope`
-        // unconditionally races with concurrent re-entry: `handleStart` early-
-        // returns on `PROCESSING`, so a second `run()` can attach to the in-
-        // flight `currentCtx`; clearing the field then would strip the scope
-        // the original run is still using.
         this.resourceScope = undefined;
       }
       this.ownsResourceScope = false;
@@ -525,11 +529,11 @@ export class TaskRunner<
   }
 
   /**
-   * Handles task start
+   * Handles task start. Concurrent-run rejection happens in {@link run} before
+   * any state mutation; by the time `handleStart` runs, the task status is
+   * guaranteed to be non-PROCESSING.
    */
   protected async handleStart(config: IRunConfig = {}): Promise<void> {
-    if (this.task.status === TaskStatus.PROCESSING) return;
-
     this.running = true;
 
     this.task.startedAt = new Date();

--- a/packages/test/src/test/ai-provider/StreamingProvider.test.ts
+++ b/packages/test/src/test/ai-provider/StreamingProvider.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AiProviderStreamFn } from "@workglow/ai";
 import {
   AiJob,
   AiJobInput,
@@ -11,10 +12,10 @@ import {
   getAiProviderRegistry,
   setAiProviderRegistry,
 } from "@workglow/ai";
-import type { AiProviderStreamFn } from "@workglow/ai";
 import { JobQueueClient, JobQueueServer, RateLimiter } from "@workglow/job-queue";
-import { InMemoryQueueStorage, InMemoryRateLimiterStorage } from "@workglow/storage";
 import type { IQueueStorage } from "@workglow/storage";
+import { InMemoryQueueStorage, InMemoryRateLimiterStorage } from "@workglow/storage";
+import type { StreamEvent } from "@workglow/task-graph";
 import {
   getTaskQueueRegistry,
   setTaskQueueRegistry,
@@ -22,8 +23,7 @@ import {
   TaskOutput,
   TaskQueueRegistry,
 } from "@workglow/task-graph";
-import type { StreamEvent } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { setLogger, sleep } from "@workglow/util";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
@@ -223,7 +223,7 @@ describe("Streaming Provider", () => {
       const mockStreamFn: AiProviderStreamFn = async function* (input, model, signal) {
         yield { type: "text-delta", port: "text", textDelta: "Hello" };
         // Simulate slow streaming
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await sleep(200);
         if (signal.aborted) return;
         yield { type: "text-delta", port: "text", textDelta: " world" };
         yield { type: "finish", data: { text: "Hello world" } };

--- a/packages/test/src/test/ai/ImageGenerationPreviewChain.test.ts
+++ b/packages/test/src/test/ai/ImageGenerationPreviewChain.test.ts
@@ -4,18 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import type { AiProviderStreamFn, ModelConfig } from "@workglow/ai";
 import {
   AiProviderRegistry,
+  DirectExecutionStrategy,
+  getAiProviderRegistry,
   ImageGenerateTask,
   setAiProviderRegistry,
-  getAiProviderRegistry,
-  DirectExecutionStrategy,
 } from "@workglow/ai";
-import type { AiProviderStreamFn, ModelConfig } from "@workglow/ai";
-import { CpuImage, imageValueFromBuffer, type ImageValue } from "@workglow/util/media";
 import { Dataflow, Workflow } from "@workglow/task-graph";
 import { ImageGrayscaleTask } from "@workglow/tasks";
+import { sleep } from "@workglow/util";
+import { CpuImage, imageValueFromBuffer, type ImageValue } from "@workglow/util/media";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const MOCK_PROVIDER = "mock-image-provider";
 
@@ -56,7 +57,7 @@ describe("Image generation preview chain", () => {
       for (let i = 0; i < partials.length; i++) {
         yield { type: "snapshot", data: { image: partials[i] } } as any;
         while (grayPreviewSamples.length <= i) {
-          await new Promise((r) => setTimeout(r, 1));
+          await sleep(1);
         }
       }
       yield { type: "finish", data: {} } as any;

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -5,13 +5,14 @@
  */
 
 import {
-  NullLimiter,
+  CompositeLimiter,
   ConcurrencyLimiter,
   DelayLimiter,
-  CompositeLimiter,
   EvenlySpacedRateLimiter,
+  NullLimiter,
 } from "@workglow/job-queue";
-import { describe, expect, it, beforeEach } from "vitest";
+import { sleep } from "@workglow/util";
+import { beforeEach, describe, expect, it } from "vitest";
 
 describe("NullLimiter", () => {
   const limiter = new NullLimiter();
@@ -98,7 +99,7 @@ describe("DelayLimiter", () => {
   it("should allow proceeding after delay expires", async () => {
     const shortDelayLimiter = new DelayLimiter(10);
     await shortDelayLimiter.recordJobStart();
-    await new Promise((r) => setTimeout(r, 20));
+    await sleep(20);
     expect(await shortDelayLimiter.canProceed()).toBe(true);
   });
 

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -59,6 +59,19 @@ class RecordingTelemetryProvider implements ITelemetryProvider {
   }
 }
 
+async function waitForCondition(
+  predicate: () => Promise<boolean>,
+  timeoutMs: number,
+  intervalMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await sleep(intervalMs);
+  }
+  return predicate();
+}
+
 export interface TInput {
   readonly taskType?: string;
   readonly data?: string;
@@ -212,6 +225,7 @@ export function runGenericJobQueueTests(
 
     it("should delete completed jobs after specified time", async () => {
       const deleteAfterCompletionMs = 10;
+      const cleanupIntervalMs = 5;
 
       // Create a new server with deletion settings
       await server.stop();
@@ -222,7 +236,7 @@ export function runGenericJobQueueTests(
         limiter,
         pollIntervalMs: 1,
         deleteAfterCompletionMs,
-        cleanupIntervalMs: 5,
+        cleanupIntervalMs,
       });
       client.attach(server);
 
@@ -235,10 +249,12 @@ export function runGenericJobQueueTests(
       const jobExists = !!(await client.getJob(handle.id));
       expect(jobExists).toBe(true);
 
-      await sleep(deleteAfterCompletionMs * 3);
-
-      const deletedJobExists = !!(await client.getJob(handle.id));
-      expect(deletedJobExists).toBe(false);
+      const deleted = await waitForCondition(
+        async () => !(await client.getJob(handle.id)),
+        500,
+        cleanupIntervalMs
+      );
+      expect(deleted).toBe(true);
     });
 
     it("should not delete jobs when timing options are undefined", async () => {

--- a/packages/test/src/test/task-graph/CacheSerialization.test.ts
+++ b/packages/test/src/test/task-graph/CacheSerialization.test.ts
@@ -3,15 +3,10 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, vi, beforeEach } from "vitest";
-import {
-  Task,
-  TaskOutputRepository,
-  registerPortCodec,
-  _resetPortCodecsForTests,
-} from "@workglow/task-graph";
 import type { TaskInput, TaskOutput } from "@workglow/task-graph";
-import type { GpuImage } from "@workglow/util/media";
+import { Task, TaskOutputRepository, registerPortCodec } from "@workglow/task-graph";
+import type { ImageValue } from "@workglow/util/media";
+import { describe, expect, test, vi } from "vitest";
 
 class SpyRepo extends TaskOutputRepository {
   private readonly map = new Map<string, unknown>();
@@ -36,14 +31,10 @@ class SpyRepo extends TaskOutputRepository {
 }
 
 describe("TaskRunner cache port serialization", () => {
-  beforeEach(() => {
-    _resetPortCodecsForTests();
-  });
-
   test("output ports declaring a registered format are serialized before saveOutput", async () => {
     const serialize = vi.fn(async (v: unknown) => ({ wire: v }));
     const deserialize = vi.fn(async (v: unknown) => (v as { wire: unknown }).wire);
-    registerPortCodec("test-port", { serialize, deserialize });
+    registerPortCodec("test-port-output", { serialize, deserialize });
 
     class MyTask extends Task<
       Record<string, unknown>,
@@ -53,7 +44,7 @@ describe("TaskRunner cache port serialization", () => {
       static override outputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-output", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -69,7 +60,7 @@ describe("TaskRunner cache port serialization", () => {
   });
 
   test("cached outputs are deserialized after getOutput", async () => {
-    registerPortCodec("test-port", {
+    registerPortCodec("test-port-cache", {
       serialize: async (v: unknown) => ({ wire: v }),
       deserialize: async (v: unknown) => (v as { wire: unknown }).wire,
     });
@@ -83,7 +74,7 @@ describe("TaskRunner cache port serialization", () => {
       static override outputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-cache", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -103,7 +94,7 @@ describe("TaskRunner cache port serialization", () => {
   });
 
   test("class-instance inputs keyed identically via the registered codec", async () => {
-    registerPortCodec("test-port", {
+    registerPortCodec("test-port-input", {
       serialize: async (v: unknown) => ({ wire: (v as { reveal(): number }).reveal() }),
       deserialize: async (v: unknown) => ({
         reveal: () => (v as { wire: number }).wire,
@@ -131,7 +122,7 @@ describe("TaskRunner cache port serialization", () => {
       static override inputSchema() {
         return {
           type: "object",
-          properties: { thing: { type: "object", format: "test-port", properties: {} } },
+          properties: { thing: { type: "object", format: "test-port-input", properties: {} } },
         } as never;
       }
       override async execute() {
@@ -147,27 +138,18 @@ describe("TaskRunner cache port serialization", () => {
 });
 
 describe("TaskRunner cache key determinism — image codec", () => {
-  test("two GpuImages with identical pixels hit the same cache entry", async () => {
+  test("two ImageValues with identical pixels hit the same cache entry", async () => {
     await import("@workglow/util/media");
-    const { CpuImage } = await import("@workglow/util/media");
+    const { imageValueFromBuffer } = await import("@workglow/util/media");
 
     const repo = new SpyRepo();
-    const bin = {
-      data: new Uint8ClampedArray([1, 2, 3, 255]),
-      width: 1,
-      height: 1,
-      channels: 4 as const,
-    };
-    const a = CpuImage.fromRaw(bin) as unknown as GpuImage;
-    const b = CpuImage.fromRaw({
-      ...bin,
-      data: new Uint8ClampedArray([1, 2, 3, 255]),
-    }) as unknown as GpuImage;
+    const a = imageValueFromBuffer(Buffer.from([1, 2, 3, 255]), "raw-rgba", 1, 1);
+    const b = imageValueFromBuffer(Buffer.from([1, 2, 3, 255]), "raw-rgba", 1, 1);
     expect(a).not.toBe(b);
 
     let calls = 0;
     class ImgKeyTask extends Task<
-      { image: GpuImage } & Record<string, unknown>,
+      { image: ImageValue } & Record<string, unknown>,
       { x: number } & Record<string, unknown>
     > {
       static override readonly type = "ImgKeyTask";

--- a/packages/test/src/test/task-graph/InputResolver.test.ts
+++ b/packages/test/src/test/task-graph/InputResolver.test.ts
@@ -17,6 +17,7 @@ import {
   globalServiceRegistry,
   registerInputResolver,
   setLogger,
+  sleep,
 } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -477,7 +478,7 @@ describe("InputResolver", () => {
 
     test("should support async resolvers", async () => {
       registerInputResolver("async", async (id, format, registry) => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await sleep(10);
         return { asyncResolved: true, id };
       });
 

--- a/packages/test/src/test/task-graph/PortCodecRegistry.test.ts
+++ b/packages/test/src/test/task-graph/PortCodecRegistry.test.ts
@@ -3,14 +3,10 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, beforeEach } from "vitest";
-import { registerPortCodec, getPortCodec, _resetPortCodecsForTests } from "@workglow/task-graph";
+import { getPortCodec, registerPortCodec } from "@workglow/task-graph";
+import { describe, expect, test } from "vitest";
 
 describe("PortCodecRegistry", () => {
-  beforeEach(() => {
-    _resetPortCodecsForTests();
-  });
-
   test("register + get round-trip by exact format", () => {
     const codec = {
       serialize: async (v: unknown) => ({ wrapped: v }),
@@ -25,10 +21,10 @@ describe("PortCodecRegistry", () => {
       serialize: async (v: unknown) => v,
       deserialize: async (v: unknown) => v,
     };
-    registerPortCodec("image", codec);
-    expect(getPortCodec("image")).toBe(codec);
-    expect(getPortCodec("image:data-uri")).toBe(codec);
-    expect(getPortCodec("image:bitmap")).toBe(codec);
+    registerPortCodec("test-image", codec);
+    expect(getPortCodec("test-image")).toBe(codec);
+    expect(getPortCodec("test-image:data-uri")).toBe(codec);
+    expect(getPortCodec("test-image:bitmap")).toBe(codec);
   });
 
   test("unknown format returns undefined", () => {

--- a/packages/test/src/test/task-graph/ProgressEvents.test.ts
+++ b/packages/test/src/test/task-graph/ProgressEvents.test.ts
@@ -6,6 +6,7 @@
 
 import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { Task, TaskAbortedError, TaskStatus } from "@workglow/task-graph";
+import { sleep } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
@@ -111,7 +112,7 @@ describe("Progress events: terminal-100 tick", () => {
       if (progress !== undefined) events.push(progress);
     });
     const runPromise = task.run();
-    await new Promise((r) => setTimeout(r, 10));
+    await sleep(10);
     await task.runner.abort();
     await expect(runPromise).rejects.toThrow();
     expect(events).toContain(100);

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -323,3 +323,39 @@ describe("TaskRunner.run auto-ownership", () => {
     expect(disposed).toEqual(["bare"]);
   });
 });
+
+describe("ResourceScope `await using` integration", () => {
+  it("runner does not dispose; block-scoped `await using` does", async () => {
+    const disposed: string[] = [];
+
+    class UsingScopeTask extends Task<{}, {}> {
+      static override readonly type = "UsingScopeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("using:t1", async () => {
+          disposed.push("t1");
+        });
+        return {};
+      }
+    }
+
+    {
+      await using scope = new ResourceScope();
+      const graph = new TaskGraph();
+      graph.addTask(new UsingScopeTask({ id: "t1" }));
+      await graph.run({}, { resourceScope: scope });
+
+      // Inside the block: runner did NOT dispose. Scope still holds the disposer.
+      expect(scope.size).toBeGreaterThan(0);
+      expect(disposed).toEqual([]);
+    }
+
+    // Block exits → `await using` invokes [Symbol.asyncDispose] → disposeAll runs.
+    expect(disposed).toEqual(["t1"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -359,3 +359,45 @@ describe("ResourceScope `await using` integration", () => {
     expect(disposed).toEqual(["t1"]);
   });
 });
+
+describe("ResourceScope nested-run forwarding under auto-ownership", () => {
+  it("GraphAsTask: outermost runner disposes exactly once", async () => {
+    const disposeCalls: string[] = [];
+
+    class CountingDisposerTask extends Task<{ tag: string }, { tag: string }> {
+      static override readonly type = "CountingDisposerTask";
+      static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { tag: { type: "string", default: "default" } },
+        } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { tag: { type: "string" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(
+        input: { tag: string },
+        ctx: IExecuteContext
+      ): Promise<{ tag: string }> {
+        ctx.resourceScope?.register(`count:${input.tag}`, async () => {
+          disposeCalls.push(input.tag);
+        });
+        return { tag: input.tag };
+      }
+    }
+
+    // Outer graph contains an inner Workflow-as-task, which contains the disposer-registering task.
+    const inner = new Workflow();
+    inner.addTask(CountingDisposerTask, { tag: "nested" });
+    const outer = new TaskGraph();
+    outer.addTask(inner.toTask());
+
+    await outer.run({ tag: "nested" });
+
+    // Disposer must fire exactly once — not once per nested level.
+    expect(disposeCalls).toEqual(["nested"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -167,3 +167,66 @@ describe("ResourceScope AI pattern", () => {
     expect(unloaded).toEqual(["test-model"]);
   });
 });
+
+describe("TaskRunner.run auto-ownership", () => {
+  it("auto-creates and disposes a ResourceScope when none is passed", async () => {
+    const disposed: string[] = [];
+
+    class AutoDisposeTask extends Task<{}, { ok: boolean }> {
+      static override readonly type = "AutoDisposeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{ ok: boolean }> {
+        ctx.resourceScope?.register("auto:bare", async () => {
+          disposed.push("bare");
+        });
+        return { ok: true };
+      }
+    }
+
+    const task = new AutoDisposeTask({ id: "t1" });
+    const result = await task.run({}, {});
+
+    expect(result).toEqual({ ok: true });
+    // Disposal awaited before run() resolves — so the side effect is visible here.
+    expect(disposed).toEqual(["bare"]);
+  });
+
+  it("does not dispose a caller-passed ResourceScope", async () => {
+    const disposed: string[] = [];
+
+    class CallerOwnsTask extends Task<{}, {}> {
+      static override readonly type = "CallerOwnsTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("caller:bare", async () => {
+          disposed.push("bare");
+        });
+        return {};
+      }
+    }
+
+    const scope = new ResourceScope();
+    const task = new CallerOwnsTask({ id: "t1" });
+    await task.run({}, { resourceScope: scope });
+
+    // Runner did NOT dispose — caller still owns the disposer.
+    expect(disposed).toEqual([]);
+    expect(scope.has("caller:bare")).toBe(true);
+
+    await scope.disposeAll();
+    expect(disposed).toEqual(["bare"]);
+  });
+});

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -360,6 +360,76 @@ describe("ResourceScope `await using` integration", () => {
   });
 });
 
+describe("ResourceScope auto-ownership failure paths", () => {
+  it("disposes auto-scope when run is aborted via parentSignal", async () => {
+    const events: string[] = [];
+
+    class HangingResourceTask extends Task<{}, {}> {
+      static override readonly type = "HangingResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("abort:t1", async () => {
+          events.push("disposed");
+        });
+        // Wait for abort
+        await new Promise<void>((resolve, reject) => {
+          ctx.signal.addEventListener("abort", () => reject(new Error("aborted")));
+        });
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new HangingResourceTask({ id: "t1" }));
+    graph.on("abort", () => events.push("abort-event"));
+
+    const ctrl = new AbortController();
+    const runPromise = graph.run({}, { parentSignal: ctrl.signal });
+    // Give the task a tick to register its disposer.
+    await new Promise((r) => setTimeout(r, 10));
+    ctrl.abort();
+
+    await expect(runPromise).rejects.toThrow();
+
+    // Both the abort event and the disposer fired.
+    expect(events).toContain("abort-event");
+    expect(events).toContain("disposed");
+    // Abort event before disposal (handleAbort is awaited in the epilogue).
+    expect(events.indexOf("abort-event")).toBeLessThan(events.indexOf("disposed"));
+  });
+
+  it("resets this.resourceScope even when handleStart rejects (maxTasks)", async () => {
+    class TrivialTask extends Task<{}, {}> {
+      static override readonly type = "TrivialTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(): Promise<{}> {
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new TrivialTask({ id: "a" }));
+    graph.addTask(new TrivialTask({ id: "b" }));
+
+    // maxTasks: 1 forces handleStart to throw before any task runs.
+    await expect(graph.run({}, { maxTasks: 1 })).rejects.toThrow();
+
+    // Subsequent run with no maxTasks should succeed — the previous run's
+    // auto-scope did not leak into the runner instance.
+    await graph.run();
+  });
+});
+
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -363,6 +363,7 @@ describe("ResourceScope `await using` integration", () => {
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];
+    const capturedScopes: ResourceScope[] = [];
 
     class CountingDisposerTask extends Task<{ tag: string }, { tag: string }> {
       static override readonly type = "CountingDisposerTask";
@@ -382,6 +383,7 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
         input: { tag: string },
         ctx: IExecuteContext
       ): Promise<{ tag: string }> {
+        if (ctx.resourceScope) capturedScopes.push(ctx.resourceScope);
         ctx.resourceScope?.register(`count:${input.tag}`, async () => {
           disposeCalls.push(input.tag);
         });
@@ -399,5 +401,58 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
 
     // Disposer must fire exactly once — not once per nested level.
     expect(disposeCalls).toEqual(["nested"]);
+    // All task executions must see the same scope identity (correct forwarding).
+    expect(new Set(capturedScopes).size).toBe(1);
+  });
+
+  it("MapTask iteration: scope persists across iterations, disposes once at end", async () => {
+    const disposeCalls: string[] = [];
+    const capturedScopes: ResourceScope[] = [];
+
+    class IteratingDisposerTask extends Task<{ item: number }, { item: number }> {
+      static override readonly type = "IteratingDisposerTask";
+      static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { item: { type: "number" } },
+          required: ["item"],
+          additionalProperties: true,
+        } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { item: { type: "number" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(
+        input: { item: number },
+        ctx: IExecuteContext
+      ): Promise<{ item: number }> {
+        if (ctx.resourceScope) capturedScopes.push(ctx.resourceScope);
+        // Same key across all 3 iterations. With one shared scope (correct
+        // forwarding), first-registration-wins keeps only the first; with
+        // per-iteration scopes (broken forwarding), each iteration's scope
+        // gets its own copy and disposes at iteration end → 3 entries.
+        ctx.resourceScope?.register("model:shared", async () => {
+          disposeCalls.push("disposed");
+        });
+        return { item: input.item };
+      }
+    }
+
+    const workflow = new Workflow();
+    workflow
+      .map({ maxIterations: "unbounded", concurrencyLimit: 1 })
+      .addTask(IteratingDisposerTask)
+      .endMap();
+
+    await workflow.run({ item: [1, 2, 3] });
+
+    // First-registration-wins held → exactly one disposer fired.
+    expect(disposeCalls).toEqual(["disposed"]);
+    // All 3 iterations saw the same scope identity → forwarding works.
+    expect(capturedScopes).toHaveLength(3);
+    expect(new Set(capturedScopes).size).toBe(1);
   });
 });

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -231,6 +231,36 @@ describe("TaskGraphRunner.runGraph auto-ownership", () => {
   });
 });
 
+describe("TaskGraphRunner terminal-event ordering", () => {
+  it("emits 'error' event before auto-disposal fires", async () => {
+    const events: string[] = [];
+
+    class FailingResourceTask extends Task<{}, {}> {
+      static override readonly type = "FailingResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("order:failing", async () => {
+          events.push("disposed");
+        });
+        throw new Error("intentional failure");
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new FailingResourceTask({ id: "t1" }));
+    graph.on("error", () => events.push("error-event"));
+
+    await expect(graph.run()).rejects.toThrow("intentional failure");
+
+    expect(events).toEqual(["error-event", "disposed"]);
+  });
+});
+
 describe("TaskRunner.run auto-ownership", () => {
   it("auto-creates and disposes a ResourceScope when none is passed", async () => {
     const disposed: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "vitest";
-import { ResourceScope } from "@workglow/util";
 import { IExecuteContext, Task, TaskGraph, Workflow } from "@workglow/task-graph";
+import { ResourceScope } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
 
 // A task that registers a disposer on the resource scope
 class ResourceAcquiringTask extends Task<{ name: string }, { name: string }> {
@@ -363,6 +363,10 @@ describe("ResourceScope `await using` integration", () => {
 describe("ResourceScope auto-ownership failure paths", () => {
   it("disposes auto-scope when run is aborted via parentSignal", async () => {
     const events: string[] = [];
+    let registered: () => void;
+    const registeredPromise = new Promise<void>((r) => {
+      registered = r;
+    });
 
     class HangingResourceTask extends Task<{}, {}> {
       static override readonly type = "HangingResourceTask";
@@ -376,8 +380,11 @@ describe("ResourceScope auto-ownership failure paths", () => {
         ctx.resourceScope?.register("abort:t1", async () => {
           events.push("disposed");
         });
-        // Wait for abort
-        await new Promise<void>((resolve, reject) => {
+        // Signal that registration is complete — replaces a wall-clock sleep
+        // so the abort fires deterministically AFTER the disposer is in the Map,
+        // regardless of how busy the test runner is.
+        registered();
+        await new Promise<void>((_resolve, reject) => {
           ctx.signal.addEventListener("abort", () => reject(new Error("aborted")));
         });
         return {};
@@ -390,8 +397,7 @@ describe("ResourceScope auto-ownership failure paths", () => {
 
     const ctrl = new AbortController();
     const runPromise = graph.run({}, { parentSignal: ctrl.signal });
-    // Give the task a tick to register its disposer.
-    await new Promise((r) => setTimeout(r, 10));
+    await registeredPromise;
     ctrl.abort();
 
     await expect(runPromise).rejects.toThrow();
@@ -559,5 +565,116 @@ describe("ResourceScope nested-run forwarding under auto-ownership", () => {
     // All 3 iterations saw the same scope identity → forwarding works.
     expect(capturedScopes).toHaveLength(3);
     expect(new Set(capturedScopes).size).toBe(1);
+  });
+});
+
+describe("ResourceScope auto-ownership does not leak through context.own()", () => {
+  it("auto-owned scope is not stamped into owned tasks' runConfig", async () => {
+    const disposed: string[] = [];
+
+    class ChildResourceTask extends Task<{}, {}> {
+      static override readonly type = "ChildResourceTaskOwn";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("child:resource", async () => {
+          disposed.push("child");
+        });
+        return {};
+      }
+    }
+
+    let ownedChild: ChildResourceTask | undefined;
+
+    class ParentTask extends Task<{}, {}> {
+      static override readonly type = "ParentOwnTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        // Just adopt — don't run it. We want to inspect the stamped runConfig.
+        ownedChild = ctx.own(new ChildResourceTask({ id: "child" }));
+        return {};
+      }
+    }
+
+    const parent = new ParentTask({ id: "parent" });
+    await parent.run();
+
+    // Parent's auto-scope was disposed in `finally`. The owned child must NOT
+    // hold a reference to that disposed scope — otherwise its next `task.run()`
+    // would skip auto-create and silently drop disposers on a cleared Map.
+    expect(ownedChild).toBeDefined();
+    expect(ownedChild!.runConfig?.resourceScope).toBeUndefined();
+
+    // Running the orphaned child should still work end-to-end: it auto-creates
+    // its own fresh scope and disposes it cleanly.
+    await ownedChild!.run();
+    expect(disposed).toEqual(["child"]);
+  });
+
+  it("caller-passed scope IS still propagated through own() (preserves resource sharing)", async () => {
+    const disposed: string[] = [];
+    const callerScope = new ResourceScope();
+
+    class ChildSharedTask extends Task<{}, {}> {
+      static override readonly type = "ChildSharedTaskOwn";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("shared:resource", async () => {
+          disposed.push("shared");
+        });
+        return {};
+      }
+    }
+
+    let ownedChild: ChildSharedTask | undefined;
+
+    class ParentSharedTask extends Task<{}, {}> {
+      static override readonly type = "ParentSharedOwnTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ownedChild = ctx.own(new ChildSharedTask({ id: "child" }));
+        // Run the owned child synchronously inside the parent run. The child
+        // pulls `resourceScope` from its (just-stamped) runConfig — so its
+        // disposer must land on the caller's scope, not on a per-child
+        // auto-scope that would be disposed when the child returns.
+        await ownedChild.run();
+        return {};
+      }
+    }
+
+    const parent = new ParentSharedTask({ id: "parent" });
+    await parent.run({}, { resourceScope: callerScope });
+
+    // Caller-passed scope IS propagated — owned child's runConfig points at it
+    // so that a follow-up `task.run()` on the child shares the same scope and
+    // benefits from first-registration-wins / shared-model semantics.
+    expect(ownedChild).toBeDefined();
+    expect(ownedChild!.runConfig?.resourceScope).toBe(callerScope);
+    // The child's disposer landed on the caller's scope, not a per-run scope.
+    expect(callerScope.has("shared:resource")).toBe(true);
+
+    // Caller still owns disposal — runner did not dispose at parent's exit.
+    expect(disposed).toEqual([]);
+    await callerScope.disposeAll();
+    expect(disposed).toEqual(["shared"]);
   });
 });

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -168,6 +168,69 @@ describe("ResourceScope AI pattern", () => {
   });
 });
 
+describe("TaskGraphRunner.runGraph auto-ownership", () => {
+  it("auto-creates and disposes a ResourceScope when none is passed", async () => {
+    const disposed: string[] = [];
+
+    class GraphAutoDisposeTask extends Task<{}, { name: string }> {
+      static override readonly type = "GraphAutoDisposeTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: { name: { type: "string" } },
+        } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{ name: string }> {
+        ctx.resourceScope?.register("auto:graph", async () => {
+          disposed.push("graph");
+        });
+        return { name: "ok" };
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new GraphAutoDisposeTask({ id: "t1" }));
+    await graph.run();
+
+    // Auto-disposal awaited before graph.run() resolves.
+    expect(disposed).toEqual(["graph"]);
+  });
+
+  it("does not dispose a caller-passed ResourceScope", async () => {
+    const disposed: string[] = [];
+
+    class CallerOwnsGraphTask extends Task<{}, {}> {
+      static override readonly type = "CallerOwnsGraphTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("caller:graph", async () => {
+          disposed.push("graph");
+        });
+        return {};
+      }
+    }
+
+    const scope = new ResourceScope();
+    const graph = new TaskGraph();
+    graph.addTask(new CallerOwnsGraphTask({ id: "t1" }));
+    await graph.run({}, { resourceScope: scope });
+
+    expect(disposed).toEqual([]);
+    expect(scope.has("caller:graph")).toBe(true);
+
+    await scope.disposeAll();
+    expect(disposed).toEqual(["graph"]);
+  });
+});
+
 describe("TaskRunner.run auto-ownership", () => {
   it("auto-creates and disposes a ResourceScope when none is passed", async () => {
     const disposed: string[] = [];

--- a/packages/test/src/test/task-graph/ResourceScope.test.ts
+++ b/packages/test/src/test/task-graph/ResourceScope.test.ts
@@ -430,6 +430,41 @@ describe("ResourceScope auto-ownership failure paths", () => {
   });
 });
 
+describe("runPreview does not auto-create a ResourceScope", () => {
+  it("runGraphPreview leaves resourceScope undefined and does not call disposers", async () => {
+    const previewSawScope: boolean[] = [];
+
+    class PreviewResourceTask extends Task<{}, {}> {
+      static override readonly type = "PreviewResourceTask";
+      static override inputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      static override outputSchema(): DataPortSchema {
+        return { type: "object", properties: {} } as const satisfies DataPortSchema;
+      }
+      override async execute(_input: {}, ctx: IExecuteContext): Promise<{}> {
+        ctx.resourceScope?.register("preview:t1", async () => {});
+        return {};
+      }
+      // Note: IExecutePreviewContext = Pick<IExecuteContext, "own"> — no resourceScope.
+      // The point of this test is that runPreview() does not throw and does not
+      // attempt to auto-create or thread a scope.
+      override async executePreview(): Promise<{}> {
+        // Can't observe ctx.resourceScope because IExecutePreviewContext excludes it.
+        // Record that executePreview ran at all (scope tracking is done externally).
+        previewSawScope.push(false); // always false: preview context has no resourceScope
+        return {};
+      }
+    }
+
+    const graph = new TaskGraph();
+    graph.addTask(new PreviewResourceTask({ id: "t1" }));
+    await graph.runPreview();
+
+    expect(previewSawScope).toEqual([false]);
+  });
+});
+
 describe("ResourceScope nested-run forwarding under auto-ownership", () => {
   it("GraphAsTask: outermost runner disposes exactly once", async () => {
     const disposeCalls: string[] = [];

--- a/packages/test/src/test/task-graph/RunPreviewStream.test.ts
+++ b/packages/test/src/test/task-graph/RunPreviewStream.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "vitest";
 import { Dataflow, Task, Workflow, type StreamEvent } from "@workglow/task-graph";
+import { sleep } from "@workglow/util";
+import { describe, expect, it } from "vitest";
 
 class SyntheticStreamSource extends Task<{ trigger: number }, { value: number }> {
   public static override type = "SyntheticStreamSource";
@@ -27,7 +28,7 @@ class SyntheticStreamSource extends Task<{ trigger: number }, { value: number }>
   async *executeStream(): AsyncIterable<StreamEvent<{ value: number }>> {
     for (let i = 1; i <= 3; i++) {
       yield { type: "snapshot", data: { value: i } };
-      await new Promise((r) => setTimeout(r, 5));
+      await sleep(5);
     }
     yield { type: "finish", data: {} as { value: number } };
   }

--- a/packages/test/src/test/task/ArrayTask.test.ts
+++ b/packages/test/src/test/task/ArrayTask.test.ts
@@ -600,13 +600,7 @@ describe("ArrayTask", () => {
       expect(task.completedAt).toBeDefined();
     });
 
-    // Manually trigger a progress event before running the task
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleStart();
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleProgress(0.5);
-
-    // Run the task
+    // Run the task — it emits start/progress/complete on its own.
     const results = await task.run();
 
     // Verify events were emitted
@@ -669,21 +663,8 @@ describe("ArrayTask", () => {
       });
     });
 
-    // Manually trigger progress events
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleStart();
-    // @ts-expect-error - we are testing the protected method
-    task.runner.handleProgress(0.5);
-
-    // Manually trigger progress events on child tasks
-    task.subGraph!.getTasks().forEach((childTask: ITask) => {
-      // @ts-expect-error - we are testing the protected method
-      childTask.runner.handleStart();
-      // @ts-expect-error - we are testing the protected method
-      childTask.runner.handleProgress(0.5);
-    });
-
-    // Run the task
+    // Run the task — start/progress/complete events fire on parent and children
+    // through the normal run path.
     await task.run();
 
     // Verify parent events were emitted

--- a/packages/test/src/test/task/ImageOp.test.ts
+++ b/packages/test/src/test/task/ImageOp.test.ts
@@ -3,14 +3,9 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { describe, expect, test, vi } from "vitest";
-import {
-  registerFilterOp,
-  applyFilter,
-  hasFilterOp,
-  _resetFilterRegistryForTests,
-} from "@workglow/tasks";
+import { applyFilter, hasFilterOp, registerFilterOp } from "@workglow/tasks";
 import { CpuImage, type GpuImage } from "@workglow/util/media";
+import { describe, expect, test, vi } from "vitest";
 
 describe("applyFilter", () => {
   test("dispatches to the registered cpu fn for CpuImage", () => {
@@ -54,14 +49,16 @@ describe("applyFilter", () => {
 
 describe("hasFilterOp", () => {
   test("returns false when no op registered for (backend, filter)", () => {
-    _resetFilterRegistryForTests();
     expect(hasFilterOp("webgpu", "__nope__")).toBe(false);
   });
 
   test("returns true after registerFilterOp for that key", () => {
-    _resetFilterRegistryForTests();
     registerFilterOp<undefined>("webgpu", "__yes__", (img) => img);
     expect(hasFilterOp("webgpu", "__yes__")).toBe(true);
     expect(hasFilterOp("cpu", "__yes__")).toBe(false);
+  });
+
+  test("keeps built-in task filter registrations available", () => {
+    expect(hasFilterOp("cpu", "sepia")).toBe(true);
   });
 });

--- a/packages/test/src/test/task/IteratorTask.test.ts
+++ b/packages/test/src/test/task/IteratorTask.test.ts
@@ -885,7 +885,7 @@ describe("IteratorTask", () => {
         }
 
         override async execute(input: { item: number }): Promise<{ item: number }> {
-          await new Promise((resolve) => setTimeout(resolve, (4 - input.item) * 5));
+          await sleep((4 - input.item) * 5);
           return { item: input.item };
         }
       }

--- a/packages/test/src/test/task/SingleTask.test.ts
+++ b/packages/test/src/test/task/SingleTask.test.ts
@@ -4,11 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Task, TaskAbortedError, TaskError, TaskStatus } from "@workglow/task-graph";
+import {
+  Task,
+  TaskAbortedError,
+  TaskConfigurationError,
+  TaskError,
+  TaskStatus,
+} from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
-import { EventTestTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
+import { EventTestTask, LongRunningTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
 
 const spyOn = vi.spyOn;
 
@@ -620,6 +626,35 @@ describe("SingleTask", () => {
         await runPromise.catch(() => {});
         expect(task.status).toBe(TaskStatus.ABORTING);
       });
+    });
+  });
+
+  describe("Concurrent run() rejection", () => {
+    it("throws TaskConfigurationError when run() is called while the task is PROCESSING", async () => {
+      const task = new LongRunningTask();
+      const inflight = task.run();
+      // Yield so handleStart sets status to PROCESSING and the execute loop is parked.
+      await sleep(0);
+      expect(task.status).toBe(TaskStatus.PROCESSING);
+
+      await expect(task.run()).rejects.toBeInstanceOf(TaskConfigurationError);
+
+      task.abort();
+      await inflight.catch(() => {});
+    });
+
+    it("does not disturb the in-flight run when a concurrent run() is rejected", async () => {
+      const task = new EventTestTask();
+      task.delayMs = 30;
+      const inflight = task.run();
+      await sleep(0);
+      expect(task.status).toBe(TaskStatus.PROCESSING);
+
+      await expect(task.run()).rejects.toBeInstanceOf(TaskConfigurationError);
+
+      const result = await inflight;
+      expect(result).toEqual({ key: "default", previewOnly: false, all: true });
+      expect(task.status).toBe(TaskStatus.COMPLETED);
     });
   });
 });

--- a/packages/test/src/test/task/SingleTask.test.ts
+++ b/packages/test/src/test/task/SingleTask.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { Task, TaskAbortedError, TaskError, TaskStatus } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { setLogger, sleep } from "@workglow/util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 import { EventTestTask, SimpleProcessingTask, TestIOTask } from "./TestTasks";
@@ -502,7 +502,7 @@ describe("SingleTask", () => {
         const runPromise = task.run();
 
         // Wait a bit to ensure progress event has time to fire
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await sleep(10);
 
         task.abort();
         await runPromise.catch(() => {});

--- a/scripts/test.test.ts
+++ b/scripts/test.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, test } from "bun:test";
+
+describe("scripts/test.ts", () => {
+  test("unit bun dry-run omits integration files and empty argv entries", async () => {
+    const proc = Bun.spawn(["bun", "scripts/test.ts", "unit", "bun", "--dry-run"], {
+      cwd: import.meta.dir + "/..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"bun","test"');
+    expect(stdout).not.toContain('""');
+    expect(stdout).not.toContain(".integration.test.ts");
+  });
+});

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -104,6 +104,7 @@ Runners:  ${KNOWN_RUNNERS.join(", ")} (default: both)
 
 Options:
   --all          Run full suite (bun + vitest, no filters, very slow)
+  --dry-run      Print runner commands without executing them
   --help         Show this usage message
 
 Examples:
@@ -166,21 +167,11 @@ function collectFiles(
 }
 
 async function runBunTest(files: string[]): Promise<number> {
-  const parallelFlag =
-    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
-      ? "--parallel=1"
-      : "--parallel";
-  // Match vitest's testTimeout: Bun's default is 5s per test, which is easy to exceed in HF/Sqlite work
-  const timeoutFlag = "--timeout=15000";
-  const proc = Bun.spawn(
-    files.length > 0
-      ? ["bun", "test", timeoutFlag, parallelFlag, ...files]
-      : ["bun", "test", timeoutFlag, parallelFlag],
-    {
-      cwd: ROOT,
-      stdio: ["inherit", "inherit", "inherit"],
-    }
-  );
+  const args = buildBunTestArgs(files);
+  const proc = Bun.spawn(args, {
+    cwd: ROOT,
+    stdio: ["inherit", "inherit", "inherit"],
+  });
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
     console.error(`Bun test failed with exit code ${exitCode}`);
@@ -188,7 +179,18 @@ async function runBunTest(files: string[]): Promise<number> {
   return exitCode;
 }
 
-async function runVitest(files: string[]): Promise<number> {
+function buildBunTestArgs(files: string[]): string[] {
+  const parallelFlag: string =
+    files.length > 0 && shouldRunLlamaCppIntegrationFilesSequentially(files)
+      ? "--parallel=1"
+      : "--parallel";
+  // Match vitest's testTimeout: Bun's default is 5s per test, which is easy to exceed in HF/Sqlite work
+  const timeoutFlag = "--timeout=15000";
+  const flags = [timeoutFlag, parallelFlag].filter((flag) => flag.length > 0);
+  return files.length > 0 ? ["bun", "test", ...flags, ...files] : ["bun", "test", ...flags];
+}
+
+function buildVitestArgs(files: string[]): string[] {
   // When no file filter: run all. Otherwise pass relative paths as name filters.
   const relFiles = files.length > 0 ? files.map((f) => relative(ROOT, f)) : [];
   const args = ["npx", "vitest", "run", ...relFiles];
@@ -198,6 +200,11 @@ async function runVitest(files: string[]): Promise<number> {
   if (process.env.CI) {
     args.push("--coverage");
   }
+  return args;
+}
+
+async function runVitest(files: string[]): Promise<number> {
+  const args = buildVitestArgs(files);
   const proc = Bun.spawn(args, {
     cwd: ROOT,
     stdio: ["inherit", "inherit", "inherit"],
@@ -219,7 +226,8 @@ if (rawArgs.includes("--help")) {
 }
 
 const runAll = rawArgs.includes("--all");
-const filteredArgs = rawArgs.filter((a) => a !== "--all");
+const dryRun = rawArgs.includes("--dry-run");
+const filteredArgs = rawArgs.filter((a) => a !== "--all" && a !== "--dry-run");
 
 if (!runAll && filteredArgs.length === 0) {
   showHelp();
@@ -274,6 +282,16 @@ const kindLabel = kinds.length > 0 ? kinds.join("+") : "all";
 const sectionLabel = sections.length > 0 ? sections.join("+") : "all";
 const fileCount = files.length > 0 ? `${files.length} file(s)` : "all files";
 console.log(`\nRunning ${kindLabel} tests in sections [${sectionLabel}] — ${fileCount}\n`);
+
+if (dryRun) {
+  if (!vitestOnly) {
+    console.log(JSON.stringify(buildBunTestArgs(files)));
+  }
+  if (!bunOnly) {
+    console.log(JSON.stringify(buildVitestArgs(files)));
+  }
+  process.exit(0);
+}
 
 // ── Execute ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Top-level runners (`TaskGraphRunner.runGraph`, `TaskRunner.run`) now auto-create + dispose a private `ResourceScope` when the caller didn't pass one. Closes the gap where casual callers of `graph.run()` / `task.run()` would silently leak heavyweight resources (model unload, AI session disposal, browser disconnect) because tasks like `AiTask` / `AiChatTask` / `ToolCallingTask` / `BrowserSessionTask` only register disposers when the scope is defined.

- **No scope passed:** runner allocates a private scope, threads it as today, `disposeAll()`s in a `finally` block before the run resolves or throws — automatic cleanup with zero ceremony.
- **Scope passed:** runner does not touch lifecycle (expert escape hatch — share a model across many runs, dispose at app shutdown).
- **Nested runs** (`GraphAsTask`, `IteratorTask`, `runTask`, `subGraph.run`) keep forwarding `this.resourceScope` unchanged — child runners observe a defined scope and skip auto-creation. Single source of ownership at the top of the call stack.
- **Preview runs** (`runPreview`) intentionally untouched — previews are lightweight.

Includes a piggyback fix: `await this.handleError(latestError)` at `TaskGraphRunner.ts:217` (was fire-and-forget while `handleAbort` was awaited) so the "events before disposal" invariant holds on the failed-task path. Symmetric with `handleAbort`.

**Spec:** `builder/docs/superpowers/specs/2026-05-03-resource-scope-auto-ownership-design.md`
**Plan:** `builder/docs/superpowers/plans/2026-05-03-resource-scope-auto-ownership.md`

## Commits (10)

1. `1d0f28bc` feat: TaskRunner.run auto-creates ResourceScope
2. `1d2d9bdf` feat: TaskGraphRunner.runGraph auto-creates ResourceScope
3. `f9d51018` fix: await handleError in runGraph epilogue
4. `043d2092` test: \`await using\` regression for caller-passed scope
5. `c33f0ce5` test: nested-run forwarding (GraphAsTask)
6. `bb9a8b32` test: strengthen + add iterator/MapTask coverage
7. `3ea43091` test: failure paths (abort + handleStart-rejection)
8. `1b3136f2` test: runPreview unchanged smoke test
9. `604718f0` docs: JSDoc updates on public surface
10. `042715ec` docs: technical guide paragraph

## Test plan

- [x] \`bun scripts/test.ts graph vitest\` — 46 files, 580 tests pass (+11 new tests for ResourceScope coverage)
- [x] \`bun scripts/test.ts ai vitest\` — 12 files, 63 tests pass (sanity check that AiTask/AiChatTask still work — they now reliably register disposers since the scope is always defined)
- [x] \`bun run build:types\` — 24/24 packages clean
- [ ] Reviewer: confirm forwarding sites unchanged (`runTask` lines 422/443/492/511, `GraphAsTaskRunner.ts:41`, `IteratorTaskRunner.ts:291`, `Workflow.run`)
- [ ] Reviewer: spot-check the `await this.handleError` change at `TaskGraphRunner.ts:217` and the new ordering test (`error` event before `disposed`)

## Notes

- Targets \`refactor-taskgraph-runner\` for clean stacking — that branch has its own decompose-runner work in flight. Retarget to \`main\` if/when \`refactor-taskgraph-runner\` lands first.
- Known limitation kept out of scope: the abort-signal listener fires \`handleAbort\` fire-and-forget. If an external abort fires mid-run, the listener-driven \`handleAbort\` may still be awaiting task aborts when \`finally\` calls \`disposeAll\`. Documented in the spec ("Known limitation"); fix requires \`RunContext\` surgery.
- One non-ResourceScope commit may appear in the diff against \`refactor-taskgraph-runner\` (\`07602ca1 test: bun 1.3.13 panics often and makes tests slow\`) — appears to be a parallel-SHA of the same change on the parent branch and should resolve as identical when \`refactor-taskgraph-runner\` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)