### PR TITLE
fix(knowledge-base,storage,postgres): cross-KB getBulk leak + restore Postgres-native hybrid search

### DIFF
--- a/.changeset/postgres-fts-hybrid-search.md
+++ b/.changeset/postgres-fts-hybrid-search.md
@@ -25,12 +25,31 @@
   snapshot rollback otherwise.
 - `textSearch` / `hybridSearch` `await` the text index's `search`
   return value so async backends are first-class.
+- **Breaking-ish (external callers of `ScopedTabularStorage` only)**:
+  the `ScopedTabularStorage` constructor now throws when the inner
+  storage's primary key does not include `kb_id`. This formalizes a
+  contract that was always required for correct kb-scoping on SQL
+  backends, which build `get` / `getBulk` `WHERE` clauses from PK
+  columns only and would otherwise silently drop the injected `kb_id`,
+  leaking rows across knowledge bases. External consumers wrapping
+  `Shared*` schemas from `@workglow/knowledge-base` are unaffected;
+  those whose custom storages omit `kb_id` from the PK will fail loudly
+  at construction rather than silently leaking rows. When the inner
+  storage doesn't expose `primaryKeyNames`, the constructor warns
+  instead of throwing.
 
 #### postgres
 
 - New `PostgresFtsTextIndex` (`@workglow/postgres/text`) restoring
   Postgres-native hybrid search. Backed by a single side table per KB
-  indexed by a GIN `tsvector`; scoring via `ts_rank_cd` / `plainto_tsquery`.
-  Plug it into a `KnowledgeBase` to get `kb.hybridSearch()` /
-  `kb.textSearch()` without loading every chunk into memory at reindex
-  time. `setupDatabase()` is required before first use.
+  indexed by a GIN `tsvector`; scoring via `ts_rank_cd` /
+  `plainto_tsquery`. Plug it into a `KnowledgeBase` to get
+  `kb.hybridSearch()` / `kb.textSearch()` with the full-text postings
+  living server-side rather than in the JS heap. Benefits versus the
+  in-memory `BM25Index` default: a durable server-side index that
+  survives process restarts, no JS-heap BM25 state, and a transactional
+  `beginRebuild` / `commitRebuild` / `abortRebuild` rebuild path.
+  `reindexText()` itself still iterates all chunks via
+  `chunkStorage.getAll()` to repopulate the index — the savings are
+  on the steady-state JS heap, not on the rebuild pass.
+  `setupDatabase()` is required before first use.

--- a/.changeset/postgres-fts-hybrid-search.md
+++ b/.changeset/postgres-fts-hybrid-search.md
@@ -1,0 +1,36 @@
+---
+"@workglow/storage": minor
+"@workglow/knowledge-base": minor
+"@workglow/postgres": minor
+---
+
+#### storage
+
+- `ITextIndex.search` may now return `Promise<TextSearchResult[]>` in
+  addition to the previous synchronous shape. External implementers
+  should re-check their return types.
+- Index-mutation methods (`add`, `remove`, `removeByDocument`, `clear`,
+  `size`) on `ITextIndex` may now return a `Promise`. In-memory
+  implementations (`BM25Index`) continue to return synchronously.
+- New optional lifecycle hooks on `ITextIndex`: `beginRebuild`,
+  `commitRebuild`, `abortRebuild`. Backends with server-side state can
+  implement these so `KnowledgeBase.reindexText` wraps the rebuild in a
+  real database transaction; in-memory backends can omit them.
+
+#### knowledge-base
+
+- `KnowledgeBase.reindexText` uses the new `ITextIndex.beginRebuild` /
+  `commitRebuild` / `abortRebuild` hooks when the installed index
+  implements them; falls back to the existing `toJSON` / `fromJSON`
+  snapshot rollback otherwise.
+- `textSearch` / `hybridSearch` `await` the text index's `search`
+  return value so async backends are first-class.
+
+#### postgres
+
+- New `PostgresFtsTextIndex` (`@workglow/postgres/text`) restoring
+  Postgres-native hybrid search. Backed by a single side table per KB
+  indexed by a GIN `tsvector`; scoring via `ts_rank_cd` / `plainto_tsquery`.
+  Plug it into a `KnowledgeBase` to get `kb.hybridSearch()` /
+  `kb.textSearch()` without loading every chunk into memory at reindex
+  time. `setupDatabase()` is required before first use.

--- a/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+++ b/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
@@ -245,10 +245,13 @@ export class KnowledgeBase {
    * after {@link installTextIndex} on a KB that already has chunks, or after
    * a tokenizer / field-weight configuration change.
    *
-   * Atomic: snapshots the index state via `toJSON()` before mutating, and
-   * rolls back via `fromJSON()` on any failure (`getAll`, `clear`, or `add`).
-   * The previous index contents are preserved unless this method returns
-   * successfully.
+   * Atomic: indices that expose the optional `beginRebuild`/`commitRebuild`/
+   * `abortRebuild` lifecycle hooks (e.g. backends with server-side state
+   * like a Postgres FTS table) wrap the rebuild in those hooks so the
+   * commit is a database transaction. Indices that omit the hooks (e.g.
+   * the in-memory `BM25Index`) fall back to the existing `toJSON()` /
+   * `fromJSON()` snapshot rollback. Either way, the previous index
+   * contents are preserved unless this method returns successfully.
    */
   async reindexText(): Promise<void> {
     const index = this.textIndex;
@@ -259,10 +262,37 @@ export class KnowledgeBase {
       const fields = chunkTextFields(entity.metadata);
       if (fields) writes.push({ chunkId: entity.chunk_id, docId: entity.doc_id, fields });
     }
+
+    const hasTxnHooks =
+      typeof index.beginRebuild === "function" &&
+      typeof index.commitRebuild === "function" &&
+      typeof index.abortRebuild === "function";
+
+    if (hasTxnHooks) {
+      await index.beginRebuild!();
+      try {
+        await index.clear();
+        for (const w of writes) {
+          await index.add(w.chunkId, w.docId, w.fields);
+        }
+        await index.commitRebuild!();
+      } catch (err) {
+        try {
+          await index.abortRebuild!();
+        } catch {
+          // Suppress abort failures; original error is what callers care about.
+        }
+        throw err;
+      }
+      return;
+    }
+
     const snapshot = index.toJSON();
     try {
-      index.clear();
-      for (const w of writes) index.add(w.chunkId, w.docId, w.fields);
+      await index.clear();
+      for (const w of writes) {
+        await index.add(w.chunkId, w.docId, w.fields);
+      }
     } catch (err) {
       index.fromJSON(snapshot);
       throw err;
@@ -281,21 +311,28 @@ export class KnowledgeBase {
     const index = this.textIndex;
     if (!index) return;
     const fields = chunkTextFields(stored.metadata);
-    try {
-      if (fields) {
-        index.add(stored.chunk_id, stored.doc_id, fields);
-      } else {
-        // Chunk has no indexable text — drop any stale postings from a
-        // prior version that did. Required for upsert correctness when text
-        // is cleared on update.
-        index.remove(stored.chunk_id);
-      }
-    } catch (err) {
+    const warn = (err: unknown): void => {
       console.warn(
         `KnowledgeBase[${this.name}]: text index write failed for chunk ${stored.chunk_id}; ` +
           `index is now stale for this chunk. Call kb.reindexText() to recover. ` +
           `Error: ${err instanceof Error ? err.message : String(err)}`
       );
+    };
+    try {
+      const result = fields
+        ? index.add(stored.chunk_id, stored.doc_id, fields)
+        : // Chunk has no indexable text — drop any stale postings from a
+          // prior version that did. Required for upsert correctness when text
+          // is cleared on update.
+          index.remove(stored.chunk_id);
+      // Backends with server-side state return a Promise; we still want
+      // fire-and-forget semantics (a failed mirror must not fail the upsert),
+      // so attach a catch instead of awaiting.
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        (result as Promise<unknown>).catch(warn);
+      }
+    } catch (err) {
+      warn(err);
     }
   }
 
@@ -485,7 +522,9 @@ export class KnowledgeBase {
    */
   async deleteChunksForDocument(doc_id: string): Promise<void> {
     await this.chunkStorage.deleteSearch({ doc_id });
-    this.textIndex?.removeByDocument(doc_id);
+    if (this.textIndex) {
+      await this.textIndex.removeByDocument(doc_id);
+    }
   }
 
   /**
@@ -568,7 +607,9 @@ export class KnowledgeBase {
 
     const [vectorResults, textResults] = await Promise.all([
       this.similaritySearch(query, { topK: poolSize, filter }),
-      Promise.resolve(index.search(textQuery, { topK: poolSize })),
+      Promise.resolve(index.search(textQuery, { topK: poolSize })) as Promise<
+        Awaited<ReturnType<ITextIndex["search"]>>
+      >,
     ]);
 
     const vectorWeightClamped = Number.isFinite(vectorWeight)
@@ -658,7 +699,7 @@ export class KnowledgeBase {
     const { topK = 10, filter, candidatePoolMultiplier = 2 } = options;
     const safePoolMultiplier = Math.max(1, candidatePoolMultiplier);
     const poolSize = filter ? Math.max(topK, Math.ceil(topK * safePoolMultiplier)) : topK;
-    const hits = index.search(query, { topK: poolSize });
+    const hits = await index.search(query, { topK: poolSize });
     if (hits.length === 0) return [];
 
     const hydrated = await this.chunkStorage.getBulk(
@@ -814,7 +855,9 @@ export class KnowledgeBase {
    */
   async clearChunks(): Promise<void> {
     await this.chunkStorage.deleteAll();
-    this.textIndex?.clear();
+    if (this.textIndex) {
+      await this.textIndex.clear();
+    }
   }
 
   /**

--- a/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
+++ b/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
@@ -143,13 +143,21 @@ export class ScopedTabularStorage<
     return this.stripArray(results);
   }
 
+  /**
+   * We deliberately do not delegate to `inner.getBulk` because SQL backends
+   * build their IN-tuple WHERE from PK columns only, dropping our injected
+   * `kb_id`. Fanning out per-key `get()` calls keeps the predicate complete
+   * on every backend; correctness over throughput.
+   */
   async getBulk(keys: readonly PrimaryKey[]): Promise<Entity[]> {
     if (keys.length === 0) return [];
-    const scopedKeys = keys.map((k) => this.inject(k));
-    const results = await this.inner.getBulk(scopedKeys);
-    const stripped = results.map((r: any) => this.strip(r)) as Entity[];
-    this.events.emit("getBulk", keys, stripped);
-    return stripped;
+    const results: Entity[] = [];
+    for (const key of keys) {
+      const row = await this.inner.get({ ...(key as any), kb_id: this.kbId } as any);
+      if (row) results.push(this.strip(row));
+    }
+    this.events.emit("getBulk", keys, results);
+    return results;
   }
 
   async getPage(request?: PageRequest<Entity>): Promise<Page<Entity>> {

--- a/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
+++ b/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
@@ -45,6 +45,39 @@ export class ScopedTabularStorage<
   constructor(inner: AnyTabularStorage, kbId: string) {
     this.inner = inner;
     this.kbId = kbId;
+    // Verify the inner storage's primary key includes `kb_id`. Scoping
+    // correctness depends on it: SQL backends build their `get` / `getBulk`
+    // WHERE clauses from PK columns only (via `getPrimaryKeyAsOrderedArray`),
+    // so a PK that omits `kb_id` would silently drop our injection and
+    // return rows from any scope. The shared-table schemas in
+    // SharedTableSchemas.ts (`SharedDocumentPrimaryKey`,
+    // `SharedChunkPrimaryKey`) both include `kb_id`; external callers that
+    // wrap their own storage MUST do the same.
+    //
+    // Implementations that extend `BaseTabularStorage` (every concrete
+    // backend in this monorepo) expose `primaryKeyNames` as a runtime
+    // field. We read it via a structural cast to fail loudly at
+    // construction rather than leaking rows on a future `get` / `getBulk`.
+    // Storages that don't expose `primaryKeyNames` (third-party impls)
+    // get a `console.warn` instead of a throw, so legitimate custom
+    // backends keep working.
+    const innerPkNames = (inner as { primaryKeyNames?: ReadonlyArray<unknown> }).primaryKeyNames;
+    if (Array.isArray(innerPkNames)) {
+      if (!innerPkNames.includes("kb_id")) {
+        throw new Error(
+          `ScopedTabularStorage requires the inner storage's primary key to include "kb_id". ` +
+            `Got primaryKeyNames=[${innerPkNames.map(String).join(", ")}]. ` +
+            `Use a shared-table primary key (SharedDocumentPrimaryKey / SharedChunkPrimaryKey ` +
+            `from @workglow/knowledge-base), or a custom PK array that includes "kb_id".`
+        );
+      }
+    } else {
+      console.warn(
+        "ScopedTabularStorage: inner.primaryKeyNames is not exposed; cannot verify kb_id is in PK. " +
+          "Scoping correctness requires `kb_id` to be part of the inner storage's primary key — " +
+          "SQL backends drop fields not in PK from `get`/`getBulk` WHERE clauses."
+      );
+    }
   }
 
   private inject(value: any): any {
@@ -144,20 +177,21 @@ export class ScopedTabularStorage<
   }
 
   /**
-   * We deliberately do not delegate to `inner.getBulk` because SQL backends
-   * build their IN-tuple WHERE from PK columns only, dropping our injected
-   * `kb_id`. Fanning out per-key `get()` calls keeps the predicate complete
-   * on every backend; correctness over throughput.
+   * Plural-get scoped to this kb_id.
+   *
+   * Delegates to `inner.getBulk` with each key augmented by `kb_id`. SQL
+   * backends build their `WHERE (pk1, pk2, ...) IN ((?, ?, ...), ...)` tuple
+   * from PK columns; because the constructor enforces that `kb_id` is part
+   * of the inner PK, the IN-tuple WHERE automatically scopes by kb_id with
+   * one round trip per call.
    */
   async getBulk(keys: readonly PrimaryKey[]): Promise<Entity[]> {
     if (keys.length === 0) return [];
-    const results: Entity[] = [];
-    for (const key of keys) {
-      const row = await this.inner.get({ ...(key as any), kb_id: this.kbId } as any);
-      if (row) results.push(this.strip(row));
-    }
-    this.events.emit("getBulk", keys, results);
-    return results;
+    const scopedKeys = keys.map((k) => this.inject(k));
+    const rows = await this.inner.getBulk(scopedKeys as readonly PrimaryKey[]);
+    const entities = (rows as any[]).map((r) => this.strip(r)) as Entity[];
+    this.events.emit("getBulk", keys, entities);
+    return entities;
   }
 
   async getPage(request?: PageRequest<Entity>): Promise<Page<Entity>> {

--- a/packages/storage/src/text/ITextIndex.ts
+++ b/packages/storage/src/text/ITextIndex.ts
@@ -42,32 +42,38 @@ export interface ITextIndex {
    * removed first. `docId` is captured so {@link removeByDocument} can cascade
    * deletions.
    */
-  add(chunkId: string, docId: string, fields: TextFields): void;
+  add(chunkId: string, docId: string, fields: TextFields): void | Promise<void>;
 
   /**
    * Remove all postings for a single chunk. No-op if the chunk is not
    * indexed.
    */
-  remove(chunkId: string): void;
+  remove(chunkId: string): void | Promise<void>;
 
   /**
    * Remove all chunks belonging to a document. Used by
    * `KnowledgeBase.deleteDocument`.
    */
-  removeByDocument(docId: string): void;
+  removeByDocument(docId: string): void | Promise<void>;
 
   /** Drop all postings and reset all statistics. */
-  clear(): void;
+  clear(): void | Promise<void>;
 
   /** Number of chunks currently indexed. */
-  size(): number;
+  size(): number | Promise<number>;
 
   /**
    * Score the corpus against `query` and return the top-K chunks. The score
    * is BM25(F)-style — unbounded above, always non-negative — and is
    * suitable for rank-based fusion (e.g. RRF) without normalisation.
+   *
+   * May return a `Promise` for backends with server-side state (e.g. a
+   * Postgres FTS index talking to a database over the network).
    */
-  search(query: string, options?: TextSearchOptions): TextSearchResult[];
+  search(
+    query: string,
+    options?: TextSearchOptions
+  ): TextSearchResult[] | Promise<TextSearchResult[]>;
 
   /**
    * Serialise the index to a JSON-safe value. Round-trips with
@@ -78,4 +84,28 @@ export interface ITextIndex {
 
   /** Replace the index's state with a value previously produced by {@link toJSON}. */
   fromJSON(state: unknown): void;
+
+  /**
+   * Optional reindex lifecycle hooks. Backends with server-side state
+   * (e.g. a Postgres-side `tsvector` table) implement these so
+   * `KnowledgeBase.reindexText` can wrap the rebuild in a database
+   * transaction and roll back atomically on error — there is no in-memory
+   * snapshot to fall back to for such backends, so the
+   * {@link toJSON}/{@link fromJSON} rollback path is not enough.
+   *
+   * In-memory backends (e.g. {@link BM25Index}) can omit these; the
+   * reindex flow falls back to the JSON snapshot path when the hooks are
+   * absent.
+   *
+   * Contract:
+   *  - `beginRebuild` opens a rebuild scope. Subsequent {@link clear} /
+   *    {@link add} calls must be visible only inside the scope until
+   *    {@link commitRebuild}.
+   *  - `commitRebuild` finalises the rebuild atomically.
+   *  - `abortRebuild` discards in-flight rebuild state and restores the
+   *    pre-`beginRebuild` index contents.
+   */
+  beginRebuild?(): Promise<void> | void;
+  commitRebuild?(): Promise<void> | void;
+  abortRebuild?(): Promise<void> | void;
 }

--- a/packages/test/src/test/rag/KnowledgeBaseHybridSearch.postgres.integration.test.ts
+++ b/packages/test/src/test/rag/KnowledgeBaseHybridSearch.postgres.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { PostgresFtsTextIndex } from "@workglow/postgres/text";
+import { uuid4 } from "@workglow/util";
+import type { Pool } from "pg";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+const dimensions = 3;
+
+const vec = (a: number, b: number, c: number) => new Float32Array([a, b, c]);
+
+const makeChunk = (
+  chunk_id: string,
+  doc_id: string,
+  text: string,
+  vector: Float32Array,
+  extras: Partial<Record<string, unknown>> = {}
+) => ({
+  chunk_id,
+  doc_id,
+  vector,
+  metadata: { chunkId: chunk_id, doc_id, text, nodePath: [chunk_id], depth: 0, ...extras },
+});
+
+const db = new PGlite() as unknown as Pool;
+
+describe("KnowledgeBase hybrid search backed by PostgresFtsTextIndex", () => {
+  let kbName: string;
+  let textIndex: PostgresFtsTextIndex;
+
+  beforeEach(async () => {
+    kbName = `hybrid-pg-${uuid4()}`;
+    const table = `fts_kb_${uuid4().replace(/-/g, "_")}`;
+    textIndex = new PostgresFtsTextIndex(db, table);
+    await textIndex.setupDatabase();
+  });
+
+  afterAll(async () => {
+    await (db as unknown as PGlite).close();
+  });
+
+  it("auto-indexes text fields on upsertChunk and exposes them via textSearch", async () => {
+    const kb = await createKnowledgeBase({
+      name: kbName,
+      vectorDimensions: dimensions,
+      textIndex,
+      register: false,
+    });
+
+    await kb.upsertChunk(makeChunk("c1", "d1", "the rabbit jumps over the fence", vec(1, 0, 0)));
+    await kb.upsertChunk(makeChunk("c2", "d2", "the fox eats grapes", vec(0, 1, 0)));
+
+    expect(kb.supportsHybridSearch()).toBe(true);
+    expect(await textIndex.size()).toBe(2);
+
+    const results = await kb.textSearch("rabbit");
+    expect(results.map((r) => r.chunk_id)).toEqual(["c1"]);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+
+  it("RRF promotes a chunk that ranks high in Postgres FTS over a mid-pack vector hit", async () => {
+    const kb = await createKnowledgeBase({
+      name: kbName,
+      vectorDimensions: dimensions,
+      textIndex,
+      register: false,
+    });
+
+    await kb.upsertChunksBulk([
+      makeChunk("c1", "d1", "unrelated content about gardens", vec(1.0, 0.0, 0.0)),
+      makeChunk("c2", "d2", "rabbit and fence and rabbit", vec(0.5, 0.5, 0.0), {
+        doc_title: "Rabbits",
+      }),
+      makeChunk("c3", "d3", "completely different topic", vec(0.0, 1.0, 0.0)),
+    ]);
+
+    // Pure vector search: c1 wins.
+    const vectorOnly = await kb.similaritySearch(vec(1, 0, 0), { topK: 3 });
+    expect(vectorOnly[0].chunk_id).toBe("c1");
+
+    // RRF is rank-based — we assert the order of chunk_ids, not exact scores
+    // (Postgres ts_rank_cd values are not portable across configurations).
+    const fused = await kb.hybridSearch(vec(1, 0, 0), {
+      textQuery: "rabbit",
+      topK: 3,
+      vectorWeight: 0.3,
+    });
+    expect(fused[0].chunk_id).toBe("c2");
+  });
+
+  it("deleteDocument cascades to the Postgres FTS index", async () => {
+    const kb = await createKnowledgeBase({
+      name: kbName,
+      vectorDimensions: dimensions,
+      textIndex,
+      register: false,
+    });
+
+    await kb.upsertChunk(makeChunk("c1", "d1", "rabbit", vec(1, 0, 0)));
+    await kb.upsertChunk(makeChunk("c2", "d2", "fox", vec(0, 1, 0)));
+    expect(await textIndex.size()).toBe(2);
+
+    await kb.deleteDocument("d1");
+    expect(await textIndex.size()).toBe(1);
+    expect(await kb.textSearch("rabbit")).toEqual([]);
+    const foxHits = await kb.textSearch("fox");
+    expect(foxHits.map((r) => r.chunk_id)).toEqual(["c2"]);
+  });
+
+  it("clearChunks empties the Postgres FTS index", async () => {
+    const kb = await createKnowledgeBase({
+      name: kbName,
+      vectorDimensions: dimensions,
+      textIndex,
+      register: false,
+    });
+
+    await kb.upsertChunk(makeChunk("c1", "d1", "rabbit fence", vec(1, 0, 0)));
+    expect(await textIndex.size()).toBe(1);
+
+    await kb.clearChunks();
+    expect(await textIndex.size()).toBe(0);
+    expect(await kb.textSearch("rabbit")).toEqual([]);
+  });
+
+  it("reindexText rebuilds the Postgres FTS table from chunk storage", async () => {
+    const kb = await createKnowledgeBase({
+      name: kbName,
+      vectorDimensions: dimensions,
+      textIndex,
+      register: false,
+    });
+
+    await kb.upsertChunksBulk([
+      makeChunk("c1", "d1", "rabbit", vec(1, 0, 0)),
+      makeChunk("c2", "d2", "fence", vec(0, 1, 0)),
+    ]);
+    expect(await textIndex.size()).toBe(2);
+
+    // Drop the FTS state out-of-band, then ask the KB to rebuild it.
+    await textIndex.clear();
+    expect(await textIndex.size()).toBe(0);
+
+    await kb.reindexText();
+    expect(await textIndex.size()).toBe(2);
+    expect((await kb.textSearch("rabbit")).map((r) => r.chunk_id)).toEqual(["c1"]);
+  });
+});

--- a/packages/test/src/test/rag/ScopedStorage.test.ts
+++ b/packages/test/src/test/rag/ScopedStorage.test.ts
@@ -102,6 +102,45 @@ describe("ScopedTabularStorage", () => {
     });
   });
 
+  describe("constructor contract", () => {
+    test("throws when inner PK omits kb_id (single-column PK)", () => {
+      const SchemaNoKbInPk = {
+        type: "object",
+        properties: {
+          doc_id: { type: "string" },
+          kb_id: { type: "string" },
+          data: { type: "string" },
+        },
+        required: ["doc_id"],
+        additionalProperties: true,
+      } as const;
+      const inner = new InMemoryTabularStorage(SchemaNoKbInPk as any, ["doc_id"] as any, []);
+      expect(() => new ScopedTabularStorage(inner, "kb-x")).toThrow(/kb_id/);
+    });
+
+    test("accepts inner PK that includes kb_id (shared-table schemas)", () => {
+      // Implicit in beforeEach scopeA/scopeB, but assert directly.
+      expect(() => new ScopedTabularStorage(sharedStorage, "kb-x")).not.toThrow();
+    });
+
+    test("warns when inner storage does not expose primaryKeyNames", () => {
+      // Custom storage stub that doesn't extend BaseTabularStorage and
+      // therefore has no `primaryKeyNames` field. The constructor should
+      // log a warning but NOT throw.
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const customInner = {
+          // Minimal stub — we never actually call any methods in this test.
+        } as any;
+        expect(() => new ScopedTabularStorage(customInner, "kb-x")).not.toThrow();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toMatch(/primaryKeyNames is not exposed/);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
   describe("getBulk isolation", () => {
     test("getBulk returns only own scope's rows when keys collide across scopes", async () => {
       await scopeA.put({ doc_id: "x", data: "from-A" });
@@ -141,6 +180,39 @@ describe("ScopedTabularStorage", () => {
       expect(emittedKeys).toEqual([{ doc_id: "e1" }, { doc_id: "missing" }]);
       expect(emittedRows).toEqual(result);
       expect(emittedRows.every((r: any) => r.kb_id === undefined)).toBe(true);
+    });
+
+    test("delegates to inner.getBulk in one round trip (IN-tuple WHERE optimization)", async () => {
+      // Contract: ScopedTabularStorage's constructor enforces kb_id is in PK,
+      // so getBulk can safely delegate to the inner's batched IN-tuple form
+      // rather than fanning out per-key. This test asserts that delegation
+      // happens — a regression to per-key fan-out would slow shared-table
+      // production deployments noticeably.
+      await scopeA.put({ doc_id: "fast1", data: "a" });
+      await scopeA.put({ doc_id: "fast2", data: "a" });
+
+      // Note: we assert `inner.getBulk` is called exactly once with all keys.
+      // We intentionally do NOT assert `inner.get` was not called — the
+      // `BaseTabularStorage.getBulk` default implementation fans out to
+      // `this.get` internally for backends without a batched override (e.g.
+      // InMemory). The contract we lock in here is: the scoped wrapper
+      // makes ONE `inner.getBulk(scopedKeys)` call rather than N
+      // `inner.get(...)` calls of its own — which is what unlocks the
+      // IN-tuple WHERE optimization on SQL backends that DO override
+      // `getBulk`. A regression to per-key fan-out from the wrapper would
+      // show as N calls here, not 1.
+      const spy = vi.spyOn(sharedStorage, "getBulk");
+      const result = await scopeA.getBulk([{ doc_id: "fast1" }, { doc_id: "fast2" }] as any);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [calledKeys] = spy.mock.calls[0];
+      expect(calledKeys).toEqual([
+        { doc_id: "fast1", kb_id: "kb-a" },
+        { doc_id: "fast2", kb_id: "kb-a" },
+      ]);
+      expect(result).toHaveLength(2);
+      expect(result.every((r: any) => r.kb_id === undefined)).toBe(true);
+      spy.mockRestore();
     });
   });
 

--- a/packages/test/src/test/storage-tabular/ScopedTabularStoragePostgres.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/ScopedTabularStoragePostgres.integration.test.ts
@@ -64,11 +64,14 @@ describe("ScopedTabularStorage over PostgresTabularStorage", () => {
       await scopeB.put({ doc_id: COLLIDE_Z, data: "from-B" });
 
       // The SQL-backend code path: `PostgresTabularStorage.getBulk` builds an
-      // IN-tuple WHERE from the declared primary-key columns only. If
-      // ScopedTabularStorage.getBulk delegates to it, our injected `kb_id`
-      // is dropped — KB-A would see KB-B's rows for the colliding key
-      // COLLIDE_X. The fix fans out per-key `get()` calls so the WHERE keeps
-      // `kb_id`.
+      // IN-tuple WHERE from the declared primary-key columns only. If the
+      // inner PK doesn't include `kb_id`, the wrapper's injected scope key
+      // gets dropped from the predicate — KB-A would see KB-B's rows for
+      // the colliding key COLLIDE_X. The fix is enforced at the
+      // `ScopedTabularStorage` constructor: it requires `kb_id` to appear in
+      // the inner PK so the existing one-round-trip `inner.getBulk(scopedKeys)`
+      // IN-tuple WHERE naturally carries the scope. This test exercises that
+      // contract on a real SQL backend.
       const fromA = await scopeA.getBulk([
         { doc_id: COLLIDE_X },
         { doc_id: COLLIDE_Y },

--- a/packages/test/src/test/storage-tabular/ScopedTabularStoragePostgres.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/ScopedTabularStoragePostgres.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import {
+  ScopedTabularStorage,
+  SharedDocumentIndexes,
+  SharedDocumentPrimaryKey,
+  SharedDocumentStorageSchema,
+} from "@workglow/knowledge-base";
+import { PostgresTabularStorage } from "@workglow/postgres/storage";
+import { uuid4 } from "@workglow/util";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+
+const db = new PGlite() as unknown as Pool;
+
+// Postgres maps `doc_id: { type: "string", "x-auto-generated": true }` to a
+// UUID column with `DEFAULT gen_random_uuid()`. To exercise key-collision
+// behaviour across scopes deterministically, we use real UUIDs for the
+// colliding keys rather than the natural-language "x"/"y"/"z" that the
+// in-memory test uses.
+const COLLIDE_X = uuid4();
+const COLLIDE_Y = uuid4();
+const COLLIDE_Z = uuid4();
+const COLLIDE_MISSING = uuid4();
+
+describe("ScopedTabularStorage over PostgresTabularStorage", () => {
+  let sharedStorage: PostgresTabularStorage<
+    typeof SharedDocumentStorageSchema,
+    typeof SharedDocumentPrimaryKey
+  >;
+  let scopeA: ScopedTabularStorage<any, any>;
+  let scopeB: ScopedTabularStorage<any, any>;
+
+  beforeAll(async () => {
+    sharedStorage = new PostgresTabularStorage<
+      typeof SharedDocumentStorageSchema,
+      typeof SharedDocumentPrimaryKey
+    >(
+      db,
+      `scoped_test_${uuid4().replace(/-/g, "_")}`,
+      SharedDocumentStorageSchema,
+      SharedDocumentPrimaryKey,
+      SharedDocumentIndexes as any
+    );
+    await sharedStorage.setupDatabase();
+    scopeA = new ScopedTabularStorage(sharedStorage as any, "kb-a");
+    scopeB = new ScopedTabularStorage(sharedStorage as any, "kb-b");
+  });
+
+  afterAll(async () => {
+    await (db as unknown as PGlite).close();
+  });
+
+  describe("getBulk cross-KB isolation", () => {
+    test("getBulk returns only own scope's rows when keys collide across scopes", async () => {
+      await scopeA.put({ doc_id: COLLIDE_X, data: "from-A" });
+      await scopeA.put({ doc_id: COLLIDE_Y, data: "from-A" });
+      await scopeB.put({ doc_id: COLLIDE_X, data: "from-B" });
+      await scopeB.put({ doc_id: COLLIDE_Z, data: "from-B" });
+
+      // The SQL-backend code path: `PostgresTabularStorage.getBulk` builds an
+      // IN-tuple WHERE from the declared primary-key columns only. If
+      // ScopedTabularStorage.getBulk delegates to it, our injected `kb_id`
+      // is dropped — KB-A would see KB-B's rows for the colliding key
+      // COLLIDE_X. The fix fans out per-key `get()` calls so the WHERE keeps
+      // `kb_id`.
+      const fromA = await scopeA.getBulk([
+        { doc_id: COLLIDE_X },
+        { doc_id: COLLIDE_Y },
+        { doc_id: COLLIDE_Z },
+      ] as any);
+      expect(fromA).toHaveLength(2);
+      const aMap = new Map(fromA.map((r: any) => [r.doc_id, r.data]));
+      expect(aMap.get(COLLIDE_X)).toBe("from-A");
+      expect(aMap.get(COLLIDE_Y)).toBe("from-A");
+      expect(aMap.has(COLLIDE_Z)).toBe(false);
+      expect(fromA.every((r: any) => r.kb_id === undefined)).toBe(true);
+
+      const fromB = await scopeB.getBulk([
+        { doc_id: COLLIDE_X },
+        { doc_id: COLLIDE_Z },
+      ] as any);
+      expect(fromB).toHaveLength(2);
+      const bMap = new Map(fromB.map((r: any) => [r.doc_id, r.data]));
+      expect(bMap.get(COLLIDE_X)).toBe("from-B");
+      expect(bMap.get(COLLIDE_Z)).toBe("from-B");
+    });
+
+    test("getBulk emits event with unscoped (kb_id-stripped) entities", async () => {
+      const fn = vi.fn();
+      scopeA.on("getBulk", fn);
+      try {
+        const result = await scopeA.getBulk([
+          { doc_id: COLLIDE_X },
+          { doc_id: COLLIDE_MISSING },
+        ] as any);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        const [emittedKeys, emittedRows] = fn.mock.calls[0];
+        expect(emittedKeys).toEqual([
+          { doc_id: COLLIDE_X },
+          { doc_id: COLLIDE_MISSING },
+        ]);
+        expect(emittedRows).toEqual(result);
+        expect(emittedRows.every((r: any) => r.kb_id === undefined)).toBe(true);
+      } finally {
+        scopeA.off("getBulk", fn);
+      }
+    });
+  });
+});

--- a/packages/test/src/test/storage-tabular/ScopedTabularStorageSqlite.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/ScopedTabularStorageSqlite.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ScopedTabularStorage,
+  SharedDocumentIndexes,
+  SharedDocumentPrimaryKey,
+  SharedDocumentStorageSchema,
+} from "@workglow/knowledge-base";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
+import { uuid4 } from "@workglow/util";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+
+describe("ScopedTabularStorage over SqliteTabularStorage", async () => {
+  await Sqlite.init();
+
+  let sharedStorage: SqliteTabularStorage<
+    typeof SharedDocumentStorageSchema,
+    typeof SharedDocumentPrimaryKey
+  >;
+  let scopeA: ScopedTabularStorage<any, any>;
+  let scopeB: ScopedTabularStorage<any, any>;
+
+  beforeAll(async () => {
+    sharedStorage = new SqliteTabularStorage<
+      typeof SharedDocumentStorageSchema,
+      typeof SharedDocumentPrimaryKey
+    >(
+      ":memory:",
+      `scoped_test_${uuid4().replace(/-/g, "_")}`,
+      SharedDocumentStorageSchema,
+      SharedDocumentPrimaryKey,
+      SharedDocumentIndexes as any
+    );
+    await sharedStorage.setupDatabase();
+    scopeA = new ScopedTabularStorage(sharedStorage as any, "kb-a");
+    scopeB = new ScopedTabularStorage(sharedStorage as any, "kb-b");
+  });
+
+  afterAll(() => {
+    sharedStorage?.destroy?.();
+  });
+
+  describe("getBulk cross-KB isolation", () => {
+    test("getBulk returns only own scope's rows when keys collide across scopes", async () => {
+      await scopeA.put({ doc_id: "x", data: "from-A" });
+      await scopeA.put({ doc_id: "y", data: "from-A" });
+      await scopeB.put({ doc_id: "x", data: "from-B" });
+      await scopeB.put({ doc_id: "z", data: "from-B" });
+
+      // The SQL-backend code path: `SqliteTabularStorage.getBulk` builds an
+      // IN-tuple WHERE from the declared primary-key columns only. If
+      // ScopedTabularStorage.getBulk delegates to it, our injected `kb_id`
+      // is dropped — KB-A would see KB-B's rows for the colliding key "x".
+      // The fix fans out per-key `get()` calls so the WHERE keeps `kb_id`.
+      const fromA = await scopeA.getBulk([
+        { doc_id: "x" },
+        { doc_id: "y" },
+        { doc_id: "z" },
+      ] as any);
+      expect(fromA).toHaveLength(2);
+      const aMap = new Map(fromA.map((r: any) => [r.doc_id, r.data]));
+      expect(aMap.get("x")).toBe("from-A");
+      expect(aMap.get("y")).toBe("from-A");
+      expect(aMap.has("z")).toBe(false);
+      expect(fromA.every((r: any) => r.kb_id === undefined)).toBe(true);
+
+      const fromB = await scopeB.getBulk([{ doc_id: "x" }, { doc_id: "z" }] as any);
+      expect(fromB).toHaveLength(2);
+      const bMap = new Map(fromB.map((r: any) => [r.doc_id, r.data]));
+      expect(bMap.get("x")).toBe("from-B");
+      expect(bMap.get("z")).toBe("from-B");
+    });
+
+    test("getBulk emits event with unscoped (kb_id-stripped) entities", async () => {
+      const fn = vi.fn();
+      scopeA.on("getBulk", fn);
+      try {
+        const result = await scopeA.getBulk([
+          { doc_id: "x" },
+          { doc_id: "missing" },
+        ] as any);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+        const [emittedKeys, emittedRows] = fn.mock.calls[0];
+        expect(emittedKeys).toEqual([{ doc_id: "x" }, { doc_id: "missing" }]);
+        expect(emittedRows).toEqual(result);
+        expect(emittedRows.every((r: any) => r.kb_id === undefined)).toBe(true);
+      } finally {
+        scopeA.off("getBulk", fn);
+      }
+    });
+  });
+});

--- a/packages/test/src/test/storage-tabular/ScopedTabularStorageSqlite.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/ScopedTabularStorageSqlite.integration.test.ts
@@ -14,9 +14,7 @@ import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
 import { uuid4 } from "@workglow/util";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 
-describe("ScopedTabularStorage over SqliteTabularStorage", async () => {
-  await Sqlite.init();
-
+describe("ScopedTabularStorage over SqliteTabularStorage", () => {
   let sharedStorage: SqliteTabularStorage<
     typeof SharedDocumentStorageSchema,
     typeof SharedDocumentPrimaryKey
@@ -25,6 +23,10 @@ describe("ScopedTabularStorage over SqliteTabularStorage", async () => {
   let scopeB: ScopedTabularStorage<any, any>;
 
   beforeAll(async () => {
+    // Vitest's `describe` callback doesn't `await` an async function, so any
+    // top-level `await Sqlite.init()` there could race with test bodies.
+    // Initialise here instead.
+    await Sqlite.init();
     sharedStorage = new SqliteTabularStorage<
       typeof SharedDocumentStorageSchema,
       typeof SharedDocumentPrimaryKey
@@ -52,10 +54,14 @@ describe("ScopedTabularStorage over SqliteTabularStorage", async () => {
       await scopeB.put({ doc_id: "z", data: "from-B" });
 
       // The SQL-backend code path: `SqliteTabularStorage.getBulk` builds an
-      // IN-tuple WHERE from the declared primary-key columns only. If
-      // ScopedTabularStorage.getBulk delegates to it, our injected `kb_id`
-      // is dropped — KB-A would see KB-B's rows for the colliding key "x".
-      // The fix fans out per-key `get()` calls so the WHERE keeps `kb_id`.
+      // IN-tuple WHERE from the declared primary-key columns only. If the
+      // inner PK doesn't include `kb_id`, the wrapper's injected scope key
+      // gets dropped from the predicate — KB-A would see KB-B's rows for
+      // the colliding key "x". The fix is enforced at the `ScopedTabularStorage`
+      // constructor: it requires `kb_id` to appear in the inner PK so the
+      // existing one-round-trip `inner.getBulk(scopedKeys)` IN-tuple WHERE
+      // naturally carries the scope. This test exercises that contract on a
+      // real SQL backend.
       const fromA = await scopeA.getBulk([
         { doc_id: "x" },
         { doc_id: "y" },

--- a/packages/test/src/test/storage-text/PostgresFtsTextIndex.integration.test.ts
+++ b/packages/test/src/test/storage-text/PostgresFtsTextIndex.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { PostgresFtsTextIndex } from "@workglow/postgres/text";
+import { uuid4 } from "@workglow/util";
+import type { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const db = new PGlite() as unknown as Pool;
+
+describe("PostgresFtsTextIndex", () => {
+  let table: string;
+  let index: PostgresFtsTextIndex;
+
+  beforeAll(async () => {
+    table = `fts_test_${uuid4().replace(/-/g, "_")}`;
+    index = new PostgresFtsTextIndex(db, table);
+    await index.setupDatabase();
+  });
+
+  afterAll(async () => {
+    await (db as unknown as PGlite).close();
+  });
+
+  async function reset(): Promise<void> {
+    await index.clear();
+  }
+
+  it("add then search returns matching chunkId with non-zero rank-ordered score", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "the rabbit jumps over the fence" });
+    await index.add("c2", "d2", { text: "the fox eats grapes" });
+
+    const results = await index.search("rabbit");
+    expect(results.map((r) => r.chunkId)).toEqual(["c1"]);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+
+  it("remove(chunkId) drops postings", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "rabbit fence garden" });
+    await index.add("c2", "d1", { text: "wombat hops" });
+    expect(await index.size()).toBe(2);
+
+    await index.remove("c1");
+    expect(await index.size()).toBe(1);
+    expect(await index.search("rabbit")).toEqual([]);
+  });
+
+  it("removeByDocument(docId) drops all chunks for the document", async () => {
+    await reset();
+    await index.add("c1", "doc-a", { text: "rabbit" });
+    await index.add("c2", "doc-a", { text: "fence" });
+    await index.add("c3", "doc-b", { text: "wombat" });
+    expect(await index.size()).toBe(3);
+
+    await index.removeByDocument("doc-a");
+    expect(await index.size()).toBe(1);
+    expect(await index.search("rabbit")).toEqual([]);
+    expect((await index.search("wombat")).map((r) => r.chunkId)).toEqual(["c3"]);
+  });
+
+  it("clear() empties the index", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "rabbit" });
+    await index.add("c2", "d2", { text: "fence" });
+    expect(await index.size()).toBe(2);
+
+    await index.clear();
+    expect(await index.size()).toBe(0);
+    expect(await index.search("rabbit")).toEqual([]);
+  });
+
+  it("search with topK respects the limit and orders by ts_rank_cd descending", async () => {
+    await reset();
+    // Each chunk gets the term once in `text`, plus a different distribution
+    // of weighted fields. The rank ordering should track field-weight buckets:
+    //   `text` is bucket A, `doc_title` is B, `summary` is C, so a chunk that
+    //   also has `text` repeated should outrank one with only one A occurrence.
+    await index.add("rare-strong", "d1", {
+      text: "rabbit rabbit rabbit",
+    });
+    await index.add("rare-weak", "d2", {
+      summary: "rabbit",
+    });
+    await index.add("noise", "d3", {
+      text: "fence garden lawn",
+    });
+
+    const results = await index.search("rabbit", { topK: 2 });
+    expect(results.length).toBeLessThanOrEqual(2);
+    expect(results[0].chunkId).toBe("rare-strong");
+    if (results.length > 1) {
+      expect(results[0].score).toBeGreaterThanOrEqual(results[1].score);
+    }
+    // The `noise` chunk shouldn't appear at all.
+    expect(results.map((r) => r.chunkId)).not.toContain("noise");
+  });
+
+  it("array-valued fields are tokenised after space-joining", async () => {
+    await reset();
+    await index.add("c1", "d1", {
+      sectionTitles: ["chapter one", "the wombat returns"],
+    });
+    const results = await index.search("wombat");
+    expect(results.map((r) => r.chunkId)).toEqual(["c1"]);
+  });
+
+  it("beginRebuild/commitRebuild round-trip leaves index empty when no chunks are added", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "rabbit" });
+
+    await index.beginRebuild();
+    await index.clear();
+    // No add() calls — simulating a reindex over an empty corpus.
+    await index.commitRebuild();
+
+    expect(await index.size()).toBe(0);
+    expect(await index.search("rabbit")).toEqual([]);
+  });
+
+  it("abortRebuild restores pre-rebuild state", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "the original rabbit" });
+    expect(await index.size()).toBe(1);
+
+    await index.beginRebuild();
+    await index.clear();
+    await index.add("c2", "d2", { text: "the doomed wombat" });
+    await index.abortRebuild();
+
+    // Rollback should have undone both the clear and the doomed add.
+    expect(await index.size()).toBe(1);
+    const results = await index.search("rabbit");
+    expect(results.map((r) => r.chunkId)).toEqual(["c1"]);
+    expect(await index.search("wombat")).toEqual([]);
+  });
+
+  it("empty query returns an empty result set without touching the database", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "rabbit" });
+    expect(await index.search("")).toEqual([]);
+    expect(await index.search("   ")).toEqual([]);
+  });
+
+  it("add with no indexable text removes prior postings for the chunk", async () => {
+    await reset();
+    await index.add("c1", "d1", { text: "rabbit" });
+    expect((await index.search("rabbit")).map((r) => r.chunkId)).toEqual(["c1"]);
+
+    await index.add("c1", "d1", { text: "" });
+    expect(await index.search("rabbit")).toEqual([]);
+  });
+});

--- a/packages/test/src/test/storage-text/PostgresFtsTextIndex.integration.test.ts
+++ b/packages/test/src/test/storage-text/PostgresFtsTextIndex.integration.test.ts
@@ -155,4 +155,25 @@ describe("PostgresFtsTextIndex", () => {
     await index.add("c1", "d1", { text: "" });
     expect(await index.search("rabbit")).toEqual([]);
   });
+
+  it("fromJSON accepts a snapshot with the same table", async () => {
+    const sameTable = `fts_roundtrip_${uuid4().replace(/-/g, "_")}`;
+    const a = new PostgresFtsTextIndex(db, sameTable);
+    const b = new PostgresFtsTextIndex(db, sameTable);
+    const snapshot = a.toJSON();
+    expect(() => b.fromJSON(snapshot)).not.toThrow();
+    // Round-trip on the same instance too.
+    expect(() => a.fromJSON(a.toJSON())).not.toThrow();
+  });
+
+  it("fromJSON throws when snapshot.table does not match this.table", async () => {
+    const tableA = `fts_a_${uuid4().replace(/-/g, "_")}`;
+    const tableB = `fts_b_${uuid4().replace(/-/g, "_")}`;
+    const idxA = new PostgresFtsTextIndex(db, tableA);
+    const idxB = new PostgresFtsTextIndex(db, tableB);
+    const snapshot = idxA.toJSON();
+    expect(() => idxB.fromJSON(snapshot)).toThrowError(
+      `PostgresFtsTextIndex.fromJSON: snapshot table "${tableA}" does not match this index's table "${tableB}".`
+    );
+  });
 });

--- a/providers/postgres/README.md
+++ b/providers/postgres/README.md
@@ -33,8 +33,23 @@ const queue = new PostgresQueueStorage(connectionConfig);
 
 `PostgresFtsTextIndex` is an `ITextIndex` backed by a single side table per
 KB indexed by a GIN `tsvector` (Postgres FTS). Plug it into a
-`KnowledgeBase` to get `kb.hybridSearch()` / `kb.textSearch()` without
-loading every chunk into memory at reindex time.
+`KnowledgeBase` to get `kb.hybridSearch()` / `kb.textSearch()` with the
+full-text postings living server-side rather than in the JS heap.
+
+Benefits over the in-memory `BM25Index` default for Postgres-backed KBs:
+
+- **Durable, server-side index**: postings live in Postgres as a side table
+  with a GIN index; the index survives process restarts without a rebuild.
+- **No in-memory BM25 state**: the JS heap doesn't hold the inverted index —
+  the database does. Incremental `add` / `remove` writes don't grow heap.
+- **Transactional rebuild**: `beginRebuild` / `commitRebuild` / `abortRebuild`
+  wrap the rebuild in a single `BEGIN` / `COMMIT` / `ROLLBACK` so a mid-
+  rebuild crash leaves the prior index intact.
+
+> **Note**: `KnowledgeBase.reindexText()` still iterates all chunks via
+> `chunkStorage.getAll()` to populate the index. The benefit here is not
+> memory savings on reindex; it's that the *index itself* lives server-
+> side and incremental writes don't grow the JS heap.
 
 ```typescript
 import { createKnowledgeBase } from "@workglow/knowledge-base";

--- a/providers/postgres/README.md
+++ b/providers/postgres/README.md
@@ -6,6 +6,7 @@ Postgres backends for @workglow/storage and @workglow/job-queue.
 
 - Postgres implementation of `@workglow/storage` interfaces
 - Postgres implementation of `@workglow/job-queue` interfaces
+- Postgres-native `ITextIndex` for `@workglow/knowledge-base` hybrid search
 - Persistent storage for tasks, vectors, and queues
 
 ## Installation
@@ -27,6 +28,33 @@ import { PostgresQueueStorage } from "@workglow/postgres/job-queue";
 const storage = new PostgresTabularStorage(connectionConfig);
 const queue = new PostgresQueueStorage(connectionConfig);
 ```
+
+### Postgres-native hybrid search
+
+`PostgresFtsTextIndex` is an `ITextIndex` backed by a single side table per
+KB indexed by a GIN `tsvector` (Postgres FTS). Plug it into a
+`KnowledgeBase` to get `kb.hybridSearch()` / `kb.textSearch()` without
+loading every chunk into memory at reindex time.
+
+```typescript
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { PostgresFtsTextIndex } from "@workglow/postgres/text";
+
+const textIndex = new PostgresFtsTextIndex(pool, "my_kb_fts");
+// One-time DDL: CREATE TABLE + GIN index, idempotent.
+await textIndex.setupDatabase();
+
+const kb = await createKnowledgeBase({
+  name: "my-kb",
+  vectorDimensions: 768,
+  textIndex,
+});
+```
+
+`reindexText` wraps the rebuild in a Postgres transaction via the
+`ITextIndex.beginRebuild` / `commitRebuild` / `abortRebuild` hooks, so a
+failed rebuild rolls back atomically. `toJSON` / `fromJSON` are no-ops:
+the table is the snapshot.
 
 ## License
 

--- a/providers/postgres/README.md
+++ b/providers/postgres/README.md
@@ -51,6 +51,14 @@ const kb = await createKnowledgeBase({
 });
 ```
 
+> **Note**: the `table` argument is validated against a strict identifier
+> whitelist — alphanumerics and underscore only, and must start with a
+> letter or underscore (regex: `/^[A-Za-z_][A-Za-z0-9_]*$/`). Schema-
+> qualified names (e.g. `public.chunks_fts`) and names containing dashes
+> are rejected with an `Error` at DDL time. If you need to use a non-
+> default schema, configure it via the Postgres pool's `search_path`
+> instead.
+
 `reindexText` wraps the rebuild in a Postgres transaction via the
 `ITextIndex.beginRebuild` / `commitRebuild` / `abortRebuild` hooks, so a
 failed rebuild rolls back atomically. `toJSON` / `fromJSON` are no-ops:

--- a/providers/postgres/package.json
+++ b/providers/postgres/package.json
@@ -10,19 +10,23 @@
   "description": "Postgres backends for @workglow/storage and @workglow/job-queue.",
   "scripts": {
     "watch": "concurrently -c 'auto' 'bun:watch-*'",
-    "watch-js": "concurrently -c 'auto' -n 'storage-br,storage-nb,jq-br,jq-nb' 'bun run watch-storage-browser' 'bun run watch-storage-node-bun' 'bun run watch-jq-browser' 'bun run watch-jq-node-bun'",
+    "watch-js": "concurrently -c 'auto' -n 'storage-br,storage-nb,jq-br,jq-nb,text-br,text-nb' 'bun run watch-storage-browser' 'bun run watch-storage-node-bun' 'bun run watch-jq-browser' 'bun run watch-jq-node-bun' 'bun run watch-text-browser' 'bun run watch-text-node-bun'",
     "watch-storage-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist/storage ./src/storage/browser.ts",
     "watch-storage-node-bun": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist/storage ./src/storage/node.ts",
     "watch-jq-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist/job-queue ./src/job-queue/browser.ts",
     "watch-jq-node-bun": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist/job-queue ./src/job-queue/node.ts",
+    "watch-text-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist/text ./src/text/browser.ts",
+    "watch-text-node-bun": "bun build --watch --no-clear-screen --target=node --sourcemap=external --packages=external --outdir ./dist/text ./src/text/node.ts",
     "watch-types": "tsc --watch --preserveWatchOutput",
     "build-package": "bun run build-js && bun run build-types",
-    "build-js": "concurrently -c 'auto' -n 'storage-br,storage-nb,jq-br,jq-nb' 'bun run build-storage-browser' 'bun run build-storage-node-bun' 'bun run build-jq-browser' 'bun run build-jq-node-bun'",
+    "build-js": "concurrently -c 'auto' -n 'storage-br,storage-nb,jq-br,jq-nb,text-br,text-nb' 'bun run build-storage-browser' 'bun run build-storage-node-bun' 'bun run build-jq-browser' 'bun run build-jq-node-bun' 'bun run build-text-browser' 'bun run build-text-node-bun'",
     "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
     "build-storage-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist/storage ./src/storage/browser.ts",
     "build-storage-node-bun": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist/storage ./src/storage/node.ts",
     "build-jq-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist/job-queue ./src/job-queue/browser.ts",
     "build-jq-node-bun": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist/job-queue ./src/job-queue/node.ts",
+    "build-text-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist/text ./src/text/browser.ts",
+    "build-text-node-bun": "bun build --target=node --sourcemap=external --packages=external --outdir ./dist/text ./src/text/node.ts",
     "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "bun test"
@@ -51,6 +55,18 @@
       },
       "types": "./dist/job-queue/node.d.ts",
       "import": "./dist/job-queue/node.js"
+    },
+    "./text": {
+      "browser": {
+        "types": "./dist/text/browser.d.ts",
+        "import": "./dist/text/browser.js"
+      },
+      "bun": {
+        "types": "./dist/text/node.d.ts",
+        "import": "./dist/text/node.js"
+      },
+      "types": "./dist/text/node.d.ts",
+      "import": "./dist/text/node.js"
     }
   },
   "peerDependencies": {

--- a/providers/postgres/src/text/PostgresFtsTextIndex.ts
+++ b/providers/postgres/src/text/PostgresFtsTextIndex.ts
@@ -83,8 +83,18 @@ export class PostgresFtsTextIndex implements ITextIndex {
   // beginRebuild; released on commit/abort. When set, all DML methods
   // (`clear`, `add`, `remove`, `removeByDocument`) route through the
   // dedicated client so the rebuild is one BEGIN…COMMIT block.
+  //
+  // We hold a pre-bound `query` reference alongside the client. `pg.PoolClient`'s
+  // `query` method depends on `this` being the client instance; if we returned
+  // the raw method reference from the `exec` getter and call sites invoked it
+  // as a plain function (which they do), `this` would be undefined and real
+  // pg drivers would throw. Binding once at acquisition keeps every `exec(...)`
+  // call safe regardless of how it's invoked.
   private rebuildClient:
-    | { query: Pool["query"]; release: () => void }
+    | {
+        boundQuery: Pool["query"];
+        release: () => void;
+      }
     | undefined;
 
   constructor(pool: Pool, table: string, options: PostgresFtsTextIndexOptions = {}) {
@@ -101,9 +111,13 @@ export class PostgresFtsTextIndex implements ITextIndex {
     return this.options.fieldWeights ?? DEFAULT_POSTGRES_FTS_FIELD_WEIGHTS;
   }
 
-  /** Routes a query to the rebuild-bound client when a rebuild is open. */
+  /**
+   * Routes a query to the rebuild-bound client when a rebuild is open.
+   * Returns a function that is safe to call without preserving `this` —
+   * the underlying `pg.PoolClient.query` is bound at acquisition time.
+   */
   private get exec(): Pool["query"] {
-    if (this.rebuildClient) return this.rebuildClient.query;
+    if (this.rebuildClient) return this.rebuildClient.boundQuery;
     return this.pool.query.bind(this.pool) as Pool["query"];
   }
 
@@ -236,7 +250,7 @@ export class PostgresFtsTextIndex implements ITextIndex {
     }
     this.rebuildClient = await this.acquireConnection();
     try {
-      await this.rebuildClient.query(`BEGIN`);
+      await this.rebuildClient.boundQuery(`BEGIN`);
     } catch (err) {
       this.rebuildClient.release();
       this.rebuildClient = undefined;
@@ -251,7 +265,7 @@ export class PostgresFtsTextIndex implements ITextIndex {
       );
     }
     try {
-      await this.rebuildClient.query(`COMMIT`);
+      await this.rebuildClient.boundQuery(`COMMIT`);
     } finally {
       this.rebuildClient.release();
       this.rebuildClient = undefined;
@@ -261,7 +275,7 @@ export class PostgresFtsTextIndex implements ITextIndex {
   async abortRebuild(): Promise<void> {
     if (!this.rebuildClient) return;
     try {
-      await this.rebuildClient.query(`ROLLBACK`);
+      await this.rebuildClient.boundQuery(`ROLLBACK`);
     } finally {
       this.rebuildClient.release();
       this.rebuildClient = undefined;
@@ -311,19 +325,27 @@ export class PostgresFtsTextIndex implements ITextIndex {
    * when available (real `pg.Pool`); fall back to routing through `pool.query`
    * directly for single-connection wrappers (PGlite / PGLitePool). Failing
    * fast on anything else keeps BEGIN/COMMIT bracket sanity.
+   *
+   * Returns a pre-bound `boundQuery` rather than the raw `query` reference so
+   * call sites invoking it as a plain function (`exec(sql, params)`) don't
+   * lose the `pg.PoolClient` `this` binding.
    */
   private async acquireConnection(): Promise<{
-    query: Pool["query"];
+    boundQuery: Pool["query"];
     release: () => void;
   }> {
     const supportsConnect =
       typeof (this.pool as unknown as { connect?: unknown }).connect === "function";
     if (supportsConnect) {
-      return await (
+      const client = await (
         this.pool as unknown as {
           connect: () => Promise<{ query: Pool["query"]; release: () => void }>;
         }
       ).connect();
+      return {
+        boundQuery: client.query.bind(client) as Pool["query"],
+        release: () => client.release(),
+      };
     }
     const poolAny = this.pool as unknown as {
       waitReady?: unknown;
@@ -341,7 +363,7 @@ export class PostgresFtsTextIndex implements ITextIndex {
       );
     }
     return {
-      query: this.pool.query.bind(this.pool) as Pool["query"],
+      boundQuery: this.pool.query.bind(this.pool) as Pool["query"],
       release: () => {},
     };
   }

--- a/providers/postgres/src/text/PostgresFtsTextIndex.ts
+++ b/providers/postgres/src/text/PostgresFtsTextIndex.ts
@@ -292,7 +292,18 @@ export class PostgresFtsTextIndex implements ITextIndex {
         )}`
       );
     }
-    // No-op: state is server-side. We accept the snapshot for API parity.
+    // Symmetric with toJSON: if the snapshot carries a `table`, it must
+    // match this instance's table. A snapshot from a different table
+    // round-tripping through a mismatched instance would silently mask
+    // bugs (the server-side data still lives in the original table).
+    const snapshotTable = (state as { table?: unknown }).table;
+    if (snapshotTable !== undefined && snapshotTable !== this.table) {
+      throw new Error(
+        `PostgresFtsTextIndex.fromJSON: snapshot table "${String(snapshotTable)}" does not match this index's table "${this.table}".`
+      );
+    }
+    // No-op beyond validation: state is server-side. We accept the
+    // snapshot for API parity.
   }
 
   /**

--- a/providers/postgres/src/text/PostgresFtsTextIndex.ts
+++ b/providers/postgres/src/text/PostgresFtsTextIndex.ts
@@ -1,0 +1,337 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Pool } from "@workglow/postgres/storage";
+import type {
+  ITextIndex,
+  TextFields,
+  TextSearchOptions,
+  TextSearchResult,
+} from "@workglow/storage";
+
+/**
+ * Per-field weights for {@link PostgresFtsTextIndex}. Postgres FTS supports
+ * exactly four weight buckets — A (heaviest), B, C, D — and that maps
+ * naturally onto the hierarchy of chunk fields:
+ *
+ *   - `text`            → A: direct chunk content
+ *   - `doc_title`       → B: navigational
+ *   - `sectionTitles`   → B: navigational
+ *   - `summary`         → C: condensed body
+ *   - `parentSummaries` → D: inherited context
+ *
+ * Fields outside this map are silently ignored at index time (no FTS bucket
+ * to assign). Callers can override the mapping via
+ * {@link PostgresFtsTextIndexOptions.fieldWeights}.
+ */
+export const DEFAULT_POSTGRES_FTS_FIELD_WEIGHTS: Readonly<
+  Record<string, "A" | "B" | "C" | "D">
+> = {
+  text: "A",
+  doc_title: "B",
+  sectionTitles: "B",
+  summary: "C",
+  parentSummaries: "D",
+};
+
+export interface PostgresFtsTextIndexOptions {
+  /** Postgres text-search configuration name. Defaults to `"english"`. */
+  readonly tsvectorConfig?: string;
+  /**
+   * Per-field FTS weight bucket. See {@link DEFAULT_POSTGRES_FTS_FIELD_WEIGHTS}
+   * for the default mapping. Fields not listed are ignored at index time.
+   */
+  readonly fieldWeights?: Readonly<Record<string, "A" | "B" | "C" | "D">>;
+}
+
+/**
+ * Postgres-native full-text index for {@link KnowledgeBase.hybridSearch} /
+ * {@link KnowledgeBase.textSearch}. Stores postings on a single side table
+ * keyed by `chunk_id`:
+ *
+ * ```sql
+ * CREATE TABLE <table> (
+ *   chunk_id TEXT PRIMARY KEY,
+ *   doc_id   TEXT NOT NULL,
+ *   tsv      TSVECTOR NOT NULL
+ * );
+ * CREATE INDEX <table>_tsv_idx ON <table> USING GIN (tsv);
+ * CREATE INDEX <table>_doc_idx ON <table> (doc_id);
+ * ```
+ *
+ * Scoring is `ts_rank_cd(tsv, plainto_tsquery(...))`; unbounded above and
+ * non-negative, suitable for RRF fusion without normalisation.
+ *
+ * Lifecycle: {@link setupDatabase} must be called before any other method.
+ * {@link beginRebuild}/{@link commitRebuild}/{@link abortRebuild} let
+ * `KnowledgeBase.reindexText` wrap a full rebuild in a database
+ * transaction; on `abort` the table is rolled back to its pre-`begin`
+ * contents.
+ *
+ * State is durable on the database side; {@link toJSON} / {@link fromJSON}
+ * are intentional no-ops (the table itself is the snapshot).
+ */
+export class PostgresFtsTextIndex implements ITextIndex {
+  private readonly pool: Pool;
+  private readonly table: string;
+  private readonly options: PostgresFtsTextIndexOptions;
+
+  // Tx state for beginRebuild/commitRebuild/abortRebuild. Acquired on
+  // beginRebuild; released on commit/abort. When set, all DML methods
+  // (`clear`, `add`, `remove`, `removeByDocument`) route through the
+  // dedicated client so the rebuild is one BEGIN…COMMIT block.
+  private rebuildClient:
+    | { query: Pool["query"]; release: () => void }
+    | undefined;
+
+  constructor(pool: Pool, table: string, options: PostgresFtsTextIndexOptions = {}) {
+    this.pool = pool;
+    this.table = table;
+    this.options = options;
+  }
+
+  private get tsvectorConfig(): string {
+    return this.options.tsvectorConfig ?? "english";
+  }
+
+  private get fieldWeights(): Readonly<Record<string, "A" | "B" | "C" | "D">> {
+    return this.options.fieldWeights ?? DEFAULT_POSTGRES_FTS_FIELD_WEIGHTS;
+  }
+
+  /** Routes a query to the rebuild-bound client when a rebuild is open. */
+  private get exec(): Pool["query"] {
+    if (this.rebuildClient) return this.rebuildClient.query;
+    return this.pool.query.bind(this.pool) as Pool["query"];
+  }
+
+  /**
+   * Identifier-quote a table name. The constructor accepts an arbitrary
+   * string, so we whitelist it (alphanumerics + underscores) and reject
+   * anything else before splicing into DDL.
+   */
+  private get quotedTable(): string {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(this.table)) {
+      throw new Error(
+        `PostgresFtsTextIndex: refusing to use unsafe table name ${JSON.stringify(this.table)}; ` +
+          `expected /^[A-Za-z_][A-Za-z0-9_]*$/.`
+      );
+    }
+    return `"${this.table}"`;
+  }
+
+  /**
+   * Create the postings table + GIN index. Idempotent.
+   */
+  async setupDatabase(): Promise<void> {
+    const table = this.quotedTable;
+    const exec = this.exec as (sql: string) => Promise<unknown>;
+    await exec(
+      `CREATE TABLE IF NOT EXISTS ${table} (
+        chunk_id TEXT PRIMARY KEY,
+        doc_id   TEXT NOT NULL,
+        tsv      TSVECTOR NOT NULL
+      )`
+    );
+    await exec(`CREATE INDEX IF NOT EXISTS "${this.table}_tsv_idx" ON ${table} USING GIN (tsv)`);
+    await exec(`CREATE INDEX IF NOT EXISTS "${this.table}_doc_idx" ON ${table} (doc_id)`);
+  }
+
+  async add(chunkId: string, docId: string, fields: TextFields): Promise<void> {
+    const weights = this.fieldWeights;
+    const cfg = this.tsvectorConfig;
+
+    const params: (string | null)[] = [];
+    const tsvParts: string[] = [];
+    params.push(cfg); // $1
+
+    let nextParam = 2;
+    for (const [field, weight] of Object.entries(weights)) {
+      const raw = fields[field];
+      if (raw === undefined) continue;
+      const text = Array.isArray(raw) ? raw.join(" ") : (raw as string);
+      // Skip empty/whitespace-only — they'd contribute a zero-length tsvector
+      // and waste a parameter slot.
+      if (typeof text !== "string" || text.trim().length === 0) continue;
+      params.push(text);
+      const pIdx = nextParam++;
+      tsvParts.push(
+        `setweight(to_tsvector($1::regconfig, coalesce($${pIdx}, '')), '${weight}')`
+      );
+    }
+
+    const table = this.quotedTable;
+
+    if (tsvParts.length === 0) {
+      // Nothing indexable on this chunk — drop any prior postings so an
+      // update that clears text is reflected. Mirror BM25Index.add's behaviour.
+      await this.remove(chunkId);
+      return;
+    }
+
+    params.push(chunkId);
+    const chunkIdParam = `$${nextParam++}`;
+    params.push(docId);
+    const docIdParam = `$${nextParam++}`;
+
+    const tsvExpr = tsvParts.join(" || ");
+    const sql = `INSERT INTO ${table} (chunk_id, doc_id, tsv)
+                 VALUES (${chunkIdParam}, ${docIdParam}, ${tsvExpr})
+                 ON CONFLICT (chunk_id) DO UPDATE
+                   SET doc_id = EXCLUDED.doc_id,
+                       tsv    = EXCLUDED.tsv`;
+    await (this.exec as (sql: string, params: unknown[]) => Promise<unknown>)(sql, params);
+  }
+
+  async remove(chunkId: string): Promise<void> {
+    const sql = `DELETE FROM ${this.quotedTable} WHERE chunk_id = $1`;
+    await (this.exec as (sql: string, params: unknown[]) => Promise<unknown>)(sql, [chunkId]);
+  }
+
+  async removeByDocument(docId: string): Promise<void> {
+    const sql = `DELETE FROM ${this.quotedTable} WHERE doc_id = $1`;
+    await (this.exec as (sql: string, params: unknown[]) => Promise<unknown>)(sql, [docId]);
+  }
+
+  async clear(): Promise<void> {
+    // TRUNCATE is faster than DELETE and friendly to the GIN index; we hold
+    // the rebuild's transaction (when present) so it still rolls back on abort.
+    await (this.exec as (sql: string) => Promise<unknown>)(`TRUNCATE TABLE ${this.quotedTable}`);
+  }
+
+  async size(): Promise<number> {
+    const res = (await (this.exec as (sql: string) => Promise<{ rows: Array<{ n: number }> }>)(
+      `SELECT count(*)::int AS n FROM ${this.quotedTable}`
+    )) as { rows: Array<{ n: number }> };
+    return res.rows[0]?.n ?? 0;
+  }
+
+  async search(query: string, options: TextSearchOptions = {}): Promise<TextSearchResult[]> {
+    const topK = options.topK ?? 10;
+    if (typeof query !== "string" || query.trim().length === 0) return [];
+    const sql = `
+      SELECT chunk_id, ts_rank_cd(tsv, plainto_tsquery($1::regconfig, $2)) AS score
+        FROM ${this.quotedTable}
+       WHERE tsv @@ plainto_tsquery($1::regconfig, $2)
+       ORDER BY score DESC
+       LIMIT $3
+    `;
+    const res = (await (
+      this.exec as (sql: string, params: unknown[]) => Promise<{
+        rows: Array<{ chunk_id: string; score: number }>;
+      }>
+    )(sql, [this.tsvectorConfig, query, topK])) as {
+      rows: Array<{ chunk_id: string; score: number }>;
+    };
+    return res.rows.map((r) => ({ chunkId: r.chunk_id, score: Number(r.score) }));
+  }
+
+  async beginRebuild(): Promise<void> {
+    if (this.rebuildClient) {
+      throw new Error(
+        `PostgresFtsTextIndex.beginRebuild on table "${this.table}" called while a rebuild was already open. Call commitRebuild() or abortRebuild() first.`
+      );
+    }
+    this.rebuildClient = await this.acquireConnection();
+    try {
+      await this.rebuildClient.query(`BEGIN`);
+    } catch (err) {
+      this.rebuildClient.release();
+      this.rebuildClient = undefined;
+      throw err;
+    }
+  }
+
+  async commitRebuild(): Promise<void> {
+    if (!this.rebuildClient) {
+      throw new Error(
+        `PostgresFtsTextIndex.commitRebuild on table "${this.table}" called without an open rebuild.`
+      );
+    }
+    try {
+      await this.rebuildClient.query(`COMMIT`);
+    } finally {
+      this.rebuildClient.release();
+      this.rebuildClient = undefined;
+    }
+  }
+
+  async abortRebuild(): Promise<void> {
+    if (!this.rebuildClient) return;
+    try {
+      await this.rebuildClient.query(`ROLLBACK`);
+    } finally {
+      this.rebuildClient.release();
+      this.rebuildClient = undefined;
+    }
+  }
+
+  /**
+   * State lives server-side. `toJSON`/`fromJSON` are no-ops, mirrored on
+   * {@link PostgresFtsTextIndex} so the {@link ITextIndex} contract still
+   * round-trips for callers that snapshot/restore the index. Callers
+   * relying on a real serialisation should use {@link beginRebuild} /
+   * {@link commitRebuild} / {@link abortRebuild} for atomic mutations
+   * instead.
+   */
+  toJSON(): { kind: "postgres-fts"; table: string } {
+    return { kind: "postgres-fts", table: this.table };
+  }
+
+  fromJSON(state: unknown): void {
+    if (
+      !state ||
+      typeof state !== "object" ||
+      (state as { kind?: unknown }).kind !== "postgres-fts"
+    ) {
+      throw new Error(
+        `PostgresFtsTextIndex.fromJSON: expected { kind: "postgres-fts" }, got ${JSON.stringify(
+          state
+        )}`
+      );
+    }
+    // No-op: state is server-side. We accept the snapshot for API parity.
+  }
+
+  /**
+   * Mirror of `PostgresTabularStorage.acquireConnection`: prefer `pool.connect()`
+   * when available (real `pg.Pool`); fall back to routing through `pool.query`
+   * directly for single-connection wrappers (PGlite / PGLitePool). Failing
+   * fast on anything else keeps BEGIN/COMMIT bracket sanity.
+   */
+  private async acquireConnection(): Promise<{
+    query: Pool["query"];
+    release: () => void;
+  }> {
+    const supportsConnect =
+      typeof (this.pool as unknown as { connect?: unknown }).connect === "function";
+    if (supportsConnect) {
+      return await (
+        this.pool as unknown as {
+          connect: () => Promise<{ query: Pool["query"]; release: () => void }>;
+        }
+      ).connect();
+    }
+    const poolAny = this.pool as unknown as {
+      waitReady?: unknown;
+      exec?: unknown;
+      constructor?: { name?: string };
+    };
+    const ctorName = poolAny.constructor?.name;
+    const looksLikePGlite = typeof poolAny.exec === "function" && poolAny.waitReady !== undefined;
+    const looksLikePGLitePool = ctorName === "PGLitePool";
+    if (!looksLikePGlite && !looksLikePGLitePool) {
+      throw new Error(
+        `PostgresFtsTextIndex requires a pg.Pool with connect() or a known single-connection wrapper (PGLitePool, PGlite); got ${
+          ctorName ?? typeof this.pool
+        }.`
+      );
+    }
+    return {
+      query: this.pool.query.bind(this.pool) as Pool["query"],
+      release: () => {},
+    };
+  }
+}

--- a/providers/postgres/src/text/browser.ts
+++ b/providers/postgres/src/text/browser.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./common";

--- a/providers/postgres/src/text/bun.ts
+++ b/providers/postgres/src/text/bun.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./common";

--- a/providers/postgres/src/text/common.ts
+++ b/providers/postgres/src/text/common.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./PostgresFtsTextIndex";

--- a/providers/postgres/src/text/node.ts
+++ b/providers/postgres/src/text/node.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./common";


### PR DESCRIPTION
## Summary
Two high-priority fixes for issues introduced in PRs #478/#480:

- **ScopedTabularStorage cross-KB contract**: SQL backends build `get`/`getBulk` `WHERE` clauses from PK columns only. The wrapper's injected `kb_id` only ends up in the predicate if `kb_id` is part of the inner PK. The constructor now verifies this at instantiation (throws on detectable violation, warns when the inner doesn't expose `primaryKeyNames`); `getBulk` keeps the one-round-trip `inner.getBulk(scopedKeys)` IN-tuple optimization. SQL-backend cross-KB isolation tests added for Postgres and SQLite (the existing in-memory test never exercised the leaking path because `InMemoryTabularStorage.getBulk` doesn't use `getPrimaryKeyAsOrderedArray`).
- **Postgres native hybrid search regression**: PR #478 removed the pgvector+FTS hybrid path; production Postgres KBs were forced onto `BM25Index`, which `KnowledgeBase.reindexText` loads via `chunkStorage.getAll()` (unbounded). Restored via a new opt-in `PostgresFtsTextIndex` (`ITextIndex` over a side `<table>_fts` GIN index using `to_tsvector`/`plainto_tsquery`), with new `beginRebuild`/`commitRebuild`/`abortRebuild` hooks on `ITextIndex` so reindex wraps in a DB transaction instead of the in-memory snapshot path.

## Breaking changes (minor)
- `ITextIndex.search` may now return `Promise` — external implementers should re-check their return types.
- `ScopedTabularStorage` constructor now throws when the inner storage's primary key does not include `kb_id` (warns when the inner storage doesn't expose `primaryKeyNames`). External callers wrapping `Shared*` schemas from `@workglow/knowledge-base` are unaffected.

## Test plan
- [x] New `getBulk` cross-KB isolation tests on Postgres and SQLite
- [x] New `PostgresFtsTextIndex` unit tests (add/remove/search/clear/topK/array-fields/begin-commit-abort)
- [x] Parametrised `KnowledgeBaseHybridSearch.postgres.test.ts` smoke test
- [x] CI: full test suite green
- [ ] Manual: verify migration note in CHANGELOG

https://claude.ai/code/session_01NDC5HAMu9gusbWHkozA1Tg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDC5HAMu9gusbWHkozA1Tg)_