### PR TITLE
test(rag): share ResourceScope across workflows to keep models warm

### DIFF
--- a/packages/test/src/test/rag/EndToEnd.integration.test.ts
+++ b/packages/test/src/test/rag/EndToEnd.integration.test.ts
@@ -37,7 +37,7 @@ import {
 } from "@workglow/huggingface-transformers/ai-runtime";
 import { createKnowledgeBase, KnowledgeBase } from "@workglow/knowledge-base";
 import { getTaskQueueRegistry, setTaskQueueRegistry, Workflow } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { ResourceScope, setLogger } from "@workglow/util";
 import { join } from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 export { FileLoaderTask } from "@workglow/tasks";
@@ -59,6 +59,10 @@ describe("End-to-End RAG Pipeline", () => {
   const sampleFileName = "history_of_the_united_states.md";
 
   let kb: KnowledgeBase;
+  // Shared across every workflow.run() in this file so loaded models stay
+  // warm until afterAll. Without this, each workflow's auto-created scope
+  // disposes (unloads) every model the workflow used as soon as run() returns.
+  let resourceScope: ResourceScope;
   const logger = getTestingLogger();
   setLogger(logger);
 
@@ -69,6 +73,8 @@ describe("End-to-End RAG Pipeline", () => {
     clearPipelineCache();
     await registerHuggingFaceTransformersInline();
     await registerHuggingfaceLocalModels();
+
+    resourceScope = new ResourceScope();
 
     // Create unified KnowledgeBase with 1024 dimensions for Qwen3 model
     kb = await createKnowledgeBase({
@@ -82,6 +88,7 @@ describe("End-to-End RAG Pipeline", () => {
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
+    await resourceScope.disposeAll();
   });
 
   it("should ingest document through complete pipeline", async () => {
@@ -120,7 +127,7 @@ describe("End-to-End RAG Pipeline", () => {
 
     expect(ingestionWorkflow.error).toBe("");
 
-    const result = await ingestionWorkflow.run();
+    const result = await ingestionWorkflow.run({}, { resourceScope });
 
     expect(result).toBeDefined();
     expect(result.count).toBeGreaterThan(0);
@@ -160,7 +167,7 @@ describe("End-to-End RAG Pipeline", () => {
 
     expect(retrievalWorkflow.error).toBe("");
 
-    const result = (await retrievalWorkflow.run()) as ContextBuilderTaskOutput;
+    const result = (await retrievalWorkflow.run({}, { resourceScope })) as ContextBuilderTaskOutput;
 
     expect(result).toBeDefined();
     expect(result.context).toBeDefined();
@@ -218,7 +225,7 @@ describe("End-to-End RAG Pipeline", () => {
         scoreThreshold: 0.0,
       });
 
-      const result = (await workflow.run()) as ChunkRetrievalTaskOutput;
+      const result = (await workflow.run({}, { resourceScope })) as ChunkRetrievalTaskOutput;
 
       expect(result.chunks).toBeDefined();
 
@@ -256,7 +263,7 @@ describe("End-to-End RAG Pipeline", () => {
 
     expect(expanderWorkflow.error).toBe("");
 
-    const expanderResult = (await expanderWorkflow.run()) as QueryExpanderTaskOutput;
+    const expanderResult = (await expanderWorkflow.run({}, { resourceScope })) as QueryExpanderTaskOutput;
 
     expect(expanderResult).toBeDefined();
     expect(expanderResult.query).toBeDefined();
@@ -282,7 +289,7 @@ describe("End-to-End RAG Pipeline", () => {
           topK: 2,
         });
 
-      const result = (await retrievalWorkflow.run()) as RerankerTaskOutput;
+      const result = (await retrievalWorkflow.run({}, { resourceScope })) as RerankerTaskOutput;
       totalChunksFound += result.count;
     }
 
@@ -302,7 +309,7 @@ describe("End-to-End RAG Pipeline", () => {
       scoreThreshold: 0.0,
     });
 
-    const retrievalResult = (await retrievalWorkflow.run()) as ChunkRetrievalTaskOutput;
+    const retrievalResult = (await retrievalWorkflow.run({}, { resourceScope })) as ChunkRetrievalTaskOutput;
     expect(retrievalResult.chunks.length).toBeGreaterThan(0);
 
     const formats = ["simple", "numbered", "xml", "markdown"] as const;
@@ -318,7 +325,7 @@ describe("End-to-End RAG Pipeline", () => {
 
       expect(contextWorkflow.error).toBe("");
 
-      const contextResult = (await contextWorkflow.run()) as ContextBuilderTaskOutput;
+      const contextResult = (await contextWorkflow.run({}, { resourceScope })) as ContextBuilderTaskOutput;
 
       expect(contextResult.context).toBeDefined();
       expect(contextResult.chunksUsed).toBeGreaterThan(0);
@@ -348,7 +355,7 @@ describe("End-to-End RAG Pipeline", () => {
 
     expect(hybridWorkflow.error).toBe("");
 
-    const result = (await hybridWorkflow.run()) as ChunkRetrievalTaskOutput;
+    const result = (await hybridWorkflow.run({}, { resourceScope })) as ChunkRetrievalTaskOutput;
 
     expect(result).toBeDefined();
     expect(result.chunks).toBeDefined();
@@ -382,7 +389,7 @@ describe("End-to-End RAG Pipeline", () => {
 
     expect(hierarchyWorkflow.error).toBe("");
 
-    const result = (await hierarchyWorkflow.run()) as HierarchyJoinTaskOutput;
+    const result = (await hierarchyWorkflow.run({}, { resourceScope })) as HierarchyJoinTaskOutput;
 
     expect(result).toBeDefined();
     expect(result.metadata).toBeDefined();

--- a/packages/test/src/test/rag/RagWorkflow.integration.test.ts
+++ b/packages/test/src/test/rag/RagWorkflow.integration.test.ts
@@ -31,7 +31,7 @@ import {
 } from "@workglow/huggingface-transformers/ai-runtime";
 import { createKnowledgeBase, KnowledgeBase } from "@workglow/knowledge-base";
 import { getTaskQueueRegistry, setTaskQueueRegistry, Workflow } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { ResourceScope, setLogger } from "@workglow/util";
 import { readdirSync } from "fs";
 import { join } from "path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -47,6 +47,10 @@ describe("RAG Workflow End-to-End", () => {
   const nerModel = "onnx:onnx-community/NeuroBERT-NER-ONNX:q8";
   const qaModel = "onnx:onnx-community/ModernBERT-finetuned-squad-ONNX";
   let kb: KnowledgeBase;
+  // Shared across every workflow.run() so loaded models stay warm until
+  // afterAll. Without this, each workflow's auto-created scope disposes
+  // every model the workflow used as soon as run() returns.
+  let resourceScope: ResourceScope;
   const logger = getTestingLogger();
   setLogger(logger);
 
@@ -58,6 +62,8 @@ describe("RAG Workflow End-to-End", () => {
     await registerHuggingFaceTransformersInline();
 
     await registerHuggingfaceLocalModels();
+
+    resourceScope = new ResourceScope();
 
     // Create unified KnowledgeBase
     kb = await createKnowledgeBase({
@@ -71,6 +77,7 @@ describe("RAG Workflow End-to-End", () => {
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
+    await resourceScope.disposeAll();
   });
 
   it("should ingest markdown documents with NER enrichment", async () => {
@@ -113,7 +120,7 @@ describe("RAG Workflow End-to-End", () => {
           knowledgeBase: kbName,
         });
 
-      const result = (await ingestionWorkflow.run()) as VectorStoreUpsertTaskOutput;
+      const result = (await ingestionWorkflow.run({}, { resourceScope })) as VectorStoreUpsertTaskOutput;
 
       logger.info(`  -> Stored ${result.count} vectors`);
       totalVectors += result.count;
@@ -139,7 +146,7 @@ describe("RAG Workflow End-to-End", () => {
       scoreThreshold: 0.3,
     });
 
-    const searchResult = (await searchWorkflow.run()) as ChunkRetrievalTaskOutput;
+    const searchResult = (await searchWorkflow.run({}, { resourceScope })) as ChunkRetrievalTaskOutput;
 
     expect(searchResult.chunks).toBeDefined();
     expect(Array.isArray(searchResult.chunks)).toBe(true);
@@ -205,7 +212,7 @@ describe("RAG Workflow End-to-End", () => {
       scoreThreshold: 0.2,
     });
 
-    const retrievalResult = (await retrievalWorkflow.run()) as ChunkRetrievalTaskOutput;
+    const retrievalResult = (await retrievalWorkflow.run({}, { resourceScope })) as ChunkRetrievalTaskOutput;
 
     if (retrievalResult.chunks.length === 0) {
       logger.info("No chunks found, skipping QA step");
@@ -220,7 +227,7 @@ describe("RAG Workflow End-to-End", () => {
       model: qaModel,
     });
 
-    const result = (await qaWorkflow.run()) as TextQuestionAnswerTaskOutput;
+    const result = (await qaWorkflow.run({}, { resourceScope })) as TextQuestionAnswerTaskOutput;
 
     expect(result.text).toBeDefined();
     expect(typeof result.text).toBe("string");


### PR DESCRIPTION
## Summary

- The RAG integration tests (`EndToEnd.integration.test.ts`, `RagWorkflow.integration.test.ts`) currently run each workflow with the auto-created ResourceScope that `TaskRunner` provides. That scope disposes the moment `Workflow.run()` returns, which fires the per-task \`model.unload\` disposer registered by `AiTask.execute` for every model the workflow used.
- For these suites it means the same embedding model (Qwen3 in EndToEnd, all-MiniLM-L6-v2 in RagWorkflow) is loaded, used, and unloaded 7+ times in a single file — once per \`it()\` block — even though the model never changes.
- This PR opts the suites into a single shared \`ResourceScope\` instantiated in \`beforeAll\` and disposed in \`afterAll\`, passed to every \`workflow.run({}, { resourceScope })\`.

## Measured impact (EndToEnd.integration.test.ts, 8 tests, 3 models)

| | wall-clock | RSS at afterAll |
|---|---|---|
| before | 240 s | 2493 MB |
| after  | 36 s  | 3788 MB |

Wall-clock improvement is ~6.5x. RSS rises because the 3 ONNX model weights now stay resident until \`afterAll\` instead of being repeatedly freed and reloaded — that is expected and bounded by the model set. The previous behaviour was effectively a load/free thrash that hid the warm-state footprint.

## Test plan

- [x] \`bun scripts/test.ts rag vitest packages/test/src/test/rag/EndToEnd.integration.test.ts\` passes 8/8 with the new scope.
- [ ] \`bun scripts/test.ts rag vitest packages/test/src/test/rag/RagWorkflow.integration.test.ts\` passes locally.
- [ ] CI green.

## Notes

- The convenience wrappers \`chunkRetrieval()\` and \`textQuestionAnswer()\` in RagWorkflow don't accept a runConfig today, so those direct calls still get their own auto-scope. They're minor and easy to migrate later if needed.
- Tests using only one model per \`it()\` (e.g. \`TextEmbeddingTask.integration.test.ts\`) do not benefit from a shared scope and are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)