### PR TITLE
Add JS-layer mutex to serialize concurrent migration runs

### DIFF
--- a/packages/test/src/test/storage-migrations/PostgresMigrationRunner.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/PostgresMigrationRunner.integration.test.ts
@@ -37,11 +37,6 @@ describe("PostgresMigrationRunner", () => {
   runMigrationRunnerContract<Pool>({
     name: "Postgres",
     timeout: 30_000,
-    // PostgresMigrationRunner relies on the bookkeeping PK to resolve
-    // concurrent runs — race losers ROLLBACK and treat 23505 as success,
-    // but their up() has already executed. Mark concurrent serialization
-    // as expected failure until a JS-layer mutex is added.
-    expectedFailures: ["concurrentRunsSerialize"],
     factory: async () => {
       const pglite = new PGlite();
       const db = pglite as unknown as Pool;

--- a/packages/test/src/test/storage-migrations/SqliteMigrationRunner.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/SqliteMigrationRunner.integration.test.ts
@@ -40,11 +40,6 @@ describe("SqliteMigrationRunner", async () => {
   runMigrationRunnerContract<Sqlite.Database>({
     name: "SQLite",
     timeout: 5_000,
-    // SqliteMigrationRunner does not serialize across run() callers and
-    // does not wrap up() in a transaction (better-sqlite3's transaction()
-    // can't span async). Both contract assertions are expected failures
-    // until those limitations change.
-    expectedFailures: ["concurrentRunsSerialize", "failedMigrationLeavesNoPartialSchema"],
     factory: async () => {
       const db = new Sqlite.Database(":memory:");
       return {

--- a/providers/postgres/src/migrations/PostgresMigrationRunner.ts
+++ b/providers/postgres/src/migrations/PostgresMigrationRunner.ts
@@ -37,12 +37,15 @@ type ConnectablePool = Pool & {
 };
 
 /**
- * Process-wide serialization of `run()` calls per backing database. Keyed
- * by the `Pool` object so independent databases don't contend, and weak so
- * disposing the pool releases the lock entry. Required because the
- * bookkeeping PK alone resolves races only after `up()` has already
- * executed — without this mutex, three racing runners would each run
- * `up()` and only one would win the INSERT.
+ * In-process serialization of `run()` calls per `Pool` wrapper. Keyed by
+ * the wrapper object (not the underlying database), so two separate pools
+ * pointing at the same database — or runners in different processes — do
+ * not contend through this map. Cross-instance races are handled by the
+ * bookkeeping PK check below (a 23505 from a concurrent INSERT is caught
+ * and treated as "already applied"). Without this in-process mutex,
+ * multiple runners sharing one pool would each invoke `up()` before the
+ * 23505 was raised. The map is a WeakMap so disposing the pool releases
+ * the entry.
  */
 const runLocks = new WeakMap<object, Promise<unknown>>();
 

--- a/providers/postgres/src/migrations/PostgresMigrationRunner.ts
+++ b/providers/postgres/src/migrations/PostgresMigrationRunner.ts
@@ -37,6 +37,16 @@ type ConnectablePool = Pool & {
 };
 
 /**
+ * Process-wide serialization of `run()` calls per backing database. Keyed
+ * by the `Pool` object so independent databases don't contend, and weak so
+ * disposing the pool releases the lock entry. Required because the
+ * bookkeeping PK alone resolves races only after `up()` has already
+ * executed — without this mutex, three racing runners would each run
+ * `up()` and only one would win the INSERT.
+ */
+const runLocks = new WeakMap<object, Promise<unknown>>();
+
+/**
  * Runs versioned migrations against a PostgreSQL pool.
  *
  * Each migration runs inside a single connection's transaction so the
@@ -47,9 +57,12 @@ type ConnectablePool = Pool & {
  * `connect()` (it is single-client by construction), so we fall back to
  * the raw pool — BEGIN/COMMIT on it still hit the same backing connection.
  *
- * A unique constraint on `(component, version)` makes concurrent runners
- * safe: the loser of a race raises a duplicate-key error (`23505`) and we
- * treat that as "already applied".
+ * Concurrent `run()` calls against the same pool are serialized through a
+ * JS-layer mutex so racing runners see each others' bookkeeping rows before
+ * deciding to invoke `up()`. The unique constraint on `(component, version)`
+ * remains a defense-in-depth check — a 23505 from a separate process (or a
+ * different pool instance backed by the same database) is still treated as
+ * "already applied".
  */
 export class PostgresMigrationRunner implements IMigrationRunner<Pool> {
   constructor(private readonly db: Pool) {}
@@ -91,6 +104,20 @@ export class PostgresMigrationRunner implements IMigrationRunner<Pool> {
   async run(
     migrations: ReadonlyArray<IMigration<Pool>>,
     options: RunMigrationsOptions = {}
+  ): Promise<ReadonlyArray<IMigration<Pool>>> {
+    const key = this.db as unknown as object;
+    const prev = runLocks.get(key) ?? Promise.resolve();
+    const result = prev.then(() => this.runInternal(migrations, options));
+    runLocks.set(
+      key,
+      result.catch(() => undefined)
+    );
+    return result;
+  }
+
+  private async runInternal(
+    migrations: ReadonlyArray<IMigration<Pool>>,
+    options: RunMigrationsOptions
   ): Promise<ReadonlyArray<IMigration<Pool>>> {
     await this.ensureBookkeepingTable();
     const sorted = sortMigrations(migrations);

--- a/providers/sqlite/src/migrations/SqliteMigrationRunner.ts
+++ b/providers/sqlite/src/migrations/SqliteMigrationRunner.ts
@@ -14,13 +14,28 @@ import {
 } from "@workglow/storage";
 
 /**
+ * Process-wide serialization of `run()` calls per backing database. Keyed
+ * by the `Sqlite.Database` object so independent databases don't contend,
+ * and weak so closing the database releases the entry. Required so racing
+ * runners against the same database execute each migration's `up()`
+ * exactly once.
+ */
+const runLocks = new WeakMap<object, Promise<unknown>>();
+
+/**
  * Runs versioned migrations against a SQLite database.
  *
- * SQLite migrations are NOT wrapped in a runner-managed transaction because
- * `up()` may be async (better-sqlite3's `transaction()` cannot span async
- * boundaries). Migrations should therefore be written to be idempotent — for
- * example, `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`. After
- * `up()` resolves successfully, a separate INSERT records the applied version.
+ * Each migration is wrapped in an explicit `BEGIN`/`COMMIT`/`ROLLBACK` so the
+ * bookkeeping INSERT and the migration's DDL commit together — and a failure
+ * in `up()` rolls back any partial schema it created. We do not use
+ * better-sqlite3's `transaction()` helper because it cannot span the `await`
+ * boundary that `up()` may introduce; manual BEGIN/COMMIT works because the
+ * surrounding `runLocks` mutex prevents any other migration call from
+ * touching the connection mid-transaction.
+ *
+ * Concurrent `run()` calls against the same database are serialized through
+ * a JS-layer mutex so racing runners see each others' bookkeeping rows
+ * before deciding to invoke `up()`.
  */
 export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> {
   constructor(private readonly db: Sqlite.Database) {}
@@ -49,6 +64,20 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
     migrations: ReadonlyArray<IMigration<Sqlite.Database>>,
     options: RunMigrationsOptions = {}
   ): Promise<ReadonlyArray<IMigration<Sqlite.Database>>> {
+    const key = this.db as unknown as object;
+    const prev = runLocks.get(key) ?? Promise.resolve();
+    const result = prev.then(() => this.runInternal(migrations, options));
+    runLocks.set(
+      key,
+      result.catch(() => undefined)
+    );
+    return result;
+  }
+
+  private async runInternal(
+    migrations: ReadonlyArray<IMigration<Sqlite.Database>>,
+    options: RunMigrationsOptions
+  ): Promise<ReadonlyArray<IMigration<Sqlite.Database>>> {
     await this.ensureBookkeepingTable();
     const sorted = sortMigrations(migrations);
     const applied: IMigration<Sqlite.Database>[] = [];
@@ -74,6 +103,7 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
         phase: "starting",
         description: m.description,
       });
+      this.db.exec("BEGIN");
       try {
         const result = m.up(this.db, (fraction) => {
           onProgress?.({
@@ -86,6 +116,7 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
         });
         if (result instanceof Promise) await result;
         insert.run(m.component, m.version, m.description ?? null);
+        this.db.exec("COMMIT");
         seen.add(m.version);
         applied.push(m);
         onProgress?.({
@@ -96,6 +127,11 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
           fraction: 1,
         });
       } catch (err) {
+        try {
+          this.db.exec("ROLLBACK");
+        } catch {
+          // Best-effort: the transaction may already be aborted.
+        }
         onProgress?.({
           component: m.component,
           version: m.version,

--- a/providers/sqlite/src/migrations/SqliteMigrationRunner.ts
+++ b/providers/sqlite/src/migrations/SqliteMigrationRunner.ts
@@ -14,13 +14,21 @@ import {
 } from "@workglow/storage";
 
 /**
- * Process-wide serialization of `run()` calls per backing database. Keyed
- * by the `Sqlite.Database` object so independent databases don't contend,
- * and weak so closing the database releases the entry. Required so racing
- * runners against the same database execute each migration's `up()`
- * exactly once.
+ * In-process serialization of `run()` calls per `Sqlite.Database` wrapper.
+ * Keyed by the wrapper object (not the underlying DB file), so two
+ * separate `new Sqlite.Database(samePath)` instances in the same process
+ * — or runners in different processes — do not contend through this
+ * map. Cross-instance races are handled by the bookkeeping PK check in
+ * `runInternal` (duplicate-key INSERT is caught and treated as
+ * "already applied"). The map is a WeakMap so closing the wrapper
+ * releases the entry.
  */
 const runLocks = new WeakMap<object, Promise<unknown>>();
+
+const isSqliteConstraintError = (err: unknown): boolean => {
+  const code = (err as { code?: string } | null)?.code;
+  return typeof code === "string" && code.startsWith("SQLITE_CONSTRAINT");
+};
 
 /**
  * Runs versioned migrations against a SQLite database.
@@ -33,9 +41,12 @@ const runLocks = new WeakMap<object, Promise<unknown>>();
  * surrounding `runLocks` mutex prevents any other migration call from
  * touching the connection mid-transaction.
  *
- * Concurrent `run()` calls against the same database are serialized through
- * a JS-layer mutex so racing runners see each others' bookkeeping rows
- * before deciding to invoke `up()`.
+ * Concurrent `run()` calls against the same wrapper are serialized through
+ * an in-process JS mutex so racing runners see each others' bookkeeping
+ * rows before deciding to invoke `up()`. The unique constraint on
+ * `(component, version)` is retained as defense-in-depth — a constraint
+ * violation from a separate wrapper or process is treated as
+ * "already applied" (same shape as the Postgres 23505 fast-path).
  */
 export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> {
   constructor(private readonly db: Sqlite.Database) {}
@@ -103,8 +114,10 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
         phase: "starting",
         description: m.description,
       });
-      this.db.exec("BEGIN");
+      let inTransaction = false;
       try {
+        this.db.exec("BEGIN");
+        inTransaction = true;
         const result = m.up(this.db, (fraction) => {
           onProgress?.({
             component: m.component,
@@ -117,6 +130,7 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
         if (result instanceof Promise) await result;
         insert.run(m.component, m.version, m.description ?? null);
         this.db.exec("COMMIT");
+        inTransaction = false;
         seen.add(m.version);
         applied.push(m);
         onProgress?.({
@@ -127,10 +141,25 @@ export class SqliteMigrationRunner implements IMigrationRunner<Sqlite.Database> 
           fraction: 1,
         });
       } catch (err) {
-        try {
-          this.db.exec("ROLLBACK");
-        } catch {
-          // Best-effort: the transaction may already be aborted.
+        if (inTransaction) {
+          try {
+            this.db.exec("ROLLBACK");
+          } catch {
+            // Best-effort: the transaction may already be aborted.
+          }
+        }
+        // Concurrent runner from another wrapper/process already inserted
+        // the bookkeeping row — treat as success, matching Postgres 23505.
+        if (isSqliteConstraintError(err)) {
+          seen.add(m.version);
+          onProgress?.({
+            component: m.component,
+            version: m.version,
+            phase: "completed",
+            description: m.description,
+            fraction: 1,
+          });
+          continue;
         }
         onProgress?.({
           component: m.component,


### PR DESCRIPTION
## Summary
This PR adds process-wide serialization of concurrent `run()` calls in both SQLite and PostgreSQL migration runners using a WeakMap-based mutex. This ensures that racing runners see each other's bookkeeping rows before deciding to invoke migrations, preventing duplicate execution of migration `up()` functions.

## Key Changes

**SQLite Migration Runner:**
- Added `runLocks` WeakMap to serialize `run()` calls per database instance
- Extracted migration execution logic into new `runInternal()` method
- Wrapped each migration in explicit `BEGIN`/`COMMIT`/`ROLLBACK` blocks (replacing reliance on better-sqlite3's `transaction()` which cannot span async boundaries)
- Added error handling to rollback failed transactions
- Removed `expectedFailures` from test contract since concurrency is now properly handled

**PostgreSQL Migration Runner:**
- Added `runLocks` WeakMap to serialize `run()` calls per pool instance
- Extracted migration execution logic into new `runInternal()` method
- Updated documentation to clarify that the JS-layer mutex prevents duplicate `up()` execution while the unique constraint remains a defense-in-depth check
- Removed `expectedFailures` from test contract since concurrency is now properly handled

## Implementation Details

The mutex implementation uses a WeakMap keyed by the database/pool object, allowing independent databases to execute concurrently while serializing calls against the same instance. Each `run()` call chains onto the previous promise, ensuring strict ordering. Failed promises are caught and stored as resolved promises to prevent blocking subsequent migrations.

For SQLite, explicit transaction management replaces the async-incompatible `transaction()` helper, with the surrounding mutex preventing mid-transaction interference from other runners.

https://claude.ai/code/session_01Kz5s5hok49bAuCqBugziqU