### PR TITLE
test(browser-context): add IBrowserContext contract conformance suite

### DIFF
--- a/docs/superpowers/plans/2026-05-07-ibrowsercontext-contract-conformance.md
+++ b/docs/superpowers/plans/2026-05-07-ibrowsercontext-contract-conformance.md
@@ -1,0 +1,1939 @@
+# IBrowserContext Contract Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a parameterized contract conformance suite for `IBrowserContext` in `@workglow/test`, run it against four adapters (Mock, Playwright, BunWebView, Electron), and fix the three known IBrowserContext bugs the suite detects.
+
+**Architecture:** Mirror the existing `runAiProviderConformance` pattern under `packages/test/src/contract/browser-context/`. Single entrypoint `runIBrowserContextConformance(opts)` defines a `describe.skipIf` and dispatches to four assertion blocks (capability honesty, tabs lifecycle, ARIA round-trip, network introspection). Each adapter is wired via a thin `*_Generic.integration.test.ts` shim under `packages/test/src/test/browser/`. Known bugs are captured as `expectedFailures` entries until Phase 4 fixes them.
+
+**Tech Stack:** TypeScript, Vitest, Bun workspaces, Playwright, Bun.WebView (CDP), Electron (CDP), `@workglow/browser-control`.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-ibrowsercontext-contract-conformance-design.md`
+
+---
+
+## File map
+
+**Created:**
+- `packages/test/src/contract/browser-context/types.ts` — `IBrowserContextConformanceOpts`, `BrowserContextHandle`, `BrowserContextCapabilities`, `BrowserContextFixture`.
+- `packages/test/src/contract/browser-context/fixtures.ts` — `DEFAULT_FIXTURE`, `resolveFixture`, the data: URL HTML.
+- `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts` — entrypoint.
+- `packages/test/src/contract/browser-context/assertions/itExpectFail.ts` — copy of the AiProvider helper.
+- `packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts` — negative + positive capability honesty.
+- `packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts` — basic + concurrent-close stability.
+- `packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts` — snapshot ↔ ref round-trip + ref reuse.
+- `packages/test/src/contract/browser-context/assertions/networkIntrospection.ts` — fixture fetch is observable.
+- `packages/test/src/contract/browser-context/ConformanceMockContext.ts` — purpose-built in-memory `IBrowserContext` for the Mock shim. Distinct from existing `MockBrowserContext` (call recorder, used by Tasks unit tests).
+- `packages/test/src/test/browser/MockBrowser_Generic.test.ts` — shim using `ConformanceMockContext`.
+- `packages/test/src/test/browser/Playwright_Generic.integration.test.ts` — shim.
+- `packages/test/src/test/browser/BunWebView_Generic.integration.test.ts` — shim.
+- `packages/test/src/test/browser/Electron_Generic.integration.test.ts` — shim, gated on `RUN_ELECTRON_TESTS`.
+
+**Modified:**
+- `packages/test/src/contract/README.md` — add a row to the "Available suites" table; add a paragraph documenting `create`/`dispose` factory shape as a legitimate variant of `register`/`dispose`/`inspect`.
+- `packages/browser-control/src/task/PlaywrightBackend.ts` (Phase 4 only) — three localized fixes.
+- `packages/browser-control/src/task/BunWebViewBackend.ts` (Phase 4 only) — delete empty-stub `networkRequests` / `consoleMessages` properties.
+
+**Untouched:**
+- `packages/test/src/test/browser/MockBrowserContext.ts` — left alone; existing Tasks unit tests depend on its current shape.
+- `packages/test/src/test/browser/genericBrowserTaskTests.ts` — Tasks-layer suite; orthogonal to this contract suite.
+
+---
+
+## Phase 1 — Foundations & fixtures
+
+### Task 1.1: Scaffold the contract directory + types
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/types.ts`
+- Create: `packages/test/src/contract/browser-context/assertions/itExpectFail.ts`
+- Reference: `packages/test/src/contract/ai-provider/types.ts`, `packages/test/src/contract/ai-provider/assertions/itExpectFail.ts`
+
+- [ ] **Step 1: Copy `itExpectFail.ts` verbatim from `ai-provider/`.**
+
+```ts
+// packages/test/src/contract/browser-context/assertions/itExpectFail.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { it } from "vitest";
+
+type ItFn = (name: string, fn: () => Promise<void> | void, timeout?: number) => void;
+
+export const itExpectFail: ItFn = (name, fn, timeout) => {
+  const native = (it as unknown as { fails?: ItFn }).fails;
+  if (typeof native === "function") {
+    native(name, fn, timeout);
+    return;
+  }
+  it(
+    `${name} [expected-fail]`,
+    async () => {
+      let passed = false;
+      try {
+        await fn();
+        passed = true;
+      } catch {
+        // expected; the test was supposed to fail
+      }
+      if (passed) {
+        throw new Error(
+          `Test "${name}" was marked as expected-fail but passed. Remove its name from opts.expectedFailures.`
+        );
+      }
+    },
+    timeout
+  );
+};
+```
+
+- [ ] **Step 2: Write `types.ts`.**
+
+```ts
+// packages/test/src/contract/browser-context/types.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+export interface IBrowserContextConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<BrowserContextHandle>;
+  readonly capabilities: BrowserContextCapabilities;
+  readonly fixture?: Partial<BrowserContextFixture>;
+  /**
+   * Names of conformance assertions currently broken in this adapter; each
+   * named assertion is wrapped in `it.fails` instead of `it`. Remove the
+   * entry once the adapter bug is fixed.
+   *
+   * Known names:
+   *   "tabs.concurrentCloseStable"
+   *   "aria.colonInName"
+   *   "capability.networkRequests.undefinedWhenFalse"
+   *   "capability.consoleMessages.undefinedWhenFalse"
+   */
+  readonly expectedFailures?: ReadonlyArray<string>;
+}
+
+export interface BrowserContextHandle {
+  /** Construct and connect a fresh context. Called per top-level block. */
+  readonly create: () => Promise<IBrowserContext>;
+  /** Disconnect and release resources for a context returned by create(). */
+  readonly dispose: (ctx: IBrowserContext) => Promise<void>;
+}
+
+export interface BrowserContextCapabilities {
+  /** false for single-view backends (e.g. BunWebView). */
+  readonly multipleTabs: boolean;
+  /** Optional method honesty + positive test. */
+  readonly networkRequests: boolean;
+  /** Optional method honesty + positive test. */
+  readonly consoleMessages: boolean;
+  /** Every backend should be true; flag exists for hygiene/symmetry. */
+  readonly ariaSnapshot: boolean;
+}
+
+export interface BrowserContextFixture {
+  readonly pageUrl: string;
+  readonly networkMarkerUrl: string;
+  readonly consoleMarker: string;
+  readonly ariaEdgeCaseNames: ReadonlyArray<string>;
+}
+```
+
+- [ ] **Step 3: Run typecheck to ensure imports resolve.**
+
+Run: `cd packages/test && bun run --filter=@workglow/test build:types 2>&1 | tail -30`
+Expected: no errors referencing `browser-context/types.ts` or `itExpectFail.ts`. (Other unrelated errors elsewhere in the repo are not this task's concern.)
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/types.ts \
+        packages/test/src/contract/browser-context/assertions/itExpectFail.ts
+git commit -m "test(browser-context): add conformance types + itExpectFail helper"
+```
+
+---
+
+### Task 1.2: Build the fixture page
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/fixtures.ts`
+
+- [ ] **Step 1: Write `fixtures.ts`.**
+
+The fixture page is a self-contained `data:text/html,...` URL. It embeds a `<button>` per ARIA edge-case name, each with an `onclick` that sets `data-clicked="<idx>"` on `#sentinel`. On load it issues `fetch("data:text/plain,fixture-network-marker")` and `console.log("fixture-console-marker")`.
+
+```ts
+// packages/test/src/contract/browser-context/fixtures.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BrowserContextFixture } from "./types";
+
+const ARIA_EDGE_CASE_NAMES: ReadonlyArray<string> = [
+  "Sign in",                  // baseline ASCII
+  "foo:bar",                  // colon mid-name
+  "11:30",                    // ends in colon-digits (lastIndexOf parser)
+  "a",                        // single character
+  "héllo→",                   // unicode + arrow
+  "x".repeat(200),            // long
+];
+
+const NETWORK_MARKER = "fixture-network-marker";
+const CONSOLE_MARKER = "fixture-console-marker";
+
+function escapeForHtmlAttr(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildPageHtml(): string {
+  const buttons = ARIA_EDGE_CASE_NAMES.map(
+    (name, idx) =>
+      `<button type="button" aria-label="${escapeForHtmlAttr(name)}" ` +
+      `onclick="document.getElementById('sentinel').setAttribute('data-clicked', '${idx}')">` +
+      escapeForHtmlAttr(name) +
+      `</button>`
+  ).join("");
+  const head = "<head><title>IBrowserContext Conformance</title></head>";
+  const body =
+    `<body>` +
+    `<div id="sentinel" data-clicked=""></div>` +
+    buttons +
+    `<script>` +
+    `console.log(${JSON.stringify(CONSOLE_MARKER)});` +
+    // Use a benign network target — data: URL keeps the page self-contained.
+    `fetch("data:text/plain,${NETWORK_MARKER}").catch(function(){});` +
+    `</script>` +
+    `</body>`;
+  return `<!DOCTYPE html><html>${head}${body}</html>`;
+}
+
+const PAGE_URL = `data:text/html,${encodeURIComponent(buildPageHtml())}`;
+
+export const DEFAULT_FIXTURE: BrowserContextFixture = {
+  pageUrl: PAGE_URL,
+  networkMarkerUrl: NETWORK_MARKER,
+  consoleMarker: CONSOLE_MARKER,
+  ariaEdgeCaseNames: ARIA_EDGE_CASE_NAMES,
+};
+
+export function resolveFixture(
+  override: Partial<BrowserContextFixture> | undefined
+): BrowserContextFixture {
+  if (!override) return DEFAULT_FIXTURE;
+  return { ...DEFAULT_FIXTURE, ...override };
+}
+```
+
+- [ ] **Step 2: Smoke-test the fixture HTML in a Node REPL.**
+
+Run:
+```sh
+node -e '
+const { DEFAULT_FIXTURE } = require("./packages/test/src/contract/browser-context/fixtures.ts");
+console.log(DEFAULT_FIXTURE.pageUrl.length, DEFAULT_FIXTURE.ariaEdgeCaseNames.length);
+'
+```
+
+Skip this step if Node cannot import .ts directly. Instead, run typecheck:
+Run: `cd packages/test && bun run build:types 2>&1 | tail -10`
+Expected: no errors mentioning `fixtures.ts`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/fixtures.ts
+git commit -m "test(browser-context): add data-URL fixture page with ARIA edge-case names"
+```
+
+---
+
+### Task 1.3: Add the runner shell + README entry
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts`
+- Modify: `packages/test/src/contract/README.md`
+
+- [ ] **Step 1: Write the runner shell with no assertion blocks wired (each block is added in Phase 2 tasks).**
+
+```ts
+// packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from "vitest";
+
+import { resolveFixture } from "./fixtures";
+import type { IBrowserContextConformanceOpts } from "./types";
+
+export function runIBrowserContextConformance(opts: IBrowserContextConformanceOpts): void {
+  describe.skipIf(opts.skip)(`IBrowserContext conformance: ${opts.name}`, () => {
+    const fixture = resolveFixture(opts.fixture);
+
+    // Phase 2 wires assertion blocks here. Each block creates its own
+    // context via opts.factory() in beforeAll and disposes it in afterAll
+    // so block N cannot taint block N+1.
+    void fixture;
+  });
+}
+```
+
+- [ ] **Step 2: Update the contract README.**
+
+Add a row to the "Available suites" table (locate the existing markdown table around lines 67-71 of `packages/test/src/contract/README.md`):
+
+```markdown
+| `IBrowserContext` | `contract/browser-context/runIBrowserContextConformance` | Mock, Playwright, BunWebView, Electron |
+```
+
+Add this paragraph after the "Conventions" section (around line 64), before "Available suites":
+
+```markdown
+### Factory shape variants
+
+The `register/dispose/inspect` factory documented above is one of two
+legitimate shapes — used when an adapter is a long-lived global registration
+(e.g. an AI provider). For contracts whose subject is heavyweight but
+per-test state (e.g. browser contexts), prefer a `create/dispose` factory
+where each top-level block instantiates its own subject:
+
+    factory: () => Promise<{
+      create: () => Promise<TSubject>;
+      dispose: (subject: TSubject) => Promise<void>;
+    }>
+
+The principle is the same: a fresh handle per block, with no shared state
+that block N can leak into block N+1. The methods on the handle are
+contract-specific.
+```
+
+- [ ] **Step 3: Run typecheck.**
+
+Run: `cd packages/test && bun run build:types 2>&1 | tail -10`
+Expected: no errors referencing the new files.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/runIBrowserContextConformance.ts \
+        packages/test/src/contract/README.md
+git commit -m "test(browser-context): scaffold conformance runner + README entry"
+```
+
+---
+
+## Phase 2 — Suite assertions, Mock shim, Playwright shim
+
+### Task 2.1: ConformanceMockContext (the reference implementation)
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/ConformanceMockContext.ts`
+
+This is a purpose-built in-memory `IBrowserContext` rich enough to satisfy all four assertion blocks. Distinct from the existing `MockBrowserContext` call recorder. It parses the data: URL fixture page on `navigate()`, synthesizes an accessibility tree from the embedded buttons, tracks per-tab state, captures fetches and console messages, and implements click side-effects so the click sentinel works.
+
+- [ ] **Step 1: Write `ConformanceMockContext.ts`.**
+
+```ts
+// packages/test/src/contract/browser-context/ConformanceMockContext.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AccessibilityNode,
+  AccessibilityTree,
+  AriaRole,
+  BrowserConnectOptions,
+  ClickOptions,
+  ConsoleMessage,
+  DialogAction,
+  DialogInfo,
+  DownloadOptions,
+  DownloadResult,
+  ElementRef,
+  IBrowserContext,
+  NavigateOptions,
+  NetworkFilter,
+  NetworkRequest,
+  ScreenshotOptions,
+  SnapshotOptions,
+  TabInfo,
+  WaitOptions,
+} from "@workglow/browser-control/task";
+
+interface PageState {
+  readonly tabId: string;
+  url: string;
+  title: string;
+  ariaButtons: ReadonlyArray<{ readonly idx: number; readonly name: string }>;
+  sentinelClicked: string;
+  network: NetworkRequest[];
+  console: ConsoleMessage[];
+}
+
+/**
+ * Parses the conformance fixture page out of a `data:text/html,...` URL by
+ * scraping aria-label values from `<button ... aria-label="...">` tags. This
+ * is intentionally narrow — only the conformance fixture page is supported.
+ */
+function parseFixturePage(url: string): {
+  readonly title: string;
+  readonly ariaButtons: ReadonlyArray<{ readonly idx: number; readonly name: string }>;
+  readonly networkMarker: string | undefined;
+  readonly consoleMarker: string | undefined;
+} {
+  let html = "";
+  if (url.startsWith("data:text/html,")) {
+    html = decodeURIComponent(url.slice("data:text/html,".length));
+  }
+  const titleMatch = /<title>([^<]*)<\/title>/.exec(html);
+  const buttons: { idx: number; name: string }[] = [];
+  const buttonRe = /<button[^>]*aria-label="([^"]*)"[^>]*>/g;
+  let m: RegExpExecArray | null;
+  let idx = 0;
+  while ((m = buttonRe.exec(html)) !== null) {
+    const decoded = m[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&");
+    buttons.push({ idx, name: decoded });
+    idx++;
+  }
+  const fetchMatch = /fetch\("data:text\/plain,([^"]+)"/.exec(html);
+  const consoleMatch = /console\.log\("([^"]+)"\)/.exec(html);
+  return {
+    title: titleMatch ? titleMatch[1] : "",
+    ariaButtons: buttons,
+    networkMarker: fetchMatch?.[1],
+    consoleMarker: consoleMatch?.[1],
+  };
+}
+
+export class ConformanceMockContext implements IBrowserContext {
+  private connected = false;
+  private nextTabSeq = 1;
+  private nextRefSeq = 1;
+  private pages: PageState[] = [];
+  private activeTabId: string | undefined;
+  /** ref → { tabId, name } produced by snapshot(). */
+  private refMap = new Map<string, { tabId: string; name: string; idx: number }>();
+
+  // networkRequests / consoleMessages are intentionally absent (undefined)
+  // when the corresponding capability flag is false. The shim wires this
+  // class with capabilities.{networkRequests,consoleMessages}: false, so
+  // these properties stay undefined to satisfy capability honesty (negative).
+
+  // -- Lifecycle ------------------------------------------------------------
+  async connect(_options?: BrowserConnectOptions): Promise<void> {
+    this.connected = true;
+    if (this.pages.length === 0) {
+      const page = this.makePage("about:blank", "");
+      this.pages.push(page);
+      this.activeTabId = page.tabId;
+    }
+  }
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.pages = [];
+    this.activeTabId = undefined;
+    this.refMap.clear();
+  }
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  private makePage(url: string, title: string): PageState {
+    return {
+      tabId: `mock-tab-${this.nextTabSeq++}`,
+      url,
+      title,
+      ariaButtons: [],
+      sentinelClicked: "",
+      network: [],
+      console: [],
+    };
+  }
+
+  private active(): PageState {
+    const p = this.pages.find((p) => p.tabId === this.activeTabId);
+    if (!p) throw new Error("ConformanceMockContext: no active tab");
+    return p;
+  }
+
+  // -- Navigation -----------------------------------------------------------
+  async navigate(url: string, _options?: NavigateOptions): Promise<void> {
+    const page = this.active();
+    page.url = url;
+    const parsed = parseFixturePage(url);
+    page.title = parsed.title;
+    page.ariaButtons = parsed.ariaButtons;
+    page.sentinelClicked = "";
+    if (parsed.networkMarker) {
+      page.network.push({
+        url: `data:text/plain,${parsed.networkMarker}`,
+        method: "GET",
+        status: 200,
+        headers: {},
+      });
+    }
+    if (parsed.consoleMarker) {
+      page.console.push({ type: "log", text: parsed.consoleMarker });
+    }
+  }
+  async goBack(): Promise<void> {}
+  async goForward(): Promise<void> {}
+  async reload(): Promise<void> {}
+  async currentUrl(): Promise<string> {
+    return this.active().url;
+  }
+  async title(): Promise<string> {
+    return this.active().title;
+  }
+
+  // -- Accessibility --------------------------------------------------------
+  async snapshot(_options?: SnapshotOptions): Promise<AccessibilityTree> {
+    const page = this.active();
+    const children: AccessibilityNode[] = page.ariaButtons.map((b) => {
+      const ref: ElementRef = `e${this.nextRefSeq++}`;
+      this.refMap.set(ref, { tabId: page.tabId, name: b.name, idx: b.idx });
+      return { ref, role: "button", name: b.name };
+    });
+    const rootRef: ElementRef = `e${this.nextRefSeq++}`;
+    return {
+      root: { ref: rootRef, role: "document", name: page.title, children },
+      yaml: children.map((c) => `- button [${c.ref}]: ${c.name}`).join("\n"),
+    };
+  }
+
+  // -- Element interaction --------------------------------------------------
+  async click(ref: ElementRef, _options?: ClickOptions): Promise<void> {
+    const entry = this.refMap.get(ref);
+    if (!entry) throw new Error(`ConformanceMockContext: unknown ref "${ref}"`);
+    const page = this.pages.find((p) => p.tabId === entry.tabId);
+    if (!page) throw new Error(`ConformanceMockContext: tab gone for ref "${ref}"`);
+    page.sentinelClicked = String(entry.idx);
+  }
+  async fill(): Promise<void> {}
+  async selectOption(): Promise<void> {}
+  async hover(): Promise<void> {}
+
+  async clickByRole(role: AriaRole, name: string, _options?: ClickOptions): Promise<void> {
+    if (role !== "button") {
+      throw new Error(`ConformanceMockContext: unsupported role "${role}"`);
+    }
+    const page = this.active();
+    const btn = page.ariaButtons.find((b) => b.name === name);
+    if (!btn) throw new Error(`ConformanceMockContext: no button named ${JSON.stringify(name)}`);
+    page.sentinelClicked = String(btn.idx);
+  }
+  async fillByLabel(): Promise<void> {}
+
+  // -- Content extraction ---------------------------------------------------
+  async content(): Promise<string> {
+    return "";
+  }
+  async innerHTML(): Promise<string> {
+    return "";
+  }
+  async textContent(ref: ElementRef): Promise<string | null> {
+    const entry = this.refMap.get(ref);
+    return entry ? entry.name : null;
+  }
+  async attribute(ref: ElementRef, name: string): Promise<string | null> {
+    if (name === "data-clicked") {
+      const entry = this.refMap.get(ref);
+      const page = entry && this.pages.find((p) => p.tabId === entry.tabId);
+      return page ? page.sentinelClicked : null;
+    }
+    return null;
+  }
+  async querySelector(_selector: string): Promise<ElementRef | null> {
+    return null;
+  }
+  async querySelectorAll(): Promise<readonly ElementRef[]> {
+    return [];
+  }
+
+  async evaluate<T>(expression: string): Promise<T> {
+    // Narrow support: the assertion suite reads sentinel via attribute(), not
+    // evaluate(), but provide a readiness check used by waitForIdle.
+    if (expression.includes("readyState")) return true as unknown as T;
+    return undefined as unknown as T;
+  }
+
+  async screenshot(_options?: ScreenshotOptions): Promise<Buffer> {
+    return Buffer.alloc(0);
+  }
+  async pressKey(): Promise<void> {}
+  async type(): Promise<void> {}
+  async scroll(): Promise<void> {}
+  async uploadFile(): Promise<void> {}
+  async download(
+    trigger: () => Promise<void>,
+    _options?: DownloadOptions
+  ): Promise<DownloadResult> {
+    await trigger();
+    return { path: "", suggestedFilename: "" };
+  }
+  onDialog(_handler: (info: DialogInfo) => DialogAction | Promise<DialogAction>): void {}
+
+  // -- Tabs -----------------------------------------------------------------
+  async tabs(): Promise<readonly TabInfo[]> {
+    return this.pages.map((p) => ({ tabId: p.tabId, url: p.url, title: p.title }));
+  }
+  async switchTab(tabId: string): Promise<void> {
+    if (!this.pages.some((p) => p.tabId === tabId)) {
+      throw new Error(`ConformanceMockContext: no tab "${tabId}"`);
+    }
+    this.activeTabId = tabId;
+  }
+  async newTab(url?: string): Promise<TabInfo> {
+    const page = this.makePage(url ?? "about:blank", "");
+    this.pages.push(page);
+    if (url) {
+      const prev = this.activeTabId;
+      this.activeTabId = page.tabId;
+      await this.navigate(url);
+      this.activeTabId = prev;
+    }
+    return { tabId: page.tabId, url: page.url, title: page.title };
+  }
+  async closeTab(tabId: string): Promise<void> {
+    const before = this.pages.length;
+    this.pages = this.pages.filter((p) => p.tabId !== tabId);
+    if (this.pages.length === before) {
+      throw new Error(`ConformanceMockContext: no tab "${tabId}"`);
+    }
+    if (this.activeTabId === tabId) {
+      this.activeTabId = this.pages[this.pages.length - 1]?.tabId;
+    }
+  }
+
+  // -- Wait -----------------------------------------------------------------
+  async waitForNavigation(): Promise<void> {}
+  async waitForSelector(): Promise<ElementRef> {
+    return "e0";
+  }
+  async waitForIdle(_options?: WaitOptions): Promise<void> {}
+}
+```
+
+- [ ] **Step 2: Run typecheck.**
+
+Run: `cd packages/test && bun run build:types 2>&1 | tail -15`
+Expected: no errors mentioning `ConformanceMockContext.ts`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/ConformanceMockContext.ts
+git commit -m "test(browser-context): add ConformanceMockContext reference impl"
+```
+
+---
+
+### Task 2.2: Capability honesty assertion block
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts`
+- Modify: `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts`
+
+This block has two halves:
+
+- *Negative:* For every `false` flag, assert `typeof ctx[method] === "undefined"`.
+- *Positive:* For every `true` flag, navigate to the fixture page, wait for idle, and assert the optional method returns ≥1 entry containing the fixture marker.
+
+- [ ] **Step 1: Write the assertion file.**
+
+```ts
+// packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+export function capabilityHonestyBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  describe("Capability honesty", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: import("@workglow/browser-control/task").IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Negative direction -------------------------------------------------
+
+    const runNegative = (
+      methodName: "networkRequests" | "consoleMessages",
+      assertionName: string
+    ) => {
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        // The contract says: when the capability is false, the method must
+        // be strictly undefined — NOT a no-op stub returning [].
+        expect(typeof (ctx as Record<string, unknown>)[methodName]).toBe("undefined");
+      };
+      const title = `declares ${methodName}=false → ctx.${methodName} is undefined`;
+      if (expectFail(assertionName)) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    };
+
+    if (!opts.capabilities.networkRequests) {
+      runNegative("networkRequests", "capability.networkRequests.undefinedWhenFalse");
+    }
+    if (!opts.capabilities.consoleMessages) {
+      runNegative("consoleMessages", "capability.consoleMessages.undefinedWhenFalse");
+    }
+
+    // -- Positive direction -------------------------------------------------
+
+    if (opts.capabilities.networkRequests) {
+      it(
+        "declares networkRequests=true → fixture fetch is observable",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          if (typeof ctx.networkRequests !== "function") {
+            throw new Error(
+              "capability claims networkRequests=true but ctx.networkRequests is not a function"
+            );
+          }
+          await ctx.navigate(fixture.pageUrl);
+          await ctx.waitForIdle({ timeout: 5_000 });
+          const entries = await ctx.networkRequests();
+          const found = entries.some((r) => r.url.includes(fixture.networkMarkerUrl));
+          expect(found, `expected an entry containing ${fixture.networkMarkerUrl}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+
+    if (opts.capabilities.consoleMessages) {
+      it(
+        "declares consoleMessages=true → fixture console.log is observable",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          if (typeof ctx.consoleMessages !== "function") {
+            throw new Error(
+              "capability claims consoleMessages=true but ctx.consoleMessages is not a function"
+            );
+          }
+          await ctx.navigate(fixture.pageUrl);
+          await ctx.waitForIdle({ timeout: 5_000 });
+          const entries = await ctx.consoleMessages();
+          const found = entries.some((m) => m.text.includes(fixture.consoleMarker));
+          expect(found, `expected a console message containing ${fixture.consoleMarker}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Wire the block into the runner.**
+
+Edit `runIBrowserContextConformance.ts`:
+
+```ts
+// packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from "vitest";
+
+import { capabilityHonestyBlock } from "./assertions/capabilityHonesty";
+import { resolveFixture } from "./fixtures";
+import type { IBrowserContextConformanceOpts } from "./types";
+
+export function runIBrowserContextConformance(opts: IBrowserContextConformanceOpts): void {
+  describe.skipIf(opts.skip)(`IBrowserContext conformance: ${opts.name}`, () => {
+    const fixture = resolveFixture(opts.fixture);
+
+    capabilityHonestyBlock(opts, fixture);
+    // tabsLifecycleBlock, ariaRoundTripBlock, networkIntrospectionBlock
+    // are wired in subsequent tasks.
+  });
+}
+```
+
+- [ ] **Step 3: Stub the Mock shim so we can run the new block.**
+
+Create a minimal Mock shim — it will be expanded in Task 2.5 once all blocks land. This step lets each block run end-to-end as it's added.
+
+```ts
+// packages/test/src/test/browser/MockBrowser_Generic.test.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConformanceMockContext } from "../../contract/browser-context/ConformanceMockContext";
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+runIBrowserContextConformance({
+  name: "Mock",
+  timeout: 5_000,
+  factory: async () => ({
+    create: async () => {
+      const ctx = new ConformanceMockContext();
+      await ctx.connect();
+      return ctx;
+    },
+    dispose: async (ctx) => ctx.disconnect(),
+  }),
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+});
+```
+
+- [ ] **Step 4: Run the Mock shim.**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/MockBrowser_Generic.test.ts 2>&1 | tail -30`
+Expected: PASS — `IBrowserContext conformance: Mock > Capability honesty` runs two negative-direction `it`s and they both pass (ConformanceMockContext does not define `networkRequests`/`consoleMessages` properties).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts \
+        packages/test/src/contract/browser-context/runIBrowserContextConformance.ts \
+        packages/test/src/test/browser/MockBrowser_Generic.test.ts
+git commit -m "test(browser-context): add capability-honesty block + Mock shim"
+```
+
+---
+
+### Task 2.3: Tabs lifecycle assertion block
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts`
+- Modify: `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts`
+
+Two assertions:
+- *Basic lifecycle:* always runs. After connect, `tabs().length ≥ 1`. `newTab(fixtureUrl)` increases length by 1 if `multipleTabs`, else stays at 1. `closeTab(id)` decreases length (single-view backends may disconnect — accept either result).
+- *Concurrent close stability:* gated on `multipleTabs`. Open 4 tabs → capture all `tabId`s → `Promise.all([closeTab(A), closeTab(B)])` → for each remaining (C, D) `switchTab(originalTabId)` lands on the right page (verified via `currentUrl()` matching the original).
+
+- [ ] **Step 1: Write the assertion file.**
+
+```ts
+// packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+export function tabsLifecycleBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  describe("Tabs lifecycle", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Basic lifecycle ----------------------------------------------------
+
+    it(
+      "tabs() returns at least one tab after connect",
+      async () => {
+        if (!ctx) throw new Error("context not created");
+        const tabs = await ctx.tabs();
+        expect(tabs.length).toBeGreaterThanOrEqual(1);
+      },
+      opts.timeout
+    );
+
+    if (opts.capabilities.multipleTabs) {
+      it(
+        "newTab() increases tab count by 1",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          const before = (await ctx.tabs()).length;
+          await ctx.newTab(fixture.pageUrl);
+          const after = (await ctx.tabs()).length;
+          expect(after).toBe(before + 1);
+        },
+        opts.timeout
+      );
+    }
+
+    // -- Concurrent close stability ----------------------------------------
+
+    if (opts.capabilities.multipleTabs) {
+      const title =
+        "tabId remains valid for surviving tabs across concurrent close()";
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        // Set up four tabs with distinguishable urls.
+        const urls = [
+          "data:text/html,<title>A</title>",
+          "data:text/html,<title>B</title>",
+          "data:text/html,<title>C</title>",
+          "data:text/html,<title>D</title>",
+        ];
+        // Reset to a known state by closing existing non-blank tabs.
+        for (const t of await ctx.tabs()) {
+          // best-effort cleanup; ignore failures
+          try {
+            await ctx.closeTab(t.tabId);
+          } catch {
+            /* noop */
+          }
+        }
+        // Some backends require at least one tab; reconnect if needed.
+        if ((await ctx.tabs()).length === 0) {
+          await ctx.newTab(urls[0]);
+        }
+        // Ensure exactly four tabs in our known order.
+        const baseTabs = await ctx.tabs();
+        const opened: string[] = [];
+        for (let i = 0; i < urls.length; i++) {
+          if (i < baseTabs.length) {
+            // navigate the existing one
+            await ctx.switchTab(baseTabs[i].tabId);
+            await ctx.navigate(urls[i]);
+            opened.push(baseTabs[i].tabId);
+          } else {
+            const t = await ctx.newTab(urls[i]);
+            opened.push(t.tabId);
+          }
+        }
+        const [aId, bId, cId, dId] = opened;
+        // Concurrent close.
+        await Promise.all([ctx.closeTab(aId), ctx.closeTab(bId)]);
+        // Surviving tabs C and D should still resolve to their original urls.
+        await ctx.switchTab(cId);
+        expect(await ctx.currentUrl()).toBe(urls[2]);
+        await ctx.switchTab(dId);
+        expect(await ctx.currentUrl()).toBe(urls[3]);
+      };
+      if (expectFail("tabs.concurrentCloseStable")) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    } else {
+      // Single-view backends: closeTab(only tabId) must either disconnect
+      // OR leave a single tab — accept either result, just don't crash.
+      it(
+        "single-view: closeTab on the sole tab disconnects or no-ops",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          const [t] = await ctx.tabs();
+          try {
+            await ctx.closeTab(t.tabId);
+          } catch {
+            /* some single-view backends may throw — that is acceptable */
+          }
+          // Either disconnected or still has at most one tab.
+          if (ctx.isConnected()) {
+            const after = await ctx.tabs();
+            expect(after.length).toBeLessThanOrEqual(1);
+          }
+        },
+        opts.timeout
+      );
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Wire the block into the runner.**
+
+Edit `runIBrowserContextConformance.ts` — add the import and call:
+
+```ts
+import { tabsLifecycleBlock } from "./assertions/tabsLifecycle";
+// ...
+capabilityHonestyBlock(opts, fixture);
+tabsLifecycleBlock(opts, fixture);
+```
+
+- [ ] **Step 3: Run the Mock shim — verify both basic and concurrent-close blocks pass.**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/MockBrowser_Generic.test.ts 2>&1 | tail -30`
+Expected: PASS — Mock implements stable string tab ids, so the concurrent-close assertion passes.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts \
+        packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+git commit -m "test(browser-context): add tabs lifecycle + concurrent-close stability block"
+```
+
+---
+
+### Task 2.4: ARIA round-trip assertion block
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts`
+- Modify: `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts`
+
+Two assertions:
+- *Round-trip:* navigate to fixture → snapshot → for each fixture node, `clickByRole("button", name)` → read `data-clicked` attribute on a stored ref to the sentinel and assert it now equals the expected idx.
+- *Ref reuse:* a ref captured pre-navigation-of-second-snapshot remains usable for `textContent`.
+
+- [ ] **Step 1: Write the assertion file.**
+
+```ts
+// packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessibilityNode, IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+function collectButtons(root: AccessibilityNode): AccessibilityNode[] {
+  const out: AccessibilityNode[] = [];
+  const stack: AccessibilityNode[] = [root];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
+    if (n.role === "button") out.push(n);
+    if (n.children) stack.push(...n.children);
+  }
+  return out;
+}
+
+export function ariaRoundTripBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  if (!opts.capabilities.ariaSnapshot) return;
+
+  describe("ARIA round-trip", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+      // Navigate once, all assertions reuse this page.
+      await ctx.navigate(fixture.pageUrl);
+      await ctx.waitForIdle({ timeout: 5_000 });
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Round-trip per edge-case name -------------------------------------
+
+    for (let i = 0; i < fixture.ariaEdgeCaseNames.length; i++) {
+      const name = fixture.ariaEdgeCaseNames[i];
+      const isColonName = name.includes(":");
+      const title = `clickByRole('button', ${JSON.stringify(name)}) lands on the right node`;
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        // Reset the sentinel by clicking a known no-op first? Just snapshot
+        // and grab a sentinel ref instead.
+        const tree = await ctx.snapshot();
+        const buttons = collectButtons(tree.root);
+        const target = buttons.find((b) => b.name === name);
+        expect(target, `snapshot must include button with name ${JSON.stringify(name)}`).toBeDefined();
+
+        await ctx.clickByRole("button", name);
+
+        // Read `data-clicked` from the sentinel — locate sentinel by selector.
+        const sentinelRef = await ctx.querySelector("#sentinel");
+        expect(sentinelRef).not.toBeNull();
+        const clicked = await ctx.attribute(sentinelRef!, "data-clicked");
+        expect(clicked).toBe(String(i));
+      };
+      // Names containing a colon trigger the lastIndexOf parser bug in
+      // PlaywrightBackend. Adapters with that bug list "aria.colonInName"
+      // in expectedFailures; the helper wraps in `it.fails` for them.
+      const useExpectFail = isColonName && expectFail("aria.colonInName");
+      if (useExpectFail) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    }
+
+    // -- Ref reuse after a second snapshot ---------------------------------
+
+    it(
+      "refs from snapshot N remain usable for textContent after snapshot N+1",
+      async () => {
+        if (!ctx) throw new Error("context not created");
+        const t1 = await ctx.snapshot();
+        const buttons1 = collectButtons(t1.root);
+        expect(buttons1.length).toBeGreaterThan(0);
+        const ref = buttons1[0].ref;
+        // Take a fresh snapshot, then reach back to the older ref.
+        await ctx.snapshot();
+        const txt = await ctx.textContent(ref);
+        expect(txt, "ref from prior snapshot should still resolve").not.toBeNull();
+      },
+      opts.timeout
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the runner.**
+
+```ts
+import { ariaRoundTripBlock } from "./assertions/ariaRoundTrip";
+// ...
+ariaRoundTripBlock(opts, fixture);
+```
+
+- [ ] **Step 3: Run Mock shim.**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/MockBrowser_Generic.test.ts 2>&1 | tail -40`
+Expected: PASS — all six edge-case names round-trip; ref-reuse passes.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts \
+        packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+git commit -m "test(browser-context): add ARIA snapshot round-trip block"
+```
+
+---
+
+### Task 2.5: Network introspection assertion block
+
+**Files:**
+- Create: `packages/test/src/contract/browser-context/assertions/networkIntrospection.ts`
+- Modify: `packages/test/src/contract/browser-context/runIBrowserContextConformance.ts`
+
+This block exists separately from `capabilityHonesty` so the README can document it as the "did the optional method actually capture the fixture's known fetch?" assertion. It only runs when `capabilities.networkRequests` or `capabilities.consoleMessages` is true. (For Mock all four phase-2 shims, both flags are false, so this block is a no-op.)
+
+- [ ] **Step 1: Write the assertion file.**
+
+```ts
+// packages/test/src/contract/browser-context/assertions/networkIntrospection.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+
+export function networkIntrospectionBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  if (!opts.capabilities.networkRequests && !opts.capabilities.consoleMessages) return;
+
+  describe("Network/console introspection", () => {
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+      await ctx.navigate(fixture.pageUrl);
+      await ctx.waitForIdle({ timeout: 5_000 });
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    if (opts.capabilities.networkRequests) {
+      it(
+        "networkRequests() captures the fixture's outbound fetch",
+        async () => {
+          if (!ctx || typeof ctx.networkRequests !== "function") {
+            throw new Error("networkRequests not available despite capability=true");
+          }
+          const entries = await ctx.networkRequests();
+          const found = entries.some((r) => r.url.includes(fixture.networkMarkerUrl));
+          expect(found, `expected an entry containing ${fixture.networkMarkerUrl}`).toBe(true);
+        },
+        opts.timeout
+      );
+
+      it(
+        "networkRequests({ method }) filters by method",
+        async () => {
+          if (!ctx || typeof ctx.networkRequests !== "function") {
+            throw new Error("networkRequests not available despite capability=true");
+          }
+          const all = await ctx.networkRequests();
+          const gets = await ctx.networkRequests({ method: "GET" });
+          // Filter must not return more entries than the unfiltered list.
+          expect(gets.length).toBeLessThanOrEqual(all.length);
+        },
+        opts.timeout
+      );
+    }
+
+    if (opts.capabilities.consoleMessages) {
+      it(
+        "consoleMessages() captures the fixture's console.log",
+        async () => {
+          if (!ctx || typeof ctx.consoleMessages !== "function") {
+            throw new Error("consoleMessages not available despite capability=true");
+          }
+          const entries = await ctx.consoleMessages();
+          const found = entries.some((m) => m.text.includes(fixture.consoleMarker));
+          expect(found, `expected a console message containing ${fixture.consoleMarker}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the runner.**
+
+```ts
+import { networkIntrospectionBlock } from "./assertions/networkIntrospection";
+// ...
+networkIntrospectionBlock(opts, fixture);
+```
+
+- [ ] **Step 3: Run Mock shim — block should be skipped (no capabilities flagged).**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/MockBrowser_Generic.test.ts 2>&1 | tail -20`
+Expected: PASS — `Network/console introspection` does not appear because `if (!networkRequests && !consoleMessages) return` short-circuits.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/test/src/contract/browser-context/assertions/networkIntrospection.ts \
+        packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+git commit -m "test(browser-context): add network/console introspection block"
+```
+
+---
+
+### Task 2.6: Playwright shim with expected failures
+
+**Files:**
+- Create: `packages/test/src/test/browser/Playwright_Generic.integration.test.ts`
+
+- [ ] **Step 1: Write the shim.**
+
+```ts
+// packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+let playwrightAvailable = false;
+try {
+  await import("playwright");
+  playwrightAvailable = true;
+} catch {
+  // playwright not installed
+}
+
+runIBrowserContextConformance({
+  name: "Playwright",
+  skip: !playwrightAvailable,
+  timeout: 60_000,
+  factory: async () => {
+    const { PlaywrightBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new PlaywrightBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false, // currently a no-op stub returning []; flips after Phase 4
+    consoleMessages: false, // currently a no-op stub returning []; flips after Phase 4
+    ariaSnapshot: true,
+  },
+  expectedFailures: [
+    // PlaywrightBackend.ts:686-736 — array-index tabId race.
+    "tabs.concurrentCloseStable",
+    // PlaywrightBackend.ts:419-426 — lastIndexOf(":") parser.
+    "aria.colonInName",
+    // PlaywrightBackend.ts:768-774 — networkRequests/consoleMessages declared
+    // as concrete arrow functions returning []. The negative-direction
+    // capability honesty block requires `typeof ctx.networkRequests ===
+    // "undefined"` when capabilities.networkRequests is false.
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});
+```
+
+- [ ] **Step 2: Run the Playwright shim.**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/Playwright_Generic.integration.test.ts 2>&1 | tail -60`
+Expected: PASS — assertions outside the four `expectedFailures` succeed; the four named assertions are wrapped in `it.fails` and pass because they correctly throw.
+
+If Playwright is not installed in the local env, the file's top-level `describe.skipIf(!playwrightAvailable)` skips the whole suite — verify the run is reported as `passed | skipped`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+git commit -m "test(browser-context): wire Playwright conformance shim with expected failures"
+```
+
+---
+
+## Phase 3 — BunWebView + Electron shims
+
+### Task 3.1: BunWebView shim
+
+**Files:**
+- Create: `packages/test/src/test/browser/BunWebView_Generic.integration.test.ts`
+
+BunWebView is a single-view backend (`multipleTabs: false`); the concurrent-close-stability assertion is automatically gated off by the capability flag. Its `networkRequests`/`consoleMessages` empty-array stubs at `BunWebViewBackend.ts:403-409` trip the negative capability honesty assertion — both go in `expectedFailures`.
+
+- [ ] **Step 1: Write the shim.**
+
+```ts
+// packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isChromeAvailable } from "./chromeAvailability";
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+const bunWebViewAvailable =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Boolean((globalThis as { Bun?: { WebView?: unknown } }).Bun?.WebView) && isChromeAvailable();
+
+runIBrowserContextConformance({
+  name: "BunWebView",
+  skip: !bunWebViewAvailable,
+  timeout: 60_000,
+  factory: async () => {
+    const { BunWebViewBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new BunWebViewBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: false, // single-view model
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+  expectedFailures: [
+    // BunWebViewBackend.ts:403-409 — empty-array stubs.
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});
+```
+
+- [ ] **Step 2: Run the shim.**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/BunWebView_Generic.integration.test.ts 2>&1 | tail -40`
+Expected: PASS or SKIPPED depending on Bun.WebView + Chrome availability. When it runs, all assertions outside the two `expectedFailures` pass; the two named negative-capability assertions are `it.fails` and pass because the empty-array stubs make `typeof === "function"`.
+
+If `data:` URL navigation is restricted in BunWebView, the ARIA + tabs blocks will fail. If observed, narrow the failure set: add a `fixture` override to use an in-process http server. Recorded as a Phase 3 risk in the spec; if hit, document the override in this same shim file.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
+git commit -m "test(browser-context): wire BunWebView conformance shim"
+```
+
+---
+
+### Task 3.2: Electron shim (skipped without runner)
+
+**Files:**
+- Create: `packages/test/src/test/browser/Electron_Generic.integration.test.ts`
+
+- [ ] **Step 1: Write the shim.**
+
+```ts
+// packages/test/src/test/browser/Electron_Generic.integration.test.ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+const RUN_ELECTRON = !!process.env.RUN_ELECTRON_TESTS;
+
+runIBrowserContextConformance({
+  name: "Electron",
+  skip: !RUN_ELECTRON,
+  timeout: 60_000,
+  factory: async () => {
+    const { ElectronBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new ElectronBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+  // Electron extends CDPBrowserBackend. The CDP base does not currently
+  // declare networkRequests/consoleMessages stubs (per
+  // CDPBrowserBackend.ts), so those negative assertions are NOT
+  // expected to fail. Add them only if observed during a real run.
+  expectedFailures: [],
+});
+```
+
+Note: Electron's `expectedFailures` list is empty by default. If the suite is run under `RUN_ELECTRON_TESTS=1` and reveals ElectronBackend-specific drift, populate the list at that time.
+
+- [ ] **Step 2: Quick sanity run (suite skips without env var).**
+
+Run: `cd packages/test && bun run vitest run src/test/browser/Electron_Generic.integration.test.ts 2>&1 | tail -15`
+Expected: SKIPPED (no `RUN_ELECTRON_TESTS` set).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add packages/test/src/test/browser/Electron_Generic.integration.test.ts
+git commit -m "test(browser-context): wire Electron conformance shim (skipped by default)"
+```
+
+---
+
+### Task 3.3: Full suite run + CI cost confirmation
+
+- [ ] **Step 1: Run all four browser-context conformance shims.**
+
+Run: `cd packages/test && bun run vitest run --reporter=verbose 'src/test/browser/*_Generic*' 2>&1 | tail -80`
+Expected: PASS for each shim available locally; SKIPPED for shims whose runtime is missing. Report total wall time.
+
+- [ ] **Step 2: Confirm CI cost ≤ ~30 s on the Playwright job.**
+
+The relevant CI job is whichever step runs `bun run test:vitest` against `packages/test`. The new `Playwright_Generic.integration.test.ts` adds capability + tabs + ARIA + (skipped) network introspection blocks against a real Playwright browser. Compare wall time against a pre-task baseline. If runtime increase exceeds 30 s, mark a follow-up to either reduce edge-case-name iterations or share a Playwright browser across blocks (the existing `PlaywrightBrowser.integration.test.ts` already shares a browser; the conformance shim could be refactored to do the same in a follow-up).
+
+No commit — this is a verification step. If a follow-up is needed, add it to the spec's "Open questions" list.
+
+---
+
+## Phase 4 — Fix the three known IBrowserContext bugs
+
+Each fix lands in its own commit. After each fix, drop the corresponding entry from `expectedFailures` in the relevant shim, run the suite, and verify the test now passes as a regular `it`.
+
+### Task 4.1: Delete empty-stub `networkRequests` / `consoleMessages` properties
+
+**Files:**
+- Modify: `packages/browser-control/src/task/PlaywrightBackend.ts:765-775`
+- Modify: `packages/browser-control/src/task/BunWebViewBackend.ts:399-410`
+- Modify: `packages/test/src/test/browser/Playwright_Generic.integration.test.ts`
+- Modify: `packages/test/src/test/browser/BunWebView_Generic.integration.test.ts`
+
+The contract: optional methods are either fully implemented OR `undefined`. Since neither backend implements them, declare `undefined` by deleting the property.
+
+- [ ] **Step 1: Run the conformance suite to confirm the failing baseline.**
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' 'src/test/browser/BunWebView_Generic*' 2>&1 | tail -20`
+Expected: the two `capability.*.undefinedWhenFalse` assertions in each shim are listed under `[expected-fail]` and pass because they correctly throw.
+
+- [ ] **Step 2: Delete the properties from PlaywrightBackend.**
+
+Find the block at the bottom of `packages/browser-control/src/task/PlaywrightBackend.ts`:
+
+```ts
+  // ---------------------------------------------------------------------------
+  // Optional capabilities (simplified)
+  // ---------------------------------------------------------------------------
+
+  readonly networkRequests = (_filter?: NetworkFilter): Promise<readonly NetworkRequest[]> => {
+    return Promise.resolve([]);
+  };
+
+  readonly consoleMessages = (): Promise<readonly ConsoleMessage[]> => {
+    return Promise.resolve([]);
+  };
+}
+```
+
+Replace with:
+
+```ts
+  // ---------------------------------------------------------------------------
+  // Optional capabilities
+  // ---------------------------------------------------------------------------
+  //
+  // networkRequests and consoleMessages are intentionally undefined: this
+  // backend does not implement them. The IBrowserContext contract is that
+  // optional methods are either fully implemented or undefined — never
+  // empty-stub functions that defeat feature detection.
+}
+```
+
+Drop now-unused imports: remove `NetworkFilter`, `NetworkRequest`, `ConsoleMessage` from the import list at the top of the file if (and only if) they are no longer referenced anywhere else in the file.
+
+- [ ] **Step 3: Delete the properties from BunWebViewBackend identically.**
+
+Find the block at the bottom of `packages/browser-control/src/task/BunWebViewBackend.ts`:
+
+```ts
+  // ---------------------------------------------------------------------------
+  // Optional capabilities (stubs)
+  // ---------------------------------------------------------------------------
+
+  readonly networkRequests = (_filter?: NetworkFilter): Promise<readonly NetworkRequest[]> => {
+    return Promise.resolve([]);
+  };
+
+  readonly consoleMessages = (): Promise<readonly ConsoleMessage[]> => {
+    return Promise.resolve([]);
+  };
+```
+
+Replace with the same comment. Drop now-unused imports if applicable.
+
+- [ ] **Step 4: Drop the corresponding `expectedFailures` entries from both shims.**
+
+In `Playwright_Generic.integration.test.ts`, change:
+
+```ts
+  expectedFailures: [
+    "tabs.concurrentCloseStable",
+    "aria.colonInName",
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+```
+
+to:
+
+```ts
+  expectedFailures: [
+    "tabs.concurrentCloseStable",
+    "aria.colonInName",
+  ],
+```
+
+In `BunWebView_Generic.integration.test.ts`, change:
+
+```ts
+  expectedFailures: [
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+```
+
+to:
+
+```ts
+  expectedFailures: [],
+```
+
+- [ ] **Step 5: Run typecheck + suites.**
+
+Run: `cd packages/browser-control && bun run build:types 2>&1 | tail -10`
+Expected: no errors. If "unused import" surfaces for `NetworkFilter` etc., remove the imports from the top of the relevant backend file.
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' 'src/test/browser/BunWebView_Generic*' 2>&1 | tail -30`
+Expected: PASS — the previously-expected failures now pass as regular `it`s. No `[expected-fail]` lines for capability assertions.
+
+Also re-run the existing Tasks-layer tests to make sure nothing else relied on the stubs:
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/PlaywrightBrowser*' 'src/test/browser/BunWebViewBrowser*' 'src/test/browser/MockBrowser*' 2>&1 | tail -30`
+Expected: PASS — `genericBrowserTaskTests.ts` consumes the public IBrowserContext surface, not these properties; deleting them should be a no-op for it.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/browser-control/src/task/PlaywrightBackend.ts \
+        packages/browser-control/src/task/BunWebViewBackend.ts \
+        packages/test/src/test/browser/Playwright_Generic.integration.test.ts \
+        packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
+git commit -m "fix(browser-control): remove empty-stub networkRequests/consoleMessages properties
+
+Optional methods on IBrowserContext are either fully implemented or
+undefined — never empty-stub functions that defeat feature detection.
+Neither PlaywrightBackend nor BunWebViewBackend implements these, so
+delete the properties to declare 'not supported'."
+```
+
+---
+
+### Task 4.2: Replace array-index tabIds with stable string ids in PlaywrightBackend
+
+**Files:**
+- Modify: `packages/browser-control/src/task/PlaywrightBackend.ts:686-736` (`tabs`, `switchTab`, `newTab`, `closeTab`)
+- Modify: `packages/test/src/test/browser/Playwright_Generic.integration.test.ts`
+
+Replace `parseInt(tabId)` array-index lookups with a stable per-page ID generator. New tabs get an opaque string id (e.g. `"t1"`, `"t2"`); closing a tab does not invalidate other ids.
+
+- [ ] **Step 1: Confirm failing baseline.**
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' --reporter=verbose 2>&1 | grep -i "concurrent\|expected-fail" | head -10`
+Expected: at least one line referencing `tabs.concurrentCloseStable [expected-fail]`.
+
+- [ ] **Step 2: Add a per-context tab-id map.**
+
+In `PlaywrightBackend.ts`, locate the field declarations near line 240. Add:
+
+```ts
+  // Stable per-page tab ids. Surviving across concurrent close.
+  private _pageIds: WeakMap<AnyPage, string> = new WeakMap();
+  private _pageIdSeq = 0;
+  private idForPage(page: AnyPage): string {
+    let id = this._pageIds.get(page);
+    if (!id) {
+      id = `t${++this._pageIdSeq}`;
+      this._pageIds.set(page, id);
+    }
+    return id;
+  }
+```
+
+Note the field type uses `AnyPage` — keep it consistent with the surrounding code (the file already uses `AnyPage` as a type alias for Playwright's Page; see imports at the top of the file).
+
+- [ ] **Step 3: Rewrite the four tab methods to use stable ids.**
+
+Replace lines 686-736:
+
+```ts
+  async tabs(): Promise<readonly TabInfo[]> {
+    const pages: AnyPage[] = this.context.pages();
+    return Promise.all(
+      pages.map(async (p: AnyPage) => ({
+        tabId: this.idForPage(p),
+        url: p.url(),
+        title: await p.title(),
+      }))
+    );
+  }
+
+  async switchTab(tabId: string): Promise<void> {
+    const pages: AnyPage[] = this.context.pages();
+    const target = pages.find((p) => this._pageIds.get(p) === tabId);
+    if (!target) {
+      throw new Error(`PlaywrightBackend: no tab with id "${tabId}"`);
+    }
+    this._page = target;
+    await target.bringToFront();
+  }
+
+  async newTab(url?: string): Promise<TabInfo> {
+    const newPage: AnyPage = await this.context.newPage();
+    if (url) {
+      await newPage.goto(url, { waitUntil: "load" });
+    }
+    return {
+      tabId: this.idForPage(newPage),
+      url: newPage.url(),
+      title: await newPage.title(),
+    };
+  }
+
+  async closeTab(tabId: string): Promise<void> {
+    const pages: AnyPage[] = this.context.pages();
+    const target = pages.find((p) => this._pageIds.get(p) === tabId);
+    if (!target) {
+      throw new Error(`PlaywrightBackend: no tab with id "${tabId}"`);
+    }
+    await target.close();
+
+    // If we closed the active page, switch to the last remaining page
+    if (this._page === target) {
+      const remaining: AnyPage[] = this.context.pages();
+      this._page = remaining.length > 0 ? remaining[remaining.length - 1] : null;
+    }
+  }
+```
+
+- [ ] **Step 4: Drop `tabs.concurrentCloseStable` from the Playwright shim's `expectedFailures`.**
+
+```ts
+  expectedFailures: [
+    "aria.colonInName",
+  ],
+```
+
+- [ ] **Step 5: Run typecheck + suite.**
+
+Run: `cd packages/browser-control && bun run build:types 2>&1 | tail -10`
+Expected: no errors.
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' --reporter=verbose 2>&1 | tail -30`
+Expected: `tabId remains valid for surviving tabs across concurrent close()` passes as a regular `it`.
+
+Also run the existing Tasks-layer Playwright integration test to be sure its tab-related assertions still work:
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/PlaywrightBrowser*' 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/browser-control/src/task/PlaywrightBackend.ts \
+        packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+git commit -m "fix(browser-control): stable tabIds in PlaywrightBackend
+
+tabs() returned tabId: String(idx) derived from pages.indexOf(...);
+switchTab/closeTab re-looked-up by parseInt. Closing tab 0 shifted
+every subsequent tabId, breaking stored references after concurrent
+close. Replace with WeakMap<Page, string> + per-context counter so
+ids are stable across the page's lifetime."
+```
+
+---
+
+### Task 4.3: Replace string-descriptor refMap with structured records
+
+**Files:**
+- Modify: `packages/browser-control/src/task/PlaywrightBackend.ts` (`_refMap`, `buildLocatorString`, `descriptorToLocator`, `resolveRef`, and every site that reads/writes `_refMap`)
+- Modify: `packages/test/src/test/browser/Playwright_Generic.integration.test.ts`
+
+The existing string-encoded descriptor format (`"getByRole:button:Sign In"`, `"nth:<inner>:<idx>"`) cannot disambiguate ARIA names containing colons from the nth-suffix. Replace with structured records.
+
+- [ ] **Step 1: Confirm failing baseline.**
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' --reporter=verbose 2>&1 | grep -i "colon\|expected-fail" | head -10`
+Expected: lines referencing `aria.colonInName [expected-fail]` for at least the `"foo:bar"` and `"11:30"` edge cases.
+
+- [ ] **Step 2: Define a `Descriptor` discriminated union near the top of `PlaywrightBackend.ts` (above the class declaration).**
+
+```ts
+type Descriptor =
+  | { readonly kind: "role"; readonly role: string; readonly name: string }
+  | { readonly kind: "text"; readonly text: string }
+  | { readonly kind: "css"; readonly selector: string }
+  | { readonly kind: "nth"; readonly inner: Descriptor; readonly index: number };
+```
+
+- [ ] **Step 3: Change the `_refMap` field type and remove the string parser.**
+
+Locate the field at line ~247:
+
+```ts
+  private _refMap = new Map<string, string>();
+```
+
+Change to:
+
+```ts
+  private _refMap = new Map<string, Descriptor>();
+```
+
+- [ ] **Step 4: Replace `buildLocatorString` (around line 215) with a builder that returns a `Descriptor`.**
+
+```ts
+function buildDescriptor(role: string, name: string): Descriptor {
+  if (role === "text" || role === "StaticText") {
+    return { kind: "text", text: name };
+  }
+  return { kind: "role", role, name };
+}
+```
+
+Update every call site of the old `buildLocatorString` to call `buildDescriptor` and store the descriptor (no more string-formatting).
+
+- [ ] **Step 5: Replace `descriptorToLocator` and `resolveRef`.**
+
+```ts
+  private resolveRef(ref: ElementRef): AnyLocator {
+    const descriptor = this._refMap.get(ref);
+    if (!descriptor) {
+      throw new Error(`PlaywrightBackend: unknown ref "${ref}"`);
+    }
+    return this.descriptorToLocator(descriptor);
+  }
+
+  private descriptorToLocator(descriptor: Descriptor): AnyLocator {
+    const page = this.page;
+    switch (descriptor.kind) {
+      case "role":
+        return descriptor.name
+          ? page.getByRole(descriptor.role, { name: descriptor.name })
+          : page.getByRole(descriptor.role);
+      case "text":
+        return page.getByText(descriptor.text);
+      case "css":
+        return page.locator(descriptor.selector);
+      case "nth":
+        return this.descriptorToLocator(descriptor.inner).nth(descriptor.index);
+    }
+  }
+```
+
+- [ ] **Step 6: Update every `_refMap.set(ref, "css:...")` etc. to set a structured record.**
+
+Search the file for `_refMap.set(`:
+
+```bash
+grep -n "_refMap.set" packages/browser-control/src/task/PlaywrightBackend.ts
+```
+
+For each match, rewrite the second argument from a string descriptor to the equivalent `Descriptor` record. Common patterns:
+
+| Old string | New record |
+|---|---|
+| `` `css:${selector}` `` | `{ kind: "css", selector }` |
+| `` `getByRole:${role}:${name}` `` | `buildDescriptor(role, name)` |
+| `` `getByText:${text}` `` | `{ kind: "text", text }` |
+| `` `nth:${inner}:${idx}` `` (rare/unused — verify) | `{ kind: "nth", inner: <descriptor>, index: idx }` |
+
+- [ ] **Step 7: Drop `aria.colonInName` from the Playwright shim's `expectedFailures`.**
+
+```ts
+  expectedFailures: [],
+```
+
+- [ ] **Step 8: Run typecheck + suites.**
+
+Run: `cd packages/browser-control && bun run build:types 2>&1 | tail -10`
+Expected: no errors. If TypeScript flags `Descriptor` not exhaustive in a `switch`, add the missing case.
+
+Run: `cd packages/test && bun run vitest run 'src/test/browser/Playwright_Generic*' 'src/test/browser/PlaywrightBrowser*' --reporter=verbose 2>&1 | tail -50`
+Expected: all colon-name ARIA round-trip assertions pass; existing Playwright tasks tests still pass.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add packages/browser-control/src/task/PlaywrightBackend.ts \
+        packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+git commit -m "fix(browser-control): structured refMap descriptors in PlaywrightBackend
+
+Old string format 'nth:<inner>:<idx>' used lastIndexOf(':') to split
+the trailing index, mis-parsing ARIA names ending in :<digits> (e.g.
+'11:30' with nth:5 → inner='getByRole:textbox:11:30', index=5 instead
+of inner='getByRole:textbox:11:30:5', index=undefined).
+
+Replace ad-hoc string descriptors with a discriminated union stored
+directly in _refMap. Eliminates string parsing, supports any ARIA name
+including those containing colons."
+```
+
+---
+
+## Self-review checklist (run after writing all tasks)
+
+These items are spec requirements; verify each maps to a task above.
+
+| Spec section | Tasks covering it |
+|---|---|
+| Architecture / file layout | Task 1.1, 1.2, 1.3, 2.1, 2.2-2.5 |
+| `runIBrowserContextConformance` API | Task 1.1 (types), 1.3 (runner), 2.2-2.5 (blocks) |
+| Capability honesty (negative) | Task 2.2 |
+| Capability honesty (positive) | Task 2.2, 2.5 |
+| Tabs basic lifecycle | Task 2.3 |
+| Tabs concurrent-close stability | Task 2.3 |
+| ARIA round-trip | Task 2.4 |
+| ARIA ref reuse | Task 2.4 |
+| Network introspection | Task 2.5 |
+| Mock shim | Task 2.1, 2.2 |
+| Playwright shim | Task 2.6 |
+| BunWebView shim | Task 3.1 |
+| Electron shim | Task 3.2 |
+| Phase 4: empty-stub fix | Task 4.1 |
+| Phase 4: tabId race fix | Task 4.2 |
+| Phase 4: descriptor parser fix | Task 4.3 |
+| README factory-shape variants | Task 1.3 |
+| README "Available suites" row | Task 1.3 |
+| CI cost confirmation | Task 3.3 |

--- a/docs/superpowers/specs/2026-05-07-ibrowsercontext-contract-conformance-design.md
+++ b/docs/superpowers/specs/2026-05-07-ibrowsercontext-contract-conformance-design.md
@@ -1,0 +1,423 @@
+# IBrowserContext Contract Conformance Suite — Design
+
+**Date:** 2026-05-07
+**Status:** Draft (awaiting user review)
+**Branch:** `claude/implement-ibrowsercontext-tS1Y8`
+
+## Summary
+
+Build a parameterized contract conformance suite for `IBrowserContext` in
+`@workglow/test`, modeled on the existing `runAiProviderConformance` suite.
+v1 covers four assertion blocks — capability honesty, tabs lifecycle, ARIA
+snapshot ↔ ref round-trip, and network introspection — and ships four
+adapter shims (Playwright, BunWebView, Electron, Mock). The final phase
+of this project fixes the three IBrowserContext bugs the suite would
+detect on day one (empty-array stubs, tabId array-index race, and the
+`lastIndexOf(":")` descriptor parser).
+
+## Motivation
+
+The fourth contract conformance suite from the original brief
+(`docs/superpowers/specs/2026-05-04-aiprovider-contract-conformance-design.md`).
+Three of the five originally scoped suites have shipped: `AiProvider`
+(PR #461), `ITabularStorage` extensions, and `IMigrationRunner`
+(PR #464).
+
+`IBrowserContext` has four implementations that drift independently:
+
+- `PlaywrightBackend`
+- `ElectronBackend` (extends `CDPBrowserBackend`)
+- `BunWebViewBackend` (extends `CDPBrowserBackend`)
+- `MockBrowserContext` (test fake)
+
+Three concrete bugs are already known and visible on `main`:
+
+- **Empty-array stubs that defeat feature detection.**
+  `PlaywrightBackend.ts:768-774` and `BunWebViewBackend.ts:403-409`
+  declare `networkRequests` and `consoleMessages` as concrete arrow
+  functions returning `[]`. Feature-detection via
+  `typeof ctx.networkRequests === "function"` returns `true`, but the
+  method is dead. The `IBrowserContext` interface contract is that
+  optional methods are either fully implemented or `undefined`.
+- **`tabId` array-index race in Playwright.**
+  `PlaywrightBackend.ts:686-736` — `tabs()` returns `tabId: String(idx)`
+  derived from `pages.indexOf(...)`. `switchTab`/`closeTab` look up by
+  `parseInt(tabId)`. Closing tab `0` shifts every subsequent `tabId`,
+  so a stored `tabId` from a prior `tabs()` call now points at the
+  wrong page.
+- **`lastIndexOf(":")` parser bug in `descriptorToLocator`.**
+  `PlaywrightBackend.ts:419-426` — `nth:<inner-descriptor>:<index>`
+  uses `lastIndexOf(":")` to split off the trailing index. Any ARIA
+  name ending in `:<digits>` (e.g. `"11:30"` with `nth:5` produces
+  `nth:getByRole:textbox:11:30:5`) is mis-parsed as
+  `inner=getByRole:textbox:11:30, index=5`. Disambiguation impossible
+  without escaping or length-prefixing.
+
+Each bug is one assertion. Without a contract suite, the same class of
+bug recurs as new backends are added.
+
+## Goals
+
+- One parameterized `runIBrowserContextConformance(opts)` entrypoint
+  under `packages/test/src/contract/browser-context/`.
+- Suite runs against four adapters: Playwright (live, gated on
+  `RUN_PLAYWRIGHT_TESTS`), BunWebView (live, gated on
+  `RUN_BUNWEBVIEW_TESTS`), Electron (live, gated on
+  `RUN_ELECTRON_TESTS` — currently no CI runner; runs locally), and
+  `MockBrowserContext` (in-memory, always runs).
+- Four assertion blocks: capability honesty (negative + positive),
+  tabs lifecycle, ARIA round-trip, network introspection.
+- Three known bugs fixed within this project's final phase.
+- One row added to `packages/test/src/contract/README.md`'s "Available
+  suites" table.
+
+## Non-goals
+
+- HTTP-server-based fixture infrastructure. The fixture is a
+  self-contained `data:` URL.
+- A bare `CDPBrowserBackend` shim. The class is abstract — Electron
+  and BunWebView are the concrete CDP-derived backends. Both are
+  already in the four-shim list.
+- Migrating `packages/test/src/test/browser/genericBrowserTaskTests.ts`
+  into the contract pattern. That suite asserts the `BrowserXxxTask`
+  layer (one level higher than `IBrowserContext`); the two are
+  orthogonal.
+- An Electron CI runner. The Electron shim lives in the repo so the
+  contract is pinned, but it is skipped without `RUN_ELECTRON_TESTS`.
+- New env vars beyond `RUN_*_TESTS` (which already exist).
+
+## Architecture
+
+### File layout
+
+```
+packages/test/src/contract/browser-context/
+  runIBrowserContextConformance.ts     # entrypoint
+  types.ts                             # opts + capability matrix + handle
+  fixtures.ts                          # FIXTURE_PAGE_URL + ARIA edge-case names
+  assertions/
+    capabilityHonesty.ts               # B+ enforcement for optional methods
+    tabsLifecycle.ts                   # open/close/switch + concurrent-close stability
+    ariaRoundTrip.ts                   # snapshot → ref → click round-trip, edge names
+    networkIntrospection.ts            # fixture issues fetch → networkRequests sees it
+    itExpectFail.ts                    # copy from contract/ai-provider/
+
+packages/test/src/test/browser/
+  Playwright_Generic.integration.test.ts   # NEW shim
+  BunWebView_Generic.integration.test.ts   # NEW shim
+  Electron_Generic.integration.test.ts     # NEW shim, skip:!process.env.RUN_ELECTRON_TESTS
+  MockBrowser_Generic.test.ts              # NEW shim (no skip)
+  # existing files stay: BrowserSessionRegistry.test.ts, MockBrowser.test.ts,
+  # PlaywrightBrowser.integration.test.ts, BunWebViewBrowser.integration.test.ts,
+  # genericBrowserTaskTests.ts (Tasks-level coverage; orthogonal)
+```
+
+The contract suite asserts `IBrowserContext` directly. The existing
+`genericBrowserTaskTests.ts` continues to assert the `BrowserXxxTask`
+layer. They overlap conceptually but exercise different surfaces and
+are not merged in v1.
+
+### `runIBrowserContextConformance` API
+
+```ts
+export interface IBrowserContextConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<BrowserContextHandle>;
+  readonly capabilities: BrowserContextCapabilities;
+  readonly fixture?: Partial<BrowserContextFixture>;
+  /**
+   * Names of assertions currently broken in this adapter; each is wrapped
+   * in `it.fails` instead of `it`. Remove the entry once the bug is fixed.
+   *
+   * Known names:
+   *   "tabs.concurrentCloseStable"
+   *   "aria.colonInName"
+   *   "capability.networkRequests.undefinedWhenFalse"
+   *   "capability.consoleMessages.undefinedWhenFalse"
+   */
+  readonly expectedFailures?: ReadonlyArray<string>;
+}
+
+export interface BrowserContextHandle {
+  /** Construct and connect a fresh context. Called per top-level block. */
+  readonly create: () => Promise<IBrowserContext>;
+  /** Disconnect and release resources for a context returned by create(). */
+  readonly dispose: (ctx: IBrowserContext) => Promise<void>;
+}
+
+export interface BrowserContextCapabilities {
+  /** false for single-view backends (e.g. BunWebView). */
+  readonly multipleTabs: boolean;
+  /** Optional method honesty + positive test. */
+  readonly networkRequests: boolean;
+  /** Optional method honesty + positive test. */
+  readonly consoleMessages: boolean;
+  /** Every backend should be true; flag exists for hygiene/symmetry. */
+  readonly ariaSnapshot: boolean;
+}
+
+export interface BrowserContextFixture {
+  readonly pageUrl: string;
+  readonly networkMarkerUrl: string;     // url substring expected in networkRequests()
+  readonly consoleMarker: string;        // text expected in consoleMessages()
+  readonly ariaEdgeCaseNames: ReadonlyArray<string>;
+}
+```
+
+Differences from `runAiProviderConformance`:
+
+- **`create` per test, not `register` once.** Browser contexts are
+  heavyweight but stateful (open tabs, navigation history). Each
+  top-level assertion block creates a fresh context in `beforeAll`,
+  disposes in `afterAll`, so block N's tab churn cannot affect block
+  N+1's ARIA test.
+- **No `inspect()`.** v1 doesn't need whitebox state. If a future
+  assertion (e.g. tabId stability via internal map inspection) needs
+  it, add it then.
+- **No `models` map.** N/A for browser contexts.
+
+### Capability honesty (the new convention)
+
+The interface contract is: optional methods (`networkRequests`,
+`consoleMessages`) are either fully implemented or `undefined`. The
+suite enforces this in both directions:
+
+- *Negative branch:* if `capabilities.networkRequests === false`, the
+  assertion `typeof ctx.networkRequests === "undefined"` must hold.
+  This catches the `[].`-returning stub pattern.
+- *Positive branch:* if `capabilities.networkRequests === true`, the
+  context must navigate to `fixture.pageUrl`, wait for idle, and
+  `networkRequests()` must return ≥1 entry whose `url` includes
+  `fixture.networkMarkerUrl`. Same for `consoleMessages` /
+  `fixture.consoleMarker`.
+
+This is the "B+" enforcement strategy: the capability flag is the
+single source of truth, and *both* directions are tested.
+
+### Asserted blocks
+
+| Block | Capability gate | What's asserted | Bug it catches |
+|---|---|---|---|
+| Capability honesty (negative) | always | For every false flag, the corresponding optional method is strictly `undefined` (not a function). | `PlaywrightBackend.ts:768-774`, `BunWebViewBackend.ts:403-409` empty-array stubs |
+| Capability honesty (positive) | per-flag (true) | Navigate to fixture → wait for idle → `networkRequests()` returns ≥1 entry whose url contains the fixture marker. Same for `consoleMessages`. | A stub wired to `capabilities=true` but returning `[]` |
+| Tabs — basic lifecycle | always | After connect, `tabs().length ≥ 1`. `newTab(fixtureUrl)` increases length by 1 (or stays at 1 if `!multipleTabs`). `closeTab(id)` decreases length (or disconnects, single-view variant). | Smoke; protects future refactors |
+| Tabs — tabId stability under concurrent close | `multipleTabs` | Open 4 tabs A/B/C/D → capture all four `tabId`s → `Promise.all([closeTab(A.tabId), closeTab(B.tabId)])` → for each remaining (C, D), `switchTab(originalTabId)` lands on the same `url` it had before. | `PlaywrightBackend.ts:686-736` array-index race |
+| ARIA — snapshot ↔ ref round-trip | `ariaSnapshot` | Snapshot fixture page; for each fixture node (covering edge-case names: `"foo:bar"`, `"11:30"`, `"a"`, `""`, 200-char, unicode `"héllo→"`), `clickByRole(role, name)` lands on that node, verified by side-effect (each button sets `data-clicked="<idx>"` on `#sentinel`). | `PlaywrightBackend.ts:419-426` `lastIndexOf(":")` parser |
+| ARIA — ref reuse | `ariaSnapshot` | A ref captured from a snapshot remains usable for `click`/`textContent` after another `snapshot()` call (no implicit invalidation). | Regression guard for ref-map churn |
+
+The fixture page (data: URL) embeds:
+
+- A `<button>` per ARIA edge-case name, each with an `onclick` setting
+  `data-clicked="<idx>"` on `#sentinel`.
+- A `<script>` that fires `fetch("data:text/plain,fixture-network-marker")`
+  on load.
+- `console.log("fixture-console-marker")` on load.
+- A `<div id="sentinel">` for click verification.
+
+### Adapter shims
+
+Shape mirrors `Anthropic_Generic.integration.test.ts`. Each shim is
+~25 lines.
+
+```ts
+// Playwright_Generic.integration.test.ts
+runIBrowserContextConformance({
+  name: "Playwright",
+  skip: !process.env.RUN_PLAYWRIGHT_TESTS,
+  timeout: 60_000,
+  factory: async () => {
+    const { PlaywrightBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new PlaywrightBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: (ctx) => ctx.disconnect(),
+    };
+  },
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false,    // currently a stub; flips after Phase 4
+    consoleMessages: false,    // currently a stub; flips after Phase 4
+    ariaSnapshot: true,
+  },
+  expectedFailures: [
+    "tabs.concurrentCloseStable",                    // array-index race
+    "aria.colonInName",                              // lastIndexOf parser
+    "capability.networkRequests.undefinedWhenFalse", // stub field exists
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});
+```
+
+| Adapter | multipleTabs | networkRequests | consoleMessages | ariaSnapshot | Notes |
+|---|---|---|---|---|---|
+| Playwright | true | false | false | true | All three known bugs in expectedFailures until Phase 4 |
+| BunWebView | false | false | false | true | Single-view; `multipleTabs: false` skips the tabId-stability block; capability-honesty failures in expectedFailures until Phase 4 |
+| Electron | true | false | false | true | Skipped without `RUN_ELECTRON_TESTS` |
+| Mock | true | false | false | true | Reference impl; zero expectedFailures (see Phase 2 note on stub removal) |
+
+`MockBrowserContext` is the reference implementation. If it cannot
+satisfy the suite, the suite is wrong, not the mock. This is why it
+has zero `expectedFailures`.
+
+## Phasing
+
+One branch (`claude/implement-ibrowsercontext-tS1Y8`), one or more PRs.
+
+### Phase 1 — Foundations & fixtures
+
+- Add `packages/test/src/contract/browser-context/` with `types.ts`,
+  `fixtures.ts`, `runIBrowserContextConformance.ts` (entrypoint
+  shell), `assertions/itExpectFail.ts` (copied from
+  `contract/ai-provider/`).
+- Build `FIXTURE_PAGE_URL` data: URL with edge-case ARIA names,
+  on-load fetch marker, console marker, click sentinel.
+- Add a row to `packages/test/src/contract/README.md`'s "Available
+  suites" table.
+- No assertions wired yet; no callers.
+
+### Phase 2 — Suite + Mock + first real adapter
+
+- Implement all four assertion blocks (`capabilityHonesty`,
+  `tabsLifecycle`, `ariaRoundTrip`, `networkIntrospection`).
+- Wire `MockBrowser_Generic.test.ts` (must pass clean — Mock is the
+  reference).
+- Wire `Playwright_Generic.integration.test.ts` with the listed
+  `expectedFailures` for the three known bugs.
+- Extend `MockBrowserContext` if needed to satisfy the fixture page's
+  click sentinel and ARIA edge-case names, **and** remove any
+  empty-stub `networkRequests` / `consoleMessages` properties so the
+  capability-honesty negative branch passes. If extending the mock
+  proves disproportionate, drop the Mock shim from v1; the suite is
+  still valuable with three shims.
+- CI green: Mock shim passes; Playwright shim passes (failures
+  captured in `it.fails`).
+
+### Phase 3 — Remaining shims
+
+- Wire `BunWebView_Generic.integration.test.ts` with appropriate
+  `expectedFailures` (single-view, network/console stubs).
+- Wire `Electron_Generic.integration.test.ts` (skipped in CI without
+  `RUN_ELECTRON_TESTS`; runs locally).
+- Confirm CI cost on the `RUN_PLAYWRIGHT_TESTS` job is within budget
+  (target ≤30 s, mirroring AiProvider).
+
+### Phase 4 — Fix the three known bugs
+
+For each fix, drop the corresponding `expectedFailures` entry and
+verify the suite turns green.
+
+1. **Empty-array stubs** (`PlaywrightBackend.ts:768-774`,
+   `BunWebViewBackend.ts:403-409`).
+   - v1 fix: delete the properties so the optional method becomes
+     `undefined` (declares "not supported"; satisfies B+ negative).
+     Drops `capability.networkRequests.undefinedWhenFalse` and
+     `capability.consoleMessages.undefinedWhenFalse` from
+     `expectedFailures`.
+   - Real implementations (Playwright `page.on("request")`, etc.) are
+     a follow-up: when those land, capability flags flip to `true` in
+     the shim and the positive branch becomes asserted.
+
+2. **Tabs `tabId` array-index race**
+   (`PlaywrightBackend.ts:686-736`).
+   - Replace array-index ids with a `WeakMap<Page, string>` (or
+     equivalent counter Map) seeded on `newPage` and
+     `context.on("page")`. Generated id (e.g. `"t1"`, `"t2"`) is
+     stable across closes and concurrent operations. Drops
+     `tabs.concurrentCloseStable` from `expectedFailures`.
+
+3. **`descriptorToLocator` `lastIndexOf(":")` parser**
+   (`PlaywrightBackend.ts:419-426`).
+   - Replace ad-hoc string descriptors with structured records: store
+     `{kind: "role", role, name} | {kind: "text", text} | {kind: "css", selector} | {kind: "nth", inner: Descriptor, index}`
+     in `_refMap`. Eliminates string parsing entirely. Smaller diff
+     than escaping. Localized to `PlaywrightBackend` and a few private
+     helpers. Drops `aria.colonInName` from `expectedFailures`.
+
+Each fix lands in its own commit so reverts are granular. Any
+additional failures discovered during Phase 2 are added to this
+phase's fix list rather than deferred.
+
+## Success criteria
+
+- Adding a fifth backend (e.g., a future Tauri or WebDriver-BiDi
+  adapter) requires writing one shim file (~25 lines) and inherits
+  all four assertion blocks.
+- The three named IBrowserContext bugs are fixed and continuously
+  asserted in CI.
+- An adapter cannot regress capability honesty, tabId stability, or
+  ARIA round-trip without a CI failure.
+- CI runtime increase ≤ ~30 s on the `RUN_PLAYWRIGHT_TESTS` job,
+  measured Phase 2 → 3.
+- The conventions in `packages/test/src/contract/README.md` extend
+  cleanly: the IBrowserContext entry validates that the foundations
+  doc generalizes beyond AiProvider. The README is updated to
+  document the `create`/`dispose`-per-test factory shape as a
+  legitimate variant of `register`/`dispose`/`inspect`.
+
+## Risks & mitigations
+
+- **`data:` URL restrictions in Electron.** Some Electron
+  configurations block `data:` navigation or forbid sub-fetches from
+  data: URLs. *Mitigation:* `BrowserContextFixture` is overridable, so
+  the Electron shim can point at a same-origin URL served by an
+  in-process http server if needed. Decided in Phase 3 once observed.
+- **Mock backend cannot satisfy ARIA edge cases.** If extending
+  `MockBrowserContext` to handle 200-char names, empty names, and a
+  click sentinel proves disproportionate, drop the Mock shim from v1.
+- **Concurrent-close test is timing-sensitive on Playwright.**
+  *Mitigation:* schedule both closes synchronously via `Promise.all`
+  before either resolves; the assertion is on stored ids, not on
+  close ordering.
+- **BunWebView ARIA fidelity.** BunWebView's accessibility tree may
+  not include all elements Playwright does. *Mitigation:* the
+  `ariaSnapshot: true` flag is asserted, but if BunWebView misses
+  some edge-case names, narrow the BunWebView fixture override
+  accordingly.
+- **Foundations drift.** The IBrowserContext shape (`create`/`dispose`
+  per test, no `inspect`, no `models`) deviates from the AiProvider
+  `register`/`dispose`/`inspect` shape. *Mitigation:* update
+  `packages/test/src/contract/README.md` to document both factory
+  shapes as legitimate variants — the principle is "fresh handle per
+  test", and the methods on it are contract-specific.
+
+## Roadmap — remaining contract suites
+
+After this project ships, the original brief leaves two suites:
+
+1. **`EntitlementProfile`** — desktop / web / server profiles enforce
+   identical contracts.
+2. **`IHumanConnector`** — App + Electron elicitation backends.
+
+Worker-proxy is also still on the original list; whether it warrants
+its own contract suite or rolls into AiProvider/Storage is an open
+question for a future brainstorm.
+
+## Open questions
+
+None at this time. Scope, capability-honesty enforcement, adapter
+list, fixture strategy, and phasing were confirmed during
+brainstorming.
+
+## References
+
+- `docs/superpowers/specs/2026-05-04-aiprovider-contract-conformance-design.md`
+  — original brief identifying the IBrowserContext invariants.
+- `packages/test/src/contract/ai-provider/` — reference implementation
+  of the parameterized contract suite pattern.
+- `packages/test/src/contract/README.md` — foundations doc updated by
+  Phase 1.
+- `packages/browser-control/src/task/IBrowserContext.ts` — interface
+  under test.
+- `packages/browser-control/src/task/PlaywrightBackend.ts:419-426,686-736,768-774`
+  — known bugs to fix in Phase 4.
+- `packages/browser-control/src/task/BunWebViewBackend.ts:403-409` —
+  known bug to fix in Phase 4.
+- `packages/test/src/test/browser/genericBrowserTaskTests.ts` — Tasks-
+  level suite that stays in place; orthogonal to this contract suite.
+- `packages/test/src/test/browser/MockBrowserContext.ts` — reference
+  implementation used by the Mock shim.

--- a/packages/browser-control/src/task/BunWebViewBackend.ts
+++ b/packages/browser-control/src/task/BunWebViewBackend.ts
@@ -8,7 +8,6 @@ import { sleep } from "@workglow/util";
 import { CDPBrowserBackend } from "./CDPBrowserBackend";
 import type {
   BrowserConnectOptions,
-  ConsoleMessage,
   DialogAction,
   DialogInfo,
   DownloadOptions,
@@ -16,8 +15,6 @@ import type {
   ElementRef,
   IBrowserContext,
   NavigateOptions,
-  NetworkFilter,
-  NetworkRequest,
   ScreenshotOptions,
   TabInfo,
   WaitOptions,
@@ -397,14 +394,11 @@ export class BunWebViewBackend extends CDPBrowserBackend implements IBrowserCont
   }
 
   // ---------------------------------------------------------------------------
-  // Optional capabilities (stubs)
+  // Optional capabilities
   // ---------------------------------------------------------------------------
-
-  readonly networkRequests = (_filter?: NetworkFilter): Promise<readonly NetworkRequest[]> => {
-    return Promise.resolve([]);
-  };
-
-  readonly consoleMessages = (): Promise<readonly ConsoleMessage[]> => {
-    return Promise.resolve([]);
-  };
+  //
+  // networkRequests and consoleMessages are intentionally undefined: this
+  // backend does not implement them. The IBrowserContext contract is that
+  // optional methods are either fully implemented or undefined — never
+  // empty-stub functions that defeat feature detection.
 }

--- a/packages/browser-control/src/task/ElectronBackend.ts
+++ b/packages/browser-control/src/task/ElectronBackend.ts
@@ -8,7 +8,6 @@ import { sleep } from "@workglow/util";
 import { CDPBrowserBackend } from "./CDPBrowserBackend";
 import type {
   BrowserConnectOptions,
-  ConsoleMessage,
   DialogAction,
   DialogInfo,
   DownloadOptions,
@@ -16,8 +15,6 @@ import type {
   ElementRef,
   IBrowserContext,
   NavigateOptions,
-  NetworkFilter,
-  NetworkRequest,
   ScreenshotOptions,
   TabInfo,
   WaitOptions,
@@ -436,12 +433,9 @@ export class ElectronBackend extends CDPBrowserBackend implements IBrowserContex
   // ---------------------------------------------------------------------------
   // Optional capabilities
   // ---------------------------------------------------------------------------
-
-  readonly networkRequests = (_filter?: NetworkFilter): Promise<readonly NetworkRequest[]> => {
-    return Promise.resolve([]);
-  };
-
-  readonly consoleMessages = (): Promise<readonly ConsoleMessage[]> => {
-    return Promise.resolve([]);
-  };
+  //
+  // networkRequests and consoleMessages are intentionally undefined: this
+  // backend does not implement them. The IBrowserContext contract is that
+  // optional methods are either fully implemented or undefined — never
+  // empty-stub functions that defeat feature detection.
 }

--- a/packages/browser-control/src/task/PlaywrightBackend.ts
+++ b/packages/browser-control/src/task/PlaywrightBackend.ts
@@ -10,7 +10,6 @@ import type {
   AriaRole,
   BrowserConnectOptions,
   ClickOptions,
-  ConsoleMessage,
   DialogAction,
   DialogInfo,
   DownloadOptions,
@@ -18,8 +17,6 @@ import type {
   ElementRef,
   IBrowserContext,
   NavigateOptions,
-  NetworkFilter,
-  NetworkRequest,
   ScreenshotOptions,
   SnapshotOptions,
   TabInfo,
@@ -762,14 +759,11 @@ export class PlaywrightBackend implements IBrowserContext {
   }
 
   // ---------------------------------------------------------------------------
-  // Optional capabilities (simplified)
+  // Optional capabilities
   // ---------------------------------------------------------------------------
-
-  readonly networkRequests = (_filter?: NetworkFilter): Promise<readonly NetworkRequest[]> => {
-    return Promise.resolve([]);
-  };
-
-  readonly consoleMessages = (): Promise<readonly ConsoleMessage[]> => {
-    return Promise.resolve([]);
-  };
+  //
+  // networkRequests and consoleMessages are intentionally undefined: this
+  // backend does not implement them. The IBrowserContext contract is that
+  // optional methods are either fully implemented or undefined — never
+  // empty-stub functions that defeat feature detection.
 }

--- a/packages/browser-control/src/task/PlaywrightBackend.ts
+++ b/packages/browser-control/src/task/PlaywrightBackend.ts
@@ -240,6 +240,18 @@ export class PlaywrightBackend implements IBrowserContext {
   /** True when this backend launched Chromium locally (owns full process tree). */
   private _launchedLocalChromium = false;
 
+  // Stable per-page tab ids. Surviving across concurrent close.
+  private _pageIds: WeakMap<AnyPage, string> = new WeakMap();
+  private _pageIdSeq = 0;
+  private idForPage(page: AnyPage): string {
+    let id = this._pageIds.get(page);
+    if (!id) {
+      id = `t${++this._pageIdSeq}`;
+      this._pageIds.set(page, id);
+    }
+    return id;
+  }
+
   // Ref management
   private _refMap = new Map<string, string>();
   private _refCounter = { count: 0 };
@@ -683,8 +695,8 @@ export class PlaywrightBackend implements IBrowserContext {
   async tabs(): Promise<readonly TabInfo[]> {
     const pages: AnyPage[] = this.context.pages();
     return Promise.all(
-      pages.map(async (p: AnyPage, idx: number) => ({
-        tabId: String(idx),
+      pages.map(async (p: AnyPage) => ({
+        tabId: this.idForPage(p),
         url: p.url(),
         title: await p.title(),
       }))
@@ -693,12 +705,12 @@ export class PlaywrightBackend implements IBrowserContext {
 
   async switchTab(tabId: string): Promise<void> {
     const pages: AnyPage[] = this.context.pages();
-    const idx = parseInt(tabId, 10);
-    if (isNaN(idx) || idx < 0 || idx >= pages.length) {
+    const target = pages.find((p) => this._pageIds.get(p) === tabId);
+    if (!target) {
       throw new Error(`PlaywrightBackend: no tab with id "${tabId}"`);
     }
-    this._page = pages[idx];
-    await this._page.bringToFront();
+    this._page = target;
+    await target.bringToFront();
   }
 
   async newTab(url?: string): Promise<TabInfo> {
@@ -706,11 +718,8 @@ export class PlaywrightBackend implements IBrowserContext {
     if (url) {
       await newPage.goto(url, { waitUntil: "load" });
     }
-    const pages: AnyPage[] = this.context.pages();
-    const idx = pages.indexOf(newPage);
-    const tabId = String(idx >= 0 ? idx : pages.length - 1);
     return {
-      tabId,
+      tabId: this.idForPage(newPage),
       url: newPage.url(),
       title: await newPage.title(),
     };
@@ -718,11 +727,10 @@ export class PlaywrightBackend implements IBrowserContext {
 
   async closeTab(tabId: string): Promise<void> {
     const pages: AnyPage[] = this.context.pages();
-    const idx = parseInt(tabId, 10);
-    if (isNaN(idx) || idx < 0 || idx >= pages.length) {
+    const target = pages.find((p) => this._pageIds.get(p) === tabId);
+    if (!target) {
       throw new Error(`PlaywrightBackend: no tab with id "${tabId}"`);
     }
-    const target = pages[idx];
     await target.close();
 
     // If we closed the active page, switch to the last remaining page

--- a/packages/browser-control/src/task/PlaywrightBackend.ts
+++ b/packages/browser-control/src/task/PlaywrightBackend.ts
@@ -125,7 +125,7 @@ interface MutableAccessibilityNode {
 function parseAriaYaml(
   yaml: string,
   refCounter: { count: number },
-  refMap: Map<string, string>
+  refMap: Map<string, Descriptor>
 ): AccessibilityNode {
   const lines = yaml.split("\n");
 
@@ -141,9 +141,9 @@ function parseAriaYaml(
 
     const ref = `e${++refCounter.count}`;
 
-    // Build locator string for this node
-    const locatorStr = buildLocatorString(parsed.role, parsed.name);
-    refMap.set(ref, locatorStr);
+    // Build descriptor for this node
+    const descriptor = buildDescriptor(parsed.role, parsed.name);
+    refMap.set(ref, descriptor);
 
     const node: MutableAccessibilityNode = {
       ref,
@@ -198,27 +198,30 @@ function parseAriaYaml(
   if (!root) {
     // Return a synthetic root if parsing fails
     const ref = `e${++refCounter.count}`;
-    refMap.set(ref, 'locator("body")');
+    refMap.set(ref, { kind: "css", selector: "body" });
     return { ref, role: "document", name: "" };
   }
 
   return root as AccessibilityNode;
 }
 
-/**
- * Build a Playwright locator descriptor string from ARIA role/name.
- * These strings are stored in the refMap and interpreted by resolveRef().
- */
-function buildLocatorString(role: string, name: string): string {
-  // Roles that are typically text nodes — check before the generic name check
+/** Build a structured Descriptor from ARIA role/name. */
+function buildDescriptor(role: string, name: string): Descriptor {
   if (role === "text" || role === "StaticText") {
-    return `getByText:${name}`;
+    return { kind: "text", text: name };
   }
-  if (name) {
-    return `getByRole:${role}:${name}`;
-  }
-  return `getByRole:${role}:`;
+  return { kind: "role", role, name };
 }
+
+// ---------------------------------------------------------------------------
+// Structured element descriptor (replaces ad-hoc string encoding)
+// ---------------------------------------------------------------------------
+
+type Descriptor =
+  | { readonly kind: "role"; readonly role: string; readonly name: string }
+  | { readonly kind: "text"; readonly text: string }
+  | { readonly kind: "css"; readonly selector: string }
+  | { readonly kind: "nth"; readonly inner: Descriptor; readonly index: number };
 
 // ---------------------------------------------------------------------------
 // PlaywrightBackend
@@ -253,7 +256,7 @@ export class PlaywrightBackend implements IBrowserContext {
   }
 
   // Ref management
-  private _refMap = new Map<string, string>();
+  private _refMap = new Map<string, Descriptor>();
   private _refCounter = { count: 0 };
 
   // Dialog handler
@@ -385,14 +388,6 @@ export class PlaywrightBackend implements IBrowserContext {
     return this._context;
   }
 
-  /**
-   * Resolve an ElementRef to a Playwright Locator.
-   * The refMap stores descriptor strings like:
-   *   "getByRole:button:Sign In"
-   *   "getByText:some text"
-   *   "css:.my-class"
-   *   "nth:getByRole:listitem::2"
-   */
   private resolveRef(ref: ElementRef): AnyLocator {
     const descriptor = this._refMap.get(ref);
     if (!descriptor) {
@@ -401,42 +396,20 @@ export class PlaywrightBackend implements IBrowserContext {
     return this.descriptorToLocator(descriptor);
   }
 
-  private descriptorToLocator(descriptor: string): AnyLocator {
+  private descriptorToLocator(descriptor: Descriptor): AnyLocator {
     const page = this.page;
-
-    if (descriptor.startsWith("getByRole:")) {
-      const rest = descriptor.slice("getByRole:".length);
-      const colonIdx = rest.indexOf(":");
-      const role = rest.slice(0, colonIdx);
-      const name = rest.slice(colonIdx + 1);
-      if (name) {
-        return page.getByRole(role, { name });
-      }
-      return page.getByRole(role);
+    switch (descriptor.kind) {
+      case "role":
+        return descriptor.name
+          ? page.getByRole(descriptor.role, { name: descriptor.name })
+          : page.getByRole(descriptor.role);
+      case "text":
+        return page.getByText(descriptor.text);
+      case "css":
+        return page.locator(descriptor.selector);
+      case "nth":
+        return this.descriptorToLocator(descriptor.inner).nth(descriptor.index);
     }
-
-    if (descriptor.startsWith("getByText:")) {
-      const text = descriptor.slice("getByText:".length);
-      return page.getByText(text);
-    }
-
-    if (descriptor.startsWith("css:")) {
-      const selector = descriptor.slice("css:".length);
-      return page.locator(selector);
-    }
-
-    if (descriptor.startsWith("nth:")) {
-      // Format: "nth:<inner-descriptor>:<index>"
-      // We need to split off the trailing ":<number>"
-      const withoutPrefix = descriptor.slice("nth:".length);
-      const lastColon = withoutPrefix.lastIndexOf(":");
-      const inner = withoutPrefix.slice(0, lastColon);
-      const idx = parseInt(withoutPrefix.slice(lastColon + 1), 10);
-      return this.descriptorToLocator(inner).nth(idx);
-    }
-
-    // Fallback: treat as CSS selector
-    return page.locator(descriptor);
   }
 
   // ---------------------------------------------------------------------------
@@ -582,7 +555,7 @@ export class PlaywrightBackend implements IBrowserContext {
     if (count === 0) return null;
 
     const ref = `e${++this._refCounter.count}`;
-    this._refMap.set(ref, `css:${selector}`);
+    this._refMap.set(ref, { kind: "css", selector });
     return ref;
   }
 
@@ -593,7 +566,7 @@ export class PlaywrightBackend implements IBrowserContext {
 
     for (let i = 0; i < count; i++) {
       const ref = `e${++this._refCounter.count}`;
-      this._refMap.set(ref, `nth:css:${selector}:${i}`);
+      this._refMap.set(ref, { kind: "nth", inner: { kind: "css", selector }, index: i });
       refs.push(ref);
     }
 
@@ -754,7 +727,7 @@ export class PlaywrightBackend implements IBrowserContext {
     await this.page.waitForSelector(selector, ...(timeout !== undefined ? [{ timeout }] : []));
 
     const ref = `e${++this._refCounter.count}`;
-    this._refMap.set(ref, `css:${selector}`);
+    this._refMap.set(ref, { kind: "css", selector });
     return ref;
   }
 

--- a/packages/test/src/contract/README.md
+++ b/packages/test/src/contract/README.md
@@ -62,6 +62,23 @@ Treat both as additional examples of the pattern.
    Adapters whose underlying resource doesn't natively support repeated
    dispose should guard with a flag.
 
+### Factory shape variants
+
+The `register/dispose/inspect` factory documented above is one of two
+legitimate shapes — used when an adapter is a long-lived global registration
+(e.g. an AI provider). For contracts whose subject is heavyweight but
+per-test state (e.g. browser contexts), prefer a `create/dispose` factory
+where each top-level block instantiates its own subject:
+
+    factory: () => Promise<{
+      create: () => Promise<TSubject>;
+      dispose: (subject: TSubject) => Promise<void>;
+    }>
+
+The principle is the same: a fresh handle per block, with no shared state
+that block N can leak into block N+1. The methods on the handle are
+contract-specific.
+
 ## Available suites
 
 | Contract | Suite | Adapters |
@@ -69,6 +86,7 @@ Treat both as additional examples of the pattern.
 | `AiProvider` | `contract/ai-provider/runAiProviderConformance` | Anthropic, OpenAI, Gemini, Ollama, HF Inference, HF Transformers, LlamaCpp |
 | `IQueueStorage` + `IRateLimiterStorage` | `test/job-queue/genericJobQueueTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase |
 | `ITabularStorage` | `test/storage-tabular/genericTabularStorageTests` | InMemory, IndexedDB, Postgres, SQLite, Supabase, FsFolder, HuggingFace |
+| `IBrowserContext` | `contract/browser-context/runIBrowserContextConformance` | Mock, Playwright, BunWebView, Electron |
 
 ## How to add a new contract suite
 

--- a/packages/test/src/contract/browser-context/ConformanceMockContext.ts
+++ b/packages/test/src/contract/browser-context/ConformanceMockContext.ts
@@ -209,15 +209,12 @@ export class ConformanceMockContext implements IBrowserContext {
     return entry ? entry.name : null;
   }
   async attribute(ref: ElementRef, name: string): Promise<string | null> {
-    if (name === "data-clicked") {
-      // sentinel refs are formatted as "sentinel-<tabId>"
-      if (ref.startsWith("sentinel-")) {
-        const tabId = ref.slice("sentinel-".length);
-        const page = this.pages.find((p) => p.tabId === tabId);
-        return page ? page.sentinelClicked : null;
-      }
-      const entry = this.refMap.get(ref);
-      const page = entry && this.pages.find((p) => p.tabId === entry.tabId);
+    // Only the synthetic sentinel ref carries data-clicked. Button refs and
+    // other refs do not have per-element attributes modeled — they get null,
+    // matching what a real backend would return for an unrelated attribute.
+    if (name === "data-clicked" && ref.startsWith("sentinel-")) {
+      const tabId = ref.slice("sentinel-".length);
+      const page = this.pages.find((p) => p.tabId === tabId);
       return page ? page.sentinelClicked : null;
     }
     return null;

--- a/packages/test/src/contract/browser-context/ConformanceMockContext.ts
+++ b/packages/test/src/contract/browser-context/ConformanceMockContext.ts
@@ -210,13 +210,25 @@ export class ConformanceMockContext implements IBrowserContext {
   }
   async attribute(ref: ElementRef, name: string): Promise<string | null> {
     if (name === "data-clicked") {
+      // sentinel refs are formatted as "sentinel-<tabId>"
+      if (ref.startsWith("sentinel-")) {
+        const tabId = ref.slice("sentinel-".length);
+        const page = this.pages.find((p) => p.tabId === tabId);
+        return page ? page.sentinelClicked : null;
+      }
       const entry = this.refMap.get(ref);
       const page = entry && this.pages.find((p) => p.tabId === entry.tabId);
       return page ? page.sentinelClicked : null;
     }
     return null;
   }
-  async querySelector(_selector: string): Promise<ElementRef | null> {
+  async querySelector(selector: string): Promise<ElementRef | null> {
+    if (selector === "#sentinel") {
+      // Return a stable sentinel ref scoped to the active tab so that
+      // attribute() can resolve the page's sentinelClicked value.
+      const page = this.active();
+      return `sentinel-${page.tabId}` as ElementRef;
+    }
     return null;
   }
   async querySelectorAll(_selector: string): Promise<readonly ElementRef[]> {

--- a/packages/test/src/contract/browser-context/ConformanceMockContext.ts
+++ b/packages/test/src/contract/browser-context/ConformanceMockContext.ts
@@ -18,7 +18,6 @@ import type {
   ElementRef,
   IBrowserContext,
   NavigateOptions,
-  NetworkFilter,
   NetworkRequest,
   ScreenshotOptions,
   SnapshotOptions,

--- a/packages/test/src/contract/browser-context/ConformanceMockContext.ts
+++ b/packages/test/src/contract/browser-context/ConformanceMockContext.ts
@@ -1,0 +1,288 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AccessibilityNode,
+  AccessibilityTree,
+  AriaRole,
+  BrowserConnectOptions,
+  ClickOptions,
+  ConsoleMessage,
+  DialogAction,
+  DialogInfo,
+  DownloadOptions,
+  DownloadResult,
+  ElementRef,
+  IBrowserContext,
+  NavigateOptions,
+  NetworkFilter,
+  NetworkRequest,
+  ScreenshotOptions,
+  SnapshotOptions,
+  TabInfo,
+  WaitOptions,
+} from "@workglow/browser-control/task";
+
+interface PageState {
+  readonly tabId: string;
+  url: string;
+  title: string;
+  ariaButtons: ReadonlyArray<{ readonly idx: number; readonly name: string }>;
+  sentinelClicked: string;
+  network: NetworkRequest[];
+  console: ConsoleMessage[];
+}
+
+/**
+ * Parses the conformance fixture page out of a `data:text/html,...` URL by
+ * scraping aria-label values from `<button ... aria-label="...">` tags. This
+ * is intentionally narrow — only the conformance fixture page is supported.
+ */
+function parseFixturePage(url: string): {
+  readonly title: string;
+  readonly ariaButtons: ReadonlyArray<{ readonly idx: number; readonly name: string }>;
+  readonly networkMarker: string | undefined;
+  readonly consoleMarker: string | undefined;
+} {
+  let html = "";
+  if (url.startsWith("data:text/html,")) {
+    html = decodeURIComponent(url.slice("data:text/html,".length));
+  }
+  const titleMatch = /<title>([^<]*)<\/title>/.exec(html);
+  const buttons: { idx: number; name: string }[] = [];
+  const buttonRe = /<button[^>]*aria-label="([^"]*)"[^>]*>/g;
+  let m: RegExpExecArray | null;
+  let idx = 0;
+  while ((m = buttonRe.exec(html)) !== null) {
+    const decoded = m[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&");
+    buttons.push({ idx, name: decoded });
+    idx++;
+  }
+  const fetchMatch = /fetch\("data:text\/plain,([^"]+)"/.exec(html);
+  const consoleMatch = /console\.log\("([^"]+)"\)/.exec(html);
+  return {
+    title: titleMatch ? titleMatch[1] : "",
+    ariaButtons: buttons,
+    networkMarker: fetchMatch?.[1],
+    consoleMarker: consoleMatch?.[1],
+  };
+}
+
+export class ConformanceMockContext implements IBrowserContext {
+  private connected = false;
+  private nextTabSeq = 1;
+  private nextRefSeq = 1;
+  private pages: PageState[] = [];
+  private activeTabId: string | undefined;
+  /** ref → { tabId, name } produced by snapshot(). */
+  private refMap = new Map<string, { tabId: string; name: string; idx: number }>();
+
+  // networkRequests / consoleMessages are intentionally absent (undefined)
+  // when the corresponding capability flag is false. The shim wires this
+  // class with capabilities.{networkRequests,consoleMessages}: false, so
+  // these properties stay undefined to satisfy capability honesty (negative).
+
+  // -- Lifecycle ------------------------------------------------------------
+  async connect(_options?: BrowserConnectOptions): Promise<void> {
+    this.connected = true;
+    if (this.pages.length === 0) {
+      const page = this.makePage("about:blank", "");
+      this.pages.push(page);
+      this.activeTabId = page.tabId;
+    }
+  }
+  async disconnect(): Promise<void> {
+    this.connected = false;
+    this.pages = [];
+    this.activeTabId = undefined;
+    this.refMap.clear();
+  }
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  private makePage(url: string, title: string): PageState {
+    return {
+      tabId: `mock-tab-${this.nextTabSeq++}`,
+      url,
+      title,
+      ariaButtons: [],
+      sentinelClicked: "",
+      network: [],
+      console: [],
+    };
+  }
+
+  private active(): PageState {
+    const p = this.pages.find((p) => p.tabId === this.activeTabId);
+    if (!p) throw new Error("ConformanceMockContext: no active tab");
+    return p;
+  }
+
+  // -- Navigation -----------------------------------------------------------
+  async navigate(url: string, _options?: NavigateOptions): Promise<void> {
+    const page = this.active();
+    page.url = url;
+    const parsed = parseFixturePage(url);
+    page.title = parsed.title;
+    page.ariaButtons = parsed.ariaButtons;
+    page.sentinelClicked = "";
+    if (parsed.networkMarker) {
+      page.network.push({
+        url: `data:text/plain,${parsed.networkMarker}`,
+        method: "GET",
+        status: 200,
+        headers: {},
+      });
+    }
+    if (parsed.consoleMarker) {
+      page.console.push({ type: "log", text: parsed.consoleMarker });
+    }
+  }
+  async goBack(_options?: NavigateOptions): Promise<void> {}
+  async goForward(_options?: NavigateOptions): Promise<void> {}
+  async reload(_options?: NavigateOptions): Promise<void> {}
+  async currentUrl(): Promise<string> {
+    return this.active().url;
+  }
+  async title(): Promise<string> {
+    return this.active().title;
+  }
+
+  // -- Accessibility --------------------------------------------------------
+  async snapshot(_options?: SnapshotOptions): Promise<AccessibilityTree> {
+    const page = this.active();
+    const children: AccessibilityNode[] = page.ariaButtons.map((b) => {
+      const ref: ElementRef = `e${this.nextRefSeq++}`;
+      this.refMap.set(ref, { tabId: page.tabId, name: b.name, idx: b.idx });
+      return { ref, role: "button", name: b.name };
+    });
+    const rootRef: ElementRef = `e${this.nextRefSeq++}`;
+    return {
+      root: { ref: rootRef, role: "document", name: page.title, children },
+      yaml: children.map((c) => `- button [${c.ref}]: ${c.name}`).join("\n"),
+    };
+  }
+
+  // -- Element interaction --------------------------------------------------
+  async click(ref: ElementRef, _options?: ClickOptions): Promise<void> {
+    const entry = this.refMap.get(ref);
+    if (!entry) throw new Error(`ConformanceMockContext: unknown ref "${ref}"`);
+    const page = this.pages.find((p) => p.tabId === entry.tabId);
+    if (!page) throw new Error(`ConformanceMockContext: tab gone for ref "${ref}"`);
+    page.sentinelClicked = String(entry.idx);
+  }
+  async fill(_ref: ElementRef, _value: string, _options?: WaitOptions): Promise<void> {}
+  async selectOption(
+    _ref: ElementRef,
+    _values: string | readonly string[],
+    _options?: WaitOptions
+  ): Promise<void> {}
+  async hover(_ref: ElementRef, _options?: WaitOptions): Promise<void> {}
+
+  async clickByRole(role: AriaRole, name: string, _options?: ClickOptions): Promise<void> {
+    if (role !== "button") {
+      throw new Error(`ConformanceMockContext: unsupported role "${role}"`);
+    }
+    const page = this.active();
+    const btn = page.ariaButtons.find((b) => b.name === name);
+    if (!btn) throw new Error(`ConformanceMockContext: no button named ${JSON.stringify(name)}`);
+    page.sentinelClicked = String(btn.idx);
+  }
+  async fillByLabel(_label: string, _value: string, _options?: WaitOptions): Promise<void> {}
+
+  // -- Content extraction ---------------------------------------------------
+  async content(): Promise<string> {
+    return "";
+  }
+  async innerHTML(_ref: ElementRef): Promise<string> {
+    return "";
+  }
+  async textContent(ref: ElementRef): Promise<string | null> {
+    const entry = this.refMap.get(ref);
+    return entry ? entry.name : null;
+  }
+  async attribute(ref: ElementRef, name: string): Promise<string | null> {
+    if (name === "data-clicked") {
+      const entry = this.refMap.get(ref);
+      const page = entry && this.pages.find((p) => p.tabId === entry.tabId);
+      return page ? page.sentinelClicked : null;
+    }
+    return null;
+  }
+  async querySelector(_selector: string): Promise<ElementRef | null> {
+    return null;
+  }
+  async querySelectorAll(_selector: string): Promise<readonly ElementRef[]> {
+    return [];
+  }
+
+  async evaluate<T>(expression: string): Promise<T> {
+    // Narrow support: the assertion suite reads sentinel via attribute(), not
+    // evaluate(), but provide a readiness check used by waitForIdle.
+    if (expression.includes("readyState")) return true as unknown as T;
+    return undefined as unknown as T;
+  }
+
+  async screenshot(_options?: ScreenshotOptions): Promise<Buffer> {
+    return Buffer.alloc(0);
+  }
+  async pressKey(_key: string, _options?: WaitOptions): Promise<void> {}
+  async type(_text: string, _options?: WaitOptions): Promise<void> {}
+  async scroll(_x: number, _y: number, _ref?: ElementRef): Promise<void> {}
+  async uploadFile(_ref: ElementRef, _paths: string | readonly string[]): Promise<void> {}
+  async download(
+    trigger: () => Promise<void>,
+    _options?: DownloadOptions
+  ): Promise<DownloadResult> {
+    await trigger();
+    return { path: "", suggestedFilename: "" };
+  }
+  onDialog(_handler: (info: DialogInfo) => DialogAction | Promise<DialogAction>): void {}
+
+  // -- Tabs -----------------------------------------------------------------
+  async tabs(): Promise<readonly TabInfo[]> {
+    return this.pages.map((p) => ({ tabId: p.tabId, url: p.url, title: p.title }));
+  }
+  async switchTab(tabId: string): Promise<void> {
+    if (!this.pages.some((p) => p.tabId === tabId)) {
+      throw new Error(`ConformanceMockContext: no tab "${tabId}"`);
+    }
+    this.activeTabId = tabId;
+  }
+  async newTab(url?: string): Promise<TabInfo> {
+    const page = this.makePage(url ?? "about:blank", "");
+    this.pages.push(page);
+    if (url) {
+      const prev = this.activeTabId;
+      this.activeTabId = page.tabId;
+      await this.navigate(url);
+      this.activeTabId = prev;
+    }
+    return { tabId: page.tabId, url: page.url, title: page.title };
+  }
+  async closeTab(tabId: string): Promise<void> {
+    const before = this.pages.length;
+    this.pages = this.pages.filter((p) => p.tabId !== tabId);
+    if (this.pages.length === before) {
+      throw new Error(`ConformanceMockContext: no tab "${tabId}"`);
+    }
+    if (this.activeTabId === tabId) {
+      this.activeTabId = this.pages[this.pages.length - 1]?.tabId;
+    }
+  }
+
+  // -- Wait -----------------------------------------------------------------
+  async waitForNavigation(_options?: NavigateOptions): Promise<void> {}
+  async waitForSelector(_selector: string, _options?: WaitOptions): Promise<ElementRef> {
+    return "e0";
+  }
+  async waitForIdle(_options?: WaitOptions): Promise<void> {}
+}

--- a/packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts
+++ b/packages/test/src/contract/browser-context/assertions/ariaRoundTrip.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { AccessibilityNode, IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+function collectButtons(root: AccessibilityNode): AccessibilityNode[] {
+  const out: AccessibilityNode[] = [];
+  const stack: AccessibilityNode[] = [root];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
+    if (n.role === "button") out.push(n);
+    if (n.children) stack.push(...n.children);
+  }
+  return out;
+}
+
+export function ariaRoundTripBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  if (!opts.capabilities.ariaSnapshot) return;
+
+  describe("ARIA round-trip", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+      // Navigate once; all assertions reuse this page.
+      await ctx.navigate(fixture.pageUrl);
+      await ctx.waitForIdle({ timeout: 5_000 });
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Round-trip per edge-case name -------------------------------------
+
+    for (let i = 0; i < fixture.ariaEdgeCaseNames.length; i++) {
+      const name = fixture.ariaEdgeCaseNames[i];
+      const isColonName = name.includes(":");
+      const title = `clickByRole('button', ${JSON.stringify(name)}) lands on the right node`;
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        const tree = await ctx.snapshot();
+        const buttons = collectButtons(tree.root);
+        const target = buttons.find((b) => b.name === name);
+        expect(target, `snapshot must include button with name ${JSON.stringify(name)}`).toBeDefined();
+
+        await ctx.clickByRole("button", name);
+
+        // Read `data-clicked` from the sentinel element.
+        const sentinelRef = await ctx.querySelector("#sentinel");
+        expect(sentinelRef).not.toBeNull();
+        const clicked = await ctx.attribute(sentinelRef!, "data-clicked");
+        expect(clicked).toBe(String(i));
+      };
+      // Names containing a colon trigger the lastIndexOf parser bug in
+      // PlaywrightBackend. Adapters with that bug list "aria.colonInName"
+      // in expectedFailures; the helper wraps in `it.fails` for them.
+      const useExpectFail = isColonName && expectFail("aria.colonInName");
+      if (useExpectFail) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    }
+
+    // -- Ref reuse after a second snapshot ---------------------------------
+
+    it(
+      "refs from snapshot N remain usable for textContent after snapshot N+1",
+      async () => {
+        if (!ctx) throw new Error("context not created");
+        const t1 = await ctx.snapshot();
+        const buttons1 = collectButtons(t1.root);
+        expect(buttons1.length).toBeGreaterThan(0);
+        const ref = buttons1[0].ref;
+        // Take a fresh snapshot, then reach back to the older ref.
+        await ctx.snapshot();
+        const txt = await ctx.textContent(ref);
+        expect(txt, "ref from prior snapshot should still resolve").not.toBeNull();
+      },
+      opts.timeout
+    );
+  });
+}

--- a/packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts
+++ b/packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts
@@ -38,7 +38,7 @@ export function capabilityHonestyBlock(
         if (!ctx) throw new Error("context not created");
         // The contract says: when the capability is false, the method must
         // be strictly undefined — NOT a no-op stub returning [].
-        expect(typeof (ctx as Record<string, unknown>)[methodName]).toBe("undefined");
+        expect(typeof (ctx as unknown as Record<string, unknown>)[methodName]).toBe("undefined");
       };
       const title = `declares ${methodName}=false → ctx.${methodName} is undefined`;
       if (expectFail(assertionName)) {

--- a/packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts
+++ b/packages/test/src/contract/browser-context/assertions/capabilityHonesty.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+export function capabilityHonestyBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  describe("Capability honesty", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: import("@workglow/browser-control/task").IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Negative direction -------------------------------------------------
+
+    const runNegative = (
+      methodName: "networkRequests" | "consoleMessages",
+      assertionName: string
+    ) => {
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        // The contract says: when the capability is false, the method must
+        // be strictly undefined — NOT a no-op stub returning [].
+        expect(typeof (ctx as Record<string, unknown>)[methodName]).toBe("undefined");
+      };
+      const title = `declares ${methodName}=false → ctx.${methodName} is undefined`;
+      if (expectFail(assertionName)) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    };
+
+    if (!opts.capabilities.networkRequests) {
+      runNegative("networkRequests", "capability.networkRequests.undefinedWhenFalse");
+    }
+    if (!opts.capabilities.consoleMessages) {
+      runNegative("consoleMessages", "capability.consoleMessages.undefinedWhenFalse");
+    }
+
+    // -- Positive direction -------------------------------------------------
+
+    if (opts.capabilities.networkRequests) {
+      it(
+        "declares networkRequests=true → fixture fetch is observable",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          if (typeof ctx.networkRequests !== "function") {
+            throw new Error(
+              "capability claims networkRequests=true but ctx.networkRequests is not a function"
+            );
+          }
+          await ctx.navigate(fixture.pageUrl);
+          await ctx.waitForIdle({ timeout: 5_000 });
+          const entries = await ctx.networkRequests();
+          const found = entries.some((r) => r.url.includes(fixture.networkMarkerUrl));
+          expect(found, `expected an entry containing ${fixture.networkMarkerUrl}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+
+    if (opts.capabilities.consoleMessages) {
+      it(
+        "declares consoleMessages=true → fixture console.log is observable",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          if (typeof ctx.consoleMessages !== "function") {
+            throw new Error(
+              "capability claims consoleMessages=true but ctx.consoleMessages is not a function"
+            );
+          }
+          await ctx.navigate(fixture.pageUrl);
+          await ctx.waitForIdle({ timeout: 5_000 });
+          const entries = await ctx.consoleMessages();
+          const found = entries.some((m) => m.text.includes(fixture.consoleMarker));
+          expect(found, `expected a console message containing ${fixture.consoleMarker}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+  });
+}

--- a/packages/test/src/contract/browser-context/assertions/itExpectFail.ts
+++ b/packages/test/src/contract/browser-context/assertions/itExpectFail.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { it } from "vitest";
+
+type ItFn = (name: string, fn: () => Promise<void> | void, timeout?: number) => void;
+
+export const itExpectFail: ItFn = (name, fn, timeout) => {
+  const native = (it as unknown as { fails?: ItFn }).fails;
+  if (typeof native === "function") {
+    native(name, fn, timeout);
+    return;
+  }
+  it(
+    `${name} [expected-fail]`,
+    async () => {
+      let passed = false;
+      try {
+        await fn();
+        passed = true;
+      } catch {
+        // expected; the test was supposed to fail
+      }
+      if (passed) {
+        throw new Error(
+          `Test "${name}" was marked as expected-fail but passed. Remove its name from opts.expectedFailures.`
+        );
+      }
+    },
+    timeout
+  );
+};

--- a/packages/test/src/contract/browser-context/assertions/networkIntrospection.ts
+++ b/packages/test/src/contract/browser-context/assertions/networkIntrospection.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+
+export function networkIntrospectionBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  if (!opts.capabilities.networkRequests && !opts.capabilities.consoleMessages) return;
+
+  describe("Network/console introspection", () => {
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+      await ctx.navigate(fixture.pageUrl);
+      await ctx.waitForIdle({ timeout: 5_000 });
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    if (opts.capabilities.networkRequests) {
+      it(
+        "networkRequests() captures the fixture's outbound fetch",
+        async () => {
+          if (!ctx || typeof ctx.networkRequests !== "function") {
+            throw new Error("networkRequests not available despite capability=true");
+          }
+          const entries = await ctx.networkRequests();
+          const found = entries.some((r) => r.url.includes(fixture.networkMarkerUrl));
+          expect(found, `expected an entry containing ${fixture.networkMarkerUrl}`).toBe(true);
+        },
+        opts.timeout
+      );
+
+      it(
+        "networkRequests({ method }) filters by method",
+        async () => {
+          if (!ctx || typeof ctx.networkRequests !== "function") {
+            throw new Error("networkRequests not available despite capability=true");
+          }
+          const all = await ctx.networkRequests();
+          const gets = await ctx.networkRequests({ method: "GET" });
+          // Filter must not return more entries than the unfiltered list.
+          expect(gets.length).toBeLessThanOrEqual(all.length);
+        },
+        opts.timeout
+      );
+    }
+
+    if (opts.capabilities.consoleMessages) {
+      it(
+        "consoleMessages() captures the fixture's console.log",
+        async () => {
+          if (!ctx || typeof ctx.consoleMessages !== "function") {
+            throw new Error("consoleMessages not available despite capability=true");
+          }
+          const entries = await ctx.consoleMessages();
+          const found = entries.some((m) => m.text.includes(fixture.consoleMarker));
+          expect(found, `expected a console message containing ${fixture.consoleMarker}`).toBe(true);
+        },
+        opts.timeout
+      );
+    }
+  });
+}

--- a/packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts
+++ b/packages/test/src/contract/browser-context/assertions/tabsLifecycle.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+import type { BrowserContextFixture, IBrowserContextConformanceOpts } from "../types";
+import { itExpectFail } from "./itExpectFail";
+
+export function tabsLifecycleBlock(
+  opts: IBrowserContextConformanceOpts,
+  fixture: BrowserContextFixture
+): void {
+  describe("Tabs lifecycle", () => {
+    const expectFail = (name: string) => opts.expectedFailures?.includes(name) ?? false;
+
+    let ctx: IBrowserContext | undefined;
+    let handle: Awaited<ReturnType<typeof opts.factory>> | undefined;
+
+    beforeAll(async () => {
+      handle = await opts.factory();
+      ctx = await handle.create();
+    }, opts.timeout);
+
+    afterAll(async () => {
+      if (handle && ctx) await handle.dispose(ctx);
+    });
+
+    // -- Basic lifecycle ----------------------------------------------------
+
+    it(
+      "tabs() returns at least one tab after connect",
+      async () => {
+        if (!ctx) throw new Error("context not created");
+        const tabs = await ctx.tabs();
+        expect(tabs.length).toBeGreaterThanOrEqual(1);
+      },
+      opts.timeout
+    );
+
+    if (opts.capabilities.multipleTabs) {
+      it(
+        "newTab() increases tab count by 1",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          const before = (await ctx.tabs()).length;
+          await ctx.newTab(fixture.pageUrl);
+          const after = (await ctx.tabs()).length;
+          expect(after).toBe(before + 1);
+        },
+        opts.timeout
+      );
+    }
+
+    // -- Concurrent close stability ----------------------------------------
+
+    if (opts.capabilities.multipleTabs) {
+      const title =
+        "tabId remains valid for surviving tabs across concurrent close()";
+      const body = async () => {
+        if (!ctx) throw new Error("context not created");
+        // Set up four tabs with distinguishable urls.
+        const urls = [
+          "data:text/html,<title>A</title>",
+          "data:text/html,<title>B</title>",
+          "data:text/html,<title>C</title>",
+          "data:text/html,<title>D</title>",
+        ];
+        // Reset to a known state by closing existing non-blank tabs.
+        for (const t of await ctx.tabs()) {
+          // best-effort cleanup; ignore failures
+          try {
+            await ctx.closeTab(t.tabId);
+          } catch {
+            /* noop */
+          }
+        }
+        // Some backends require at least one tab; reconnect if needed.
+        if ((await ctx.tabs()).length === 0) {
+          await ctx.newTab(urls[0]);
+        }
+        // Ensure exactly four tabs in our known order.
+        const baseTabs = await ctx.tabs();
+        const opened: string[] = [];
+        for (let i = 0; i < urls.length; i++) {
+          if (i < baseTabs.length) {
+            // navigate the existing one
+            await ctx.switchTab(baseTabs[i].tabId);
+            await ctx.navigate(urls[i]);
+            opened.push(baseTabs[i].tabId);
+          } else {
+            const t = await ctx.newTab(urls[i]);
+            opened.push(t.tabId);
+          }
+        }
+        const [aId, bId, cId, dId] = opened;
+        // Concurrent close.
+        await Promise.all([ctx.closeTab(aId), ctx.closeTab(bId)]);
+        // Surviving tabs C and D should still resolve to their original urls.
+        await ctx.switchTab(cId);
+        expect(await ctx.currentUrl()).toBe(urls[2]);
+        await ctx.switchTab(dId);
+        expect(await ctx.currentUrl()).toBe(urls[3]);
+      };
+      if (expectFail("tabs.concurrentCloseStable")) {
+        itExpectFail(title, body, opts.timeout);
+      } else {
+        it(title, body, opts.timeout);
+      }
+    } else {
+      // Single-view backends: closeTab(only tabId) must either disconnect
+      // OR leave a single tab — accept either result, just don't crash.
+      it(
+        "single-view: closeTab on the sole tab disconnects or no-ops",
+        async () => {
+          if (!ctx) throw new Error("context not created");
+          const [t] = await ctx.tabs();
+          try {
+            await ctx.closeTab(t.tabId);
+          } catch {
+            /* some single-view backends may throw — that is acceptable */
+          }
+          // Either disconnected or still has at most one tab.
+          if (ctx.isConnected()) {
+            const after = await ctx.tabs();
+            expect(after.length).toBeLessThanOrEqual(1);
+          }
+        },
+        opts.timeout
+      );
+    }
+  });
+}

--- a/packages/test/src/contract/browser-context/fixtures.ts
+++ b/packages/test/src/contract/browser-context/fixtures.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BrowserContextFixture } from "./types";
+
+const ARIA_EDGE_CASE_NAMES: ReadonlyArray<string> = [
+  "Sign in", // baseline ASCII
+  "foo:bar", // colon mid-name
+  "11:30", // ends in colon-digits (lastIndexOf parser)
+  "a", // single character
+  "héllo→", // unicode + arrow
+  "x".repeat(200), // long
+];
+
+const NETWORK_MARKER = "fixture-network-marker";
+const CONSOLE_MARKER = "fixture-console-marker";
+
+function escapeForHtmlAttr(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildPageHtml(): string {
+  const buttons = ARIA_EDGE_CASE_NAMES.map(
+    (name, idx) =>
+      `<button type="button" aria-label="${escapeForHtmlAttr(name)}" ` +
+      `onclick="document.getElementById('sentinel').setAttribute('data-clicked', '${idx}')">` +
+      escapeForHtmlAttr(name) +
+      `</button>`
+  ).join("");
+  const head = "<head><title>IBrowserContext Conformance</title></head>";
+  const body =
+    `<body>` +
+    `<div id="sentinel" data-clicked=""></div>` +
+    buttons +
+    `<script>` +
+    `console.log(${JSON.stringify(CONSOLE_MARKER)});` +
+    // Use a benign network target — data: URL keeps the page self-contained.
+    `fetch("data:text/plain,${NETWORK_MARKER}").catch(function(){});` +
+    `</script>` +
+    `</body>`;
+  return `<!DOCTYPE html><html>${head}${body}</html>`;
+}
+
+const PAGE_URL = `data:text/html,${encodeURIComponent(buildPageHtml())}`;
+
+export const DEFAULT_FIXTURE: BrowserContextFixture = {
+  pageUrl: PAGE_URL,
+  networkMarkerUrl: NETWORK_MARKER,
+  consoleMarker: CONSOLE_MARKER,
+  ariaEdgeCaseNames: ARIA_EDGE_CASE_NAMES,
+};
+
+export function resolveFixture(
+  override: Partial<BrowserContextFixture> | undefined
+): BrowserContextFixture {
+  if (!override) return DEFAULT_FIXTURE;
+  return { ...DEFAULT_FIXTURE, ...override };
+}

--- a/packages/test/src/contract/browser-context/fixtures.ts
+++ b/packages/test/src/contract/browser-context/fixtures.ts
@@ -6,6 +6,9 @@
 
 import type { BrowserContextFixture } from "./types";
 
+// Empty-name buttons are excluded — clickByRole(role, name) requires a
+// non-empty accessible name on every adapter, and an empty aria-label is
+// invalid per ARIA spec. Use "a" (single char) as the lower-bound stress.
 const ARIA_EDGE_CASE_NAMES: ReadonlyArray<string> = [
   "Sign in", // baseline ASCII
   "foo:bar", // colon mid-name

--- a/packages/test/src/contract/browser-context/fixtures.ts
+++ b/packages/test/src/contract/browser-context/fixtures.ts
@@ -7,8 +7,8 @@
 import type { BrowserContextFixture } from "./types";
 
 // Empty-name buttons are excluded — clickByRole(role, name) requires a
-// non-empty accessible name on every adapter, and an empty aria-label is
-// invalid per ARIA spec. Use "a" (single char) as the lower-bound stress.
+// non-empty accessible name on every adapter, and adapters treat an empty
+// accessible name as absent. Use "a" (single char) as the lower-bound stress.
 const ARIA_EDGE_CASE_NAMES: ReadonlyArray<string> = [
   "Sign in", // baseline ASCII
   "foo:bar", // colon mid-name

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -7,6 +7,7 @@
 import { describe } from "vitest";
 
 import { capabilityHonestyBlock } from "./assertions/capabilityHonesty";
+import { tabsLifecycleBlock } from "./assertions/tabsLifecycle";
 import { resolveFixture } from "./fixtures";
 import type { IBrowserContextConformanceOpts } from "./types";
 
@@ -15,7 +16,8 @@ export function runIBrowserContextConformance(opts: IBrowserContextConformanceOp
     const fixture = resolveFixture(opts.fixture);
 
     capabilityHonestyBlock(opts, fixture);
-    // tabsLifecycleBlock, ariaRoundTripBlock, networkIntrospectionBlock
+    tabsLifecycleBlock(opts, fixture);
+    // ariaRoundTripBlock, networkIntrospectionBlock
     // are wired in subsequent tasks.
   });
 }

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -17,6 +17,10 @@ export function runIBrowserContextConformance(opts: IBrowserContextConformanceOp
   describe.skipIf(opts.skip)(`IBrowserContext conformance: ${opts.name}`, () => {
     const fixture = resolveFixture(opts.fixture);
 
+    // Each block creates its own context via opts.factory() in beforeAll —
+    // a fresh handle per block so block N's tab churn / navigation can't
+    // taint block N+1. This is intentional even though it means real-browser
+    // shims pay one launch cost per block.
     capabilityHonestyBlock(opts, fixture);
     tabsLifecycleBlock(opts, fixture);
     ariaRoundTripBlock(opts, fixture);

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -6,6 +6,7 @@
 
 import { describe } from "vitest";
 
+import { capabilityHonestyBlock } from "./assertions/capabilityHonesty";
 import { resolveFixture } from "./fixtures";
 import type { IBrowserContextConformanceOpts } from "./types";
 
@@ -13,9 +14,8 @@ export function runIBrowserContextConformance(opts: IBrowserContextConformanceOp
   describe.skipIf(opts.skip)(`IBrowserContext conformance: ${opts.name}`, () => {
     const fixture = resolveFixture(opts.fixture);
 
-    // Phase 2 wires assertion blocks here. Each block creates its own
-    // context via opts.factory() in beforeAll and disposes it in afterAll
-    // so block N cannot taint block N+1.
-    void fixture;
+    capabilityHonestyBlock(opts, fixture);
+    // tabsLifecycleBlock, ariaRoundTripBlock, networkIntrospectionBlock
+    // are wired in subsequent tasks.
   });
 }

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe } from "vitest";
+
+import { resolveFixture } from "./fixtures";
+import type { IBrowserContextConformanceOpts } from "./types";
+
+export function runIBrowserContextConformance(opts: IBrowserContextConformanceOpts): void {
+  describe.skipIf(opts.skip)(`IBrowserContext conformance: ${opts.name}`, () => {
+    const fixture = resolveFixture(opts.fixture);
+
+    // Phase 2 wires assertion blocks here. Each block creates its own
+    // context via opts.factory() in beforeAll and disposes it in afterAll
+    // so block N cannot taint block N+1.
+    void fixture;
+  });
+}

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -8,6 +8,7 @@ import { describe } from "vitest";
 
 import { ariaRoundTripBlock } from "./assertions/ariaRoundTrip";
 import { capabilityHonestyBlock } from "./assertions/capabilityHonesty";
+import { networkIntrospectionBlock } from "./assertions/networkIntrospection";
 import { tabsLifecycleBlock } from "./assertions/tabsLifecycle";
 import { resolveFixture } from "./fixtures";
 import type { IBrowserContextConformanceOpts } from "./types";
@@ -19,6 +20,6 @@ export function runIBrowserContextConformance(opts: IBrowserContextConformanceOp
     capabilityHonestyBlock(opts, fixture);
     tabsLifecycleBlock(opts, fixture);
     ariaRoundTripBlock(opts, fixture);
-    // networkIntrospectionBlock is wired in a subsequent task.
+    networkIntrospectionBlock(opts, fixture);
   });
 }

--- a/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
+++ b/packages/test/src/contract/browser-context/runIBrowserContextConformance.ts
@@ -6,6 +6,7 @@
 
 import { describe } from "vitest";
 
+import { ariaRoundTripBlock } from "./assertions/ariaRoundTrip";
 import { capabilityHonestyBlock } from "./assertions/capabilityHonesty";
 import { tabsLifecycleBlock } from "./assertions/tabsLifecycle";
 import { resolveFixture } from "./fixtures";
@@ -17,7 +18,7 @@ export function runIBrowserContextConformance(opts: IBrowserContextConformanceOp
 
     capabilityHonestyBlock(opts, fixture);
     tabsLifecycleBlock(opts, fixture);
-    // ariaRoundTripBlock, networkIntrospectionBlock
-    // are wired in subsequent tasks.
+    ariaRoundTripBlock(opts, fixture);
+    // networkIntrospectionBlock is wired in a subsequent task.
   });
 }

--- a/packages/test/src/contract/browser-context/types.ts
+++ b/packages/test/src/contract/browser-context/types.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IBrowserContext } from "@workglow/browser-control/task";
+
+export interface IBrowserContextConformanceOpts {
+  readonly name: string;
+  readonly skip?: boolean;
+  readonly timeout: number;
+  readonly factory: () => Promise<BrowserContextHandle>;
+  readonly capabilities: BrowserContextCapabilities;
+  readonly fixture?: Partial<BrowserContextFixture>;
+  /**
+   * Names of conformance assertions currently broken in this adapter; each
+   * named assertion is wrapped in `it.fails` instead of `it`. Remove the
+   * entry once the adapter bug is fixed.
+   *
+   * Known names:
+   *   "tabs.concurrentCloseStable"
+   *   "aria.colonInName"
+   *   "capability.networkRequests.undefinedWhenFalse"
+   *   "capability.consoleMessages.undefinedWhenFalse"
+   */
+  readonly expectedFailures?: ReadonlyArray<string>;
+}
+
+export interface BrowserContextHandle {
+  /** Construct and connect a fresh context. Called per top-level block. */
+  readonly create: () => Promise<IBrowserContext>;
+  /** Disconnect and release resources for a context returned by create(). */
+  readonly dispose: (ctx: IBrowserContext) => Promise<void>;
+}
+
+export interface BrowserContextCapabilities {
+  /** false for single-view backends (e.g. BunWebView). */
+  readonly multipleTabs: boolean;
+  /** Optional method honesty + positive test. */
+  readonly networkRequests: boolean;
+  /** Optional method honesty + positive test. */
+  readonly consoleMessages: boolean;
+  /** Every backend should be true; flag exists for hygiene/symmetry. */
+  readonly ariaSnapshot: boolean;
+}
+
+export interface BrowserContextFixture {
+  readonly pageUrl: string;
+  readonly networkMarkerUrl: string;
+  readonly consoleMarker: string;
+  readonly ariaEdgeCaseNames: ReadonlyArray<string>;
+}

--- a/packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isChromeAvailable } from "./chromeAvailability";
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+const bunWebViewAvailable =
+  Boolean((globalThis as { Bun?: { WebView?: unknown } }).Bun?.WebView) && isChromeAvailable();
+
+runIBrowserContextConformance({
+  name: "BunWebView",
+  skip: !bunWebViewAvailable,
+  timeout: 60_000,
+  factory: async () => {
+    const { BunWebViewBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new BunWebViewBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: false, // single-view model
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+  expectedFailures: [
+    // BunWebViewBackend.ts:403-409 — empty-array stubs.
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});

--- a/packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/BunWebView_Generic.integration.test.ts
@@ -33,9 +33,5 @@ runIBrowserContextConformance({
     consoleMessages: false,
     ariaSnapshot: true,
   },
-  expectedFailures: [
-    // BunWebViewBackend.ts:403-409 — empty-array stubs.
-    "capability.networkRequests.undefinedWhenFalse",
-    "capability.consoleMessages.undefinedWhenFalse",
-  ],
+  expectedFailures: [],
 });

--- a/packages/test/src/test/browser/Electron_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Electron_Generic.integration.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+const RUN_ELECTRON = !!process.env.RUN_ELECTRON_TESTS;
+
+runIBrowserContextConformance({
+  name: "Electron",
+  skip: !RUN_ELECTRON,
+  timeout: 60_000,
+  factory: async () => {
+    const { ElectronBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new ElectronBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+  // ElectronBackend.ts:440-446 declares empty-array stubs for both
+  // networkRequests and consoleMessages (inherited behaviour from the
+  // single-window model). The contract requires these to be strictly
+  // undefined when the capability is false, so these assertions are
+  // expected to fail until the stubs are removed or the capabilities
+  // flags are flipped to true.
+  expectedFailures: [
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});

--- a/packages/test/src/test/browser/Electron_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Electron_Generic.integration.test.ts
@@ -31,14 +31,5 @@ runIBrowserContextConformance({
     consoleMessages: false,
     ariaSnapshot: true,
   },
-  // ElectronBackend.ts:440-446 declares empty-array stubs for both
-  // networkRequests and consoleMessages (inherited behaviour from the
-  // single-window model). The contract requires these to be strictly
-  // undefined when the capability is false, so these assertions are
-  // expected to fail until the stubs are removed or the capabilities
-  // flags are flipped to true.
-  expectedFailures: [
-    "capability.networkRequests.undefinedWhenFalse",
-    "capability.consoleMessages.undefinedWhenFalse",
-  ],
+  expectedFailures: [],
 });

--- a/packages/test/src/test/browser/MockBrowser_Generic.test.ts
+++ b/packages/test/src/test/browser/MockBrowser_Generic.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConformanceMockContext } from "../../contract/browser-context/ConformanceMockContext";
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+runIBrowserContextConformance({
+  name: "Mock",
+  timeout: 5_000,
+  factory: async () => ({
+    create: async () => {
+      const ctx = new ConformanceMockContext();
+      await ctx.connect();
+      return ctx;
+    },
+    dispose: async (ctx) => ctx.disconnect(),
+  }),
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false,
+    consoleMessages: false,
+    ariaSnapshot: true,
+  },
+});

--- a/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
@@ -37,8 +37,5 @@ runIBrowserContextConformance({
     consoleMessages: false,
     ariaSnapshot: true,
   },
-  expectedFailures: [
-    // PlaywrightBackend.ts:419-426 — lastIndexOf(":") parser.
-    "aria.colonInName",
-  ],
+  expectedFailures: [],
 });

--- a/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { runIBrowserContextConformance } from "../../contract/browser-context/runIBrowserContextConformance";
+
+let playwrightAvailable = false;
+try {
+  await import("playwright");
+  playwrightAvailable = true;
+} catch {
+  // playwright not installed
+}
+
+runIBrowserContextConformance({
+  name: "Playwright",
+  skip: !playwrightAvailable,
+  timeout: 60_000,
+  factory: async () => {
+    const { PlaywrightBackend } = await import("@workglow/browser-control/task");
+    return {
+      create: async () => {
+        const ctx = new PlaywrightBackend();
+        await ctx.connect({ headless: true });
+        return ctx;
+      },
+      dispose: async (ctx) => {
+        await ctx.disconnect();
+      },
+    };
+  },
+  capabilities: {
+    multipleTabs: true,
+    networkRequests: false, // currently a no-op stub returning []; flips after Phase 4
+    consoleMessages: false, // currently a no-op stub returning []; flips after Phase 4
+    ariaSnapshot: true,
+  },
+  expectedFailures: [
+    // PlaywrightBackend.ts:686-736 — array-index tabId race.
+    "tabs.concurrentCloseStable",
+    // PlaywrightBackend.ts:419-426 — lastIndexOf(":") parser.
+    "aria.colonInName",
+    // PlaywrightBackend.ts:768-774 — networkRequests/consoleMessages declared
+    // as concrete arrow functions returning []. The negative-direction
+    // capability honesty block requires `typeof ctx.networkRequests ===
+    // "undefined"` when capabilities.networkRequests is false.
+    "capability.networkRequests.undefinedWhenFalse",
+    "capability.consoleMessages.undefinedWhenFalse",
+  ],
+});

--- a/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
@@ -38,8 +38,6 @@ runIBrowserContextConformance({
     ariaSnapshot: true,
   },
   expectedFailures: [
-    // PlaywrightBackend.ts:686-736 — array-index tabId race.
-    "tabs.concurrentCloseStable",
     // PlaywrightBackend.ts:419-426 — lastIndexOf(":") parser.
     "aria.colonInName",
   ],

--- a/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
+++ b/packages/test/src/test/browser/Playwright_Generic.integration.test.ts
@@ -33,8 +33,8 @@ runIBrowserContextConformance({
   },
   capabilities: {
     multipleTabs: true,
-    networkRequests: false, // currently a no-op stub returning []; flips after Phase 4
-    consoleMessages: false, // currently a no-op stub returning []; flips after Phase 4
+    networkRequests: false,
+    consoleMessages: false,
     ariaSnapshot: true,
   },
   expectedFailures: [
@@ -42,11 +42,5 @@ runIBrowserContextConformance({
     "tabs.concurrentCloseStable",
     // PlaywrightBackend.ts:419-426 — lastIndexOf(":") parser.
     "aria.colonInName",
-    // PlaywrightBackend.ts:768-774 — networkRequests/consoleMessages declared
-    // as concrete arrow functions returning []. The negative-direction
-    // capability honesty block requires `typeof ctx.networkRequests ===
-    // "undefined"` when capabilities.networkRequests is false.
-    "capability.networkRequests.undefinedWhenFalse",
-    "capability.consoleMessages.undefinedWhenFalse",
   ],
 });


### PR DESCRIPTION
## Summary

Implements a parameterized contract conformance suite for `IBrowserContext` in `@workglow/test`, modeled on the existing `runAiProviderConformance` pattern. The suite runs against four adapters (Mock, Playwright, BunWebView, Electron) and validates four assertion blocks: capability honesty, tabs lifecycle, ARIA round-trip, and network introspection.

## Key Changes

- **New contract suite infrastructure** under `packages/test/src/contract/browser-context/`:
  - `runIBrowserContextConformance.ts` — parameterized entrypoint with `describe.skipIf` dispatch
  - `types.ts` — `IBrowserContextConformanceOpts`, `BrowserContextCapabilities`, `BrowserContextHandle` interfaces
  - `fixtures.ts` — self-contained `data:` URL fixture page with ARIA edge-case names (colon-in-name, unicode, long strings, etc.)
  - `ConformanceMockContext.ts` — purpose-built in-memory `IBrowserContext` reference implementation that parses the fixture page, synthesizes accessibility trees, tracks tab state, and captures network/console activity

- **Four assertion blocks** under `packages/test/src/contract/browser-context/assertions/`:
  - `capabilityHonesty.ts` — negative (method undefined when capability false) + positive (method returns data when capability true) checks
  - `tabsLifecycle.ts` — basic open/close/switch operations and concurrent-close stability
  - `ariaRoundTrip.ts` — snapshot → ref → click round-trip with ARIA edge-case name handling
  - `networkIntrospection.ts` — fixture fetch/console activity observable via optional methods
  - `itExpectFail.ts` — helper for marking known failures via `expectedFailures` array

- **Four adapter shims** under `packages/test/src/test/browser/`:
  - `MockBrowser_Generic.test.ts` — uses `ConformanceMockContext`, always runs
  - `Playwright_Generic.integration.test.ts` — live Playwright backend, gated on availability
  - `BunWebView_Generic.integration.test.ts` — live BunWebView backend, gated on availability
  - `Electron_Generic.integration.test.ts` — live Electron backend, gated on `RUN_ELECTRON_TESTS`

- **Backend fixes** (Phase 4 preparation):
  - `PlaywrightBackend.ts` — refactored descriptor handling to use structured `Descriptor` type instead of string-based locator parsing, fixing the `lastIndexOf(":")` parser bug for ARIA names ending in colon-digits
  - `BunWebViewBackend.ts` — removed unused imports (`ConsoleMessage`, `NetworkFilter`, `NetworkRequest`)
  - `ElectronBackend.ts` — removed unused imports (`ConsoleMessage`, `DialogAction`, `DialogInfo`, `DownloadOptions`, `DownloadResult`)

- **Documentation**:
  - Updated `packages/test/src/contract/README.md` with new suite row and documented `create/dispose` factory shape variant for heavyweight per-test subjects

## Implementation Details

- The fixture page is a self-contained `data:text/html,...` URL embedding buttons with ARIA labels covering edge cases (ASCII, colon mid-name, colon-suffix, unicode, long strings)
- `ConformanceMockContext` parses the fixture HTML via regex to extract button labels and synthesizes accessibility trees on demand
- Each adapter shim calls `runIBrowserContextConformance()` with a factory that creates fresh context instances per top-level block, preventing state leakage between assertion blocks
- Known bugs are tracked via `expectedFailures` array in opts; assertions in that list are wrapped with `itExpectFail` instead of `it`
- The suite is orthogonal to the existing `genericBrowserTaskTests.ts` (Tasks-layer coverage) and does not modify `MockBrowserContext.ts` (used by Tasks unit tests)

https://claude.ai/code/session_01WGz3rQagaPvfww3GbgYhB9