### PR TITLE
Fix abort signal handling race condition in Ollama text generation

### DIFF
--- a/packages/ollama/src/ai-provider/common/Ollama_TextGeneration.test.ts
+++ b/packages/ollama/src/ai-provider/common/Ollama_TextGeneration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createOllamaTextGenerationStream } from "./Ollama_TextGeneration";
+
+type FakeStream = {
+  abort: ReturnType<typeof vi.fn>;
+  [Symbol.asyncIterator](): AsyncIterator<{ message: { content: string } }>;
+};
+
+function makeFakeStream(chunks: string[]): FakeStream {
+  let aborted = false;
+  const abort = vi.fn(() => {
+    aborted = true;
+  });
+  return {
+    abort,
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        if (aborted) return;
+        yield { message: { content: c } };
+      }
+    },
+  };
+}
+
+describe("createOllamaTextGenerationStream abort behavior", () => {
+  const model = {
+    model_id: "ollama:test",
+    provider_config: { model_name: "llama3.2" },
+  } as any;
+  const input = { prompt: "hi" } as any;
+
+  it("yields zero deltas and aborts the stream when signal aborts during chat() (pre-attach race)", async () => {
+    const fakeStream = makeFakeStream(["a", "b", "c"]);
+    const controller = new AbortController();
+    const getClient = vi.fn().mockResolvedValue({
+      chat: vi.fn().mockImplementation(async () => {
+        // Simulate the signal aborting after the pre-call throwIfAborted check
+        // but before the abort listener is attached — the bug class this fix targets.
+        controller.abort();
+        return fakeStream;
+      }),
+    });
+    const streamFn = createOllamaTextGenerationStream(getClient);
+
+    const events: any[] = [];
+    let threw = false;
+    try {
+      for await (const ev of streamFn(input, model, controller.signal)) {
+        events.push(ev);
+      }
+    } catch {
+      threw = true;
+    }
+
+    const deltas = events.filter((e) => e.type === "text-delta");
+    expect(deltas).toHaveLength(0);
+    expect(fakeStream.abort).toHaveBeenCalledTimes(1);
+    // post-attach throwIfAborted should propagate the abort
+    expect(threw).toBe(true);
+  });
+
+  it("does not throw when signal is undefined", async () => {
+    const fakeStream = makeFakeStream(["hello", " world"]);
+    const getClient = vi.fn().mockResolvedValue({
+      chat: vi.fn().mockResolvedValue(fakeStream),
+    });
+    const streamFn = createOllamaTextGenerationStream(getClient);
+
+    const events: any[] = [];
+    for await (const ev of streamFn(input, model, undefined as any)) {
+      events.push(ev);
+    }
+
+    const deltas = events
+      .filter((e) => e.type === "text-delta")
+      .map((e) => (e as any).textDelta);
+    expect(deltas).toEqual(["hello", " world"]);
+    expect(events[events.length - 1]).toEqual({ type: "finish", data: {} });
+    expect(fakeStream.abort).not.toHaveBeenCalled();
+  });
+
+  it("calls fakeStream.abort exactly once when signal is aborted mid-iteration", async () => {
+    const chunks = ["one", "two", "three", "four", "five"];
+    const fakeStream = makeFakeStream(chunks);
+    const getClient = vi.fn().mockResolvedValue({
+      chat: vi.fn().mockResolvedValue(fakeStream),
+    });
+    const streamFn = createOllamaTextGenerationStream(getClient);
+
+    const controller = new AbortController();
+    const deltas: string[] = [];
+
+    for await (const ev of streamFn(input, model, controller.signal)) {
+      if (ev.type === "text-delta") {
+        deltas.push(ev.textDelta);
+        if (deltas.length === 2) {
+          controller.abort();
+        }
+      }
+    }
+
+    expect(fakeStream.abort).toHaveBeenCalledTimes(1);
+    expect(deltas.length).toBeLessThan(chunks.length);
+    expect(deltas.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/ollama/src/ai-provider/common/Ollama_TextGeneration.ts
+++ b/packages/ollama/src/ai-provider/common/Ollama_TextGeneration.ts
@@ -81,11 +81,12 @@ export function createOllamaTextGenerationStream(
     });
 
     const onAbort = () => stream.abort();
-    signal.addEventListener("abort", onAbort, { once: true });
+    signal?.addEventListener("abort", onAbort, { once: true });
     try {
       // Re-check after the listener is attached to close the
       // attach-vs-aborted race.
-      if (signal.aborted) stream.abort();
+      if (signal?.aborted) stream.abort();
+      signal?.throwIfAborted?.();
       for await (const chunk of stream) {
         const delta = chunk.message.content;
         if (delta) {
@@ -94,7 +95,7 @@ export function createOllamaTextGenerationStream(
       }
       yield { type: "finish", data: {} as TextGenerationTaskOutput };
     } finally {
-      signal.removeEventListener("abort", onAbort);
+      signal?.removeEventListener("abort", onAbort);
     }
   };
 }

--- a/packages/ollama/src/ai-provider/runtime.ts
+++ b/packages/ollama/src/ai-provider/runtime.ts
@@ -12,5 +12,6 @@
  * Use `export *` (not `export { … } from "…"`) so the Bun bundler keeps the module graph.
  */
 export * from "./common/Ollama_Client";
+export * from "./common/Ollama_TextGeneration";
 export * from "./registerOllamaInline";
 export * from "./registerOllamaWorker";

--- a/packages/test/src/test/ai-provider/Ollama_TextGenerationStream.test.ts
+++ b/packages/test/src/test/ai-provider/Ollama_TextGenerationStream.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createOllamaTextGenerationStream } from "../../../../ollama/src/ai-provider/common/Ollama_TextGeneration";
+import { createOllamaTextGenerationStream } from "@workglow/ollama/ai-provider-runtime";
 
 type FakeStream = {
   abort: ReturnType<typeof vi.fn>;

--- a/packages/test/src/test/ai-provider/Ollama_TextGenerationStream.test.ts
+++ b/packages/test/src/test/ai-provider/Ollama_TextGenerationStream.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
-import { createOllamaTextGenerationStream } from "./Ollama_TextGeneration";
+import { createOllamaTextGenerationStream } from "../../../../ollama/src/ai-provider/common/Ollama_TextGeneration";
 
 type FakeStream = {
   abort: ReturnType<typeof vi.fn>;
@@ -26,6 +26,13 @@ function makeFakeStream(chunks: string[]): FakeStream {
       }
     },
   };
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { name?: unknown; message?: unknown };
+  if (e.name === "AbortError") return true;
+  return typeof e.message === "string" && e.message.toLowerCase().includes("abort");
 }
 
 describe("createOllamaTextGenerationStream abort behavior", () => {
@@ -49,20 +56,20 @@ describe("createOllamaTextGenerationStream abort behavior", () => {
     const streamFn = createOllamaTextGenerationStream(getClient);
 
     const events: any[] = [];
-    let threw = false;
+    let caught: unknown;
     try {
       for await (const ev of streamFn(input, model, controller.signal)) {
         events.push(ev);
       }
-    } catch {
-      threw = true;
+    } catch (err) {
+      caught = err;
     }
 
     const deltas = events.filter((e) => e.type === "text-delta");
     expect(deltas).toHaveLength(0);
     expect(fakeStream.abort).toHaveBeenCalledTimes(1);
-    // post-attach throwIfAborted should propagate the abort
-    expect(threw).toBe(true);
+    // post-attach throwIfAborted should propagate the abort as an AbortError
+    expect(isAbortError(caught)).toBe(true);
   });
 
   it("does not throw when signal is undefined", async () => {


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the Ollama text generation stream where an abort signal could be triggered between the initial abort check and the attachment of the abort event listener, causing the stream to not be properly aborted.

## Key Changes
- Added optional chaining (`?.`) to all signal method calls to safely handle `undefined` signals
- Added `signal?.throwIfAborted?.()` call after attaching the abort listener to catch aborts that occur during the attach window
- Added comprehensive test suite covering three critical scenarios:
  - Pre-attach race condition where signal aborts after `chat()` call but before listener attachment
  - Undefined signal handling to ensure no errors when signal is not provided
  - Mid-iteration abort to verify proper cleanup and single abort call

## Implementation Details
The fix addresses a classic race condition by:
1. Safely handling optional signals with optional chaining throughout
2. Re-checking the abort state after the listener is attached (existing pattern)
3. Explicitly calling `throwIfAborted()` to propagate any abort that occurred between the initial check and listener attachment
4. Ensuring the stream's `abort()` method is called exactly once via proper cleanup in the finally block

This ensures that regardless of when the abort signal is triggered, the underlying stream is properly aborted and the async iteration terminates cleanly.

https://claude.ai/code/session_013GKUZqeqzsfVWGGb2YhD99