### PR TITLE
refactor(storage): real migrations + shared SQL builder + vector index tuning

### DIFF
--- a/packages/test/src/contract/README.md
+++ b/packages/test/src/contract/README.md
@@ -67,6 +67,7 @@ Treat both as additional examples of the pattern.
 | Contract | Suite | Adapters |
 |---|---|---|
 | `AiProvider` | `contract/ai-provider/runAiProviderConformance` | Anthropic, OpenAI, Gemini, Ollama, HF Inference, HF Transformers, LlamaCpp |
+| `IMigrationRunner` | `contract/storage-migrations/runMigrationRunnerContract` | Postgres, SQLite, IndexedDB |
 | `IQueueStorage` + `IRateLimiterStorage` | `test/job-queue/genericJobQueueTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase |
 | `ITabularStorage` | `test/storage-tabular/genericTabularStorageTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase, FsFolder, HuggingFace |
 

--- a/packages/test/src/contract/storage-migrations/assertions/appliesAndRecords.ts
+++ b/packages/test/src/contract/storage-migrations/assertions/appliesAndRecords.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { itExpectFail } from "../../ai-provider/assertions/itExpectFail";
+import {
+  createMigrationCallRecorder,
+  type MigrationContractHandle,
+  type MigrationRunnerContractOpts,
+} from "../types";
+
+export function appliesAndRecordsBlock<DB>(
+  opts: MigrationRunnerContractOpts<DB>,
+  getHandle: () => MigrationContractHandle<DB>
+): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("appliesAndRecords") ? itExpectFail : it;
+
+  describe("Applies and records", () => {
+    itImpl(
+      "first run applies all migrations in (component, version) order and records each version",
+      async () => {
+        const handle = getHandle();
+        const runner = await handle.createRunner();
+        const recorder = createMigrationCallRecorder();
+        const component = `contract-applies-${Date.now()}`;
+        const migrations = [
+          handle.buildMigration(component, 2, recorder),
+          handle.buildMigration(component, 1, recorder),
+          handle.buildMigration(component, 3, recorder),
+        ];
+
+        const applied = await runner.run(migrations);
+
+        expect(applied.length).toBe(3);
+        expect(applied.map((m) => m.version)).toEqual([1, 2, 3]);
+        expect(recorder.calls.map((c) => c.version)).toEqual([1, 2, 3]);
+        const recordedVersions = await runner.appliedVersions(component);
+        expect([...recordedVersions].sort()).toEqual([1, 2, 3]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/storage-migrations/assertions/ensureBookkeepingIdempotent.ts
+++ b/packages/test/src/contract/storage-migrations/assertions/ensureBookkeepingIdempotent.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { itExpectFail } from "../../ai-provider/assertions/itExpectFail";
+import type { MigrationContractHandle, MigrationRunnerContractOpts } from "../types";
+
+export function ensureBookkeepingIdempotentBlock<DB>(
+  opts: MigrationRunnerContractOpts<DB>,
+  getHandle: () => MigrationContractHandle<DB>
+): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("ensureBookkeepingIdempotent") ? itExpectFail : it;
+
+  describe("Ensure bookkeeping idempotent", () => {
+    itImpl(
+      "calling ensureBookkeepingTable twice does not throw",
+      async () => {
+        const runner = await getHandle().createRunner();
+        await runner.ensureBookkeepingTable();
+        await expect(runner.ensureBookkeepingTable()).resolves.toBeUndefined();
+      },
+      opts.timeout
+    );
+
+    itImpl(
+      "appliedVersions on a never-touched component returns an empty set",
+      async () => {
+        const runner = await getHandle().createRunner();
+        await runner.ensureBookkeepingTable();
+        const seen = await runner.appliedVersions(`never-touched-${Date.now()}`);
+        expect(seen.size).toBe(0);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/storage-migrations/assertions/failedMigrationNotRecorded.ts
+++ b/packages/test/src/contract/storage-migrations/assertions/failedMigrationNotRecorded.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { itExpectFail } from "../../ai-provider/assertions/itExpectFail";
+import {
+  createMigrationCallRecorder,
+  type MigrationContractHandle,
+  type MigrationRunnerContractOpts,
+} from "../types";
+
+export function failedMigrationNotRecordedBlock<DB>(
+  opts: MigrationRunnerContractOpts<DB>,
+  getHandle: () => MigrationContractHandle<DB>
+): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("failedMigrationNotRecorded") ? itExpectFail : it;
+
+  describe("Failed migration not recorded", () => {
+    itImpl(
+      "when up() throws, the failed migration's version is not recorded and a re-run with a healthy version applies it",
+      async () => {
+        const handle = getHandle();
+        const runner = await handle.createRunner();
+        const recorder = createMigrationCallRecorder();
+        const component = `contract-failure-${Date.now()}`;
+
+        // First migration succeeds; second migration is configured to throw.
+        const v1 = handle.buildMigration(component, 1, recorder);
+        const v2Failing = handle.buildMigration(component, 2, recorder, { fail: true });
+
+        await expect(runner.run([v1, v2Failing])).rejects.toThrow();
+
+        // The failed version MUST NOT be recorded (otherwise retry is
+        // impossible). Whether v1 is recorded depends on per-migration
+        // versus per-batch atomicity — Postgres commits each migration
+        // independently, while IndexedDB rolls back the entire upgrade
+        // transaction. Both behaviors are spec-compliant; the contract
+        // only requires that the failed version stays absent.
+        const afterFailure = await runner.appliedVersions(component);
+        expect(afterFailure.has(2)).toBe(false);
+
+        // Re-running with a non-failing v2 must converge to the full
+        // applied set [1, 2] regardless of which atomicity style the
+        // adapter uses.
+        recorder.clear();
+        const v2Recovered = handle.buildMigration(component, 2, recorder);
+        const applied = await runner.run([v1, v2Recovered]);
+        expect(applied.length).toBeGreaterThanOrEqual(1);
+        expect(applied.some((m) => m.version === 2)).toBe(true);
+
+        const finalVersions = await runner.appliedVersions(component);
+        expect([...finalVersions].sort()).toEqual([1, 2]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/storage-migrations/assertions/idempotentRun.ts
+++ b/packages/test/src/contract/storage-migrations/assertions/idempotentRun.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { itExpectFail } from "../../ai-provider/assertions/itExpectFail";
+import {
+  createMigrationCallRecorder,
+  type MigrationContractHandle,
+  type MigrationRunnerContractOpts,
+} from "../types";
+
+export function idempotentRunBlock<DB>(
+  opts: MigrationRunnerContractOpts<DB>,
+  getHandle: () => MigrationContractHandle<DB>
+): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("idempotentRun") ? itExpectFail : it;
+
+  describe("Idempotent run", () => {
+    itImpl(
+      "second run with the same migration set applies nothing and re-invokes no up()",
+      async () => {
+        const handle = getHandle();
+        const runner = await handle.createRunner();
+        const recorder = createMigrationCallRecorder();
+        const component = `contract-idempotent-${Date.now()}`;
+        const migrations = [
+          handle.buildMigration(component, 1, recorder),
+          handle.buildMigration(component, 2, recorder),
+        ];
+
+        const firstApplied = await runner.run(migrations);
+        expect(firstApplied.length).toBe(2);
+        expect(recorder.calls.length).toBe(2);
+
+        recorder.clear();
+        const secondApplied = await runner.run(migrations);
+        expect(secondApplied.length).toBe(0);
+        expect(recorder.calls.length).toBe(0);
+
+        // Bookkeeping table still reports both versions.
+        const recordedVersions = await runner.appliedVersions(component);
+        expect([...recordedVersions].sort()).toEqual([1, 2]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/storage-migrations/assertions/incrementalApplication.ts
+++ b/packages/test/src/contract/storage-migrations/assertions/incrementalApplication.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { itExpectFail } from "../../ai-provider/assertions/itExpectFail";
+import {
+  createMigrationCallRecorder,
+  type MigrationContractHandle,
+  type MigrationRunnerContractOpts,
+} from "../types";
+
+export function incrementalApplicationBlock<DB>(
+  opts: MigrationRunnerContractOpts<DB>,
+  getHandle: () => MigrationContractHandle<DB>
+): void {
+  const expectFails = new Set(opts.expectedFailures ?? []);
+  const itImpl = expectFails.has("incrementalApplication") ? itExpectFail : it;
+
+  describe("Incremental application", () => {
+    itImpl(
+      "adding a new version to an already-migrated component runs only the new version",
+      async () => {
+        const handle = getHandle();
+        const runner = await handle.createRunner();
+        const recorder = createMigrationCallRecorder();
+        const component = `contract-incremental-${Date.now()}`;
+
+        await runner.run([
+          handle.buildMigration(component, 1, recorder),
+          handle.buildMigration(component, 2, recorder),
+        ]);
+        expect(recorder.calls.length).toBe(2);
+
+        recorder.clear();
+        const applied = await runner.run([
+          handle.buildMigration(component, 1, recorder),
+          handle.buildMigration(component, 2, recorder),
+          handle.buildMigration(component, 3, recorder),
+        ]);
+
+        expect(applied.length).toBe(1);
+        expect(applied[0].version).toBe(3);
+        expect(recorder.calls.length).toBe(1);
+        expect(recorder.calls[0].version).toBe(3);
+
+        const recordedVersions = await runner.appliedVersions(component);
+        expect([...recordedVersions].sort()).toEqual([1, 2, 3]);
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/storage-migrations/runMigrationRunnerContract.ts
+++ b/packages/test/src/contract/storage-migrations/runMigrationRunnerContract.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe } from "vitest";
+
+import { appliesAndRecordsBlock } from "./assertions/appliesAndRecords";
+import { ensureBookkeepingIdempotentBlock } from "./assertions/ensureBookkeepingIdempotent";
+import { failedMigrationNotRecordedBlock } from "./assertions/failedMigrationNotRecorded";
+import { idempotentRunBlock } from "./assertions/idempotentRun";
+import { incrementalApplicationBlock } from "./assertions/incrementalApplication";
+import type { MigrationContractHandle, MigrationRunnerContractOpts } from "./types";
+
+export function runMigrationRunnerContract<DB>(opts: MigrationRunnerContractOpts<DB>): void {
+  describe.skipIf(opts.skip)(`Migration runner contract: ${opts.name}`, () => {
+    let handle: MigrationContractHandle<DB> | undefined;
+    const getHandle = (): MigrationContractHandle<DB> => {
+      if (!handle) throw new Error("migration contract handle not initialized");
+      return handle;
+    };
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle) await handle.dispose();
+    });
+
+    ensureBookkeepingIdempotentBlock(opts, getHandle);
+    appliesAndRecordsBlock(opts, getHandle);
+    idempotentRunBlock(opts, getHandle);
+    incrementalApplicationBlock(opts, getHandle);
+    failedMigrationNotRecordedBlock(opts, getHandle);
+  });
+}
+
+export type {
+  BuildMigrationFn,
+  BuildMigrationOptions,
+  MigrationCallRecorder,
+  MigrationContractHandle,
+  MigrationRunnerContractOpts,
+} from "./types";
+export { createMigrationCallRecorder } from "./types";

--- a/packages/test/src/contract/storage-migrations/types.ts
+++ b/packages/test/src/contract/storage-migrations/types.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMigration, IMigrationRunner } from "@workglow/storage";
+
+/**
+ * Records each invocation of a migration's `up()` callback. The contract
+ * suite uses this to verify which migrations actually ran (orthogonal to
+ * the runner's own bookkeeping table).
+ */
+export interface MigrationCallRecorder {
+  readonly calls: ReadonlyArray<{ readonly component: string; readonly version: number }>;
+  readonly record: (component: string, version: number) => void;
+  readonly clear: () => void;
+}
+
+export function createMigrationCallRecorder(): MigrationCallRecorder {
+  const calls: { component: string; version: number }[] = [];
+  return {
+    get calls() {
+      return calls;
+    },
+    record: (component: string, version: number) => {
+      calls.push({ component, version });
+    },
+    clear: () => {
+      calls.length = 0;
+    },
+  };
+}
+
+export interface BuildMigrationOptions {
+  /** When set, the migration's `up()` throws synchronously. */
+  readonly fail?: boolean;
+}
+
+/**
+ * Adapter-supplied factory that constructs a migration of the right
+ * shape for the underlying DB (Postgres pool, SQLite database, or
+ * IndexedDb upgrade context). The returned migration's `up()` calls the
+ * recorder unless `opts.fail` is true.
+ */
+export type BuildMigrationFn<DB> = (
+  component: string,
+  version: number,
+  recorder: MigrationCallRecorder,
+  opts?: BuildMigrationOptions
+) => IMigration<DB>;
+
+export interface MigrationContractHandle<DB> {
+  readonly createRunner: () => Promise<IMigrationRunner<DB>>;
+  readonly buildMigration: BuildMigrationFn<DB>;
+  readonly dispose: () => Promise<void>;
+}
+
+export interface MigrationRunnerContractOpts<DB> {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<MigrationContractHandle<DB>>;
+  /**
+   * Names of contract assertions currently broken in this adapter; each
+   * named test wraps with itExpectFail. Known names:
+   *   "appliesAndRecords"
+   *   "idempotentRun"
+   *   "incrementalApplication"
+   *   "failedMigrationNotRecorded"
+   *   "ensureBookkeepingIdempotent"
+   */
+  readonly expectedFailures?: ReadonlyArray<string>;
+}

--- a/packages/test/src/test/storage-migrations/IndexedDbMigrationRunner.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/IndexedDbMigrationRunner.integration.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "fake-indexeddb/auto";
+
+import type { IndexedDbUpgradeContext } from "@workglow/indexeddb/storage";
+import { IndexedDbMigrationRunner } from "@workglow/indexeddb/storage";
+import { setLogger, uuid4 } from "@workglow/util";
+import { describe } from "vitest";
+
+import { runMigrationRunnerContract } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import type { BuildMigrationFn } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import { getTestingLogger } from "../../binding/TestingLogger";
+
+// IndexedDB upgrade transactions auto-commit when control returns to the
+// event loop, so migration `up()` callbacks must be synchronous. Callers
+// that pass `recorder.record(...)` synchronously are safe; the contract
+// suite's recorder is in-memory and synchronous, so this is fine.
+const buildMigration: BuildMigrationFn<IndexedDbUpgradeContext> = (
+  component,
+  version,
+  recorder,
+  options
+) => ({
+  component,
+  version,
+  description: `idb migration v${version}`,
+  up: (_ctx) => {
+    if (options?.fail) throw new Error(`idb migration v${version} failed (synthetic)`);
+    recorder.record(component, version);
+  },
+});
+
+describe("IndexedDbMigrationRunner", () => {
+  setLogger(getTestingLogger());
+
+  runMigrationRunnerContract<IndexedDbUpgradeContext>({
+    name: "IndexedDB",
+    timeout: 5_000,
+    factory: async () => {
+      const dbName = `idb_migration_test_${uuid4().replace(/-/g, "_")}`;
+      return {
+        createRunner: async () => new IndexedDbMigrationRunner(dbName),
+        buildMigration,
+        dispose: async () => {
+          await new Promise<void>((resolve, reject) => {
+            const req = indexedDB.deleteDatabase(dbName);
+            req.onsuccess = () => resolve();
+            req.onerror = () => reject(req.error);
+            req.onblocked = () => resolve();
+          });
+        },
+      };
+    },
+  });
+});

--- a/packages/test/src/test/storage-migrations/PostgresMigrationRunner.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/PostgresMigrationRunner.integration.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { PostgresMigrationRunner } from "@workglow/postgres/storage";
+import type { Pool } from "@workglow/postgres/storage";
+import { setLogger } from "@workglow/util";
+import { afterAll, describe } from "vitest";
+
+import { runMigrationRunnerContract } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import type { BuildMigrationFn } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import { getTestingLogger } from "../../binding/TestingLogger";
+
+const db = new PGlite() as unknown as Pool;
+
+const buildMigration: BuildMigrationFn<Pool> = (component, version, recorder, options) => ({
+  component,
+  version,
+  description: `pg migration v${version}`,
+  up: async () => {
+    if (options?.fail) throw new Error(`pg migration v${version} failed (synthetic)`);
+    recorder.record(component, version);
+  },
+});
+
+describe("PostgresMigrationRunner", () => {
+  setLogger(getTestingLogger());
+
+  afterAll(async () => {
+    await (db as unknown as PGlite).close();
+  });
+
+  runMigrationRunnerContract<Pool>({
+    name: "Postgres",
+    timeout: 30_000,
+    factory: async () => ({
+      createRunner: async () => new PostgresMigrationRunner(db),
+      buildMigration,
+      dispose: async () => {},
+    }),
+  });
+});

--- a/packages/test/src/test/storage-migrations/SqliteMigrationRunner.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/SqliteMigrationRunner.integration.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Sqlite, SqliteMigrationRunner } from "@workglow/sqlite/storage";
+import { setLogger } from "@workglow/util";
+import { describe } from "vitest";
+
+import { runMigrationRunnerContract } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import type { BuildMigrationFn } from "../../contract/storage-migrations/runMigrationRunnerContract";
+import { getTestingLogger } from "../../binding/TestingLogger";
+
+const buildMigration: BuildMigrationFn<Sqlite.Database> = (
+  component,
+  version,
+  recorder,
+  options
+) => ({
+  component,
+  version,
+  description: `sqlite migration v${version}`,
+  up: async () => {
+    if (options?.fail) throw new Error(`sqlite migration v${version} failed (synthetic)`);
+    recorder.record(component, version);
+  },
+});
+
+describe("SqliteMigrationRunner", async () => {
+  await Sqlite.init();
+  setLogger(getTestingLogger());
+
+  // Each contract suite invocation owns its own in-memory database so the
+  // bookkeeping table starts clean.
+  runMigrationRunnerContract<Sqlite.Database>({
+    name: "SQLite",
+    timeout: 5_000,
+    factory: async () => {
+      const db = new Sqlite.Database(":memory:");
+      return {
+        createRunner: async () => new SqliteMigrationRunner(db),
+        buildMigration,
+        dispose: async () => {
+          db.close();
+        },
+      };
+    },
+  });
+});


### PR DESCRIPTION
Re-applies the storage refactor against the post-#456 package layout where
SQL backends now live in @workglow/postgres, @workglow/sqlite, @workglow/
indexeddb instead of a monolithic @workglow/storage.

@workglow/storage (driver-agnostic):
- New `sql/` module: ISqlDialect (Sqlite/Postgres dialects), shared
  buildSearchWhere() predicate builder, prefix-DDL helpers parameterised
  over a structural ISqlPrefixColumn (no dependency on @workglow/job-queue).
  Helpers self-validate with assertPrefixesSafe().
- New `migrations/` module: IMigration<DB>, IMigrationRunner<DB>,
  sortMigrations(), MIGRATIONS_TABLE constant. Concrete runners live in
  driver packages so storage stays driver-free.
- ITabularStorage.setupDatabase marked @deprecated, pointing to the
  per-backend migrate()/getMigrations().
- IVectorStorage gains VectorIndexOptions (HNSW {m,efConstruction,efSearch},
  IVFFlat {lists,probes}, distance metric).

@workglow/postgres:
- New `migrations/` module: PostgresMigrationRunner uses pool.connect()
  with feature detection so BEGIN/up()/INSERT/COMMIT all run on the same
  client (PGlite-as-Pool falls back to the raw pool). Race-safe via 23505
  catch.
- postgresQueueMigrations: v1 schema + indexes + LISTEN/NOTIFY trigger.
  job_status enum literal is FROZEN (JOB_STATUS_V1) — adding a status
  requires a new migration. Module-load assertion fails fast if JobStatus
  drifts from v1 without a follow-up migration.
- postgresRateLimiterMigrations: v1 schema + indexes.
- PostgresQueueStorage / PostgresRateLimiterStorage / PostgresTabularStorage
  use the shared sql/ helpers; setupDatabase() now delegates to migrate()
  and is @deprecated.
- PostgresTabularStorage.createVectorIndexes honours VectorIndexOptions
  via overrideable getVectorIndexOptions() — HNSW (m, efConstruction)
  build params, IVFFlat path, distance-metric-aware operator class.
- PostgresVectorStorage takes VectorIndexOptions in constructor.
  similaritySearch + hybridSearch use metric-aware distance operators
  (<=>, <->, <#>) and per-metric score expressions so scoreThreshold
  comparisons stay consistent and the configured index serves ORDER BY.

@workglow/sqlite:
- New `migrations/` module: SqliteMigrationRunner (idempotent — SQLite
  migrations cannot wrap async up() in a transaction).
- sqliteQueueMigrations / sqliteRateLimiterMigrations.
- SqliteQueueStorage / SqliteRateLimiterStorage / SqliteTabularStorage
  use shared sql/ helpers; setupDatabase() delegates to migrate() and is
  @deprecated.
- SqliteAiVectorStorage takes VectorIndexOptions; throws on non-cosine
  distance because its 1-distance score is cosine-only.

@workglow/job-queue:
- IQueueStorage / IRateLimiterStorage: setupDatabase @deprecated pointing
  at optional migrate()/getMigrations() (declared in the interface).

Tests: 1214 pass / 26 skip across queue + storage + rag vitest suites.