### PR TITLE
Add positive capability assertions to AI provider conformance tests

### DIFF
--- a/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
+++ b/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
@@ -5,7 +5,6 @@
  */
 
 import { getAiProviderRegistry, getGlobalModelRepository, textEmbedding } from "@workglow/ai";
-import { TaskRegistry } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
 import type { AiProviderConformanceOpts } from "../types";
@@ -81,18 +80,26 @@ export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
       opts.timeout
     );
 
-    it.skipIf(!opts.capabilities.tools)(
-      "declares tools=true → ToolCallingTask is registered globally",
-      () => {
-        expect(TaskRegistry.all.has("ToolCallingTask")).toBe(true);
+    it.skipIf(!opts.capabilities.tools || !opts.models.toolCalling)(
+      "declares tools=true → registry has a ToolCallingTask run function",
+      async () => {
+        const registry = getAiProviderRegistry();
+        const model = await getGlobalModelRepository().findByName(opts.models.toolCalling!);
+        expect(model).toBeDefined();
+        expect(() => registry.getDirectRunFn(model!.provider, "ToolCallingTask")).not.toThrow();
       },
       opts.timeout
     );
 
-    it.skipIf(!opts.capabilities.structured)(
-      "declares structured=true → StructuredGenerationTask is registered globally",
-      () => {
-        expect(TaskRegistry.all.has("StructuredGenerationTask")).toBe(true);
+    it.skipIf(!opts.capabilities.structured || !opts.models.structured)(
+      "declares structured=true → registry has a StructuredGenerationTask run function",
+      async () => {
+        const registry = getAiProviderRegistry();
+        const model = await getGlobalModelRepository().findByName(opts.models.structured!);
+        expect(model).toBeDefined();
+        expect(() =>
+          registry.getDirectRunFn(model!.provider, "StructuredGenerationTask")
+        ).not.toThrow();
       },
       opts.timeout
     );

--- a/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
+++ b/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getAiProviderRegistry, getGlobalModelRepository } from "@workglow/ai";
+import { getAiProviderRegistry, getGlobalModelRepository, textEmbedding } from "@workglow/ai";
+import { TaskRegistry } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
 import type { AiProviderConformanceOpts } from "../types";
 
 export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
   describe("Capability honesty", () => {
+    // ------------------------------------------------------------------
+    // Negative direction: declared false → no run/stream function exists.
+    // ------------------------------------------------------------------
+
     it.skipIf(opts.capabilities.streaming || !opts.models.textGeneration)(
       "declares streaming=false → registry has no stream function",
       async () => {
@@ -29,9 +34,7 @@ export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
         const registry = getAiProviderRegistry();
         const model = await getGlobalModelRepository().findByName(opts.models.textGeneration!);
         expect(model).toBeDefined();
-        expect(() =>
-          registry.getDirectRunFn(model!.provider, "ToolCallingTask")
-        ).toThrow();
+        expect(() => registry.getDirectRunFn(model!.provider, "ToolCallingTask")).toThrow();
       },
       opts.timeout
     );
@@ -42,9 +45,7 @@ export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
         const registry = getAiProviderRegistry();
         const model = await getGlobalModelRepository().findByName(opts.models.textGeneration!);
         expect(model).toBeDefined();
-        expect(() =>
-          registry.getDirectRunFn(model!.provider, "TextEmbeddingTask")
-        ).toThrow();
+        expect(() => registry.getDirectRunFn(model!.provider, "TextEmbeddingTask")).toThrow();
       },
       opts.timeout
     );
@@ -58,6 +59,63 @@ export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
         expect(() =>
           registry.getDirectRunFn(model!.provider, "StructuredGenerationTask")
         ).toThrow();
+      },
+      opts.timeout
+    );
+
+    // ------------------------------------------------------------------
+    // Positive direction: declared true → the wiring actually exists.
+    // Calling a capability "supported" without testing it was the
+    // original sin these blocks exist to prevent.
+    // ------------------------------------------------------------------
+
+    it.skipIf(!opts.capabilities.streaming || !opts.models.textGeneration)(
+      "declares streaming=true → registry has a stream function",
+      async () => {
+        const registry = getAiProviderRegistry();
+        const model = await getGlobalModelRepository().findByName(opts.models.textGeneration!);
+        expect(model).toBeDefined();
+        const fn = registry.getStreamFn(model!.provider, "TextGenerationTask");
+        expect(fn).toBeDefined();
+      },
+      opts.timeout
+    );
+
+    it.skipIf(!opts.capabilities.tools)(
+      "declares tools=true → ToolCallingTask is registered globally",
+      () => {
+        expect(TaskRegistry.all.has("ToolCallingTask")).toBe(true);
+      },
+      opts.timeout
+    );
+
+    it.skipIf(!opts.capabilities.structured)(
+      "declares structured=true → StructuredGenerationTask is registered globally",
+      () => {
+        expect(TaskRegistry.all.has("StructuredGenerationTask")).toBe(true);
+      },
+      opts.timeout
+    );
+
+    it.skipIf(!opts.capabilities.embeddings || !opts.models.embeddings)(
+      "declares embeddings=true → registry has a run function and produces a finite vector",
+      async () => {
+        const registry = getAiProviderRegistry();
+        const model = await getGlobalModelRepository().findByName(opts.models.embeddings!);
+        expect(model).toBeDefined();
+        expect(() => registry.getDirectRunFn(model!.provider, "TextEmbeddingTask")).not.toThrow();
+
+        const result = await textEmbedding({
+          model: opts.models.embeddings!,
+          text: "hello",
+        });
+
+        expect(result.vector).toBeInstanceOf(Float32Array);
+        const vector = result.vector as Float32Array;
+        expect(vector.length).toBeGreaterThan(0);
+        for (const v of vector) {
+          expect(Number.isFinite(v)).toBe(true);
+        }
       },
       opts.timeout
     );

--- a/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
+++ b/packages/test/src/contract/ai-provider/assertions/capabilityHonesty.ts
@@ -117,10 +117,15 @@ export function capabilityHonestyBlock(opts: AiProviderConformanceOpts): void {
           text: "hello",
         });
 
-        expect(result.vector).toBeInstanceOf(Float32Array);
-        const vector = result.vector as Float32Array;
-        expect(vector.length).toBeGreaterThan(0);
-        for (const v of vector) {
+        const vector = result.vector;
+        // TextEmbeddingTaskOutput.vector is TypedArraySchema — accept any
+        // typed-array view (Float32Array, Float64Array, etc.). DataView is
+        // explicitly excluded since it's not a numeric typed array.
+        const isTypedArray = ArrayBuffer.isView(vector) && !(vector instanceof DataView);
+        expect(isTypedArray, "vector must be a numeric typed array").toBe(true);
+        const values = Array.from(vector as ArrayLike<number>);
+        expect(values.length).toBeGreaterThan(0);
+        for (const v of values) {
           expect(Number.isFinite(v)).toBe(true);
         }
       },

--- a/packages/test/src/contract/ai-provider/runAiProviderConformance.ts
+++ b/packages/test/src/contract/ai-provider/runAiProviderConformance.ts
@@ -19,6 +19,17 @@ import { resolveFixture } from "./fixtures";
 import type { AiProviderConformanceOpts, ConformanceHandle } from "./types";
 
 export function runAiProviderConformance(opts: AiProviderConformanceOpts): void {
+  // Capability invariants: a positive capability claim must be backed by a
+  // model the conformance suite can exercise. Without this, "embeddings: true"
+  // would silently pass when no embedding model is wired up, defeating the
+  // whole point of capabilityHonestyBlock's positive assertions.
+  if (opts.capabilities.embeddings && !opts.models.embeddings) {
+    throw new Error(
+      `AiProvider conformance "${opts.name}": capabilities.embeddings is true but models.embeddings is not set. ` +
+        `Either provide an embedding model id or set capabilities.embeddings to false.`
+    );
+  }
+
   describe.skipIf(opts.skip)(`AiProvider conformance: ${opts.name}`, () => {
     let handle: ConformanceHandle | undefined;
     const getHandle = (): ConformanceHandle => {

--- a/packages/test/src/contract/ai-provider/runAiProviderConformance.ts
+++ b/packages/test/src/contract/ai-provider/runAiProviderConformance.ts
@@ -20,14 +20,22 @@ import type { AiProviderConformanceOpts, ConformanceHandle } from "./types";
 
 export function runAiProviderConformance(opts: AiProviderConformanceOpts): void {
   // Capability invariants: a positive capability claim must be backed by a
-  // model the conformance suite can exercise. Without this, "embeddings: true"
-  // would silently pass when no embedding model is wired up, defeating the
-  // whole point of capabilityHonestyBlock's positive assertions.
-  if (opts.capabilities.embeddings && !opts.models.embeddings) {
-    throw new Error(
-      `AiProvider conformance "${opts.name}": capabilities.embeddings is true but models.embeddings is not set. ` +
-        `Either provide an embedding model id or set capabilities.embeddings to false.`
-    );
+  // model the conformance suite can exercise. Without these, a true capability
+  // would silently pass when no model is wired up, defeating the whole point
+  // of capabilityHonestyBlock's positive assertions.
+  const requiredModels: ReadonlyArray<readonly [boolean, string, string]> = [
+    [opts.capabilities.streaming, "streaming", "textGeneration"],
+    [opts.capabilities.tools, "tools", "toolCalling"],
+    [opts.capabilities.structured, "structured", "structured"],
+    [opts.capabilities.embeddings, "embeddings", "embeddings"],
+  ];
+  for (const [claimed, capabilityKey, modelKey] of requiredModels) {
+    if (claimed && !opts.models[modelKey as keyof typeof opts.models]) {
+      throw new Error(
+        `AiProvider conformance "${opts.name}": capabilities.${capabilityKey} is true but models.${modelKey} is not set. ` +
+          `Either provide a model id or set capabilities.${capabilityKey} to false.`
+      );
+    }
   }
 
   describe.skipIf(opts.skip)(`AiProvider conformance: ${opts.name}`, () => {

--- a/packages/test/src/test/ai-provider/Gemini_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/Gemini_Generic.integration.test.ts
@@ -19,6 +19,7 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 
 const RUN = !!process.env.GOOGLE_API_KEY || !!process.env.GEMINI_API_KEY;
 const MODEL_ID = "gemini:gemini-2.5-flash";
+const EMBED_MODEL_ID = "gemini:gemini-embedding-001";
 
 runAiProviderConformance({
   name: "Google Gemini",
@@ -46,6 +47,15 @@ runAiProviderConformance({
         provider_config: { model_name: "gemini-2.5-flash" },
         metadata: {},
       });
+      await getGlobalModelRepository().addModel({
+        model_id: EMBED_MODEL_ID,
+        title: "Gemini Embedding 001",
+        description: "Google Gemini embedding model",
+        tasks: ["TextEmbeddingTask"],
+        provider: GOOGLE_GEMINI as typeof GOOGLE_GEMINI,
+        provider_config: { model_name: "gemini-embedding-001" },
+        metadata: {},
+      });
     },
     dispose: async () => {
       await setTaskQueueRegistry(null);
@@ -56,11 +66,7 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    // Embeddings would require registering a separate embedding model
-    // (e.g. text-embedding-004) — defer to a dedicated suite. The chat
-    // model wired up here (gemini-2.5-flash) does not advertise
-    // TextEmbeddingTask, so claiming embeddings=true was dishonest.
-    embeddings: false,
+    embeddings: true,
     sessions: false,
     abortMidStream: true,
   },
@@ -68,5 +74,6 @@ runAiProviderConformance({
     textGeneration: MODEL_ID,
     toolCalling: MODEL_ID,
     structured: MODEL_ID,
+    embeddings: EMBED_MODEL_ID,
   },
 });

--- a/packages/test/src/test/ai-provider/Gemini_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/Gemini_Generic.integration.test.ts
@@ -56,7 +56,11 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    embeddings: true,
+    // Embeddings would require registering a separate embedding model
+    // (e.g. text-embedding-004) — defer to a dedicated suite. The chat
+    // model wired up here (gemini-2.5-flash) does not advertise
+    // TextEmbeddingTask, so claiming embeddings=true was dishonest.
+    embeddings: false,
     sessions: false,
     abortMidStream: true,
   },

--- a/packages/test/src/test/ai-provider/HFI_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/HFI_Generic.integration.test.ts
@@ -19,6 +19,7 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 
 const RUN = !!process.env.HF_TOKEN;
 const MODEL_ID = "hf-inference:meta-llama/Llama-3.1-8B-Instruct";
+const EMBED_MODEL_ID = "hf-inference:sentence-transformers/all-MiniLM-L6-v2";
 
 runAiProviderConformance({
   name: "HuggingFace Inference",
@@ -45,6 +46,15 @@ runAiProviderConformance({
         provider_config: { model_name: "meta-llama/Llama-3.1-8B-Instruct" },
         metadata: {},
       });
+      await getGlobalModelRepository().addModel({
+        model_id: EMBED_MODEL_ID,
+        title: "All-MiniLM-L6-v2 (HF Inference)",
+        description: "sentence-transformers/all-MiniLM-L6-v2 via HF Inference",
+        tasks: ["TextEmbeddingTask"],
+        provider: HF_INFERENCE as typeof HF_INFERENCE,
+        provider_config: { model_name: "sentence-transformers/all-MiniLM-L6-v2" },
+        metadata: {},
+      });
     },
     dispose: async () => {
       await setTaskQueueRegistry(null);
@@ -55,12 +65,13 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: false,
-    embeddings: false,
+    embeddings: true,
     sessions: false,
     abortMidStream: true,
   },
   models: {
     textGeneration: MODEL_ID,
     toolCalling: MODEL_ID,
+    embeddings: EMBED_MODEL_ID,
   },
 });

--- a/packages/test/src/test/ai-provider/HFT_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/HFT_Generic.integration.test.ts
@@ -24,6 +24,7 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 const TEXT_MODEL_ID = "onnx:onnx-community/Qwen2.5-1.5B-Instruct:q4";
 const THINKING_MODEL_ID = "onnx:LiquidAI/LFM2.5-1.2B-Thinking-WebGPU:q4";
 const INSTRUCT_MODEL_ID = "onnx:LiquidAI/LFM2.5-1.2B-Instruct-WebGPU:q4";
+const EMBED_MODEL_ID = "onnx:Xenova/all-MiniLM-L6-v2:q8";
 
 const textModel: HfTransformersOnnxModelRecord = {
   model_id: TEXT_MODEL_ID,
@@ -70,6 +71,21 @@ const thinkingModel: HfTransformersOnnxModelRecord = {
   metadata: {},
 };
 
+const embeddingModel: HfTransformersOnnxModelRecord = {
+  model_id: EMBED_MODEL_ID,
+  title: "All-MiniLM-L6-v2 (384D)",
+  description: "Sentence embedding model for the embeddings conformance assertion",
+  tasks: ["TextEmbeddingTask"],
+  provider: HF_TRANSFORMERS_ONNX,
+  provider_config: {
+    pipeline: "feature-extraction",
+    model_path: "Xenova/all-MiniLM-L6-v2",
+    native_dimensions: 384,
+    dtype: "q8",
+  },
+  metadata: {},
+};
+
 runAiProviderConformance({
   name: "HFT (HuggingFace Transformers)",
   timeout: 300_000,
@@ -84,6 +100,7 @@ runAiProviderConformance({
       await getGlobalModelRepository().addModel(textModel);
       await getGlobalModelRepository().addModel(thinkingModel);
       await getGlobalModelRepository().addModel(instructModel);
+      await getGlobalModelRepository().addModel(embeddingModel);
     },
     dispose: async () => {
       await setTaskQueueRegistry(null);
@@ -94,11 +111,7 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    // Embeddings would require loading a separate embeddings model — defer to
-    // a dedicated suite. The decoder-only LFM2.5 / Qwen2.5-Instruct models
-    // wired up here have no pooled embedding head, so claiming embeddings=true
-    // here is dishonest. Flip back once an embedding-only model is registered.
-    embeddings: false,
+    embeddings: true,
     sessions: false,
     abortMidStream: true,
   },
@@ -106,6 +119,7 @@ runAiProviderConformance({
     textGeneration: INSTRUCT_MODEL_ID,
     toolCalling: INSTRUCT_MODEL_ID,
     structured: INSTRUCT_MODEL_ID,
+    embeddings: EMBED_MODEL_ID,
   },
   // Local ONNX inference is slow; relax the abort window so the
   // mid-stream-abort assertion has room to fire and shut down cleanly.

--- a/packages/test/src/test/ai-provider/HFT_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/HFT_Generic.integration.test.ts
@@ -94,7 +94,11 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    embeddings: true,
+    // Embeddings would require loading a separate embeddings model — defer to
+    // a dedicated suite. The decoder-only LFM2.5 / Qwen2.5-Instruct models
+    // wired up here have no pooled embedding head, so claiming embeddings=true
+    // here is dishonest. Flip back once an embedding-only model is registered.
+    embeddings: false,
     sessions: false,
     abortMidStream: true,
   },

--- a/packages/test/src/test/ai-provider/LlamaCpp_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/LlamaCpp_Generic.integration.test.ts
@@ -62,6 +62,21 @@ const toolModel: LlamaCppModelRecord = {
   metadata: {},
 };
 
+const embeddingModel: LlamaCppModelRecord = {
+  model_id: "llamacpp:bge-small-en-v1.5:Q8_0",
+  title: "BGE Small EN v1.5",
+  description: "A small English text embedding model, quantized Q8_0 (~34 MB)",
+  tasks: ["DownloadModelTask", "TextEmbeddingTask"],
+  provider: LOCAL_LLAMACPP,
+  provider_config: {
+    model_path: "./models/bge-small-en-v1.5-Q8_0.gguf",
+    model_url: "hf:CompendiumLabs/bge-small-en-v1.5-gguf:Q8_0",
+    models_dir: "./models",
+    embedding: true,
+  },
+  metadata: {},
+};
+
 runAiProviderConformance({
   name: "LlamaCpp (node-llama-cpp)",
   timeout: 10 * 60 * 1000,
@@ -74,7 +89,8 @@ runAiProviderConformance({
       await registerLlamaCppInline();
       await getGlobalModelRepository().addModel(llmModel);
       await getGlobalModelRepository().addModel(toolModel);
-      for (const modelId of [llmModel.model_id, toolModel.model_id]) {
+      await getGlobalModelRepository().addModel(embeddingModel);
+      for (const modelId of [llmModel.model_id, toolModel.model_id, embeddingModel.model_id]) {
         const download = new DownloadModelTask({ defaults: { model: modelId } });
         download.on("progress", (progress, _message, details) => {
           logger.info(
@@ -94,11 +110,7 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    // Embeddings would require loading a separate embeddings model — defer to
-    // a dedicated suite. SmolLM2 is decoder-only and has no pooled embedding
-    // head, so claiming embeddings=true here is dishonest. Flip back once an
-    // embedding-only model is registered alongside the generation models.
-    embeddings: false,
+    embeddings: true,
     sessions: true,
     abortMidStream: true,
   },
@@ -106,6 +118,7 @@ runAiProviderConformance({
     textGeneration: llmModel.model_id,
     toolCalling: toolModel.model_id,
     structured: toolModel.model_id,
+    embeddings: embeddingModel.model_id,
   },
   fixture: { maxTokens: 200, abortGraceMs: 500 },
   // TODO(workglow): Sessions test fails because earlier suite tests

--- a/packages/test/src/test/ai-provider/LlamaCpp_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/LlamaCpp_Generic.integration.test.ts
@@ -94,7 +94,11 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    embeddings: true,
+    // Embeddings would require loading a separate embeddings model — defer to
+    // a dedicated suite. SmolLM2 is decoder-only and has no pooled embedding
+    // head, so claiming embeddings=true here is dishonest. Flip back once an
+    // embedding-only model is registered alongside the generation models.
+    embeddings: false,
     sessions: true,
     abortMidStream: true,
   },

--- a/packages/test/src/test/ai-provider/OpenAI_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAI_Generic.integration.test.ts
@@ -19,6 +19,7 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 
 const RUN = !!process.env.OPENAI_API_KEY;
 const MODEL_ID = "openai:gpt-4o-mini";
+const EMBED_MODEL_ID = "openai:text-embedding-3-small";
 
 runAiProviderConformance({
   name: "OpenAI",
@@ -46,6 +47,15 @@ runAiProviderConformance({
         provider_config: { model_name: "gpt-4o-mini" },
         metadata: {},
       });
+      await getGlobalModelRepository().addModel({
+        model_id: EMBED_MODEL_ID,
+        title: "Text Embedding 3 Small",
+        description: "OpenAI text-embedding-3-small (1536D)",
+        tasks: ["TextEmbeddingTask"],
+        provider: OPENAI as typeof OPENAI,
+        provider_config: { model_name: "text-embedding-3-small" },
+        metadata: {},
+      });
     },
     dispose: async () => {
       await setTaskQueueRegistry(null);
@@ -56,11 +66,7 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    // Embeddings would require registering a separate embedding model
-    // (e.g. text-embedding-3-small) — defer to a dedicated suite. The
-    // chat model wired up here (gpt-4o-mini) does not advertise
-    // TextEmbeddingTask, so claiming embeddings=true was dishonest.
-    embeddings: false,
+    embeddings: true,
     sessions: false,
     abortMidStream: true,
   },
@@ -68,5 +74,6 @@ runAiProviderConformance({
     textGeneration: MODEL_ID,
     toolCalling: MODEL_ID,
     structured: MODEL_ID,
+    embeddings: EMBED_MODEL_ID,
   },
 });

--- a/packages/test/src/test/ai-provider/OpenAI_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAI_Generic.integration.test.ts
@@ -56,7 +56,11 @@ runAiProviderConformance({
     streaming: true,
     tools: true,
     structured: true,
-    embeddings: true,
+    // Embeddings would require registering a separate embedding model
+    // (e.g. text-embedding-3-small) — defer to a dedicated suite. The
+    // chat model wired up here (gpt-4o-mini) does not advertise
+    // TextEmbeddingTask, so claiming embeddings=true was dishonest.
+    embeddings: false,
     sessions: false,
     abortMidStream: true,
   },


### PR DESCRIPTION
## Summary

Strengthens the AI provider conformance suite with **positive capability assertions** (verifying claimed capabilities actually work end-to-end) and adds registration-time invariants so a declared capability can't silently skip due to missing model wiring.

## Changes

### `capabilityHonestyBlock` — positive direction added

Each capability is now checked in both directions:

- `streaming=true` → registry has a `getStreamFn` for `TextGenerationTask`
- `tools=true` → registry has a `getDirectRunFn` for `ToolCallingTask` against the configured `models.toolCalling`
- `structured=true` → registry has a `getDirectRunFn` for `StructuredGenerationTask` against `models.structured`
- `embeddings=true` → registry has a `getDirectRunFn` for `TextEmbeddingTask` AND a real `textEmbedding({ text: "hello", model: models.embeddings })` call returns a numeric typed-array view of finite values

The vector type check accepts any numeric typed-array (`ArrayBuffer.isView` excluding `DataView`), matching the `TypedArraySchema` contract rather than tightening it to `Float32Array`.

### `runAiProviderConformance` — capability/model invariants

A claimed capability must be backed by a testable model. Registration throws if any of these are inconsistent:

| capability       | required model key   |
| ---------------- | -------------------- |
| `streaming`      | `models.textGeneration` |
| `tools`          | `models.toolCalling` |
| `structured`     | `models.structured`  |
| `embeddings`     | `models.embeddings`  |

This prevents the silent-pass case where a positive assertion skips because the corresponding model id isn't set.

### Provider conformance fixtures

Wired dedicated embedding models into every provider that registers a `TextEmbeddingTask` run fn:

- HFT: `onnx:Xenova/all-MiniLM-L6-v2:q8` (384D, q8 ONNX)
- LlamaCpp: `llamacpp:bge-small-en-v1.5:Q8_0` (~34 MB GGUF) — added to the download loop
- OpenAI: `openai:text-embedding-3-small`
- Gemini: `gemini:gemini-embedding-001`
- HFI: `hf-inference:sentence-transformers/all-MiniLM-L6-v2`

Anthropic stays `embeddings: false` — its provider genuinely doesn't register a `TextEmbeddingTask` run fn, so the negative assertion still fires there.

### Why this matters

The original negative-only block let providers claim `embeddings: true` (or any other capability) without ever exercising the wiring — exactly the kind of test debt that drifts into production. Calling a capability "supported" without testing it was the original sin these blocks exist to prevent.

https://claude.ai/code/session_017AxfztsbrUQiTZtErLSiEh