### PR TITLE
feat: introduce IEntitlementProfile with signal-source port and conformance suite

### DIFF
--- a/docs/superpowers/plans/2026-05-07-entitlementprofile-contract-conformance.md
+++ b/docs/superpowers/plans/2026-05-07-entitlementprofile-contract-conformance.md
@@ -1,0 +1,2635 @@
+# EntitlementProfile Contract Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `IEntitlementProfile` (extends `IEntitlementEnforcer`) with single-key `requestEntitlement`, change-event subscription, and a pluggable `IEntitlementSignalSource` port; ship a parameterized contract conformance suite that the three built-in profiles plus a custom profile shim must pass.
+
+**Architecture:** New library file `EntitlementProfile.ts` hosts the profile interface, signal-source port, no-op `STATIC_SIGNAL_SOURCE`, and a `createPolicyProfile` constructor that wraps `createPolicyEnforcer` plus signal-source bookkeeping. `createProfileEnforcer` is refactored to delegate to `createPolicyProfile` and widen its return type to `IEntitlementProfile`. The conformance suite under `packages/test/src/contract/entitlement-profile/` mirrors the AiProvider layout: `runEntitlementProfileConformance` + per-assertion blocks gated by capability flags. Four adapter shims (browser, desktop, server, custom-with-controllable-source) live under `packages/test/src/test/entitlement-profile/`.
+
+**Tech Stack:** TypeScript, Vitest, Bun workspace.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md`.
+
+**Naming note (deviation from spec):** The spec proposed a new exported type `EntitlementVerdict` (discriminated union for `requestEntitlement`). The name is already taken by an existing type in `EntitlementPolicy.ts` (`"granted" | "denied" | "ask"`). To avoid a breaking rename we use **`EntitlementRequestResult`** for the new discriminated union. Everywhere the spec says "EntitlementVerdict" in the context of `requestEntitlement`'s return type, this plan uses `EntitlementRequestResult`.
+
+---
+
+## File structure
+
+**Phase 1 — Library types + profile constructor**
+- Create: `packages/task-graph/src/task/EntitlementProfile.ts`
+- Modify: `packages/task-graph/src/task/EntitlementProfiles.ts` (refactor `createProfileEnforcer`)
+- Modify: `packages/task-graph/src/task/index.ts` (add export)
+- Create: `packages/test/src/test/task-graph/EntitlementProfile.test.ts` (unit tests for the new constructor + lattice)
+
+**Phase 2 — Conformance suite scaffolding**
+- Create: `packages/test/src/contract/entitlement-profile/types.ts`
+- Create: `packages/test/src/contract/entitlement-profile/fixtures.ts`
+- Create: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+**Phase 3 — Conformance assertions**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/surfaceCoverage.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/hierarchyHonoring.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/optionalNeverDenied.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/denialShape.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeRevocation.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/unsubscribeIdempotent.ts`
+- Create: `packages/test/src/contract/entitlement-profile/assertions/dispose.ts`
+
+**Phase 4 — Adapter shims**
+- Create: `packages/test/src/test/entitlement-profile/Browser_Profile.test.ts`
+- Create: `packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts`
+- Create: `packages/test/src/test/entitlement-profile/Server_Profile.test.ts`
+- Create: `packages/test/src/test/entitlement-profile/Custom_Profile.test.ts`
+
+**Phase 5 — Documentation**
+- Modify: `packages/test/src/contract/README.md`
+- Modify: `docs/technical/14-entitlements-system.md`
+
+---
+
+# Phase 1 — Library types + profile constructor
+
+## Task 1.1: Add signal-source types and `STATIC_SIGNAL_SOURCE`
+
+**Files:**
+- Create: `packages/task-graph/src/task/EntitlementProfile.ts`
+- Test: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { STATIC_SIGNAL_SOURCE, type EntitlementSignal } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+describe("STATIC_SIGNAL_SOURCE", () => {
+  it("subscribe returns a no-op unsubscribe and never invokes the listener", () => {
+    const calls: EntitlementSignal[] = [];
+    const unsub = STATIC_SIGNAL_SOURCE.subscribe((s) => calls.push(s));
+    expect(typeof unsub).toBe("function");
+    // Calling unsub repeatedly must not throw.
+    unsub();
+    unsub();
+    expect(calls).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: FAIL with "Module '\"@workglow/task-graph\"' has no exported member 'STATIC_SIGNAL_SOURCE'" or similar.
+
+- [ ] **Step 3: Create `EntitlementProfile.ts` with signal-source types**
+
+Create `packages/task-graph/src/task/EntitlementProfile.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * IEntitlementProfile — runtime-environment view of an entitlement system.
+ * Extends IEntitlementEnforcer with a single-key request API, change-event
+ * subscription, surface introspection, and disposal. Profiles delegate
+ * signal observation to a pluggable IEntitlementSignalSource.
+ */
+
+import type { TaskEntitlement } from "./TaskEntitlements";
+
+// ========================================================================
+// Signal Source (port)
+// ========================================================================
+
+/**
+ * A signal emitted by an external source telling profiles that a permission
+ * may have changed.
+ *
+ * - `revoke`: a previously granted entitlement may now be denied.
+ * - `grant`: a previously denied entitlement may now be granted.
+ * - `reload`: the underlying policy may have changed in arbitrary ways;
+ *   profiles should re-evaluate every entitlement they have been queried
+ *   about.
+ */
+export type EntitlementSignal =
+  | { readonly kind: "revoke"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "grant"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "reload" };
+
+/**
+ * Pluggable port that produces signals about external permission changes.
+ * Built-in profiles default to `STATIC_SIGNAL_SOURCE`. Downstream packages
+ * (e.g. workflow-builder Electron) provide implementations that wrap
+ * platform events.
+ */
+export interface IEntitlementSignalSource {
+  /**
+   * Register a listener for signals. The returned function unsubscribes.
+   * Implementations must make the unsubscribe idempotent.
+   */
+  subscribe(listener: (signal: EntitlementSignal) => void): () => void;
+}
+
+/** Frozen no-op signal source. Never emits; subscribe returns a no-op unsub. */
+export const STATIC_SIGNAL_SOURCE: IEntitlementSignalSource = Object.freeze({
+  subscribe(_listener: (signal: EntitlementSignal) => void): () => void {
+    return () => {
+      // no-op
+    };
+  },
+});
+```
+
+- [ ] **Step 4: Add the export to `index.ts`**
+
+In `packages/task-graph/src/task/index.ts`, add the line `export * from "./EntitlementProfile";` in alphabetical position (between `EntitlementPolicy` and `EntitlementProfiles` lines):
+
+Replace:
+```ts
+export * from "./EntitlementPolicy";
+export * from "./EntitlementProfiles";
+```
+
+With:
+```ts
+export * from "./EntitlementPolicy";
+export * from "./EntitlementProfile";
+export * from "./EntitlementProfiles";
+```
+
+- [ ] **Step 5: Build types and run test**
+
+```sh
+bun run build:types
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add packages/task-graph/src/task/EntitlementProfile.ts \
+        packages/task-graph/src/task/index.ts \
+        packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "feat(task-graph): add IEntitlementSignalSource port + STATIC_SIGNAL_SOURCE"
+```
+
+---
+
+## Task 1.2: Add `IEntitlementProfile`, `EntitlementChangeEvent`, `EntitlementRequestResult`
+
+**Files:**
+- Modify: `packages/task-graph/src/task/EntitlementProfile.ts`
+- Test: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+import {
+  type EntitlementChangeEvent,
+  type EntitlementRequestResult,
+  type IEntitlementProfile,
+} from "@workglow/task-graph";
+
+describe("IEntitlementProfile types", () => {
+  it("EntitlementRequestResult discriminates on outcome", () => {
+    const granted: EntitlementRequestResult = {
+      outcome: "granted",
+      entitlement: { id: "network:http" },
+    };
+    const denied: EntitlementRequestResult = {
+      outcome: "denied",
+      denial: { entitlement: { id: "filesystem" }, reason: "default-deny" },
+    };
+    expect(granted.outcome).toBe("granted");
+    expect(denied.outcome).toBe("denied");
+  });
+
+  it("EntitlementChangeEvent has revoked or granted kind", () => {
+    const event: EntitlementChangeEvent = {
+      kind: "revoked",
+      entitlement: { id: "network:http" },
+    };
+    expect(event.kind).toBe("revoked");
+  });
+
+  it("IEntitlementProfile is structurally a superset of IEntitlementEnforcer", () => {
+    // Compile-time check via type assertion. Runtime: a stub satisfying the shape.
+    const stub: IEntitlementProfile = {
+      name: "test",
+      checkAll: async () => [],
+      checkTask: async () => [],
+      surface: () => [],
+      requestEntitlement: async (e) => ({ outcome: "granted", entitlement: e }),
+      subscribe: () => () => {},
+      dispose: async () => {},
+    };
+    expect(stub.name).toBe("test");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: FAIL with "no exported member 'EntitlementRequestResult'" / "EntitlementChangeEvent" / "IEntitlementProfile".
+
+- [ ] **Step 3: Add the new types**
+
+In `packages/task-graph/src/task/EntitlementProfile.ts`, append after the signal-source section:
+
+```ts
+import type { EntitlementDenial, IEntitlementEnforcer } from "./EntitlementEnforcer";
+import type { EntitlementGrant } from "./TaskEntitlements";
+
+// ========================================================================
+// Request / Verdict
+// ========================================================================
+
+/**
+ * Result of `requestEntitlement(required)`. Discriminated union on `outcome`.
+ *
+ * Optional entitlements always map to `outcome: "granted"` regardless of the
+ * underlying policy verdict — matching the rule that optional entitlements
+ * are filtered out of `IEntitlementEnforcer.checkAll`.
+ *
+ * `"ask"` policy verdicts are resolved internally via the registered
+ * `IEntitlementResolver` before this function returns; callers only ever
+ * see `"granted"` or `"denied"`.
+ */
+export type EntitlementRequestResult =
+  | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
+  | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
+
+// ========================================================================
+// Change Events
+// ========================================================================
+
+/**
+ * Emitted by an `IEntitlementProfile` when a previously-observed entitlement
+ * verdict transitions. Profiles only emit events for entitlements whose
+ * verdict actually flipped between two queries.
+ */
+export type EntitlementChangeEvent = {
+  readonly kind: "revoked" | "granted";
+  readonly entitlement: TaskEntitlement;
+};
+
+// ========================================================================
+// Profile Interface
+// ========================================================================
+
+/**
+ * Runtime-environment view of an entitlement system.
+ *
+ * Extends `IEntitlementEnforcer` with:
+ * - `name`: free-form identifier for diagnostics.
+ * - `surface()`: maximum set of entitlements this profile may grant.
+ * - `requestEntitlement()`: single-key request returning a discriminated verdict.
+ * - `subscribe()`: observe change events from the bound signal source.
+ * - `dispose()`: idempotent teardown including signal-source unsubscribe.
+ */
+export interface IEntitlementProfile extends IEntitlementEnforcer {
+  /** Free-form identifier (e.g. "browser", "desktop", "server"). */
+  readonly name: string;
+  /** The maximum set of grants this profile may issue. */
+  surface(): readonly EntitlementGrant[];
+  /** Single-key request. See `EntitlementRequestResult`. */
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
+  /** Subscribe to change events. The returned unsubscribe must be idempotent. */
+  subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
+  /** Idempotent teardown. */
+  dispose(): Promise<void>;
+}
+```
+
+- [ ] **Step 4: Build types and run test**
+
+```sh
+bun run build:types
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/task-graph/src/task/EntitlementProfile.ts \
+        packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "feat(task-graph): add IEntitlementProfile + EntitlementRequestResult + EntitlementChangeEvent"
+```
+
+---
+
+## Task 1.3: Implement `createPolicyProfile`
+
+**Files:**
+- Modify: `packages/task-graph/src/task/EntitlementProfile.ts`
+- Test: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+import {
+  createPolicyProfile,
+  Entitlements,
+  type EntitlementPolicy,
+  type EntitlementSignal,
+  type IEntitlementSignalSource,
+} from "@workglow/task-graph";
+
+describe("createPolicyProfile", () => {
+  const policy: EntitlementPolicy = {
+    deny: [],
+    grant: [{ id: Entitlements.NETWORK_HTTP }, { id: Entitlements.AI }],
+    ask: [],
+  };
+
+  it("builds a profile whose surface() reflects the policy grants", () => {
+    const profile = createPolicyProfile("test", policy);
+    expect(profile.name).toBe("test");
+    expect(profile.surface().map((g) => g.id).sort()).toEqual(
+      [Entitlements.AI, Entitlements.NETWORK_HTTP].sort()
+    );
+  });
+
+  it("requestEntitlement returns granted for covered, denied for uncovered", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const granted = await profile.requestEntitlement({ id: Entitlements.NETWORK_HTTP });
+    expect(granted.outcome).toBe("granted");
+    const denied = await profile.requestEntitlement({ id: Entitlements.FILESYSTEM });
+    expect(denied.outcome).toBe("denied");
+    if (denied.outcome === "denied") {
+      expect(denied.denial.reason).toBe("default-deny");
+    }
+  });
+
+  it("requestEntitlement returns granted for optional even when uncovered", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const result = await profile.requestEntitlement({
+      id: Entitlements.FILESYSTEM,
+      optional: true,
+    });
+    expect(result.outcome).toBe("granted");
+  });
+
+  it("checkAll keeps existing semantics (empty array means granted)", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const denials = await profile.checkAll({
+      entitlements: [{ id: Entitlements.NETWORK_HTTP }],
+    });
+    expect(denials).toEqual([]);
+  });
+
+  it("subscribe + signal source revoke fires change event after a previous grant query", async () => {
+    let emit: ((s: EntitlementSignal) => void) | undefined;
+    const source: IEntitlementSignalSource = {
+      subscribe(listener) {
+        emit = listener;
+        return () => {
+          emit = undefined;
+        };
+      },
+    };
+    const profile = createPolicyProfile("test", policy, { signalSource: source });
+    // Query first to seed previous-verdict tracking.
+    await profile.requestEntitlement({ id: Entitlements.NETWORK_HTTP });
+    const events: Array<{ kind: string; id: string }> = [];
+    profile.subscribe((e) => events.push({ kind: e.kind, id: e.entitlement.id }));
+    // Mutate the policy through a mutable wrapper. Since createPolicyProfile takes
+    // the policy by reference, we test revoke by swapping in a profile that uses
+    // a simple in-memory mutable policy holder. Here we exercise the no-flip case:
+    // a revoke for an entitlement that is already denied does not emit.
+    emit!({ kind: "revoke", entitlement: { id: Entitlements.FILESYSTEM } });
+    // Allow the async re-evaluation to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(events).toEqual([]);
+  });
+
+  it("dispose unsubscribes from the signal source", async () => {
+    let unsubCalls = 0;
+    const source: IEntitlementSignalSource = {
+      subscribe() {
+        return () => {
+          unsubCalls++;
+        };
+      },
+    };
+    const profile = createPolicyProfile("test", policy, { signalSource: source });
+    await profile.dispose();
+    await profile.dispose(); // idempotent
+    expect(unsubCalls).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: FAIL with "no exported member 'createPolicyProfile'".
+
+- [ ] **Step 3: Implement `createPolicyProfile`**
+
+In `packages/task-graph/src/task/EntitlementProfile.ts`, append:
+
+```ts
+import { createPolicyEnforcer } from "./EntitlementEnforcer";
+import type { EntitlementPolicy } from "./EntitlementPolicy";
+import type { IEntitlementResolver } from "./EntitlementResolver";
+
+// ========================================================================
+// Profile Constructor
+// ========================================================================
+
+export interface CreateProfileOptions {
+  readonly resolver?: IEntitlementResolver;
+  /** Defaults to `STATIC_SIGNAL_SOURCE`. */
+  readonly signalSource?: IEntitlementSignalSource;
+}
+
+/**
+ * Build an `IEntitlementProfile` from a policy.
+ *
+ * Wraps `createPolicyEnforcer` and adds:
+ * - `surface()` returning the policy's grants
+ * - `requestEntitlement()` reusing `checkAll` for a single entitlement
+ * - signal-source subscription with verdict-flip change events
+ * - idempotent `dispose()`
+ *
+ * The "previously queried" set used to scope `reload` events is private to
+ * the profile and cleared on `dispose`.
+ */
+export function createPolicyProfile(
+  name: string,
+  policy: EntitlementPolicy,
+  options: CreateProfileOptions = {}
+): IEntitlementProfile {
+  const enforcer = createPolicyEnforcer(policy, options.resolver);
+  const signalSource = options.signalSource ?? STATIC_SIGNAL_SOURCE;
+  const listeners = new Set<(event: EntitlementChangeEvent) => void>();
+  /**
+   * Map from entitlement-id|resources-key → last observed outcome.
+   * Used to compute verdict flips for change-event emission and to scope
+   * `reload`-triggered re-evaluation.
+   */
+  const lastOutcome = new Map<string, "granted" | "denied">();
+  /** Reference to the original entitlement object so reload can re-query. */
+  const lastEntitlement = new Map<string, TaskEntitlement>();
+  let disposed = false;
+
+  function key(e: TaskEntitlement): string {
+    const resources = e.resources ? [...e.resources].sort().join(",") : "";
+    return `${e.id}|${resources}`;
+  }
+
+  async function evaluate(e: TaskEntitlement): Promise<"granted" | "denied"> {
+    if (e.optional) return "granted";
+    const denials = await enforcer.checkAll({ entitlements: [e] });
+    return denials.length === 0 ? "granted" : "denied";
+  }
+
+  async function emitFlipFor(e: TaskEntitlement): Promise<void> {
+    const k = key(e);
+    const previous = lastOutcome.get(k);
+    if (previous === undefined) return; // never queried; nothing to flip
+    const current = await evaluate(e);
+    if (current === previous) return;
+    lastOutcome.set(k, current);
+    const event: EntitlementChangeEvent = {
+      kind: current === "granted" ? "granted" : "revoked",
+      entitlement: e,
+    };
+    for (const l of listeners) l(event);
+  }
+
+  const sourceUnsub = signalSource.subscribe((signal) => {
+    if (disposed) return;
+    if (signal.kind === "reload") {
+      // Re-evaluate every previously-queried entitlement.
+      for (const [, e] of lastEntitlement) {
+        void emitFlipFor(e);
+      }
+    } else {
+      // revoke or grant: re-evaluate the targeted entitlement.
+      void emitFlipFor(signal.entitlement);
+    }
+  });
+
+  const profile: IEntitlementProfile = {
+    name,
+    checkAll: enforcer.checkAll.bind(enforcer),
+    checkTask: enforcer.checkTask.bind(enforcer),
+    surface: () => policy.grant,
+    async requestEntitlement(required) {
+      if (required.optional) {
+        return { outcome: "granted", entitlement: required };
+      }
+      const denials = await enforcer.checkAll({ entitlements: [required] });
+      const k = key(required);
+      lastEntitlement.set(k, required);
+      if (denials.length === 0) {
+        lastOutcome.set(k, "granted");
+        return { outcome: "granted", entitlement: required };
+      }
+      lastOutcome.set(k, "denied");
+      return { outcome: "denied", denial: denials[0]! };
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      let unsubbed = false;
+      return () => {
+        if (unsubbed) return;
+        unsubbed = true;
+        listeners.delete(listener);
+      };
+    },
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      sourceUnsub();
+      listeners.clear();
+      lastOutcome.clear();
+      lastEntitlement.clear();
+    },
+  };
+  return profile;
+}
+```
+
+- [ ] **Step 4: Build types and run test**
+
+```sh
+bun run build:types
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/task-graph/src/task/EntitlementProfile.ts \
+        packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "feat(task-graph): add createPolicyProfile constructor"
+```
+
+---
+
+## Task 1.4: Refactor `createProfileEnforcer` to return `IEntitlementProfile`
+
+**Files:**
+- Modify: `packages/task-graph/src/task/EntitlementProfiles.ts`
+- Test: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Audit existing call sites**
+
+```sh
+grep -rn "createProfileEnforcer" /home/user/libs/packages/ /home/user/libs/docs/ 2>/dev/null
+```
+
+Note every call site that passes a second positional argument. The plan author found one usage pattern (resolver passed positionally) only inside docs and `Entitlements.test.ts`. Confirm the inventory; any test or non-test call site must be updated in this task.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+import { createProfileEnforcer } from "@workglow/task-graph";
+
+describe("createProfileEnforcer (refactored)", () => {
+  it("returns an IEntitlementProfile (has name, surface, requestEntitlement, subscribe, dispose)", () => {
+    const profile = createProfileEnforcer("browser");
+    expect(profile.name).toBe("browser");
+    expect(typeof profile.surface).toBe("function");
+    expect(typeof profile.requestEntitlement).toBe("function");
+    expect(typeof profile.subscribe).toBe("function");
+    expect(typeof profile.dispose).toBe("function");
+  });
+
+  it("accepts an options bag with resolver and signalSource", () => {
+    const profile = createProfileEnforcer("browser", {
+      resolver: { lookup: () => undefined, prompt: async () => "allow", save: () => {} },
+    });
+    expect(profile.name).toBe("browser");
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: FAIL — `profile.name` is undefined because the current return type is `IEntitlementEnforcer`.
+
+- [ ] **Step 4: Refactor `createProfileEnforcer`**
+
+In `packages/task-graph/src/task/EntitlementProfiles.ts`, replace the current `createProfileEnforcer` with:
+
+```ts
+import { createPolicyProfile, type CreateProfileOptions } from "./EntitlementProfile";
+import type { IEntitlementProfile } from "./EntitlementProfile";
+
+// (existing imports of createPolicyEnforcer and IEntitlementEnforcer can stay
+// only if other exports below still reference them; otherwise remove unused.)
+
+/**
+ * Creates an entitlement profile for the given runtime profile.
+ * The profile's grants become the policy's grant rules.
+ * Deny and ask arrays are empty by default — callers can extend the returned profile.
+ *
+ * @param profile - The runtime profile to use
+ * @param options - Optional resolver (for "ask" verdicts) and signal source
+ */
+export function createProfileEnforcer(
+  profile: EntitlementProfile,
+  options?: CreateProfileOptions
+): IEntitlementProfile {
+  return createPolicyProfile(profile, createProfilePolicy(profile), options);
+}
+```
+
+Remove the now-unused `createPolicyEnforcer` import and the `IEntitlementEnforcer` import if not referenced elsewhere in the file. Also remove the unused `IEntitlementResolver` import; it's reachable through `CreateProfileOptions`.
+
+- [ ] **Step 5: Update existing call sites discovered in Step 1**
+
+For every call site that passes a positional resolver:
+
+Replace:
+```ts
+createProfileEnforcer("browser", myResolver);
+```
+
+With:
+```ts
+createProfileEnforcer("browser", { resolver: myResolver });
+```
+
+Any docs blocks (`docs/technical/14-entitlements-system.md`) showing the old form are updated in Phase 5 / Task 5.2.
+
+- [ ] **Step 6: Build and run all task-graph tests**
+
+```sh
+bun run build:types
+bun test packages/test/src/test/task-graph/
+```
+
+Expected: PASS (including the existing 1208-line `Entitlements.test.ts`, which should still type-check since `IEntitlementProfile extends IEntitlementEnforcer`).
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add packages/task-graph/src/task/EntitlementProfiles.ts \
+        packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "refactor(task-graph): createProfileEnforcer returns IEntitlementProfile"
+```
+
+---
+
+## Task 1.5: Add `ENTITLEMENT_PROFILE` service token
+
+**Files:**
+- Modify: `packages/task-graph/src/task/EntitlementProfile.ts`
+- Test: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+import { ENTITLEMENT_PROFILE, createProfileEnforcer } from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+
+describe("ENTITLEMENT_PROFILE service token", () => {
+  it("registers and resolves a profile through ServiceRegistry", () => {
+    const registry = new ServiceRegistry();
+    const profile = createProfileEnforcer("browser");
+    registry.registerInstance(ENTITLEMENT_PROFILE, profile);
+    expect(registry.get(ENTITLEMENT_PROFILE)).toBe(profile);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: FAIL — `ENTITLEMENT_PROFILE` not exported.
+
+- [ ] **Step 3: Add the token**
+
+In `packages/task-graph/src/task/EntitlementProfile.ts`, append:
+
+```ts
+import { createServiceToken } from "@workglow/util";
+
+// ========================================================================
+// Service Token
+// ========================================================================
+
+/**
+ * Service token for registering an `IEntitlementProfile`.
+ * Distinct from `ENTITLEMENT_ENFORCER`: a profile is a richer surface
+ * (subscribe + dispose + surface). Registering a profile also satisfies
+ * any consumer that resolves `ENTITLEMENT_ENFORCER` because
+ * `IEntitlementProfile extends IEntitlementEnforcer`.
+ */
+export const ENTITLEMENT_PROFILE = createServiceToken<IEntitlementProfile>(
+  "workglow.entitlementProfile"
+);
+```
+
+- [ ] **Step 4: Run test**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/task-graph/src/task/EntitlementProfile.ts \
+        packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "feat(task-graph): add ENTITLEMENT_PROFILE service token"
+```
+
+---
+
+## Task 1.6: Inclusion-lattice test (BROWSER ⊆ DESKTOP ⊆ SERVER)
+
+**Files:**
+- Modify: `packages/test/src/test/task-graph/EntitlementProfile.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Append to `packages/test/src/test/task-graph/EntitlementProfile.test.ts`:
+
+```ts
+import { BROWSER_GRANTS, DESKTOP_GRANTS, SERVER_GRANTS } from "@workglow/task-graph";
+
+describe("Built-in profile inclusion lattice", () => {
+  function ids(grants: ReadonlyArray<{ id: string }>): ReadonlySet<string> {
+    return new Set(grants.map((g) => g.id));
+  }
+
+  it("BROWSER_GRANTS ⊆ DESKTOP_GRANTS", () => {
+    const browser = ids(BROWSER_GRANTS);
+    const desktop = ids(DESKTOP_GRANTS);
+    for (const id of browser) {
+      expect(desktop.has(id)).toBe(true);
+    }
+  });
+
+  it("DESKTOP_GRANTS ⊆ SERVER_GRANTS", () => {
+    const desktop = ids(DESKTOP_GRANTS);
+    const server = ids(SERVER_GRANTS);
+    for (const id of desktop) {
+      expect(server.has(id)).toBe(true);
+    }
+  });
+
+  it("DESKTOP grants are a strict superset of BROWSER", () => {
+    expect(DESKTOP_GRANTS.length).toBeGreaterThan(BROWSER_GRANTS.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+```sh
+bun test packages/test/src/test/task-graph/EntitlementProfile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/test/task-graph/EntitlementProfile.test.ts
+git commit -m "test(task-graph): assert BROWSER ⊆ DESKTOP ⊆ SERVER inclusion lattice"
+```
+
+---
+
+# Phase 2 — Conformance suite scaffolding
+
+## Task 2.1: Create `types.ts`
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/types.ts`
+
+- [ ] **Step 1: Write the file**
+
+Create `packages/test/src/contract/entitlement-profile/types.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  EntitlementId,
+  EntitlementSignal,
+  IEntitlementProfile,
+} from "@workglow/task-graph";
+
+export interface EntitlementProfileConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<EntitlementProfileConformanceHandle>;
+  readonly capabilities: EntitlementProfileCapabilities;
+  readonly expected: EntitlementProfileExpected;
+}
+
+export interface EntitlementProfileCapabilities {
+  /**
+   * If true, the factory returns a handle whose `simulateSignal` method
+   * is wired to the profile's signal source. Subscribe/* assertions are
+   * gated on this flag.
+   */
+  readonly mutableSignalSource: boolean;
+  /**
+   * If true, hierarchyHonoringBlock runs. All built-ins set this true
+   * because they use `createPolicyEnforcer` which honors hierarchy.
+   */
+  readonly hierarchyHonoring: boolean;
+  /** If true, resourceScopingBlock runs. */
+  readonly resourceScoping: boolean;
+}
+
+export interface EntitlementProfileExpected {
+  /** Entitlement IDs that MUST appear in the profile's surface(). */
+  readonly surfaceIncludes: readonly EntitlementId[];
+  /** Entitlement IDs that MUST NOT appear in the profile's surface(). */
+  readonly surfaceExcludes: readonly EntitlementId[];
+}
+
+export interface EntitlementProfileConformanceHandle {
+  readonly profile: IEntitlementProfile;
+  /**
+   * Present iff `capabilities.mutableSignalSource` is true. Pushes a signal
+   * as if the underlying source emitted it, so subscribe/* assertions can
+   * exercise the verdict-flip path.
+   */
+  simulateSignal?(signal: EntitlementSignal): void;
+  dispose(): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/types.ts
+git commit -m "test(contract): add entitlement-profile conformance types"
+```
+
+---
+
+## Task 2.2: Create `fixtures.ts`
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/fixtures.ts`
+
+- [ ] **Step 1: Write the file**
+
+Create `packages/test/src/contract/entitlement-profile/fixtures.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Entitlements,
+  type EntitlementSignal,
+  type IEntitlementSignalSource,
+  type TaskEntitlement,
+} from "@workglow/task-graph";
+
+export const NETWORK_HTTP_REQUIRED: TaskEntitlement = {
+  id: Entitlements.NETWORK_HTTP,
+  reason: "Conformance fixture: HTTP request",
+};
+
+export const FILESYSTEM_REQUIRED: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM,
+  reason: "Conformance fixture: filesystem access",
+};
+
+export const OPTIONAL_CREDENTIAL: TaskEntitlement = {
+  id: Entitlements.CREDENTIAL,
+  reason: "Conformance fixture: optional credential",
+  optional: true,
+};
+
+export const SCOPED_FILESYSTEM_TMP_OK: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM_READ,
+  reason: "Conformance fixture: scoped read of /tmp",
+  resources: ["/tmp/data.json"],
+};
+
+export const SCOPED_FILESYSTEM_ETC_BAD: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM_READ,
+  reason: "Conformance fixture: scoped read of /etc",
+  resources: ["/etc/passwd"],
+};
+
+/** Guaranteed not to appear in any built-in profile surface. */
+export const UNCOVERED_FOO: TaskEntitlement = {
+  id: "foo:bar",
+  reason: "Conformance fixture: uncovered entitlement",
+};
+
+/**
+ * In-memory signal source for the Custom_Profile shim. The returned source
+ * exposes `emit` so the shim's `simulateSignal` can drive listeners.
+ */
+export interface ControllableSignalSource extends IEntitlementSignalSource {
+  emit(signal: EntitlementSignal): void;
+}
+
+export function createControllableSignalSource(): ControllableSignalSource {
+  const listeners = new Set<(s: EntitlementSignal) => void>();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      let unsubbed = false;
+      return () => {
+        if (unsubbed) return;
+        unsubbed = true;
+        listeners.delete(listener);
+      };
+    },
+    emit(signal) {
+      for (const l of listeners) l(signal);
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/fixtures.ts
+git commit -m "test(contract): add entitlement-profile fixtures + controllable signal source"
+```
+
+---
+
+## Task 2.3: Create `runEntitlementProfileConformance.ts` skeleton
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Write the skeleton**
+
+Create `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe } from "vitest";
+
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "./types";
+
+export function runEntitlementProfileConformance(
+  opts: EntitlementProfileConformanceOpts
+): void {
+  describe.skipIf(opts.skip)(`EntitlementProfile conformance: ${opts.name}`, () => {
+    let handle: EntitlementProfileConformanceHandle | undefined;
+    const getHandle = (): EntitlementProfileConformanceHandle => {
+      if (!handle) throw new Error("conformance handle not initialized");
+      return handle;
+    };
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle) await handle.dispose();
+    });
+
+    // Assertion blocks are wired up in Phase 3 tasks. They are imported and
+    // invoked here as each one is added.
+    void getHandle; // silence "unused" until Phase 3 wires the blocks
+  });
+}
+```
+
+- [ ] **Step 2: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+git commit -m "test(contract): add entitlement-profile conformance entrypoint skeleton"
+```
+
+---
+
+# Phase 3 — Conformance assertions
+
+Each task in this phase: (1) creates the assertion file, (2) wires it into `runEntitlementProfileConformance.ts`. The shims aren't built yet, so verification at this stage is type-check only. Behavioral verification happens in Phase 4 when shims are added.
+
+## Task 3.1: `surfaceCoverage` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/surfaceCoverage.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+export function surfaceCoverageBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Surface coverage", () => {
+    it("surface() includes every entitlement listed in expected.surfaceIncludes", async () => {
+      const profile = getHandle().profile;
+      const surface = profile.surface().map((g) => g.id);
+      for (const id of opts.expected.surfaceIncludes) {
+        expect(surface).toContain(id);
+      }
+    });
+
+    it("surface() excludes every entitlement listed in expected.surfaceExcludes", async () => {
+      const profile = getHandle().profile;
+      const surface = profile.surface().map((g) => g.id);
+      for (const id of opts.expected.surfaceExcludes) {
+        expect(surface).not.toContain(id);
+      }
+    });
+
+    it("requestEntitlement returns granted for an entitlement covered by surface", async () => {
+      const profile = getHandle().profile;
+      const firstGrant = profile.surface()[0];
+      if (!firstGrant) {
+        // empty surface — assertion vacuous; opts.expected.surfaceIncludes
+        // would have been empty too.
+        return;
+      }
+      const result = await profile.requestEntitlement({ id: firstGrant.id });
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("requestEntitlement returns denied with default-deny reason for an uncovered entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      expect(result.outcome).toBe("denied");
+      if (result.outcome === "denied") {
+        expect(result.denial.reason).toBe("default-deny");
+        expect(result.denial.entitlement).toBe(UNCOVERED_FOO);
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+In `runEntitlementProfileConformance.ts`, replace `void getHandle;` with:
+
+```ts
+import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
+// ... inside the describe body:
+surfaceCoverageBlock(opts, getHandle);
+```
+
+(Place the import at the top of the file alongside the existing imports.)
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add surfaceCoverage assertion"
+```
+
+---
+
+## Task 3.2: `hierarchyHonoring` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/hierarchyHonoring.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * If the profile surface includes a parent entitlement (e.g. "network"),
+ * requesting a child entitlement (e.g. "network:http") must be granted.
+ */
+export function hierarchyHonoringBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.hierarchyHonoring)("Hierarchy honoring", () => {
+    it("granting a parent ID covers child IDs in the namespace", async () => {
+      const profile = getHandle().profile;
+      // Find a grant whose ID has no colon (a parent), then probe a child.
+      const parentGrant = profile.surface().find((g) => !g.id.includes(":") && !g.resources);
+      if (!parentGrant) {
+        // No broad parent grant in this profile; assertion vacuous.
+        return;
+      }
+      const childId = `${parentGrant.id}:probe`;
+      const result = await profile.requestEntitlement({ id: childId });
+      expect(result.outcome).toBe("granted");
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+Add to `runEntitlementProfileConformance.ts`:
+
+```ts
+import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
+// ... inside describe body, after surfaceCoverageBlock:
+hierarchyHonoringBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add hierarchyHonoring assertion"
+```
+
+---
+
+## Task 3.3: `resourceScoping` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { SCOPED_FILESYSTEM_ETC_BAD, SCOPED_FILESYSTEM_TMP_OK } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * For a profile that supports resource scoping, build a temporary scoped
+ * grant by augmenting the profile is out of scope here — instead we
+ * exercise the policy with a known-scoped fixture only when the profile
+ * already grants filesystem broadly. When `filesystem` is broadly granted,
+ * a scoped read of any resource succeeds. This block additionally verifies
+ * that profiles which DO NOT grant filesystem deny a /tmp read.
+ */
+export function resourceScopingBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.resourceScoping)("Resource scoping", () => {
+    it("scoped read succeeds when the profile broadly grants filesystem", async () => {
+      const profile = getHandle().profile;
+      const hasBroadFilesystem = profile.surface().some(
+        (g) => g.id === "filesystem" && !g.resources
+      );
+      if (!hasBroadFilesystem) {
+        // Profile does not broadly grant filesystem; this assertion is vacuous.
+        return;
+      }
+      const result = await profile.requestEntitlement(SCOPED_FILESYSTEM_TMP_OK);
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("scoped read fails when the profile does not grant filesystem at all", async () => {
+      const profile = getHandle().profile;
+      const hasFilesystem = profile.surface().some(
+        (g) => g.id === "filesystem" || g.id === "filesystem:read"
+      );
+      if (hasFilesystem) {
+        return; // not the negative case
+      }
+      const result = await profile.requestEntitlement(SCOPED_FILESYSTEM_ETC_BAD);
+      expect(result.outcome).toBe("denied");
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+Add to `runEntitlementProfileConformance.ts`:
+
+```ts
+import { resourceScopingBlock } from "./assertions/resourceScoping";
+// ... inside describe body:
+resourceScopingBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add resourceScoping assertion"
+```
+
+---
+
+## Task 3.4: `optionalNeverDenied` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/optionalNeverDenied.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { OPTIONAL_CREDENTIAL } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Optional entitlements must never be reported as denied — neither by
+ * `requestEntitlement` nor by `checkAll`.
+ */
+export function optionalNeverDeniedBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Optional entitlements never denied", () => {
+    it("requestEntitlement returns granted for an optional entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(OPTIONAL_CREDENTIAL);
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("checkAll returns no denials for an optional entitlement even when uncovered", async () => {
+      const profile = getHandle().profile;
+      const denials = await profile.checkAll({
+        entitlements: [{ id: "uncovered:optional", optional: true }],
+      });
+      expect(denials).toEqual([]);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
+// ... inside describe body:
+optionalNeverDeniedBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add optionalNeverDenied assertion"
+```
+
+---
+
+## Task 3.5: `denialShape` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/denialShape.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * The denial returned by requestEntitlement for an uncovered entitlement
+ * must satisfy the EntitlementDenial discriminated union: a `reason` of
+ * "policy-deny" / "user-deny" requires `matchedRule`; "default-deny"
+ * forbids it.
+ */
+export function denialShapeBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Denial shape", () => {
+    it("denial.entitlement is reference-equal to the requested entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      expect(result.outcome).toBe("denied");
+      if (result.outcome === "denied") {
+        expect(result.denial.entitlement).toBe(UNCOVERED_FOO);
+      }
+    });
+
+    it("denial.reason matches the EntitlementDenialReason union", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      if (result.outcome === "denied") {
+        expect(["policy-deny", "default-deny", "user-deny"]).toContain(result.denial.reason);
+      }
+    });
+
+    it("policy-deny and user-deny carry matchedRule; default-deny does not", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      if (result.outcome === "denied") {
+        const d = result.denial;
+        if (d.reason === "default-deny") {
+          // Discriminated union: default-deny variant has no matchedRule property.
+          expect("matchedRule" in d).toBe(false);
+        } else {
+          // policy-deny / user-deny carry matchedRule.
+          expect(d.matchedRule).toBeDefined();
+        }
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { denialShapeBlock } from "./assertions/denialShape";
+// ... inside describe body:
+denialShapeBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add denialShape assertion"
+```
+
+---
+
+## Task 3.6: `requestEntitlementShape` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * For the same input, `requestEntitlement` and `checkAll([input])` agree:
+ * - granted ↔ empty denial array
+ * - denied ↔ single-element denial array with matching reason
+ */
+export function requestEntitlementShapeBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("requestEntitlement shape parity with checkAll", () => {
+    it("granted: requestEntitlement and checkAll agree", async () => {
+      const profile = getHandle().profile;
+      const isCovered = profile
+        .surface()
+        .some((g) => g.id === NETWORK_HTTP_REQUIRED.id && !g.resources);
+      if (!isCovered) return; // assertion vacuous if profile doesn't grant network:http
+      const single = await profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      const all = await profile.checkAll({ entitlements: [NETWORK_HTTP_REQUIRED] });
+      expect(single.outcome).toBe("granted");
+      expect(all).toEqual([]);
+    });
+
+    it("denied: requestEntitlement and checkAll agree on reason", async () => {
+      const profile = getHandle().profile;
+      const single = await profile.requestEntitlement(UNCOVERED_FOO);
+      const all = await profile.checkAll({ entitlements: [UNCOVERED_FOO] });
+      expect(single.outcome).toBe("denied");
+      expect(all).toHaveLength(1);
+      if (single.outcome === "denied") {
+        expect(all[0]!.reason).toBe(single.denial.reason);
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
+// ... inside describe body:
+requestEntitlementShapeBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add requestEntitlementShape assertion"
+```
+
+---
+
+## Task 3.7: `subscribeRevocation` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeRevocation.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Verify that the profile re-evaluates and emits a "revoked" change event
+ * when the signal source emits a revoke for a previously-granted
+ * entitlement, and emits nothing when no flip occurred.
+ */
+export function subscribeRevocationBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe revocation", () => {
+    it("emits revoked when previously-granted entitlement becomes denied", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) {
+        throw new Error("simulateSignal must be present when mutableSignalSource is true");
+      }
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Seed: query and confirm currently granted.
+        const before = await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+        if (before.outcome !== "granted") {
+          // Profile does not grant this; this assertion is vacuous for it.
+          return;
+        }
+        // The Custom_Profile shim's underlying policy mutates so that revoke
+        // signals reflect a real flip; the simulateSignal hook on the shim
+        // is responsible for staging that policy change before emitting.
+        handle.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+        await new Promise((r) => setTimeout(r, 0));
+        const revoked = events.find((e) => e.kind === "revoked");
+        expect(revoked).toBeDefined();
+        expect(revoked?.entitlement.id).toBe(NETWORK_HTTP_REQUIRED.id);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("does not emit when no flip occurs (revoke for never-granted entitlement)", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Query an uncovered entitlement: it's already denied.
+        await handle.profile.requestEntitlement(UNCOVERED_FOO);
+        handle.simulateSignal({ kind: "revoke", entitlement: UNCOVERED_FOO });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(events).toEqual([]);
+      } finally {
+        unsub();
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { subscribeRevocationBlock } from "./assertions/subscribeRevocation";
+// ... inside describe body:
+subscribeRevocationBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add subscribeRevocation assertion"
+```
+
+---
+
+## Task 3.8: `subscribeGrant` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Verify that the profile emits a "granted" change event when the signal
+ * source emits a grant for a previously-denied entitlement.
+ */
+export function subscribeGrantBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe grant", () => {
+    it("emits granted when previously-denied entitlement becomes granted", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) {
+        throw new Error("simulateSignal must be present when mutableSignalSource is true");
+      }
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Seed: query an entitlement that is currently denied. The Custom shim's
+        // simulateSignal stages the policy flip before emitting the signal.
+        const before = await handle.profile.requestEntitlement(UNCOVERED_FOO);
+        if (before.outcome !== "denied") return; // not the case for this profile
+        handle.simulateSignal({ kind: "grant", entitlement: UNCOVERED_FOO });
+        await new Promise((r) => setTimeout(r, 0));
+        const granted = events.find((e) => e.kind === "granted");
+        expect(granted).toBeDefined();
+        expect(granted?.entitlement.id).toBe(UNCOVERED_FOO.id);
+      } finally {
+        unsub();
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { subscribeGrantBlock } from "./assertions/subscribeGrant";
+// ... inside describe body:
+subscribeGrantBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add subscribeGrant assertion"
+```
+
+---
+
+## Task 3.9: `subscribeReload` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * After querying a set of entitlements then signalling reload, change events
+ * fire only for entitlements whose verdict actually flipped.
+ */
+export function subscribeReloadBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe reload", () => {
+    it("reload fires events only for previously-queried entitlements that flipped", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      // Pre-seed by querying two entitlements before subscribing.
+      await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      await handle.profile.requestEntitlement(UNCOVERED_FOO);
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // The shim's simulateSignal stages a policy mutation that flips
+        // exactly one of the two seeded entitlements before emitting reload.
+        handle.simulateSignal({ kind: "reload" });
+        await new Promise((r) => setTimeout(r, 0));
+        // We expect exactly one change event corresponding to the flipped
+        // entitlement. The shim controls which one.
+        expect(events.length).toBeGreaterThanOrEqual(1);
+        for (const e of events) {
+          expect([NETWORK_HTTP_REQUIRED.id, UNCOVERED_FOO.id]).toContain(e.entitlement.id);
+        }
+      } finally {
+        unsub();
+      }
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { subscribeReloadBlock } from "./assertions/subscribeReload";
+// ... inside describe body:
+subscribeReloadBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add subscribeReload assertion"
+```
+
+---
+
+## Task 3.10: `unsubscribeIdempotent` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/unsubscribeIdempotent.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+export function unsubscribeIdempotentBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Unsubscribe idempotent", () => {
+    it("calling unsubscribe twice does not throw", () => {
+      const profile = getHandle().profile;
+      const unsub = profile.subscribe(() => {});
+      unsub();
+      expect(() => unsub()).not.toThrow();
+    });
+
+    it("after unsubscribe, no further events are delivered", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      // Seed and unsub before signalling.
+      await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      unsub();
+      handle.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(events).toEqual([]);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+```ts
+import { unsubscribeIdempotentBlock } from "./assertions/unsubscribeIdempotent";
+// ... inside describe body:
+unsubscribeIdempotentBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add unsubscribeIdempotent assertion"
+```
+
+---
+
+## Task 3.11: `dispose` assertion
+
+**Files:**
+- Create: `packages/test/src/contract/entitlement-profile/assertions/dispose.ts`
+- Modify: `packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts`
+
+- [ ] **Step 1: Create the assertion file**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * dispose() is idempotent. After dispose, a simulateSignal does not deliver
+ * events to listeners that subscribed before dispose.
+ *
+ * NOTE: This block uses an isolated profile via the factory, not the shared
+ * conformance handle, because disposing the shared handle would break later
+ * blocks. The factory is invoked again here; afterAll on the shared handle
+ * still runs against its own profile.
+ */
+export function disposeBlock(
+  opts: EntitlementProfileConformanceOpts,
+  _getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Dispose", () => {
+    it("dispose is idempotent (two calls succeed)", async () => {
+      const local = await opts.factory();
+      try {
+        await local.profile.dispose();
+        await expect(local.profile.dispose()).resolves.toBeUndefined();
+      } finally {
+        // local.dispose() is itself idempotent and will exercise dispose() again.
+        await local.dispose();
+      }
+    });
+
+    it.skipIf(!opts.capabilities.mutableSignalSource)(
+      "after dispose, signal source no longer drives events",
+      async () => {
+        const local = await opts.factory();
+        try {
+          if (!local.simulateSignal) return;
+          const events: EntitlementChangeEvent[] = [];
+          local.profile.subscribe((e) => events.push(e));
+          await local.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+          await local.profile.dispose();
+          local.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+          await new Promise((r) => setTimeout(r, 0));
+          expect(events).toEqual([]);
+        } finally {
+          await local.dispose();
+        }
+      }
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the entrypoint**
+
+In `runEntitlementProfileConformance.ts`, add the import and place the call **last** (so dispose-related tests run after every other block has used the shared handle):
+
+```ts
+import { disposeBlock } from "./assertions/dispose";
+// ... inside describe body, AFTER all other blocks:
+disposeBlock(opts, getHandle);
+```
+
+- [ ] **Step 3: Build types**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/contract/entitlement-profile/
+git commit -m "test(contract): add dispose assertion (final block)"
+```
+
+---
+
+# Phase 4 — Adapter shims
+
+This is where the suite first executes end-to-end. Each shim provides a factory and capability flags. Builds plus `bun test` should pass after each shim is added.
+
+## Task 4.1: Browser profile shim
+
+**Files:**
+- Create: `packages/test/src/test/entitlement-profile/Browser_Profile.test.ts`
+
+- [ ] **Step 1: Write the shim**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "browser",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("browser");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.NETWORK_WEBSOCKET,
+      Entitlements.AI,
+      Entitlements.MCP_TOOL_CALL,
+      Entitlements.STORAGE,
+      Entitlements.CREDENTIAL,
+    ],
+    surfaceExcludes: [
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.MCP_STDIO,
+      Entitlements.BROWSER_CONTROL,
+    ],
+  },
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```sh
+bun test packages/test/src/test/entitlement-profile/Browser_Profile.test.ts
+```
+
+Expected: PASS — all assertion blocks except the `mutableSignalSource`-gated ones (subscribe*, unsubscribeIdempotent, second dispose case).
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/test/entitlement-profile/Browser_Profile.test.ts
+git commit -m "test(entitlement-profile): add browser profile conformance shim"
+```
+
+---
+
+## Task 4.2: Desktop profile shim
+
+**Files:**
+- Create: `packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts`
+
+- [ ] **Step 1: Write the shim**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "desktop",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("desktop");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.MCP_STDIO,
+      Entitlements.BROWSER_CONTROL_LOCAL,
+    ],
+    surfaceExcludes: [
+      // Desktop intentionally does NOT include the cloud variant.
+      Entitlements.BROWSER_CONTROL_CLOUD,
+    ],
+  },
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```sh
+bun test packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts
+git commit -m "test(entitlement-profile): add desktop profile conformance shim"
+```
+
+---
+
+## Task 4.3: Server profile shim
+
+**Files:**
+- Create: `packages/test/src/test/entitlement-profile/Server_Profile.test.ts`
+
+- [ ] **Step 1: Write the shim**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "server",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("server");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.BROWSER_CONTROL_CLOUD,
+    ],
+    surfaceExcludes: [],
+  },
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```sh
+bun test packages/test/src/test/entitlement-profile/Server_Profile.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/test/entitlement-profile/Server_Profile.test.ts
+git commit -m "test(entitlement-profile): add server profile conformance shim"
+```
+
+---
+
+## Task 4.4: Custom profile shim with controllable signal source
+
+This shim is the only one that exercises the subscribe/* assertion blocks. It builds a profile with a mutable in-memory policy holder so signal-source-driven flips actually flip verdicts.
+
+**Files:**
+- Create: `packages/test/src/test/entitlement-profile/Custom_Profile.test.ts`
+
+- [ ] **Step 1: Write the shim**
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Entitlements,
+  createPolicyProfile,
+  type EntitlementGrant,
+  type EntitlementPolicy,
+  type EntitlementSignal,
+  type IEntitlementProfile,
+  type IEntitlementSignalSource,
+} from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+import { createControllableSignalSource } from "../../contract/entitlement-profile/fixtures";
+
+/**
+ * A custom profile backed by a mutable grant set. The accompanying
+ * controllable signal source has a `simulateSignal` wrapper that:
+ *  - on `revoke(e)`: removes any grant whose ID equals `e.id`
+ *  - on `grant(e)`:  adds a broad grant for `e.id`
+ *  - on `reload`:    flips one specific entitlement (NETWORK_HTTP) per
+ *                    invocation so the suite can observe a deterministic
+ *                    flip; subsequent calls flip it back.
+ *
+ * The mutable backing is the `grant` array of the policy used to build
+ * the profile. We replace it via reassignment of a wrapper holder; the
+ * profile reads it lazily via a getter.
+ */
+function buildCustomProfile(): {
+  readonly profile: IEntitlementProfile;
+  simulateSignal(signal: EntitlementSignal): void;
+} {
+  let grants: EntitlementGrant[] = [
+    { id: Entitlements.NETWORK_HTTP },
+    { id: Entitlements.AI },
+  ];
+  // The policy's `grant` array is read each time the underlying enforcer
+  // calls `evaluatePolicy`, so we wrap it in a getter via Object.defineProperty.
+  const policy = {
+    deny: [] as never[],
+    ask: [] as never[],
+  } as EntitlementPolicy as { deny: readonly never[]; grant: readonly EntitlementGrant[]; ask: readonly never[] };
+  Object.defineProperty(policy, "grant", {
+    get: () => grants,
+    enumerable: true,
+  });
+
+  const source = createControllableSignalSource();
+
+  const profile = createPolicyProfile("custom", policy, { signalSource: source });
+
+  let reloadFlipState = false;
+  return {
+    profile,
+    simulateSignal(signal) {
+      if (signal.kind === "revoke") {
+        grants = grants.filter((g) => g.id !== signal.entitlement.id);
+      } else if (signal.kind === "grant") {
+        if (!grants.some((g) => g.id === signal.entitlement.id)) {
+          grants = [...grants, { id: signal.entitlement.id }];
+        }
+      } else {
+        // reload: flip NETWORK_HTTP grant state.
+        if (reloadFlipState) {
+          grants = grants.filter((g) => g.id !== Entitlements.NETWORK_HTTP);
+        } else {
+          if (!grants.some((g) => g.id === Entitlements.NETWORK_HTTP)) {
+            grants = [...grants, { id: Entitlements.NETWORK_HTTP }];
+          }
+        }
+        reloadFlipState = !reloadFlipState;
+      }
+      source.emit(signal);
+    },
+  };
+}
+
+runEntitlementProfileConformance({
+  name: "custom",
+  timeout: 5_000,
+  factory: async () => {
+    const built = buildCustomProfile();
+    return {
+      profile: built.profile,
+      simulateSignal: built.simulateSignal,
+      dispose: () => built.profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: true,
+    hierarchyHonoring: true,
+    resourceScoping: false, // custom profile only declares broad grants
+  },
+  expected: {
+    surfaceIncludes: [Entitlements.NETWORK_HTTP, Entitlements.AI],
+    surfaceExcludes: [Entitlements.FILESYSTEM],
+  },
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```sh
+bun test packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
+```
+
+Expected: PASS — including the subscribe/* and dispose-after-revoke blocks. If any subscribe block fails because the shim's reload flip state interacts with prior assertion runs (e.g., NETWORK_HTTP got revoked by the revoke test before reload runs), reset `grants` and `reloadFlipState` per top-level `factory()` call. The factory is called twice (once for the shared handle, once for the dispose block's local instance); the closure in `buildCustomProfile` already isolates state per call, so this should not be an issue.
+
+- [ ] **Step 3: Run the entire entitlement-profile suite together**
+
+```sh
+bun test packages/test/src/test/entitlement-profile/
+```
+
+Expected: PASS for all four shim files.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
+git commit -m "test(entitlement-profile): add custom profile shim with controllable signal source"
+```
+
+---
+
+# Phase 5 — Documentation
+
+## Task 5.1: Update contract README
+
+**Files:**
+- Modify: `packages/test/src/contract/README.md`
+
+- [ ] **Step 1: Add row to "Available suites" table**
+
+In `packages/test/src/contract/README.md`, find the table:
+
+```markdown
+| `AiProvider` | `contract/ai-provider/runAiProviderConformance` | Anthropic, OpenAI, Gemini, Ollama, HF Inference, HF Transformers, LlamaCpp |
+| `IQueueStorage` + `IRateLimiterStorage` | `test/job-queue/genericJobQueueTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase |
+| `ITabularStorage` | `test/storage-tabular/genericTabularStorageTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase, FsFolder, HuggingFace |
+```
+
+Add row:
+```markdown
+| `IEntitlementProfile` | `contract/entitlement-profile/runEntitlementProfileConformance` | Browser, Desktop, Server, Custom |
+```
+
+- [ ] **Step 2: Update the Roadmap section**
+
+Find:
+```markdown
+4. `EntitlementProfile` — desktop / web / server profiles.
+```
+
+Remove that line (suite shipped). Renumber the remaining items.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/test/src/contract/README.md
+git commit -m "docs(contract): record EntitlementProfile suite as shipped"
+```
+
+---
+
+## Task 5.2: Update entitlements technical doc
+
+**Files:**
+- Modify: `docs/technical/14-entitlements-system.md`
+
+- [ ] **Step 1: Add a new section on `IEntitlementProfile`**
+
+After the existing "Entitlement Profiles" section (currently ends at the
+`createProfileEnforcer("browser")` example), insert:
+
+```markdown
+## IEntitlementProfile
+
+`createProfileEnforcer` returns an `IEntitlementProfile`, a richer surface
+than the bare `IEntitlementEnforcer`:
+
+```ts
+interface IEntitlementProfile extends IEntitlementEnforcer {
+  readonly name: string;
+  surface(): readonly EntitlementGrant[];
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
+  subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
+  dispose(): Promise<void>;
+}
+
+type EntitlementRequestResult =
+  | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
+  | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
+
+type EntitlementChangeEvent = {
+  readonly kind: "revoked" | "granted";
+  readonly entitlement: TaskEntitlement;
+};
+```
+
+- `surface()` returns the maximum set of grants the profile may issue.
+- `requestEntitlement(e)` is the single-key form of `checkAll`. Optional
+  entitlements always map to `{ outcome: "granted" }`. `"ask"` policy
+  verdicts are resolved internally before returning.
+- `subscribe(listener)` returns events when previously-observed
+  entitlements transition between granted and denied. Built-in profiles
+  with the default `STATIC_SIGNAL_SOURCE` never emit. Downstream profiles
+  plug in a platform signal source (Electron permission events,
+  browser Permissions API onchange, etc.).
+- `dispose()` is idempotent and unsubscribes from the signal source.
+
+### Pluggable signal source
+
+```ts
+interface IEntitlementSignalSource {
+  subscribe(listener: (signal: EntitlementSignal) => void): () => void;
+}
+
+type EntitlementSignal =
+  | { readonly kind: "revoke"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "grant"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "reload" };
+```
+
+Pass a custom source to `createProfileEnforcer`:
+
+```ts
+const profile = createProfileEnforcer("desktop", {
+  signalSource: myElectronPermissionsSource,
+});
+```
+
+The default is `STATIC_SIGNAL_SOURCE` (no-op). On `revoke`/`grant`, the
+profile re-evaluates the targeted entitlement and emits a change event
+only if the verdict actually flipped. On `reload`, the profile
+re-evaluates every entitlement it has previously been queried about.
+
+### ENTITLEMENT_PROFILE service token
+
+A separate service token registers profiles in the global registry.
+It coexists with `ENTITLEMENT_ENFORCER`; consumers that only need the
+basic enforcer surface can register the profile under that token too,
+since `IEntitlementProfile extends IEntitlementEnforcer`.
+
+```ts
+import { globalServiceRegistry } from "@workglow/util";
+import { ENTITLEMENT_PROFILE, createProfileEnforcer } from "@workglow/task-graph";
+
+globalServiceRegistry.registerInstance(ENTITLEMENT_PROFILE, createProfileEnforcer("browser"));
+```
+```
+
+- [ ] **Step 2: Update the existing `createProfileEnforcer` signature in the API Reference table**
+
+Find:
+```markdown
+| `createProfileEnforcer`    | `(profile: EntitlementProfile) => IEntitlementEnforcer`           | Create an enforcer for a standard runtime profile                   |
+```
+
+Replace with:
+```markdown
+| `createProfileEnforcer`    | `(profile: EntitlementProfile, options?: CreateProfileOptions) => IEntitlementProfile` | Create a profile for a standard runtime configuration |
+| `createPolicyProfile`      | `(name: string, policy: EntitlementPolicy, options?: CreateProfileOptions) => IEntitlementProfile` | Create a profile from an arbitrary policy |
+```
+
+Also add to the Constants table:
+```markdown
+| `STATIC_SIGNAL_SOURCE` | No-op `IEntitlementSignalSource` (built-in profile default) |
+| `ENTITLEMENT_PROFILE`  | Service token for registering an `IEntitlementProfile`      |
+```
+
+And add to the Types table:
+```markdown
+| `IEntitlementProfile`     | Profile interface — extends `IEntitlementEnforcer` with surface, requestEntitlement, subscribe, dispose |
+| `EntitlementRequestResult`| Discriminated union returned by `requestEntitlement`                                                    |
+| `EntitlementChangeEvent`  | `{ kind: "revoked" \| "granted", entitlement }`                                                          |
+| `EntitlementSignal`       | `{ kind: "revoke" \| "grant", entitlement } \| { kind: "reload" }`                                       |
+| `IEntitlementSignalSource`| Pluggable port that emits `EntitlementSignal`                                                            |
+| `CreateProfileOptions`    | `{ resolver?, signalSource? }`                                                                           |
+```
+
+- [ ] **Step 3: Update the existing example that passes a positional resolver**
+
+If any code block in this file shows `createProfileEnforcer(profile, resolver)` (two-arg positional form), replace with the options-bag form:
+
+```ts
+const enforcer = createProfileEnforcer("browser", { resolver });
+```
+
+- [ ] **Step 4: Build types and run all task-graph + entitlement-profile tests**
+
+```sh
+bun run build:types
+bun test packages/test/src/test/task-graph/
+bun test packages/test/src/test/entitlement-profile/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add docs/technical/14-entitlements-system.md
+git commit -m "docs(entitlements): document IEntitlementProfile + signal source + ENTITLEMENT_PROFILE token"
+```
+
+---
+
+# Final verification
+
+- [ ] **Step 1: Run the full test runner for the relevant section**
+
+```sh
+bun scripts/test.ts task-graph vitest
+bun scripts/test.ts entitlement-profile vitest
+```
+
+Expected: PASS.
+
+If `bun scripts/test.ts` does not recognize `entitlement-profile` as a section, the section name is the directory under `packages/test/src/test/`. Confirm by checking `scripts/test.ts` argument parsing; the directory name `entitlement-profile` should be auto-discovered.
+
+- [ ] **Step 2: Run the full type build**
+
+```sh
+bun run build:types
+```
+
+Expected: succeeds with no errors.
+
+- [ ] **Step 3: Format**
+
+```sh
+bun run format
+```
+
+If anything was reformatted, commit:
+```sh
+git add -A
+git commit -m "chore: format"
+```
+
+- [ ] **Step 4: Push**
+
+```sh
+git push -u origin claude/entitlementprofile-contract-vD9QY
+```

--- a/docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md
@@ -64,13 +64,17 @@ that any profile implementation — built-in or downstream — must pass.
 All additions live in `@workglow/task-graph`. Existing exports are unchanged
 in shape; one return type widens additively.
 
-### `EntitlementVerdict`
+### `EntitlementRequestResult`
+
+> **Implementation note:** The implementation uses `EntitlementRequestResult`
+> (not `EntitlementVerdict`) to avoid shadowing the existing
+> `evaluatePolicy`-style verdict terminology already present in the codebase.
 
 A discriminated union that mirrors `checkAll` semantics for a single
 required entitlement.
 
 ```ts
-export type EntitlementVerdict =
+export type EntitlementRequestResult =
   | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
   | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
 ```
@@ -129,7 +133,7 @@ export type EntitlementChangeEvent = {
 export interface IEntitlementProfile extends IEntitlementEnforcer {
   readonly name: string;
   surface(): readonly EntitlementGrant[];
-  requestEntitlement(required: TaskEntitlement): Promise<EntitlementVerdict>;
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
   subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
   dispose(): Promise<void>;
 }

--- a/docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md
@@ -1,0 +1,428 @@
+<!--
+  @license
+  Copyright 2026 Steven Roussey <sroussey@gmail.com>
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# EntitlementProfile Contract Conformance — Design
+
+## Background
+
+Three of the five contract suites planned in
+`docs/superpowers/specs/2026-05-04-aiprovider-contract-conformance-design.md`
+have shipped (AiProvider, ITabularStorage extensions, IMigrationRunner). This
+document specifies the fourth: **EntitlementProfile**.
+
+Today the entitlement system in `@workglow/task-graph` exposes three named
+grant configurations — `"browser"`, `"desktop"`, `"server"` — that all reduce
+to a single `createPolicyEnforcer` implementation. They are not separate
+adapter implementations; they are different inputs to one function. Downstream
+consumers (e.g. workflow-builder's Electron/web/server packages) layer
+platform-specific behavior on top of these grant lists, but there is no
+library-level contract that those layered profiles must satisfy.
+
+This proposal introduces a profile abstraction (`IEntitlementProfile`),
+extends the entitlement API with single-key requests and
+revocation/grant change events sourced from a pluggable signal port
+(`IEntitlementSignalSource`), and ships a parameterized conformance suite
+that any profile implementation — built-in or downstream — must pass.
+
+## Goals
+
+1. Make "profile" a first-class abstraction with a stable contract that
+   library and downstream implementations can satisfy.
+2. Add a single-key `requestEntitlement` API whose verdict shape is uniform
+   across implementations.
+3. Add an observable change-event mechanism so consumers can react when a
+   previously-granted entitlement is revoked (or vice versa).
+4. Decouple the *source* of permission changes from the profile by
+   introducing a pluggable `IEntitlementSignalSource` port.
+5. Ship a parameterized conformance suite (matching the AiProvider pattern
+   in `packages/test/src/contract/`) that exercises every profile
+   implementation against a shared invariant set.
+
+## Non-goals
+
+- Replacing or removing `IEntitlementEnforcer`. The profile interface
+  *extends* it; ad-hoc enforcers (`PERMISSIVE_ENFORCER`,
+  `createGrantListEnforcer`, `createScopedEnforcer`) keep the simpler
+  surface.
+- Defining new well-known entitlements. The set in
+  `TaskEntitlements.Entitlements` stays as-is.
+- Changing the JSON serialization of tasks or graphs.
+- Shipping platform-specific signal sources (Electron, browser Permissions
+  API, server config reload). Those live in the consumer packages. This
+  spec only defines the port and a static no-op default.
+- Re-running every existing assertion in `Entitlements.test.ts` through the
+  conformance suite. The 1208-line existing file covers the underlying
+  primitives (`entitlementCovers`, `evaluatePolicy`, `mergeEntitlements`,
+  scoped/grant-list enforcers). The new suite tests profile-level
+  invariants only.
+
+## Library API additions
+
+All additions live in `@workglow/task-graph`. Existing exports are unchanged
+in shape; one return type widens additively.
+
+### `EntitlementVerdict`
+
+A discriminated union that mirrors `checkAll` semantics for a single
+required entitlement.
+
+```ts
+export type EntitlementVerdict =
+  | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
+  | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
+```
+
+Semantics:
+
+- A **non-optional** required entitlement that the policy denies (any
+  reason in `EntitlementDenialReason`) maps to
+  `{ outcome: "denied", denial }`.
+- An **optional** required entitlement always maps to
+  `{ outcome: "granted", entitlement }` regardless of the underlying
+  policy verdict — matching the existing rule that optional entitlements
+  are filtered out of `checkAll`'s denial list.
+- An `"ask"` verdict is resolved internally via the registered
+  `IEntitlementResolver` before the function returns; the caller only
+  ever sees `granted` or `denied`.
+
+### `IEntitlementSignalSource` and `EntitlementSignal`
+
+A port that produces signals about external permission changes. Profiles
+subscribe to a source on construction and translate signals into change
+events.
+
+```ts
+export type EntitlementSignal =
+  | { readonly kind: "revoke"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "grant"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "reload" };
+
+export interface IEntitlementSignalSource {
+  subscribe(listener: (signal: EntitlementSignal) => void): () => void;
+}
+
+export const STATIC_SIGNAL_SOURCE: IEntitlementSignalSource;
+```
+
+`STATIC_SIGNAL_SOURCE` is a frozen no-op singleton: its `subscribe`
+returns a no-op unsubscribe and never invokes the listener. It is the
+default source for the three built-in profiles, which model immutable
+grant lists. Downstream packages provide their own implementations
+(e.g., wrapping Electron `permission-request` events).
+
+A `kind: "reload"` signal means "the underlying policy may have changed
+in arbitrary ways; consumers should re-query." Profiles translate
+`reload` into per-entitlement change events for any entitlement whose
+verdict actually flipped (see *Change-event derivation* below).
+
+### `IEntitlementProfile`
+
+```ts
+export type EntitlementChangeEvent = {
+  readonly kind: "revoked" | "granted";
+  readonly entitlement: TaskEntitlement;
+};
+
+export interface IEntitlementProfile extends IEntitlementEnforcer {
+  readonly name: string;
+  surface(): readonly EntitlementGrant[];
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementVerdict>;
+  subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
+  dispose(): Promise<void>;
+}
+```
+
+- `name` — a free-form identifier for diagnostics. Built-ins return
+  `"browser"`, `"desktop"`, `"server"`.
+- `surface()` — the maximum set of entitlements this profile may grant.
+  Returned as `readonly EntitlementGrant[]` so downstream profiles can
+  advertise resource-scoped grants. The conformance suite uses this for
+  the surface-coverage invariant: every granted entitlement must be
+  covered by something in `surface()`.
+- `requestEntitlement(required)` — single-key request returning the
+  verdict shape above.
+- `subscribe(listener)` — register for change events; returns an
+  unsubscribe function. The unsubscribe must be idempotent.
+- `dispose()` — release resources, including unsubscribing from the
+  signal source. Must be idempotent.
+
+### Change-event derivation
+
+When the signal source emits:
+
+| Signal             | Profile behavior                                                                 |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `revoke(e)`        | Re-evaluate `e`; if previous verdict was `granted` and current is `denied`, emit `{ kind: "revoked", entitlement: e }`. |
+| `grant(e)`         | Re-evaluate `e`; if previous verdict was `denied` and current is `granted`, emit `{ kind: "granted", entitlement: e }`. |
+| `reload`           | The profile re-evaluates *every* entitlement it has previously been queried about (tracked in a private set) and emits change events for any whose verdict flipped. |
+
+The "previously queried" tracking exists only to scope `reload` work; it
+is not visible through the public API. Built-in profiles (with
+`STATIC_SIGNAL_SOURCE`) never receive signals and therefore never emit
+change events.
+
+### `createProfileEnforcer` widening
+
+Today:
+
+```ts
+export function createProfileEnforcer(
+  profile: EntitlementProfile,
+  resolver?: IEntitlementResolver
+): IEntitlementEnforcer;
+```
+
+After:
+
+```ts
+export interface CreateProfileOptions {
+  readonly resolver?: IEntitlementResolver;
+  readonly signalSource?: IEntitlementSignalSource;  // defaults to STATIC_SIGNAL_SOURCE
+}
+
+export function createProfileEnforcer(
+  profile: EntitlementProfile,
+  options?: CreateProfileOptions
+): IEntitlementProfile;
+```
+
+The two-argument legacy form (`createProfileEnforcer(profile, resolver)`)
+is dropped; the single-argument form continues to work. Call sites that
+pass a resolver migrate to the options-bag form. There is one such call
+site to migrate: `globalServiceRegistry.registerInstance(...)` examples
+in docs and any internal usage discovered during implementation.
+
+The return type widens from `IEntitlementEnforcer` to
+`IEntitlementProfile`, which is a superset; consumers that store the
+result as `IEntitlementEnforcer` are unaffected.
+
+`getProfileGrants` and `createProfilePolicy` are unchanged.
+
+## Conformance suite
+
+Lives in `packages/test/src/contract/entitlement-profile/`, mirroring the
+AiProvider layout (`packages/test/src/contract/ai-provider/`).
+
+### Layout
+
+```
+packages/test/src/contract/entitlement-profile/
+  types.ts
+  fixtures.ts
+  runEntitlementProfileConformance.ts
+  assertions/
+    surfaceCoverage.ts
+    hierarchyHonoring.ts
+    resourceScoping.ts
+    optionalNeverDenied.ts
+    denialShape.ts
+    requestEntitlementShape.ts
+    subscribeRevocation.ts
+    subscribeGrant.ts
+    subscribeReload.ts
+    unsubscribeIdempotent.ts
+    dispose.ts
+```
+
+### `types.ts`
+
+```ts
+export interface EntitlementProfileConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<EntitlementProfileConformanceHandle>;
+  readonly capabilities: {
+    readonly mutableSignalSource: boolean;
+    readonly hierarchyHonoring: boolean;     // true for all built-ins
+    readonly resourceScoping: boolean;       // true if profile supports scoped grants
+  };
+  readonly expected: {
+    /** IDs that must appear in the profile's surface(). */
+    readonly surfaceIncludes: readonly EntitlementId[];
+    /** IDs that must NOT appear in the profile's surface(). */
+    readonly surfaceExcludes: readonly EntitlementId[];
+  };
+}
+
+export interface EntitlementProfileConformanceHandle {
+  readonly profile: IEntitlementProfile;
+  /**
+   * Only present when capabilities.mutableSignalSource is true.
+   * Pushes a signal as if the underlying source emitted it.
+   */
+  simulateSignal?(signal: EntitlementSignal): void;
+  dispose(): Promise<void>;
+}
+```
+
+### `fixtures.ts`
+
+Provides constant `TaskEntitlement` values used across assertions:
+
+- `NETWORK_HTTP_REQUIRED` — `{ id: "network:http", reason: "..." }`
+- `FILESYSTEM_REQUIRED` — `{ id: "filesystem", reason: "..." }`
+- `OPTIONAL_CREDENTIAL` — `{ id: "credential", optional: true }`
+- `SCOPED_FILESYSTEM_TMP` — `{ id: "filesystem:read", resources: ["/tmp/*"] }`
+- `UNCOVERED_FOO` — `{ id: "foo:bar", reason: "guaranteed not in any built-in profile" }`
+
+These are imported by assertion files; per-shim fixtures are not needed.
+
+### `runEntitlementProfileConformance.ts`
+
+```ts
+export function runEntitlementProfileConformance(
+  opts: EntitlementProfileConformanceOpts
+): void {
+  describe.skipIf(opts.skip)(`EntitlementProfile conformance: ${opts.name}`, () => {
+    let handle: EntitlementProfileConformanceHandle | undefined;
+    const getHandle = () => {
+      if (!handle) throw new Error("conformance handle not initialized");
+      return handle;
+    };
+
+    beforeAll(async () => { handle = await opts.factory(); }, opts.timeout);
+    afterAll(async () => { if (handle) await handle.dispose(); });
+
+    surfaceCoverageBlock(opts, getHandle);
+    hierarchyHonoringBlock(opts, getHandle);
+    resourceScopingBlock(opts, getHandle);
+    optionalNeverDeniedBlock(opts, getHandle);
+    denialShapeBlock(opts, getHandle);
+    requestEntitlementShapeBlock(opts, getHandle);
+    subscribeRevocationBlock(opts, getHandle);
+    subscribeGrantBlock(opts, getHandle);
+    subscribeReloadBlock(opts, getHandle);
+    unsubscribeIdempotentBlock(opts, getHandle);
+    disposeBlock(opts, getHandle);
+  });
+}
+```
+
+### Assertions
+
+| Block | Asserts | Gated on capability? |
+| --- | --- | --- |
+| `surfaceCoverage` | For every grant returned from `surface()`, calling `requestEntitlement` for an entitlement covered by that grant returns `outcome: "granted"`. For `UNCOVERED_FOO`, returns `outcome: "denied"` with `denial.reason === "default-deny"`. | always |
+| `hierarchyHonoring` | If `surface()` includes a parent ID (e.g., `"network"`), `requestEntitlement` for a child ID (`"network:http"`) returns granted. | `hierarchyHonoring` |
+| `resourceScoping` | If `surface()` includes a scoped grant (`{ id, resources: ["/tmp/*"] }`), `requestEntitlement` for an entitlement requiring `"/tmp/x"` is granted; for `"/etc/x"` is denied. | `resourceScoping` |
+| `optionalNeverDenied` | `requestEntitlement(OPTIONAL_CREDENTIAL)` returns `outcome: "granted"` even when `credential` is not in `surface()`. Also: `checkAll({ entitlements: [OPTIONAL_CREDENTIAL] })` returns `[]` regardless of policy. | always |
+| `denialShape` | `requestEntitlement(UNCOVERED_FOO)` returns `denial` whose `reason` is one of `policy-deny`/`default-deny`/`user-deny` and whose `entitlement` is reference-equal to the input. The discriminated-union invariant for `matchedRule` holds. | always |
+| `requestEntitlementShape` | For the same input, `requestEntitlement` and `checkAll([input])` agree: granted ↔ empty denial array; denied ↔ single-element denial array with matching `reason` and `matchedRule`. | always |
+| `subscribeRevocation` | After `simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED })`, the listener receives `{ kind: "revoked", entitlement: NETWORK_HTTP_REQUIRED }` exactly once *if* the entitlement was previously granted; otherwise no event. | `mutableSignalSource` |
+| `subscribeGrant` | Symmetric: a `grant` signal for a previously-denied entitlement produces `{ kind: "granted", ... }`; for an already-granted one, no event. | `mutableSignalSource` |
+| `subscribeReload` | After querying entitlements `A`, `B`, `C` and then signalling `reload`, change events fire only for entitlements whose verdict flipped between the previous query and the current one. | `mutableSignalSource` |
+| `unsubscribeIdempotent` | Calling the unsub function twice does not throw. After unsub, no further events are delivered to that listener. | `mutableSignalSource` |
+| `dispose` | `dispose()` is idempotent (two calls succeed). After `dispose`, the handle's signal source no longer drives events through the profile (call `simulateSignal`; assert listener does not fire). | `mutableSignalSource` for the post-dispose simulation; idempotency assertion always runs. |
+
+Each assertion file exports one block function (e.g.
+`surfaceCoverageBlock(opts, getHandle)`) following the AiProvider
+pattern. Blocks always call `describe.skipIf(...)` when their capability
+gate is off; they never silently skip.
+
+### Adapter shims
+
+```
+packages/test/src/test/entitlement-profile/
+  Browser_Profile.integration.test.ts
+  Desktop_Profile.integration.test.ts
+  Server_Profile.integration.test.ts
+  Custom_Profile.integration.test.ts
+```
+
+Each is ~30 LOC: imports, factory, capability flags, expected surface.
+Example sketch for `Browser_Profile`:
+
+```ts
+runEntitlementProfileConformance({
+  name: "browser",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("browser");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: ["network:http", "ai", "credential"],
+    surfaceExcludes: ["filesystem", "code-execution", "mcp:stdio"],
+  },
+});
+```
+
+The `Custom_Profile` shim constructs a profile with a controllable
+in-memory signal source (a thin helper exported from the conformance
+suite as `createControllableSignalSource()` in `fixtures.ts` *or* defined
+inline in the shim — TBD by writing-plans). It enables
+`mutableSignalSource: true` and is the only shim that exercises the
+subscribe/* assertions. Its expected surface is whatever grant list it
+is constructed with — this shim primarily proves that a downstream
+profile pattern works.
+
+## Inclusion-lattice test
+
+A separate, non-parameterized test asserts the cross-profile relation:
+
+```
+BROWSER_GRANTS ⊆ DESKTOP_GRANTS ⊆ SERVER_GRANTS
+```
+
+This belongs to the three built-ins as a triple, not to any single
+profile, so it lives outside the conformance suite. Add it to
+`packages/test/src/test/task-graph/Entitlements.test.ts` (or a sibling
+`EntitlementProfiles.test.ts`) — placement decided in writing-plans.
+
+## Backwards compatibility
+
+- `IEntitlementProfile extends IEntitlementEnforcer`, so anywhere an
+  enforcer is consumed, a profile is too.
+- `createProfileEnforcer` keeps its single-argument form and widens its
+  return type. Callers that passed `(profile, resolver)` migrate to
+  `(profile, { resolver })`.
+- `ENTITLEMENT_ENFORCER` service token type is unchanged
+  (`IEntitlementEnforcer`). Registering a profile under this token
+  continues to work; consumers who want the richer profile API can
+  register under a new `ENTITLEMENT_PROFILE` token (added in this work)
+  or cast.
+- `Entitlements.test.ts` is unchanged. The new suite is additive.
+
+## Open questions for writing-plans
+
+1. **Tracking set for `reload` events.** The "previously queried"
+   tracking is behavioral but not exposed. Should it persist past
+   `dispose`? (Probably no — cleared on dispose.)
+2. **Service-token strategy.** Add `ENTITLEMENT_PROFILE` alongside
+   `ENTITLEMENT_ENFORCER`, or repurpose? The conservative path is to
+   add a new token; existing registrations stay intact.
+3. **Documentation update.** `docs/technical/14-entitlements-system.md`
+   needs a section on `IEntitlementProfile` and the signal source. The
+   plan should include this as a step.
+4. **Migration of internal call sites.** Before changing
+   `createProfileEnforcer`'s signature, audit and migrate every call
+   site that passes a resolver positionally.
+
+## Risks
+
+- **Scope creep into platform sources.** This spec deliberately stops at
+  the port. Resist the urge to ship Electron/web/server signal sources
+  in the same plan — they belong in their respective consumer packages
+  and have their own design questions.
+- **Asymmetric event semantics.** `subscribeRevocation`/`subscribeGrant`
+  rely on the profile remembering previous verdicts to compute
+  flips. The fixtures must drive a deterministic sequence of queries
+  before signalling. The conformance suite should not assume the profile
+  caches verdicts — only that flips it can detect produce events.
+- **Optional entitlements collapsing to "granted" hides the underlying
+  reason.** This matches `checkAll` semantics today, but consumers that
+  *want* the underlying verdict for diagnostics get nothing. A future
+  extension could expose `requestEntitlementVerbose()` returning the
+  raw `evaluatePolicy` result. Out of scope here.

--- a/docs/technical/14-entitlements-system.md
+++ b/docs/technical/14-entitlements-system.md
@@ -460,6 +460,81 @@ import { ENTITLEMENT_ENFORCER, createProfileEnforcer } from "@workglow/task-grap
 globalServiceRegistry.registerInstance(ENTITLEMENT_ENFORCER, createProfileEnforcer("browser"));
 ```
 
+## IEntitlementProfile
+
+`createProfileEnforcer` returns an `IEntitlementProfile`, a richer surface
+than the bare `IEntitlementEnforcer`:
+
+```ts
+interface IEntitlementProfile extends IEntitlementEnforcer {
+  readonly name: string;
+  surface(): readonly EntitlementGrant[];
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
+  subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
+  dispose(): Promise<void>;
+}
+
+type EntitlementRequestResult =
+  | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
+  | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
+
+type EntitlementChangeEvent = {
+  readonly kind: "revoked" | "granted";
+  readonly entitlement: TaskEntitlement;
+};
+```
+
+- `surface()` returns the maximum set of grants the profile may issue.
+- `requestEntitlement(e)` is the single-key form of `checkAll`. Optional
+  entitlements always map to `{ outcome: "granted" }`. `"ask"` policy
+  verdicts are resolved internally before returning.
+- `subscribe(listener)` returns events when previously-observed
+  entitlements transition between granted and denied. Built-in profiles
+  with the default `STATIC_SIGNAL_SOURCE` never emit. Downstream profiles
+  plug in a platform signal source (Electron permission events,
+  browser Permissions API onchange, etc.).
+- `dispose()` is idempotent and unsubscribes from the signal source.
+
+### Pluggable signal source
+
+```ts
+interface IEntitlementSignalSource {
+  subscribe(listener: (signal: EntitlementSignal) => void): () => void;
+}
+
+type EntitlementSignal =
+  | { readonly kind: "revoke"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "grant"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "reload" };
+```
+
+Pass a custom source to `createProfileEnforcer`:
+
+```ts
+const profile = createProfileEnforcer("desktop", {
+  signalSource: myElectronPermissionsSource,
+});
+```
+
+The default is `STATIC_SIGNAL_SOURCE` (no-op). On `revoke`/`grant`, the
+profile re-evaluates the targeted entitlement and emits a change event
+only if the verdict actually flipped. On `reload`, the profile
+re-evaluates every entitlement it has previously been queried about.
+
+### ENTITLEMENT_PROFILE service token
+
+A separate service token registers profiles in the global registry.
+It coexists with `ENTITLEMENT_ENFORCER`; consumers that only need the
+basic enforcer surface can register the profile under that token too,
+since `IEntitlementProfile extends IEntitlementEnforcer`.
+
+```ts
+import { globalServiceRegistry } from "@workglow/util";
+import { ENTITLEMENT_PROFILE, createProfileEnforcer } from "@workglow/task-graph";
+
+globalServiceRegistry.registerInstance(ENTITLEMENT_PROFILE, createProfileEnforcer("browser"));
+```
+
 ## Graph-Level Entitlement Analysis
 
 The `computeGraphEntitlements()` function aggregates entitlements across all
@@ -562,6 +637,12 @@ without needing to instantiate task classes.
 | `EntitlementDenial`       | Denied entitlement: `{ entitlement, reason, matchedRule? }` (discriminated) |
 | `EntitlementDenialReason` | `"policy-deny" \| "default-deny" \| "user-deny"`                            |
 | `IEntitlementEnforcer`    | Interface with async `checkAll(required)` and `checkTask(task)` methods     |
+| `IEntitlementProfile`     | Profile interface — extends `IEntitlementEnforcer` with surface, requestEntitlement, subscribe, dispose |
+| `EntitlementRequestResult`| Discriminated union returned by `requestEntitlement`                                                    |
+| `EntitlementChangeEvent`  | `{ kind: "revoked" \| "granted", entitlement }`                                                          |
+| `EntitlementSignal`       | `{ kind: "revoke" \| "grant", entitlement } \| { kind: "reload" }`                                       |
+| `IEntitlementSignalSource`| Pluggable port that emits `EntitlementSignal`                                                            |
+| `CreateProfileOptions`    | `{ resolver?, signalSource? }`                                                                           |
 
 ### Functions
 
@@ -573,7 +654,8 @@ without needing to instantiate task classes.
 | `mergeEntitlements`        | `(a: TaskEntitlements, b: TaskEntitlements) => TaskEntitlements`  | Merge two entitlement sets into their union                         |
 | `createGrantListEnforcer`  | `(grants: readonly string[]) => IEntitlementEnforcer`             | Create an enforcer from a list of broad grant IDs                   |
 | `createScopedEnforcer`     | `(grants: readonly EntitlementGrant[]) => IEntitlementEnforcer`   | Create an enforcer with resource-level scoping                      |
-| `createProfileEnforcer`    | `(profile: EntitlementProfile) => IEntitlementEnforcer`           | Create an enforcer for a standard runtime profile                   |
+| `createProfileEnforcer`    | `(profile: EntitlementProfile, options?: CreateProfileOptions) => IEntitlementProfile` | Create a profile for a standard runtime configuration |
+| `createPolicyProfile`      | `(name: string, policy: EntitlementPolicy, options?: CreateProfileOptions) => IEntitlementProfile` | Create a profile from an arbitrary policy |
 | `getProfileGrants`         | `(profile: EntitlementProfile) => readonly EntitlementGrant[]`    | Get the grant list for a profile                                    |
 | `computeGraphEntitlements` | `(graph: TaskGraph, options?) => TaskEntitlements`                | Aggregate entitlements across all tasks in a graph                  |
 | `formatEntitlementDenial`  | `(denial: EntitlementDenial) => string`                           | Render a denial as a human-readable error-message fragment          |
@@ -589,3 +671,5 @@ without needing to instantiate task classes.
 | `BROWSER_GRANTS`       | Grant array for browser environments                      |
 | `DESKTOP_GRANTS`       | Grant array for desktop environments                      |
 | `SERVER_GRANTS`        | Grant array for server environments                       |
+| `STATIC_SIGNAL_SOURCE` | No-op `IEntitlementSignalSource` (built-in profile default) |
+| `ENTITLEMENT_PROFILE`  | Service token for registering an `IEntitlementProfile`      |

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -9,6 +9,7 @@
  * signal observation to a pluggable IEntitlementSignalSource.
  */
 
+import { createServiceToken } from "@workglow/util";
 import { createPolicyEnforcer } from "./EntitlementEnforcer";
 import type { EntitlementDenial, IEntitlementEnforcer } from "./EntitlementEnforcer";
 import type { EntitlementPolicy } from "./EntitlementPolicy";
@@ -234,3 +235,18 @@ export function createPolicyProfile(
   };
   return profile;
 }
+
+// ========================================================================
+// Service Token
+// ========================================================================
+
+/**
+ * Service token for registering an `IEntitlementProfile`.
+ * Distinct from `ENTITLEMENT_ENFORCER`: a profile is a richer surface
+ * (subscribe + dispose + surface). Registering a profile also satisfies
+ * any consumer that resolves `ENTITLEMENT_ENFORCER` because
+ * `IEntitlementProfile extends IEntitlementEnforcer`.
+ */
+export const ENTITLEMENT_PROFILE = createServiceToken<IEntitlementProfile>(
+  "workglow.entitlementProfile"
+);

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -108,7 +108,14 @@ export type EntitlementChangeEvent = {
 export interface IEntitlementProfile extends IEntitlementEnforcer {
   /** Free-form identifier (e.g. "browser", "desktop", "server"). */
   readonly name: string;
-  /** The maximum set of grants this profile may issue. */
+  /**
+   * The maximum set of grants this profile may issue.
+   *
+   * Implementations MAY return a live view of the underlying policy's
+   * grant array — callers must not mutate the returned array. Treat the
+   * return value as `Readonly<readonly EntitlementGrant[]>` even though
+   * `Object.freeze` is not guaranteed.
+   */
   surface(): readonly EntitlementGrant[];
   /** Single-key request. See `EntitlementRequestResult`. */
   requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
@@ -177,13 +184,23 @@ export function createPolicyProfile(
     const previous = lastOutcome.get(k);
     if (previous === undefined) return; // never queried; nothing to flip
     const current = await evaluate(e);
+    if (disposed) return; // dispose() was called while we were awaiting evaluate
     if (current === previous) return;
     lastOutcome.set(k, current);
     const event: EntitlementChangeEvent = {
       kind: current === "granted" ? "granted" : "revoked",
       entitlement: e,
     };
-    for (const l of listeners) l(event);
+    for (const l of listeners) {
+      try {
+        l(event);
+      } catch (err) {
+        // L2 fix: isolate listener failures so one bad listener doesn't
+        // prevent later listeners from receiving the event.
+        // eslint-disable-next-line no-console
+        console.error(`[EntitlementProfile:${name}] listener threw:`, err);
+      }
+    }
   }
 
   function safeEmitFlipFor(e: TaskEntitlement): void {

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * IEntitlementProfile — runtime-environment view of an entitlement system.
+ * Extends IEntitlementEnforcer with a single-key request API, change-event
+ * subscription, surface introspection, and disposal. Profiles delegate
+ * signal observation to a pluggable IEntitlementSignalSource.
+ */
+
+import type { TaskEntitlement } from "./TaskEntitlements";
+
+// ========================================================================
+// Signal Source (port)
+// ========================================================================
+
+/**
+ * A signal emitted by an external source telling profiles that a permission
+ * may have changed.
+ *
+ * - `revoke`: a previously granted entitlement may now be denied.
+ * - `grant`: a previously denied entitlement may now be granted.
+ * - `reload`: the underlying policy may have changed in arbitrary ways;
+ *   profiles should re-evaluate every entitlement they have been queried
+ *   about.
+ */
+export type EntitlementSignal =
+  | { readonly kind: "revoke"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "grant"; readonly entitlement: TaskEntitlement }
+  | { readonly kind: "reload" };
+
+/**
+ * Pluggable port that produces signals about external permission changes.
+ * Built-in profiles default to `STATIC_SIGNAL_SOURCE`. Downstream packages
+ * (e.g. workflow-builder Electron) provide implementations that wrap
+ * platform events.
+ */
+export interface IEntitlementSignalSource {
+  /**
+   * Register a listener for signals. The returned function unsubscribes.
+   * Implementations must make the unsubscribe idempotent.
+   */
+  subscribe(listener: (signal: EntitlementSignal) => void): () => void;
+}
+
+/** Frozen no-op signal source. Never emits; subscribe returns a no-op unsub. */
+export const STATIC_SIGNAL_SOURCE: IEntitlementSignalSource = Object.freeze({
+  subscribe(_listener: (signal: EntitlementSignal) => void): () => void {
+    return () => {
+      // no-op
+    };
+  },
+});

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -159,8 +159,11 @@ export function createPolicyProfile(
   let disposed = false;
 
   function key(e: TaskEntitlement): string {
-    const resources = e.resources ? [...e.resources].sort().join(",") : "";
-    return `${e.id}|${resources}`;
+    // JSON.stringify with a sentinel for `undefined` so that we don't conflate
+    // `resources: undefined` (broad) with `resources: []` (narrowly empty),
+    // and so that resource strings containing commas don't collide.
+    const resources = e.resources === undefined ? null : [...e.resources].sort();
+    return `${e.id}|${JSON.stringify(resources)}`;
   }
 
   async function evaluate(e: TaskEntitlement): Promise<"granted" | "denied"> {
@@ -183,16 +186,26 @@ export function createPolicyProfile(
     for (const l of listeners) l(event);
   }
 
+  function safeEmitFlipFor(e: TaskEntitlement): void {
+    // Signal callbacks run synchronously from the source, so we can't await.
+    // Surface evaluation errors via console.error rather than letting them
+    // become unhandled promise rejections that may crash the host.
+    emitFlipFor(e).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(`[EntitlementProfile:${name}] error evaluating signal:`, err);
+    });
+  }
+
   const sourceUnsub = signalSource.subscribe((signal) => {
     if (disposed) return;
     if (signal.kind === "reload") {
       // Re-evaluate every previously-queried entitlement.
       for (const [, e] of lastEntitlement) {
-        void emitFlipFor(e);
+        safeEmitFlipFor(e);
       }
     } else {
       // revoke or grant: re-evaluate the targeted entitlement.
-      void emitFlipFor(signal.entitlement);
+      safeEmitFlipFor(signal.entitlement);
     }
   });
 
@@ -242,10 +255,15 @@ export function createPolicyProfile(
 
 /**
  * Service token for registering an `IEntitlementProfile`.
- * Distinct from `ENTITLEMENT_ENFORCER`: a profile is a richer surface
- * (subscribe + dispose + surface). Registering a profile also satisfies
- * any consumer that resolves `ENTITLEMENT_ENFORCER` because
- * `IEntitlementProfile extends IEntitlementEnforcer`.
+ *
+ * Distinct from `ENTITLEMENT_ENFORCER`: a profile exposes a richer surface
+ * (subscribe + dispose + surface). `ServiceRegistry` resolves by token
+ * identity, so a registration under `ENTITLEMENT_PROFILE` is NOT
+ * automatically visible to consumers resolving `ENTITLEMENT_ENFORCER`.
+ *
+ * Because `IEntitlementProfile extends IEntitlementEnforcer`, the same
+ * profile instance can be registered under both tokens if both consumer
+ * styles need to resolve it.
  */
 export const ENTITLEMENT_PROFILE = createServiceToken<IEntitlementProfile>(
   "workglow.entitlementProfile"

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -9,7 +9,8 @@
  * signal observation to a pluggable IEntitlementSignalSource.
  */
 
-import type { TaskEntitlement } from "./TaskEntitlements";
+import type { EntitlementDenial, IEntitlementEnforcer } from "./EntitlementEnforcer";
+import type { EntitlementGrant, TaskEntitlement } from "./TaskEntitlements";
 
 // ========================================================================
 // Signal Source (port)
@@ -52,3 +53,63 @@ export const STATIC_SIGNAL_SOURCE: IEntitlementSignalSource = Object.freeze({
     };
   },
 });
+
+// ========================================================================
+// Request / Verdict
+// ========================================================================
+
+/**
+ * Result of `requestEntitlement(required)`. Discriminated union on `outcome`.
+ *
+ * Optional entitlements always map to `outcome: "granted"` regardless of the
+ * underlying policy verdict — matching the rule that optional entitlements
+ * are filtered out of `IEntitlementEnforcer.checkAll`.
+ *
+ * `"ask"` policy verdicts are resolved internally via the registered
+ * `IEntitlementResolver` before this function returns; callers only ever
+ * see `"granted"` or `"denied"`.
+ */
+export type EntitlementRequestResult =
+  | { readonly outcome: "granted"; readonly entitlement: TaskEntitlement }
+  | { readonly outcome: "denied"; readonly denial: EntitlementDenial };
+
+// ========================================================================
+// Change Events
+// ========================================================================
+
+/**
+ * Emitted by an `IEntitlementProfile` when a previously-observed entitlement
+ * verdict transitions. Profiles only emit events for entitlements whose
+ * verdict actually flipped between two queries.
+ */
+export type EntitlementChangeEvent = {
+  readonly kind: "revoked" | "granted";
+  readonly entitlement: TaskEntitlement;
+};
+
+// ========================================================================
+// Profile Interface
+// ========================================================================
+
+/**
+ * Runtime-environment view of an entitlement system.
+ *
+ * Extends `IEntitlementEnforcer` with:
+ * - `name`: free-form identifier for diagnostics.
+ * - `surface()`: maximum set of entitlements this profile may grant.
+ * - `requestEntitlement()`: single-key request returning a discriminated verdict.
+ * - `subscribe()`: observe change events from the bound signal source.
+ * - `dispose()`: idempotent teardown including signal-source unsubscribe.
+ */
+export interface IEntitlementProfile extends IEntitlementEnforcer {
+  /** Free-form identifier (e.g. "browser", "desktop", "server"). */
+  readonly name: string;
+  /** The maximum set of grants this profile may issue. */
+  surface(): readonly EntitlementGrant[];
+  /** Single-key request. See `EntitlementRequestResult`. */
+  requestEntitlement(required: TaskEntitlement): Promise<EntitlementRequestResult>;
+  /** Subscribe to change events. The returned unsubscribe must be idempotent. */
+  subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
+  /** Idempotent teardown. */
+  dispose(): Promise<void>;
+}

--- a/packages/task-graph/src/task/EntitlementProfile.ts
+++ b/packages/task-graph/src/task/EntitlementProfile.ts
@@ -9,7 +9,10 @@
  * signal observation to a pluggable IEntitlementSignalSource.
  */
 
+import { createPolicyEnforcer } from "./EntitlementEnforcer";
 import type { EntitlementDenial, IEntitlementEnforcer } from "./EntitlementEnforcer";
+import type { EntitlementPolicy } from "./EntitlementPolicy";
+import type { IEntitlementResolver } from "./EntitlementResolver";
 import type { EntitlementGrant, TaskEntitlement } from "./TaskEntitlements";
 
 // ========================================================================
@@ -112,4 +115,122 @@ export interface IEntitlementProfile extends IEntitlementEnforcer {
   subscribe(listener: (event: EntitlementChangeEvent) => void): () => void;
   /** Idempotent teardown. */
   dispose(): Promise<void>;
+}
+
+// ========================================================================
+// Profile Constructor
+// ========================================================================
+
+export interface CreateProfileOptions {
+  readonly resolver?: IEntitlementResolver;
+  /** Defaults to `STATIC_SIGNAL_SOURCE`. */
+  readonly signalSource?: IEntitlementSignalSource;
+}
+
+/**
+ * Build an `IEntitlementProfile` from a policy.
+ *
+ * Wraps `createPolicyEnforcer` and adds:
+ * - `surface()` returning the policy's grants
+ * - `requestEntitlement()` reusing `checkAll` for a single entitlement
+ * - signal-source subscription with verdict-flip change events
+ * - idempotent `dispose()`
+ *
+ * The "previously queried" set used to scope `reload` events is private to
+ * the profile and cleared on `dispose`.
+ */
+export function createPolicyProfile(
+  name: string,
+  policy: EntitlementPolicy,
+  options: CreateProfileOptions = {}
+): IEntitlementProfile {
+  const enforcer = createPolicyEnforcer(policy, options.resolver);
+  const signalSource = options.signalSource ?? STATIC_SIGNAL_SOURCE;
+  const listeners = new Set<(event: EntitlementChangeEvent) => void>();
+  /**
+   * Map from entitlement-id|resources-key → last observed outcome.
+   * Used to compute verdict flips for change-event emission and to scope
+   * `reload`-triggered re-evaluation.
+   */
+  const lastOutcome = new Map<string, "granted" | "denied">();
+  /** Reference to the original entitlement object so reload can re-query. */
+  const lastEntitlement = new Map<string, TaskEntitlement>();
+  let disposed = false;
+
+  function key(e: TaskEntitlement): string {
+    const resources = e.resources ? [...e.resources].sort().join(",") : "";
+    return `${e.id}|${resources}`;
+  }
+
+  async function evaluate(e: TaskEntitlement): Promise<"granted" | "denied"> {
+    if (e.optional) return "granted";
+    const denials = await enforcer.checkAll({ entitlements: [e] });
+    return denials.length === 0 ? "granted" : "denied";
+  }
+
+  async function emitFlipFor(e: TaskEntitlement): Promise<void> {
+    const k = key(e);
+    const previous = lastOutcome.get(k);
+    if (previous === undefined) return; // never queried; nothing to flip
+    const current = await evaluate(e);
+    if (current === previous) return;
+    lastOutcome.set(k, current);
+    const event: EntitlementChangeEvent = {
+      kind: current === "granted" ? "granted" : "revoked",
+      entitlement: e,
+    };
+    for (const l of listeners) l(event);
+  }
+
+  const sourceUnsub = signalSource.subscribe((signal) => {
+    if (disposed) return;
+    if (signal.kind === "reload") {
+      // Re-evaluate every previously-queried entitlement.
+      for (const [, e] of lastEntitlement) {
+        void emitFlipFor(e);
+      }
+    } else {
+      // revoke or grant: re-evaluate the targeted entitlement.
+      void emitFlipFor(signal.entitlement);
+    }
+  });
+
+  const profile: IEntitlementProfile = {
+    name,
+    checkAll: enforcer.checkAll.bind(enforcer),
+    checkTask: enforcer.checkTask.bind(enforcer),
+    surface: () => policy.grant,
+    async requestEntitlement(required) {
+      if (required.optional) {
+        return { outcome: "granted", entitlement: required };
+      }
+      const denials = await enforcer.checkAll({ entitlements: [required] });
+      const k = key(required);
+      lastEntitlement.set(k, required);
+      if (denials.length === 0) {
+        lastOutcome.set(k, "granted");
+        return { outcome: "granted", entitlement: required };
+      }
+      lastOutcome.set(k, "denied");
+      return { outcome: "denied", denial: denials[0]! };
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      let unsubbed = false;
+      return () => {
+        if (unsubbed) return;
+        unsubbed = true;
+        listeners.delete(listener);
+      };
+    },
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      sourceUnsub();
+      listeners.clear();
+      lastOutcome.clear();
+      lastEntitlement.clear();
+    },
+  };
+  return profile;
 }

--- a/packages/task-graph/src/task/EntitlementProfiles.ts
+++ b/packages/task-graph/src/task/EntitlementProfiles.ts
@@ -8,9 +8,8 @@
  * only capability profiles expressed as entitlement policies.
  */
 
-import { createPolicyEnforcer, type IEntitlementEnforcer } from "./EntitlementEnforcer";
+import { createPolicyProfile, type CreateProfileOptions, type IEntitlementProfile } from "./EntitlementProfile";
 import type { EntitlementPolicy } from "./EntitlementPolicy";
-import type { IEntitlementResolver } from "./EntitlementResolver";
 import type { EntitlementGrant } from "./TaskEntitlements";
 import { Entitlements } from "./TaskEntitlements";
 
@@ -87,17 +86,18 @@ export function createProfilePolicy(profile: EntitlementProfile): EntitlementPol
 }
 
 /**
- * Creates an entitlement enforcer for the given runtime profile.
- * Tasks requiring entitlements not in the profile will be denied.
+ * Creates an entitlement profile for the given runtime profile.
+ * The profile's grants become the policy's grant rules.
+ * Deny and ask arrays are empty by default — callers can extend the returned profile.
  *
  * @param profile - The runtime profile to use
- * @param resolver - Optional resolver for handling "ask" verdicts
+ * @param options - Optional resolver (for "ask" verdicts) and signal source
  */
 export function createProfileEnforcer(
   profile: EntitlementProfile,
-  resolver?: IEntitlementResolver
-): IEntitlementEnforcer {
-  return createPolicyEnforcer(createProfilePolicy(profile), resolver);
+  options?: CreateProfileOptions
+): IEntitlementProfile {
+  return createPolicyProfile(profile, createProfilePolicy(profile), options);
 }
 
 /**

--- a/packages/task-graph/src/task/index.ts
+++ b/packages/task-graph/src/task/index.ts
@@ -8,6 +8,7 @@ export * from "./ConditionalTask";
 export * from "./ConditionUtils";
 export * from "./EntitlementEnforcer";
 export * from "./EntitlementPolicy";
+export * from "./EntitlementProfile";
 export * from "./EntitlementProfiles";
 export * from "./EntitlementResolver";
 export * from "./FallbackTask";

--- a/packages/test/src/contract/README.md
+++ b/packages/test/src/contract/README.md
@@ -69,6 +69,7 @@ Treat both as additional examples of the pattern.
 | `AiProvider` | `contract/ai-provider/runAiProviderConformance` | Anthropic, OpenAI, Gemini, Ollama, HF Inference, HF Transformers, LlamaCpp |
 | `IQueueStorage` + `IRateLimiterStorage` | `test/job-queue/genericJobQueueTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase |
 | `ITabularStorage` | `test/storage-tabular/genericTabularStorageTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase, FsFolder, HuggingFace |
+| `IEntitlementProfile` | `contract/entitlement-profile/runEntitlementProfileConformance` | Browser, Desktop, Server, Custom |
 
 ## How to add a new contract suite
 
@@ -94,5 +95,4 @@ Future contract suites in priority order:
 2. Worker-proxy contract — every provider in worker mode round-trips
    identical assertions to direct mode.
 3. `IBrowserContext` — Playwright / Electron / BunWebView / CDP backends.
-4. `EntitlementProfile` — desktop / web / server profiles.
-5. `IHumanConnector` — App + Electron elicitation backends.
+4. `IHumanConnector` — App + Electron elicitation backends.

--- a/packages/test/src/contract/entitlement-profile/assertions/denialShape.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/denialShape.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * The denial returned by requestEntitlement for an uncovered entitlement
+ * must satisfy the EntitlementDenial discriminated union: a `reason` of
+ * "policy-deny" / "user-deny" requires `matchedRule`; "default-deny"
+ * forbids it.
+ */
+export function denialShapeBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Denial shape", () => {
+    it("denial.entitlement is reference-equal to the requested entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      expect(result.outcome).toBe("denied");
+      if (result.outcome === "denied") {
+        expect(result.denial.entitlement).toBe(UNCOVERED_FOO);
+      }
+    });
+
+    it("denial.reason matches the EntitlementDenialReason union", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      if (result.outcome === "denied") {
+        expect(["policy-deny", "default-deny", "user-deny"]).toContain(result.denial.reason);
+      }
+    });
+
+    it("policy-deny and user-deny carry matchedRule; default-deny does not", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      if (result.outcome === "denied") {
+        const d = result.denial;
+        if (d.reason === "default-deny") {
+          // Discriminated union: default-deny variant has no matchedRule property.
+          expect("matchedRule" in d).toBe(false);
+        } else {
+          // policy-deny / user-deny carry matchedRule.
+          expect(d.matchedRule).toBeDefined();
+        }
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/dispose.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/dispose.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * dispose() is idempotent. After dispose, a simulateSignal does not deliver
+ * events to listeners that subscribed before dispose.
+ *
+ * NOTE: This block uses an isolated profile via the factory, not the shared
+ * conformance handle, because disposing the shared handle would break later
+ * blocks. The factory is invoked again here; afterAll on the shared handle
+ * still runs against its own profile.
+ */
+export function disposeBlock(
+  opts: EntitlementProfileConformanceOpts,
+  _getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Dispose", () => {
+    it("dispose is idempotent (two calls succeed)", async () => {
+      const local = await opts.factory();
+      try {
+        await local.profile.dispose();
+        await expect(local.profile.dispose()).resolves.toBeUndefined();
+      } finally {
+        // local.dispose() is itself idempotent and will exercise dispose() again.
+        await local.dispose();
+      }
+    });
+
+    it.skipIf(!opts.capabilities.mutableSignalSource)(
+      "after dispose, signal source no longer drives events",
+      async () => {
+        const local = await opts.factory();
+        try {
+          if (!local.simulateSignal) return;
+          const events: EntitlementChangeEvent[] = [];
+          local.profile.subscribe((e) => events.push(e));
+          await local.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+          await local.profile.dispose();
+          local.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+          await new Promise((r) => setTimeout(r, 0));
+          expect(events).toEqual([]);
+        } finally {
+          await local.dispose();
+        }
+      }
+    );
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/hierarchyHonoring.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/hierarchyHonoring.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * If the profile surface includes a parent entitlement (e.g. "network"),
+ * requesting a child entitlement (e.g. "network:http") must be granted.
+ */
+export function hierarchyHonoringBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.hierarchyHonoring)("Hierarchy honoring", () => {
+    it("granting a parent ID covers child IDs in the namespace", async () => {
+      const profile = getHandle().profile;
+      // Find a grant whose ID has no colon (a parent), then probe a child.
+      const parentGrant = profile.surface().find((g) => !g.id.includes(":") && !g.resources);
+      if (!parentGrant) {
+        // No broad parent grant in this profile; assertion vacuous.
+        return;
+      }
+      const childId = `${parentGrant.id}:probe`;
+      const result = await profile.requestEntitlement({ id: childId });
+      expect(result.outcome).toBe("granted");
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/optionalNeverDenied.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/optionalNeverDenied.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { OPTIONAL_CREDENTIAL } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Optional entitlements must never be reported as denied — neither by
+ * `requestEntitlement` nor by `checkAll`.
+ */
+export function optionalNeverDeniedBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Optional entitlements never denied", () => {
+    it("requestEntitlement returns granted for an optional entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(OPTIONAL_CREDENTIAL);
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("checkAll returns no denials for an optional entitlement even when uncovered", async () => {
+      const profile = getHandle().profile;
+      const denials = await profile.checkAll({
+        entitlements: [{ id: "uncovered:optional", optional: true }],
+      });
+      expect(denials).toEqual([]);
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts
@@ -42,6 +42,13 @@ export function requestEntitlementShapeBlock(
       expect(all).toHaveLength(1);
       if (single.outcome === "denied") {
         expect(all[0]!.reason).toBe(single.denial.reason);
+        // Spec parity: when reason is policy-deny / user-deny, both calls must
+        // return the same matchedRule. default-deny carries no matchedRule.
+        if (single.denial.reason !== "default-deny") {
+          expect((all[0]! as { matchedRule?: unknown }).matchedRule).toEqual(
+            (single.denial as { matchedRule?: unknown }).matchedRule
+          );
+        }
       }
     });
   });

--- a/packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/requestEntitlementShape.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * For the same input, `requestEntitlement` and `checkAll([input])` agree:
+ * - granted ↔ empty denial array
+ * - denied ↔ single-element denial array with matching reason
+ */
+export function requestEntitlementShapeBlock(
+  _opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("requestEntitlement shape parity with checkAll", () => {
+    it("granted: requestEntitlement and checkAll agree", async () => {
+      const profile = getHandle().profile;
+      const isCovered = profile
+        .surface()
+        .some((g) => g.id === NETWORK_HTTP_REQUIRED.id && !g.resources);
+      if (!isCovered) return; // assertion vacuous if profile doesn't grant network:http
+      const single = await profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      const all = await profile.checkAll({ entitlements: [NETWORK_HTTP_REQUIRED] });
+      expect(single.outcome).toBe("granted");
+      expect(all).toEqual([]);
+    });
+
+    it("denied: requestEntitlement and checkAll agree on reason", async () => {
+      const profile = getHandle().profile;
+      const single = await profile.requestEntitlement(UNCOVERED_FOO);
+      const all = await profile.checkAll({ entitlements: [UNCOVERED_FOO] });
+      expect(single.outcome).toBe("denied");
+      expect(all).toHaveLength(1);
+      if (single.outcome === "denied") {
+        expect(all[0]!.reason).toBe(single.denial.reason);
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { SCOPED_FILESYSTEM_ETC_BAD, SCOPED_FILESYSTEM_TMP_OK } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * For a profile that supports resource scoping, build a temporary scoped
+ * grant by augmenting the profile is out of scope here — instead we
+ * exercise the policy with a known-scoped fixture only when the profile
+ * already grants filesystem broadly. When `filesystem` is broadly granted,
+ * a scoped read of any resource succeeds. This block additionally verifies
+ * that profiles which DO NOT grant filesystem deny a /tmp read.
+ */
+export function resourceScopingBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.resourceScoping)("Resource scoping", () => {
+    it("scoped read succeeds when the profile broadly grants filesystem", async () => {
+      const profile = getHandle().profile;
+      const hasBroadFilesystem = profile.surface().some(
+        (g) => g.id === "filesystem" && !g.resources
+      );
+      if (!hasBroadFilesystem) {
+        // Profile does not broadly grant filesystem; this assertion is vacuous.
+        return;
+      }
+      const result = await profile.requestEntitlement(SCOPED_FILESYSTEM_TMP_OK);
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("scoped read fails when the profile does not grant filesystem at all", async () => {
+      const profile = getHandle().profile;
+      const hasFilesystem = profile.surface().some(
+        (g) => g.id === "filesystem" || g.id === "filesystem:read"
+      );
+      if (hasFilesystem) {
+        return; // not the negative case
+      }
+      const result = await profile.requestEntitlement(SCOPED_FILESYSTEM_ETC_BAD);
+      expect(result.outcome).toBe("denied");
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/resourceScoping.ts
@@ -18,7 +18,8 @@ import type {
  * exercise the policy with a known-scoped fixture only when the profile
  * already grants filesystem broadly. When `filesystem` is broadly granted,
  * a scoped read of any resource succeeds. This block additionally verifies
- * that profiles which DO NOT grant filesystem deny a /tmp read.
+ * that profiles which DO NOT grant filesystem deny a scoped read of
+ * `/etc/passwd`.
  */
 export function resourceScopingBlock(
   opts: EntitlementProfileConformanceOpts,

--- a/packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Verify that the profile emits a "granted" change event when the signal
+ * source emits a grant for a previously-denied entitlement.
+ */
+export function subscribeGrantBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe grant", () => {
+    it("emits granted when previously-denied entitlement becomes granted", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) {
+        throw new Error("simulateSignal must be present when mutableSignalSource is true");
+      }
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Seed: query an entitlement that is currently denied. The Custom shim's
+        // simulateSignal stages the policy flip before emitting the signal.
+        const before = await handle.profile.requestEntitlement(UNCOVERED_FOO);
+        if (before.outcome !== "denied") return; // not the case for this profile
+        handle.simulateSignal({ kind: "grant", entitlement: UNCOVERED_FOO });
+        await new Promise((r) => setTimeout(r, 0));
+        const granted = events.find((e) => e.kind === "granted");
+        expect(granted).toBeDefined();
+        expect(granted?.entitlement.id).toBe(UNCOVERED_FOO.id);
+      } finally {
+        unsub();
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/subscribeGrant.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { UNCOVERED_FOO } from "../fixtures";
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
 import type {
   EntitlementChangeEvent,
 } from "@workglow/task-graph";
@@ -41,6 +41,23 @@ export function subscribeGrantBlock(
         const granted = events.find((e) => e.kind === "granted");
         expect(granted).toBeDefined();
         expect(granted?.entitlement.id).toBe(UNCOVERED_FOO.id);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("does not emit when grant signal arrives for already-granted entitlement", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Seed: query an entitlement currently granted by the policy.
+        const before = await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+        if (before.outcome !== "granted") return; // not the case for this profile
+        handle.simulateSignal({ kind: "grant", entitlement: NETWORK_HTTP_REQUIRED });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(events).toEqual([]);
       } finally {
         unsub();
       }

--- a/packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * After querying a set of entitlements then signalling reload, change events
+ * fire only for entitlements whose verdict actually flipped.
+ */
+export function subscribeReloadBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe reload", () => {
+    it("reload fires events only for previously-queried entitlements that flipped", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      // Pre-seed by querying two entitlements before subscribing.
+      await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      await handle.profile.requestEntitlement(UNCOVERED_FOO);
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // The shim's simulateSignal stages a policy mutation that flips
+        // exactly one of the two seeded entitlements before emitting reload.
+        handle.simulateSignal({ kind: "reload" });
+        await new Promise((r) => setTimeout(r, 0));
+        // We expect exactly one change event corresponding to the flipped
+        // entitlement. The shim controls which one.
+        expect(events.length).toBeGreaterThanOrEqual(1);
+        for (const e of events) {
+          expect([NETWORK_HTTP_REQUIRED.id, UNCOVERED_FOO.id]).toContain(e.entitlement.id);
+        }
+      } finally {
+        unsub();
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/subscribeReload.ts
@@ -37,12 +37,11 @@ export function subscribeReloadBlock(
         // exactly one of the two seeded entitlements before emitting reload.
         handle.simulateSignal({ kind: "reload" });
         await new Promise((r) => setTimeout(r, 0));
-        // We expect exactly one change event corresponding to the flipped
-        // entitlement. The shim controls which one.
-        expect(events.length).toBeGreaterThanOrEqual(1);
-        for (const e of events) {
-          expect([NETWORK_HTTP_REQUIRED.id, UNCOVERED_FOO.id]).toContain(e.entitlement.id);
-        }
+        // The shim's simulateSignal stages a policy mutation that flips exactly
+        // one of the two seeded entitlements (NETWORK_HTTP) before emitting reload.
+        // A conforming profile emits change events ONLY for entitlements that
+        // actually flipped — never for entitlements whose verdict is unchanged.
+        expect(events.map((e) => e.entitlement.id)).toEqual([NETWORK_HTTP_REQUIRED.id]);
       } finally {
         unsub();
       }

--- a/packages/test/src/contract/entitlement-profile/assertions/subscribeRevocation.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/subscribeRevocation.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED, UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+/**
+ * Verify that the profile re-evaluates and emits a "revoked" change event
+ * when the signal source emits a revoke for a previously-granted
+ * entitlement, and emits nothing when no flip occurred.
+ */
+export function subscribeRevocationBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Subscribe revocation", () => {
+    it("emits revoked when previously-granted entitlement becomes denied", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) {
+        throw new Error("simulateSignal must be present when mutableSignalSource is true");
+      }
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Seed: query and confirm currently granted.
+        const before = await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+        if (before.outcome !== "granted") {
+          // Profile does not grant this; this assertion is vacuous for it.
+          return;
+        }
+        // The Custom_Profile shim's underlying policy mutates so that revoke
+        // signals reflect a real flip; the simulateSignal hook on the shim
+        // is responsible for staging that policy change before emitting.
+        handle.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+        await new Promise((r) => setTimeout(r, 0));
+        const revoked = events.find((e) => e.kind === "revoked");
+        expect(revoked).toBeDefined();
+        expect(revoked?.entitlement.id).toBe(NETWORK_HTTP_REQUIRED.id);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("does not emit when no flip occurs (revoke for never-granted entitlement)", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      try {
+        // Query an uncovered entitlement: it's already denied.
+        await handle.profile.requestEntitlement(UNCOVERED_FOO);
+        handle.simulateSignal({ kind: "revoke", entitlement: UNCOVERED_FOO });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(events).toEqual([]);
+      } finally {
+        unsub();
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/surfaceCoverage.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/surfaceCoverage.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { UNCOVERED_FOO } from "../fixtures";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+export function surfaceCoverageBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe("Surface coverage", () => {
+    it("surface() includes every entitlement listed in expected.surfaceIncludes", async () => {
+      const profile = getHandle().profile;
+      const surface = profile.surface().map((g) => g.id);
+      for (const id of opts.expected.surfaceIncludes) {
+        expect(surface).toContain(id);
+      }
+    });
+
+    it("surface() excludes every entitlement listed in expected.surfaceExcludes", async () => {
+      const profile = getHandle().profile;
+      const surface = profile.surface().map((g) => g.id);
+      for (const id of opts.expected.surfaceExcludes) {
+        expect(surface).not.toContain(id);
+      }
+    });
+
+    it("requestEntitlement returns granted for an entitlement covered by surface", async () => {
+      const profile = getHandle().profile;
+      const firstGrant = profile.surface()[0];
+      if (!firstGrant) {
+        // empty surface — assertion vacuous; opts.expected.surfaceIncludes
+        // would have been empty too.
+        return;
+      }
+      const result = await profile.requestEntitlement({ id: firstGrant.id });
+      expect(result.outcome).toBe("granted");
+    });
+
+    it("requestEntitlement returns denied with default-deny reason for an uncovered entitlement", async () => {
+      const profile = getHandle().profile;
+      const result = await profile.requestEntitlement(UNCOVERED_FOO);
+      expect(result.outcome).toBe("denied");
+      if (result.outcome === "denied") {
+        expect(result.denial.reason).toBe("default-deny");
+        expect(result.denial.entitlement).toBe(UNCOVERED_FOO);
+      }
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/assertions/unsubscribeIdempotent.ts
+++ b/packages/test/src/contract/entitlement-profile/assertions/unsubscribeIdempotent.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { NETWORK_HTTP_REQUIRED } from "../fixtures";
+import type {
+  EntitlementChangeEvent,
+} from "@workglow/task-graph";
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "../types";
+
+export function unsubscribeIdempotentBlock(
+  opts: EntitlementProfileConformanceOpts,
+  getHandle: () => EntitlementProfileConformanceHandle
+): void {
+  describe.skipIf(!opts.capabilities.mutableSignalSource)("Unsubscribe idempotent", () => {
+    it("calling unsubscribe twice does not throw", () => {
+      const profile = getHandle().profile;
+      const unsub = profile.subscribe(() => {});
+      unsub();
+      expect(() => unsub()).not.toThrow();
+    });
+
+    it("after unsubscribe, no further events are delivered", async () => {
+      const handle = getHandle();
+      if (!handle.simulateSignal) return;
+      const events: EntitlementChangeEvent[] = [];
+      const unsub = handle.profile.subscribe((e) => events.push(e));
+      // Seed and unsub before signalling.
+      await handle.profile.requestEntitlement(NETWORK_HTTP_REQUIRED);
+      unsub();
+      handle.simulateSignal({ kind: "revoke", entitlement: NETWORK_HTTP_REQUIRED });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(events).toEqual([]);
+    });
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/fixtures.ts
+++ b/packages/test/src/contract/entitlement-profile/fixtures.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Entitlements,
+  type EntitlementSignal,
+  type IEntitlementSignalSource,
+  type TaskEntitlement,
+} from "@workglow/task-graph";
+
+export const NETWORK_HTTP_REQUIRED: TaskEntitlement = {
+  id: Entitlements.NETWORK_HTTP,
+  reason: "Conformance fixture: HTTP request",
+};
+
+export const FILESYSTEM_REQUIRED: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM,
+  reason: "Conformance fixture: filesystem access",
+};
+
+export const OPTIONAL_CREDENTIAL: TaskEntitlement = {
+  id: Entitlements.CREDENTIAL,
+  reason: "Conformance fixture: optional credential",
+  optional: true,
+};
+
+export const SCOPED_FILESYSTEM_TMP_OK: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM_READ,
+  reason: "Conformance fixture: scoped read of /tmp",
+  resources: ["/tmp/data.json"],
+};
+
+export const SCOPED_FILESYSTEM_ETC_BAD: TaskEntitlement = {
+  id: Entitlements.FILESYSTEM_READ,
+  reason: "Conformance fixture: scoped read of /etc",
+  resources: ["/etc/passwd"],
+};
+
+/** Guaranteed not to appear in any built-in profile surface. */
+export const UNCOVERED_FOO: TaskEntitlement = {
+  id: "foo:bar",
+  reason: "Conformance fixture: uncovered entitlement",
+};
+
+/**
+ * In-memory signal source for the Custom_Profile shim. The returned source
+ * exposes `emit` so the shim's `simulateSignal` can drive listeners.
+ */
+export interface ControllableSignalSource extends IEntitlementSignalSource {
+  emit(signal: EntitlementSignal): void;
+}
+
+export function createControllableSignalSource(): ControllableSignalSource {
+  const listeners = new Set<(s: EntitlementSignal) => void>();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      let unsubbed = false;
+      return () => {
+        if (unsubbed) return;
+        unsubbed = true;
+        listeners.delete(listener);
+      };
+    },
+    emit(signal) {
+      for (const l of listeners) l(signal);
+    },
+  };
+}

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, describe } from "vitest";
 
+import { denialShapeBlock } from "./assertions/denialShape";
 import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
@@ -39,5 +40,6 @@ export function runEntitlementProfileConformance(
     hierarchyHonoringBlock(opts, getHandle);
     resourceScopingBlock(opts, getHandle);
     optionalNeverDeniedBlock(opts, getHandle);
+    denialShapeBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeAll, describe } from "vitest";
 
 import { denialShapeBlock } from "./assertions/denialShape";
+import { disposeBlock } from "./assertions/dispose";
 import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
@@ -51,5 +52,6 @@ export function runEntitlementProfileConformance(
     subscribeGrantBlock(opts, getHandle);
     subscribeReloadBlock(opts, getHandle);
     unsubscribeIdempotentBlock(opts, getHandle);
+    disposeBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -15,6 +15,7 @@ import { subscribeGrantBlock } from "./assertions/subscribeGrant";
 import { subscribeReloadBlock } from "./assertions/subscribeReload";
 import { subscribeRevocationBlock } from "./assertions/subscribeRevocation";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
+import { unsubscribeIdempotentBlock } from "./assertions/unsubscribeIdempotent";
 import type {
   EntitlementProfileConformanceHandle,
   EntitlementProfileConformanceOpts,
@@ -49,5 +50,6 @@ export function runEntitlementProfileConformance(
     subscribeRevocationBlock(opts, getHandle);
     subscribeGrantBlock(opts, getHandle);
     subscribeReloadBlock(opts, getHandle);
+    unsubscribeIdempotentBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe } from "vitest";
 import { denialShapeBlock } from "./assertions/denialShape";
 import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
+import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
@@ -41,5 +42,6 @@ export function runEntitlementProfileConformance(
     resourceScopingBlock(opts, getHandle);
     optionalNeverDeniedBlock(opts, getHandle);
     denialShapeBlock(opts, getHandle);
+    requestEntitlementShapeBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeAll, describe } from "vitest";
 
 import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
+import { resourceScopingBlock } from "./assertions/resourceScoping";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
   EntitlementProfileConformanceHandle,
@@ -35,5 +36,6 @@ export function runEntitlementProfileConformance(
     // invoked here as each one is added.
     surfaceCoverageBlock(opts, getHandle);
     hierarchyHonoringBlock(opts, getHandle);
+    resourceScopingBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe } from "vitest";
+
+import type {
+  EntitlementProfileConformanceHandle,
+  EntitlementProfileConformanceOpts,
+} from "./types";
+
+export function runEntitlementProfileConformance(
+  opts: EntitlementProfileConformanceOpts
+): void {
+  describe.skipIf(opts.skip)(`EntitlementProfile conformance: ${opts.name}`, () => {
+    let handle: EntitlementProfileConformanceHandle | undefined;
+    const getHandle = (): EntitlementProfileConformanceHandle => {
+      if (!handle) throw new Error("conformance handle not initialized");
+      return handle;
+    };
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle) await handle.dispose();
+    });
+
+    // Assertion blocks are wired up in Phase 3 tasks. They are imported and
+    // invoked here as each one is added.
+    void getHandle; // silence "unused" until Phase 3 wires the blocks
+  });
+}

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, describe } from "vitest";
 
+import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
   EntitlementProfileConformanceHandle,
   EntitlementProfileConformanceOpts,
@@ -31,6 +32,6 @@ export function runEntitlementProfileConformance(
 
     // Assertion blocks are wired up in Phase 3 tasks. They are imported and
     // invoked here as each one is added.
-    void getHandle; // silence "unused" until Phase 3 wires the blocks
+    surfaceCoverageBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeAll, describe } from "vitest";
 
 import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
+import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
@@ -37,5 +38,6 @@ export function runEntitlementProfileConformance(
     surfaceCoverageBlock(opts, getHandle);
     hierarchyHonoringBlock(opts, getHandle);
     resourceScopingBlock(opts, getHandle);
+    optionalNeverDeniedBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -11,6 +11,7 @@ import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
+import { subscribeRevocationBlock } from "./assertions/subscribeRevocation";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
   EntitlementProfileConformanceHandle,
@@ -43,5 +44,6 @@ export function runEntitlementProfileConformance(
     optionalNeverDeniedBlock(opts, getHandle);
     denialShapeBlock(opts, getHandle);
     requestEntitlementShapeBlock(opts, getHandle);
+    subscribeRevocationBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -12,6 +12,7 @@ import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
 import { subscribeGrantBlock } from "./assertions/subscribeGrant";
+import { subscribeReloadBlock } from "./assertions/subscribeReload";
 import { subscribeRevocationBlock } from "./assertions/subscribeRevocation";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
@@ -47,5 +48,6 @@ export function runEntitlementProfileConformance(
     requestEntitlementShapeBlock(opts, getHandle);
     subscribeRevocationBlock(opts, getHandle);
     subscribeGrantBlock(opts, getHandle);
+    subscribeReloadBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, describe } from "vitest";
 
+import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
   EntitlementProfileConformanceHandle,
@@ -33,5 +34,6 @@ export function runEntitlementProfileConformance(
     // Assertion blocks are wired up in Phase 3 tasks. They are imported and
     // invoked here as each one is added.
     surfaceCoverageBlock(opts, getHandle);
+    hierarchyHonoringBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
+++ b/packages/test/src/contract/entitlement-profile/runEntitlementProfileConformance.ts
@@ -11,6 +11,7 @@ import { hierarchyHonoringBlock } from "./assertions/hierarchyHonoring";
 import { optionalNeverDeniedBlock } from "./assertions/optionalNeverDenied";
 import { requestEntitlementShapeBlock } from "./assertions/requestEntitlementShape";
 import { resourceScopingBlock } from "./assertions/resourceScoping";
+import { subscribeGrantBlock } from "./assertions/subscribeGrant";
 import { subscribeRevocationBlock } from "./assertions/subscribeRevocation";
 import { surfaceCoverageBlock } from "./assertions/surfaceCoverage";
 import type {
@@ -45,5 +46,6 @@ export function runEntitlementProfileConformance(
     denialShapeBlock(opts, getHandle);
     requestEntitlementShapeBlock(opts, getHandle);
     subscribeRevocationBlock(opts, getHandle);
+    subscribeGrantBlock(opts, getHandle);
   });
 }

--- a/packages/test/src/contract/entitlement-profile/types.ts
+++ b/packages/test/src/contract/entitlement-profile/types.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  EntitlementId,
+  EntitlementSignal,
+  IEntitlementProfile,
+} from "@workglow/task-graph";
+
+export interface EntitlementProfileConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<EntitlementProfileConformanceHandle>;
+  readonly capabilities: EntitlementProfileCapabilities;
+  readonly expected: EntitlementProfileExpected;
+}
+
+export interface EntitlementProfileCapabilities {
+  /**
+   * If true, the factory returns a handle whose `simulateSignal` method
+   * is wired to the profile's signal source. Subscribe/* assertions are
+   * gated on this flag.
+   */
+  readonly mutableSignalSource: boolean;
+  /**
+   * If true, hierarchyHonoringBlock runs. All built-ins set this true
+   * because they use `createPolicyEnforcer` which honors hierarchy.
+   */
+  readonly hierarchyHonoring: boolean;
+  /** If true, resourceScopingBlock runs. */
+  readonly resourceScoping: boolean;
+}
+
+export interface EntitlementProfileExpected {
+  /** Entitlement IDs that MUST appear in the profile's surface(). */
+  readonly surfaceIncludes: readonly EntitlementId[];
+  /** Entitlement IDs that MUST NOT appear in the profile's surface(). */
+  readonly surfaceExcludes: readonly EntitlementId[];
+}
+
+export interface EntitlementProfileConformanceHandle {
+  readonly profile: IEntitlementProfile;
+  /**
+   * Present iff `capabilities.mutableSignalSource` is true. Pushes a signal
+   * as if the underlying source emitted it, so subscribe/* assertions can
+   * exercise the verdict-flip path.
+   */
+  simulateSignal?(signal: EntitlementSignal): void;
+  dispose(): Promise<void>;
+}

--- a/packages/test/src/test/entitlement-profile/Browser_Profile.test.ts
+++ b/packages/test/src/test/entitlement-profile/Browser_Profile.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "browser",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("browser");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.NETWORK_WEBSOCKET,
+      Entitlements.AI,
+      Entitlements.MCP_TOOL_CALL,
+      Entitlements.STORAGE,
+      Entitlements.CREDENTIAL,
+    ],
+    surfaceExcludes: [
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.MCP_STDIO,
+      Entitlements.BROWSER_CONTROL,
+    ],
+  },
+});

--- a/packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
+++ b/packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  Entitlements,
+  createPolicyProfile,
+  type EntitlementGrant,
+  type EntitlementPolicy,
+  type EntitlementSignal,
+  type IEntitlementProfile,
+} from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+import { createControllableSignalSource } from "../../contract/entitlement-profile/fixtures";
+
+/**
+ * A custom profile backed by a mutable grant set. The accompanying
+ * controllable signal source has a `simulateSignal` wrapper that:
+ *  - on `revoke(e)`: removes any grant whose ID equals `e.id`
+ *  - on `grant(e)`:  adds a broad grant for `e.id`
+ *  - on `reload`:    flips one specific entitlement (NETWORK_HTTP) per
+ *                    invocation so the suite can observe a deterministic
+ *                    flip; subsequent calls flip it back.
+ *
+ * The mutable backing is the `grant` array of the policy used to build
+ * the profile. We replace it via reassignment of a wrapper holder; the
+ * profile reads it lazily via a getter.
+ */
+function buildCustomProfile(): {
+  readonly profile: IEntitlementProfile;
+  simulateSignal(signal: EntitlementSignal): void;
+} {
+  let grants: EntitlementGrant[] = [
+    { id: Entitlements.NETWORK_HTTP },
+    { id: Entitlements.AI },
+  ];
+  // The policy's `grant` array is read each time the underlying enforcer
+  // calls `evaluatePolicy`, so we wrap it in a getter via Object.defineProperty.
+  const policy = {
+    deny: [] as never[],
+    ask: [] as never[],
+  } as EntitlementPolicy as { deny: readonly never[]; grant: readonly EntitlementGrant[]; ask: readonly never[] };
+  Object.defineProperty(policy, "grant", {
+    get: () => grants,
+    enumerable: true,
+  });
+
+  const source = createControllableSignalSource();
+
+  const profile = createPolicyProfile("custom", policy, { signalSource: source });
+
+  let reloadFlipState = false;
+  return {
+    profile,
+    simulateSignal(signal) {
+      if (signal.kind === "revoke") {
+        grants = grants.filter((g) => g.id !== signal.entitlement.id);
+      } else if (signal.kind === "grant") {
+        if (!grants.some((g) => g.id === signal.entitlement.id)) {
+          grants = [...grants, { id: signal.entitlement.id }];
+        }
+      } else {
+        // reload: flip NETWORK_HTTP grant state.
+        if (reloadFlipState) {
+          grants = grants.filter((g) => g.id !== Entitlements.NETWORK_HTTP);
+        } else {
+          if (!grants.some((g) => g.id === Entitlements.NETWORK_HTTP)) {
+            grants = [...grants, { id: Entitlements.NETWORK_HTTP }];
+          }
+        }
+        reloadFlipState = !reloadFlipState;
+      }
+      source.emit(signal);
+    },
+  };
+}
+
+runEntitlementProfileConformance({
+  name: "custom",
+  timeout: 5_000,
+  factory: async () => {
+    const built = buildCustomProfile();
+    return {
+      profile: built.profile,
+      simulateSignal: built.simulateSignal,
+      dispose: () => built.profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: true,
+    hierarchyHonoring: true,
+    resourceScoping: false, // custom profile only declares broad grants
+  },
+  expected: {
+    surfaceIncludes: [Entitlements.NETWORK_HTTP, Entitlements.AI],
+    surfaceExcludes: [Entitlements.FILESYSTEM],
+  },
+});

--- a/packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
+++ b/packages/test/src/test/entitlement-profile/Custom_Profile.test.ts
@@ -42,7 +42,7 @@ function buildCustomProfile(): {
   const policy = {
     deny: [] as never[],
     ask: [] as never[],
-  } as EntitlementPolicy as { deny: readonly never[]; grant: readonly EntitlementGrant[]; ask: readonly never[] };
+  } as unknown as EntitlementPolicy;
   Object.defineProperty(policy, "grant", {
     get: () => grants,
     enumerable: true,

--- a/packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts
+++ b/packages/test/src/test/entitlement-profile/Desktop_Profile.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "desktop",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("desktop");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.MCP_STDIO,
+      Entitlements.BROWSER_CONTROL_LOCAL,
+    ],
+    surfaceExcludes: [
+      // Desktop intentionally does NOT include the cloud variant.
+      Entitlements.BROWSER_CONTROL_CLOUD,
+    ],
+  },
+});

--- a/packages/test/src/test/entitlement-profile/Server_Profile.test.ts
+++ b/packages/test/src/test/entitlement-profile/Server_Profile.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Entitlements, createProfileEnforcer } from "@workglow/task-graph";
+
+import { runEntitlementProfileConformance } from "../../contract/entitlement-profile/runEntitlementProfileConformance";
+
+runEntitlementProfileConformance({
+  name: "server",
+  timeout: 5_000,
+  factory: async () => {
+    const profile = createProfileEnforcer("server");
+    return {
+      profile,
+      dispose: () => profile.dispose(),
+    };
+  },
+  capabilities: {
+    mutableSignalSource: false,
+    hierarchyHonoring: true,
+    resourceScoping: true,
+  },
+  expected: {
+    surfaceIncludes: [
+      Entitlements.NETWORK_HTTP,
+      Entitlements.FILESYSTEM,
+      Entitlements.CODE_EXECUTION,
+      Entitlements.BROWSER_CONTROL_CLOUD,
+    ],
+    surfaceExcludes: [],
+  },
+});

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { STATIC_SIGNAL_SOURCE, type EntitlementSignal } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+describe("STATIC_SIGNAL_SOURCE", () => {
+  it("subscribe returns a no-op unsubscribe and never invokes the listener", () => {
+    const calls: EntitlementSignal[] = [];
+    const unsub = STATIC_SIGNAL_SOURCE.subscribe((s) => calls.push(s));
+    expect(typeof unsub).toBe("function");
+    // Calling unsub repeatedly must not throw.
+    unsub();
+    unsub();
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -61,3 +61,94 @@ describe("IEntitlementProfile types", () => {
     expect(stub.name).toBe("test");
   });
 });
+
+import {
+  createPolicyProfile,
+  Entitlements,
+  type EntitlementPolicy,
+  type IEntitlementSignalSource,
+} from "@workglow/task-graph";
+
+describe("createPolicyProfile", () => {
+  const policy: EntitlementPolicy = {
+    deny: [],
+    grant: [{ id: Entitlements.NETWORK_HTTP }, { id: Entitlements.AI }],
+    ask: [],
+  };
+
+  it("builds a profile whose surface() reflects the policy grants", () => {
+    const profile = createPolicyProfile("test", policy);
+    expect(profile.name).toBe("test");
+    expect(profile.surface().map((g) => g.id).sort()).toEqual(
+      [Entitlements.AI, Entitlements.NETWORK_HTTP].sort()
+    );
+  });
+
+  it("requestEntitlement returns granted for covered, denied for uncovered", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const granted = await profile.requestEntitlement({ id: Entitlements.NETWORK_HTTP });
+    expect(granted.outcome).toBe("granted");
+    const denied = await profile.requestEntitlement({ id: Entitlements.FILESYSTEM });
+    expect(denied.outcome).toBe("denied");
+    if (denied.outcome === "denied") {
+      expect(denied.denial.reason).toBe("default-deny");
+    }
+  });
+
+  it("requestEntitlement returns granted for optional even when uncovered", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const result = await profile.requestEntitlement({
+      id: Entitlements.FILESYSTEM,
+      optional: true,
+    });
+    expect(result.outcome).toBe("granted");
+  });
+
+  it("checkAll keeps existing semantics (empty array means granted)", async () => {
+    const profile = createPolicyProfile("test", policy);
+    const denials = await profile.checkAll({
+      entitlements: [{ id: Entitlements.NETWORK_HTTP }],
+    });
+    expect(denials).toEqual([]);
+  });
+
+  it("subscribe + signal source revoke fires change event after a previous grant query", async () => {
+    let emit: ((s: EntitlementSignal) => void) | undefined;
+    const source: IEntitlementSignalSource = {
+      subscribe(listener) {
+        emit = listener;
+        return () => {
+          emit = undefined;
+        };
+      },
+    };
+    const profile = createPolicyProfile("test", policy, { signalSource: source });
+    // Query first to seed previous-verdict tracking.
+    await profile.requestEntitlement({ id: Entitlements.NETWORK_HTTP });
+    const events: Array<{ kind: string; id: string }> = [];
+    profile.subscribe((e) => events.push({ kind: e.kind, id: e.entitlement.id }));
+    // Mutate the policy through a mutable wrapper. Since createPolicyProfile takes
+    // the policy by reference, we test revoke by swapping in a profile that uses
+    // a simple in-memory mutable policy holder. Here we exercise the no-flip case:
+    // a revoke for an entitlement that is already denied does not emit.
+    emit!({ kind: "revoke", entitlement: { id: Entitlements.FILESYSTEM } });
+    // Allow the async re-evaluation to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(events).toEqual([]);
+  });
+
+  it("dispose unsubscribes from the signal source", async () => {
+    let unsubCalls = 0;
+    const source: IEntitlementSignalSource = {
+      subscribe() {
+        return () => {
+          unsubCalls++;
+        };
+      },
+    };
+    const profile = createPolicyProfile("test", policy, { signalSource: source });
+    await profile.dispose();
+    await profile.dispose(); // idempotent
+    expect(unsubCalls).toBe(1);
+  });
+});

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -183,3 +183,31 @@ describe("ENTITLEMENT_PROFILE service token", () => {
     expect(registry.get(ENTITLEMENT_PROFILE)).toBe(profile);
   });
 });
+
+import { BROWSER_GRANTS, DESKTOP_GRANTS, SERVER_GRANTS } from "@workglow/task-graph";
+
+describe("Built-in profile inclusion lattice", () => {
+  function ids(grants: ReadonlyArray<{ id: string }>): ReadonlySet<string> {
+    return new Set(grants.map((g) => g.id));
+  }
+
+  it("BROWSER_GRANTS ⊆ DESKTOP_GRANTS", () => {
+    const browser = ids(BROWSER_GRANTS);
+    const desktop = ids(DESKTOP_GRANTS);
+    for (const id of browser) {
+      expect(desktop.has(id)).toBe(true);
+    }
+  });
+
+  it("DESKTOP_GRANTS ⊆ SERVER_GRANTS", () => {
+    const desktop = ids(DESKTOP_GRANTS);
+    const server = ids(SERVER_GRANTS);
+    for (const id of desktop) {
+      expect(server.has(id)).toBe(true);
+    }
+  });
+
+  it("DESKTOP grants are a strict superset of BROWSER", () => {
+    expect(DESKTOP_GRANTS.length).toBeGreaterThan(BROWSER_GRANTS.length);
+  });
+});

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { STATIC_SIGNAL_SOURCE, type EntitlementSignal } from "@workglow/task-graph";
+import {
+  STATIC_SIGNAL_SOURCE,
+  type EntitlementSignal,
+  type EntitlementChangeEvent,
+  type EntitlementRequestResult,
+  type IEntitlementProfile,
+} from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
 describe("STATIC_SIGNAL_SOURCE", () => {
@@ -16,5 +22,42 @@ describe("STATIC_SIGNAL_SOURCE", () => {
     unsub();
     unsub();
     expect(calls).toEqual([]);
+  });
+});
+
+describe("IEntitlementProfile types", () => {
+  it("EntitlementRequestResult discriminates on outcome", () => {
+    const granted: EntitlementRequestResult = {
+      outcome: "granted",
+      entitlement: { id: "network:http" },
+    };
+    const denied: EntitlementRequestResult = {
+      outcome: "denied",
+      denial: { entitlement: { id: "filesystem" }, reason: "default-deny" },
+    };
+    expect(granted.outcome).toBe("granted");
+    expect(denied.outcome).toBe("denied");
+  });
+
+  it("EntitlementChangeEvent has revoked or granted kind", () => {
+    const event: EntitlementChangeEvent = {
+      kind: "revoked",
+      entitlement: { id: "network:http" },
+    };
+    expect(event.kind).toBe("revoked");
+  });
+
+  it("IEntitlementProfile is structurally a superset of IEntitlementEnforcer", () => {
+    // Compile-time check via type assertion. Runtime: a stub satisfying the shape.
+    const stub: IEntitlementProfile = {
+      name: "test",
+      checkAll: async () => [],
+      checkTask: async () => [],
+      surface: () => [],
+      requestEntitlement: async (e) => ({ outcome: "granted", entitlement: e }),
+      subscribe: () => () => {},
+      dispose: async () => {},
+    };
+    expect(stub.name).toBe("test");
   });
 });

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -171,3 +171,15 @@ describe("createProfileEnforcer (refactored)", () => {
     expect(profile.name).toBe("browser");
   });
 });
+
+import { ENTITLEMENT_PROFILE } from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+
+describe("ENTITLEMENT_PROFILE service token", () => {
+  it("registers and resolves a profile through ServiceRegistry", () => {
+    const registry = new ServiceRegistry();
+    const profile = createProfileEnforcer("browser");
+    registry.registerInstance(ENTITLEMENT_PROFILE, profile);
+    expect(registry.get(ENTITLEMENT_PROFILE)).toBe(profile);
+  });
+});

--- a/packages/test/src/test/task-graph/EntitlementProfile.test.ts
+++ b/packages/test/src/test/task-graph/EntitlementProfile.test.ts
@@ -64,6 +64,7 @@ describe("IEntitlementProfile types", () => {
 
 import {
   createPolicyProfile,
+  createProfileEnforcer,
   Entitlements,
   type EntitlementPolicy,
   type IEntitlementSignalSource,
@@ -150,5 +151,23 @@ describe("createPolicyProfile", () => {
     await profile.dispose();
     await profile.dispose(); // idempotent
     expect(unsubCalls).toBe(1);
+  });
+});
+
+describe("createProfileEnforcer (refactored)", () => {
+  it("returns an IEntitlementProfile (has name, surface, requestEntitlement, subscribe, dispose)", () => {
+    const profile = createProfileEnforcer("browser");
+    expect(profile.name).toBe("browser");
+    expect(typeof profile.surface).toBe("function");
+    expect(typeof profile.requestEntitlement).toBe("function");
+    expect(typeof profile.subscribe).toBe("function");
+    expect(typeof profile.dispose).toBe("function");
+  });
+
+  it("accepts an options bag with resolver and signalSource", () => {
+    const profile = createProfileEnforcer("browser", {
+      resolver: { lookup: () => undefined, prompt: async () => "grant", save: () => {} },
+    });
+    expect(profile.name).toBe("browser");
   });
 });


### PR DESCRIPTION
## Summary

This PR introduces `IEntitlementProfile`, a first-class abstraction for entitlement systems that extends `IEntitlementEnforcer` with single-key request API, change-event subscription, and a pluggable signal source port. It includes a parameterized conformance suite that all profile implementations (built-in and downstream) must satisfy.

## Key Changes

- **New library types** (`packages/task-graph/src/task/EntitlementProfile.ts`):
  - `IEntitlementSignalSource` port for pluggable external permission-change signals
  - `STATIC_SIGNAL_SOURCE` no-op default implementation
  - `EntitlementSignal` discriminated union (`revoke`, `grant`, `reload`)
  - `IEntitlementProfile` interface extending `IEntitlementEnforcer` with:
    - `name: string` identifier
    - `surface(): EntitlementGrant[]` maximum grantable set
    - `requestEntitlement(required): Promise<EntitlementRequestResult>` single-key request
    - `subscribe(listener): () => void` change-event subscription
    - `dispose(): Promise<void>` idempotent teardown
  - `EntitlementRequestResult` discriminated union (`granted` | `denied`)
  - `EntitlementChangeEvent` type for revocation/grant notifications
  - `createPolicyProfile()` constructor wrapping `createPolicyEnforcer` with signal-source bookkeeping and verdict-flip tracking
  - `ENTITLEMENT_PROFILE` service token for DI registration

- **Refactored `createProfileEnforcer`** (`packages/task-graph/src/task/EntitlementProfiles.ts`):
  - Now returns `IEntitlementProfile` instead of `IEntitlementEnforcer`
  - Delegates to `createPolicyProfile` internally
  - Accepts options bag with optional `resolver` and `signalSource`

- **Conformance suite** (`packages/test/src/contract/entitlement-profile/`):
  - `runEntitlementProfileConformance()` parameterized test runner
  - 11 assertion blocks covering:
    - Surface coverage and hierarchy honoring
    - Resource scoping
    - Optional entitlements never denied
    - Denial shape validation
    - `requestEntitlement` shape consistency
    - Change-event subscription (revocation, grant, reload)
    - Unsubscribe idempotency
    - Disposal semantics
  - Capability flags gate assertions for profile-specific features
  - Fixtures and controllable signal source for testing

- **Adapter shims** (`packages/test/src/test/entitlement-profile/`):
  - Browser, Desktop, Server profiles run conformance suite
  - Custom profile with controllable signal source for advanced testing

- **Documentation**:
  - Design spec (`docs/superpowers/specs/2026-05-07-entitlementprofile-contract-conformance-design.md`)
  - Implementation plan (`docs/superpowers/plans/2026-05-07-entitlementprofile-contract-conformance.md`)
  - Updated entitlements system docs with `IEntitlementProfile` examples

## Notable Implementation Details

- **Naming deviation**: Spec proposed `EntitlementVerdict` but that name conflicts with existing `EntitlementPolicy` type; uses `EntitlementRequestResult` instead
- **Verdict-flip tracking**: Profiles track previously-queried entitlements to emit change events only when verdicts actually flip
- **Signal source subscription**: Profiles subscribe on construction and unsubscribe on `dispose()` for cleanup
- **Optional entitlements**: Always return `outcome: "granted"` regardless of policy, matching existing `checkAll` semantics
- **Idempotent operations**: `dispose()` and unsubscribe functions are idempotent per contract

https://claude.ai/code/session_01LzAzwGRStYZVwuGo4MNQ3z