### PR TITLE
feat(ai,task-graph): thread runConfig through CreateWorkflow and AI wrappers

### DIFF
--- a/packages/ai/src/task/BackgroundRemovalTask.ts
+++ b/packages/ai/src/task/BackgroundRemovalTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { ImageValueSchema } from "@workglow/util/media";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
@@ -68,9 +68,10 @@ export class BackgroundRemovalTask extends AiVisionTask<
  */
 export const backgroundRemoval = (
   input: BackgroundRemovalTaskInput,
-  config?: BackgroundRemovalTaskConfig
+  config?: BackgroundRemovalTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new BackgroundRemovalTask(config).run(input);
+  return new BackgroundRemovalTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ChunkRetrievalTask.ts
+++ b/packages/ai/src/task/ChunkRetrievalTask.ts
@@ -7,7 +7,7 @@
 import { KnowledgeBase, TypeKnowledgeBase } from "@workglow/knowledge-base";
 import type { ChunkRecord } from "@workglow/knowledge-base";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import {
   DataPortSchema,
   FromSchema,
@@ -289,7 +289,8 @@ export class ChunkRetrievalTask extends Task<
       method === "hybrid" && (queryText === undefined || queryText.trim().length === 0);
     const defaultScoreType: "cosine" | "bm25" | "rrf" =
       method === "hybrid" && !hybridFallsBackToCosine ? "rrf" : "cosine";
-    const scoreType = results.length > 0 ? (results[0].scoreType ?? defaultScoreType) : defaultScoreType;
+    const scoreType =
+      results.length > 0 ? (results[0].scoreType ?? defaultScoreType) : defaultScoreType;
 
     const output: ChunkRetrievalTaskOutput = {
       chunks,
@@ -311,9 +312,10 @@ export class ChunkRetrievalTask extends Task<
 
 export const chunkRetrieval = (
   input: ChunkRetrievalTaskInput,
-  config?: ChunkRetrievalTaskConfig
+  config?: ChunkRetrievalTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ChunkRetrievalTask(config).run(input);
+  return new ChunkRetrievalTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ChunkVectorUpsertTask.ts
+++ b/packages/ai/src/task/ChunkVectorUpsertTask.ts
@@ -6,7 +6,7 @@
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
 import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import {
   DataPortSchema,
@@ -156,9 +156,10 @@ export class ChunkVectorUpsertTask extends Task<
 
 export const chunkVectorUpsert = (
   input: VectorStoreUpsertTaskInput,
-  config?: ChunkVectorUpsertTaskConfig
+  config?: ChunkVectorUpsertTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ChunkVectorUpsertTask(config).run(input);
+  return new ChunkVectorUpsertTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ContextBuilderTask.ts
+++ b/packages/ai/src/task/ContextBuilderTask.ts
@@ -12,7 +12,7 @@ import {
   Task,
   Workflow,
 } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { CountTokensTask } from "./CountTokensTask";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -387,9 +387,10 @@ export class ContextBuilderTask extends Task<
 
 export const contextBuilder = (
   input: ContextBuilderTaskInput,
-  config?: ContextBuilderTaskConfig
+  config?: ContextBuilderTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ContextBuilderTask(config).run(input);
+  return new ContextBuilderTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/CountTokensTask.ts
+++ b/packages/ai/src/task/CountTokensTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
@@ -74,8 +74,12 @@ export class CountTokensTask extends AiTask<
  * @param input - Input containing text and model for token counting
  * @returns Promise resolving to the token count
  */
-export const countTokens = async (input: CountTokensTaskInput, config?: CountTokensTaskConfig) => {
-  return new CountTokensTask(config).run(input);
+export const countTokens = async (
+  input: CountTokensTaskInput,
+  config?: CountTokensTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new CountTokensTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/DocumentEnricherTask.ts
+++ b/packages/ai/src/task/DocumentEnricherTask.ts
@@ -7,7 +7,7 @@
 import { DocumentRootNode, getChildren, hasChildren } from "@workglow/knowledge-base";
 
 import type { DocumentNode, Entity, NodeEnrichment } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { ModelConfig } from "../model/ModelSchema";
@@ -398,9 +398,10 @@ export class DocumentEnricherTask extends Task<
 
 export const documentEnricher = (
   input: DocumentEnricherTaskInput,
-  config?: DocumentEnricherTaskConfig
+  config?: DocumentEnricherTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new DocumentEnricherTask(config).run(input);
+  return new DocumentEnricherTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/DocumentUpsertTask.ts
+++ b/packages/ai/src/task/DocumentUpsertTask.ts
@@ -11,7 +11,7 @@ import {
   KnowledgeBase,
   TypeKnowledgeBase,
 } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
@@ -135,9 +135,10 @@ export class DocumentUpsertTask extends Task<
 
 export const documentUpsert = (
   input: DocumentUpsertTaskInput,
-  config?: DocumentUpsertTaskConfig
+  config?: DocumentUpsertTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new DocumentUpsertTask(config).run(input);
+  return new DocumentUpsertTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/DownloadModelTask.ts
+++ b/packages/ai/src/task/DownloadModelTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -120,9 +120,10 @@ export class DownloadModelTask extends AiTask<
  */
 export const downloadModel = (
   input: DownloadModelTaskRunInput,
-  config?: DownloadModelTaskConfig
+  config?: DownloadModelTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new DownloadModelTask(config).run(input);
+  return new DownloadModelTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/FaceDetectorTask.ts
+++ b/packages/ai/src/task/FaceDetectorTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeModel } from "./base/AiTaskSchemas";
@@ -168,8 +168,12 @@ export class FaceDetectorTask extends AiVisionTask<
  * @param input The input parameters for face detection (image, model, and optional configuration)
  * @returns Promise resolving to the detected faces with bounding boxes and keypoints
  */
-export const faceDetector = (input: FaceDetectorTaskInput, config?: FaceDetectorTaskConfig) => {
-  return new FaceDetectorTask(config).run(input);
+export const faceDetector = (
+  input: FaceDetectorTaskInput,
+  config?: FaceDetectorTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new FaceDetectorTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/FaceLandmarkerTask.ts
+++ b/packages/ai/src/task/FaceLandmarkerTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeLandmark, TypeModel } from "./base/AiTaskSchemas";
@@ -181,9 +181,10 @@ export class FaceLandmarkerTask extends AiVisionTask<
  */
 export const faceLandmarker = (
   input: FaceLandmarkerTaskInput,
-  config?: FaceLandmarkerTaskConfig
+  config?: FaceLandmarkerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new FaceLandmarkerTask(config).run(input);
+  return new FaceLandmarkerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/GestureRecognizerTask.ts
+++ b/packages/ai/src/task/GestureRecognizerTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeLandmark, TypeModel } from "./base/AiTaskSchemas";
@@ -188,9 +188,10 @@ export class GestureRecognizerTask extends AiVisionTask<
  */
 export const gestureRecognizer = (
   input: GestureRecognizerTaskInput,
-  config?: GestureRecognizerTaskConfig
+  config?: GestureRecognizerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new GestureRecognizerTask(config).run(input);
+  return new GestureRecognizerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/HandLandmarkerTask.ts
+++ b/packages/ai/src/task/HandLandmarkerTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeLandmark, TypeModel } from "./base/AiTaskSchemas";
@@ -160,9 +160,10 @@ export class HandLandmarkerTask extends AiVisionTask<
  */
 export const handLandmarker = (
   input: HandLandmarkerTaskInput,
-  config?: HandLandmarkerTaskConfig
+  config?: HandLandmarkerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new HandLandmarkerTask(config).run(input);
+  return new HandLandmarkerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/HierarchicalChunkerTask.ts
+++ b/packages/ai/src/task/HierarchicalChunkerTask.ts
@@ -14,7 +14,7 @@ import {
 } from "@workglow/knowledge-base";
 
 import type { ChunkRecord, DocumentNode, SectionNode, TokenBudget } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { uuid4 } from "@workglow/util";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
@@ -417,9 +417,10 @@ export class HierarchicalChunkerTask extends Task<
 
 export const hierarchicalChunker = (
   input: HierarchicalChunkerTaskInput,
-  config?: HierarchicalChunkerTaskConfig
+  config?: HierarchicalChunkerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new HierarchicalChunkerTask(config).run(input);
+  return new HierarchicalChunkerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/HierarchyJoinTask.ts
+++ b/packages/ai/src/task/HierarchyJoinTask.ts
@@ -8,7 +8,7 @@ import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-b
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 const inputSchema = {
@@ -214,8 +214,12 @@ export class HierarchyJoinTask extends Task<
   }
 }
 
-export const hierarchyJoin = (input: HierarchyJoinTaskInput, config?: HierarchyJoinTaskConfig) => {
-  return new HierarchyJoinTask(config).run(input);
+export const hierarchyJoin = (
+  input: HierarchyJoinTaskInput,
+  config?: HierarchyJoinTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new HierarchyJoinTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ImageClassificationTask.ts
+++ b/packages/ai/src/task/ImageClassificationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeCategory, TypeImageInput, TypeModel } from "./base/AiTaskSchemas";
@@ -91,9 +91,10 @@ export class ImageClassificationTask extends AiVisionTask<
  */
 export const imageClassification = (
   input: ImageClassificationTaskInput,
-  config?: ImageClassificationTaskConfig
+  config?: ImageClassificationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ImageClassificationTask(config).run(input);
+  return new ImageClassificationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ImageEmbeddingTask.ts
+++ b/packages/ai/src/task/ImageEmbeddingTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import {
   DataPortSchema,
@@ -79,9 +79,10 @@ export class ImageEmbeddingTask extends AiVisionTask<
  */
 export const imageEmbedding = (
   input: ImageEmbeddingTaskInput,
-  config?: ImageEmbeddingTaskConfig
+  config?: ImageEmbeddingTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ImageEmbeddingTask(config).run(input);
+  return new ImageEmbeddingTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ImageSegmentationTask.ts
+++ b/packages/ai/src/task/ImageSegmentationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeModel } from "./base/AiTaskSchemas";
@@ -115,9 +115,10 @@ export class ImageSegmentationTask extends AiVisionTask<
  */
 export const imageSegmentation = (
   input: ImageSegmentationTaskInput,
-  config?: ImageSegmentationTaskConfig
+  config?: ImageSegmentationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ImageSegmentationTask(config).run(input);
+  return new ImageSegmentationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ImageToTextTask.ts
+++ b/packages/ai/src/task/ImageToTextTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeModel } from "./base/AiTaskSchemas";
@@ -80,8 +80,12 @@ export class ImageToTextTask extends AiVisionTask<
  * @param input The input parameters for image to text (image and model)
  * @returns Promise resolving to the generated text description
  */
-export const imageToText = (input: ImageToTextTaskInput, config?: ImageToTextTaskConfig) => {
-  return new ImageToTextTask(config).run(input);
+export const imageToText = (
+  input: ImageToTextTaskInput,
+  config?: ImageToTextTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new ImageToTextTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/KbSearchTask.ts
+++ b/packages/ai/src/task/KbSearchTask.ts
@@ -7,7 +7,7 @@
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 const inputSchema = {
@@ -102,8 +102,12 @@ export class KbSearchTask extends Task<KbSearchTaskInput, KbSearchTaskOutput, Kb
   }
 }
 
-export const kbSearch = (input: KbSearchTaskInput, config?: KbSearchTaskConfig) => {
-  return new KbSearchTask(config).run(input);
+export const kbSearch = (
+  input: KbSearchTaskInput,
+  config?: KbSearchTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbSearchTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/KbToDocumentsTask.ts
+++ b/packages/ai/src/task/KbToDocumentsTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { DocumentNode, KnowledgeBase, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
@@ -121,8 +121,12 @@ export class KbToDocumentsTask extends Task<
   }
 }
 
-export const kbToDocuments = (input: KbToDocumentsTaskInput, config?: KbToDocumentsTaskConfig) => {
-  return new KbToDocumentsTask(config).run(input);
+export const kbToDocuments = (
+  input: KbToDocumentsTaskInput,
+  config?: KbToDocumentsTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbToDocumentsTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ModelInfoTask.ts
+++ b/packages/ai/src/task/ModelInfoTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 
-import type { IExecuteContext, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { ModelConfig } from "../model/ModelSchema";
 import { getAiProviderRegistry } from "../provider/AiProviderRegistry";
@@ -116,8 +116,12 @@ export class ModelInfoTask extends AiTask<
  * @param input - Input containing the model to query
  * @returns Promise resolving to model info including locality and cache status
  */
-export const modelInfo = (input: ModelInfoTaskInput, config?: ModelInfoTaskConfig) => {
-  return new ModelInfoTask(config).run(input);
+export const modelInfo = (
+  input: ModelInfoTaskInput,
+  config?: ModelInfoTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new ModelInfoTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ModelSearchTask.ts
+++ b/packages/ai/src/task/ModelSearchTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { ModelRecord } from "../model/ModelSchema";
 import { getAiProviderRegistry } from "../provider/AiProviderRegistry";
@@ -148,8 +148,12 @@ export class ModelSearchTask extends Task<
 /**
  * Search for models using a provider-specific search function.
  */
-export const modelSearch = (input: ModelSearchTaskInput, config?: ModelSearchTaskConfig) => {
-  return new ModelSearchTask(config).run(input);
+export const modelSearch = (
+  input: ModelSearchTaskInput,
+  config?: ModelSearchTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new ModelSearchTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ObjectDetectionTask.ts
+++ b/packages/ai/src/task/ObjectDetectionTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeBoundingBox, TypeImageInput, TypeModel } from "./base/AiTaskSchemas";
@@ -112,9 +112,10 @@ export class ObjectDetectionTask extends AiVisionTask<
  */
 export const objectDetection = (
   input: ObjectDetectionTaskInput,
-  config?: ObjectDetectionTaskConfig
+  config?: ObjectDetectionTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new ObjectDetectionTask(config).run(input);
+  return new ObjectDetectionTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/PoseLandmarkerTask.ts
+++ b/packages/ai/src/task/PoseLandmarkerTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeImageInput, TypeModel, TypePoseLandmark } from "./base/AiTaskSchemas";
@@ -165,9 +165,10 @@ export class PoseLandmarkerTask extends AiVisionTask<
  */
 export const poseLandmarker = (
   input: PoseLandmarkerTaskInput,
-  config?: PoseLandmarkerTaskConfig
+  config?: PoseLandmarkerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new PoseLandmarkerTask(config).run(input);
+  return new PoseLandmarkerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/QueryExpanderTask.ts
+++ b/packages/ai/src/task/QueryExpanderTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 export const QueryExpansionMethod = {
@@ -212,8 +212,12 @@ export class QueryExpanderTask extends Task<
   }
 }
 
-export const queryExpander = (input: QueryExpanderTaskInput, config?: QueryExpanderTaskConfig) => {
-  return new QueryExpanderTask(config).run(input);
+export const queryExpander = (
+  input: QueryExpanderTaskInput,
+  config?: QueryExpanderTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new QueryExpanderTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/RerankerTask.ts
+++ b/packages/ai/src/task/RerankerTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 const inputSchema = {
@@ -211,8 +211,12 @@ export class RerankerTask extends Task<RerankerTaskInput, RerankerTaskOutput, Re
   }
 }
 
-export const reranker = (input: RerankerTaskInput, config?: RerankerTaskConfig) => {
-  return new RerankerTask(config).run(input);
+export const reranker = (
+  input: RerankerTaskInput,
+  config?: RerankerTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new RerankerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/StructuralParserTask.ts
+++ b/packages/ai/src/task/StructuralParserTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { DocumentRootNode, StructuralParser } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { uuid4 } from "@workglow/util";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
@@ -142,9 +142,10 @@ export class StructuralParserTask extends Task<
 
 export const structuralParser = (
   input: StructuralParserTaskInput,
-  config?: StructuralParserTaskConfig
+  config?: StructuralParserTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new StructuralParserTask(config).run(input);
+  return new StructuralParserTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/StructuredGenerationTask.ts
+++ b/packages/ai/src/task/StructuredGenerationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, StreamEvent, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, StreamEvent, TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, TaskConfigurationError, TaskError, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
@@ -261,9 +261,10 @@ export class StructuredGenerationTask extends StreamingAiTask<
  */
 export const structuredGeneration = (
   input: StructuredGenerationTaskInput,
-  config?: StructuredGenerationTaskConfig
+  config?: StructuredGenerationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new StructuredGenerationTask(config).run(input);
+  return new StructuredGenerationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextChunkerTask.ts
+++ b/packages/ai/src/task/TextChunkerTask.ts
@@ -8,7 +8,7 @@ import type { ChunkRecord } from "@workglow/knowledge-base";
 import { ChunkRecordArraySchema } from "@workglow/knowledge-base";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 export const ChunkingStrategy = {
@@ -312,8 +312,12 @@ export class TextChunkerTask extends Task<
   }
 }
 
-export const textChunker = (input: TextChunkerTaskInput, config?: TextChunkerTaskConfig) => {
-  return new TextChunkerTask(config).run(input);
+export const textChunker = (
+  input: TextChunkerTaskInput,
+  config?: TextChunkerTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new TextChunkerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextClassificationTask.ts
+++ b/packages/ai/src/task/TextClassificationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
@@ -108,9 +108,10 @@ export class TextClassificationTask extends AiTask<
  */
 export const textClassification = (
   input: TextClassificationTaskInput,
-  config?: TextClassificationTaskConfig
+  config?: TextClassificationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextClassificationTask(config).run(input);
+  return new TextClassificationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextEmbeddingTask.ts
+++ b/packages/ai/src/task/TextEmbeddingTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import {
   DataPortSchema,
@@ -87,9 +87,10 @@ export class TextEmbeddingTask extends AiTask<
  */
 export const textEmbedding = async (
   input: TextEmbeddingTaskInput,
-  config?: TextEmbeddingTaskConfig
+  config?: TextEmbeddingTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextEmbeddingTask(config).run(input);
+  return new TextEmbeddingTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextFillMaskTask.ts
+++ b/packages/ai/src/task/TextFillMaskTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
@@ -91,8 +91,12 @@ export class TextFillMaskTask extends AiTask<
  * @param input The input parameters for fill mask (text with mask token and model)
  * @returns Promise resolving to the predicted tokens with scores and complete sequences
  */
-export const textFillMask = (input: TextFillMaskTaskInput, config?: TextFillMaskTaskConfig) => {
-  return new TextFillMaskTask(config).run(input);
+export const textFillMask = (
+  input: TextFillMaskTaskInput,
+  config?: TextFillMaskTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new TextFillMaskTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextGenerationTask.ts
+++ b/packages/ai/src/task/TextGenerationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -110,9 +110,10 @@ export class TextGenerationTask extends StreamingAiTask<
  */
 export const textGeneration = (
   input: TextGenerationTaskInput,
-  config?: TextGenerationTaskConfig
+  config?: TextGenerationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextGenerationTask(config).run(input);
+  return new TextGenerationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextLanguageDetectionTask.ts
+++ b/packages/ai/src/task/TextLanguageDetectionTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
@@ -131,9 +131,10 @@ export class TextLanguageDetectionTask extends AiTask<
  */
 export const textLanguageDetection = (
   input: TextLanguageDetectionTaskInput,
-  config?: TextLanguageDetectionTaskConfig
+  config?: TextLanguageDetectionTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextLanguageDetectionTask(config).run(input);
+  return new TextLanguageDetectionTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextNamedEntityRecognitionTask.ts
+++ b/packages/ai/src/task/TextNamedEntityRecognitionTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
@@ -107,9 +107,10 @@ export class TextNamedEntityRecognitionTask extends AiTask<
  */
 export const textNamedEntityRecognition = (
   input: TextNamedEntityRecognitionTaskInput,
-  config?: TextNamedEntityRecognitionTaskConfig
+  config?: TextNamedEntityRecognitionTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextNamedEntityRecognitionTask(config).run(input);
+  return new TextNamedEntityRecognitionTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextQuestionAnswerTask.ts
+++ b/packages/ai/src/task/TextQuestionAnswerTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -85,9 +85,10 @@ export class TextQuestionAnswerTask extends StreamingAiTask<
  */
 export const textQuestionAnswer = (
   input: TextQuestionAnswerTaskInput,
-  config?: TextQuestionAnswerTaskConfig
+  config?: TextQuestionAnswerTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextQuestionAnswerTask(config).run(input);
+  return new TextQuestionAnswerTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextRewriterTask.ts
+++ b/packages/ai/src/task/TextRewriterTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -77,8 +77,12 @@ export class TextRewriterTask extends StreamingAiTask<
  * @param input The input parameters for text rewriting (text, prompt, and model)
  * @returns Promise resolving to the rewritten text output(s)
  */
-export const textRewriter = (input: TextRewriterTaskInput, config?: TextRewriterTaskConfig) => {
-  return new TextRewriterTask(config).run(input);
+export const textRewriter = (
+  input: TextRewriterTaskInput,
+  config?: TextRewriterTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new TextRewriterTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextSummaryTask.ts
+++ b/packages/ai/src/task/TextSummaryTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -73,8 +73,12 @@ export class TextSummaryTask extends StreamingAiTask<
  * @param input The input parameters for text summary (text and model)
  * @returns Promise resolving to the summarized text output(s)
  */
-export const textSummary = async (input: TextSummaryTaskInput, config?: TextSummaryTaskConfig) => {
-  return new TextSummaryTask(config).run(input);
+export const textSummary = async (
+  input: TextSummaryTaskInput,
+  config?: TextSummaryTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new TextSummaryTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TextTranslationTask.ts
+++ b/packages/ai/src/task/TextTranslationTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { TypeLanguage, TypeModel } from "./base/AiTaskSchemas";
@@ -94,9 +94,10 @@ export class TextTranslationTask extends StreamingAiTask<
  */
 export const textTranslation = (
   input: TextTranslationTaskInput,
-  config?: TextTranslationTaskConfig
+  config?: TextTranslationTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TextTranslationTask(config).run(input);
+  return new TextTranslationTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/ToolCallingTask.ts
+++ b/packages/ai/src/task/ToolCallingTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, getTaskConstructors, Workflow } from "@workglow/task-graph";
 
-import type { IExecuteContext, StreamEvent, TaskConfig } from "@workglow/task-graph";
+import type { IExecuteContext, StreamEvent, TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { makeFingerprint, ServiceRegistry } from "@workglow/util";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { AiJobInput } from "../job/AiJob";
@@ -345,8 +345,12 @@ export class ToolCallingTask extends StreamingAiTask<
 /**
  * Convenience function to run a tool calling task.
  */
-export const toolCalling = (input: ToolCallingTaskInput, config?: ToolCallingTaskConfig) => {
-  return new ToolCallingTask(config).run(input);
+export const toolCalling = (
+  input: ToolCallingTaskInput,
+  config?: ToolCallingTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new ToolCallingTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/TopicSegmenterTask.ts
+++ b/packages/ai/src/task/TopicSegmenterTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
 export const SegmentationMethod = {
@@ -419,9 +419,10 @@ export class TopicSegmenterTask extends Task<
 
 export const topicSegmenter = (
   input: TopicSegmenterTaskInput,
-  config?: TopicSegmenterTaskConfig
+  config?: TopicSegmenterTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new TopicSegmenterTask(config).run(input);
+  return new TopicSegmenterTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/UnloadModelTask.ts
+++ b/packages/ai/src/task/UnloadModelTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { AiTask } from "./base/AiTask";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -65,8 +65,12 @@ export class UnloadModelTask extends AiTask<
  * @param input - Input containing model(s) to unload
  * @returns Promise resolving to the unloaded model(s)
  */
-export const unloadModel = (input: UnloadModelTaskRunInput, config?: UnloadModelTaskConfig) => {
-  return new UnloadModelTask(config).run(input);
+export const unloadModel = (
+  input: UnloadModelTaskRunInput,
+  config?: UnloadModelTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new UnloadModelTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/VectorQuantizeTask.ts
+++ b/packages/ai/src/task/VectorQuantizeTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { CreateWorkflow, Task, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import {
   DataPortSchema,
   FromSchema,
@@ -241,9 +241,10 @@ export class VectorQuantizeTask extends Task<
 
 export const vectorQuantize = (
   input: VectorQuantizeTaskInput,
-  config?: VectorQuantizeTaskConfig
+  config?: VectorQuantizeTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new VectorQuantizeTask(config).run(input);
+  return new VectorQuantizeTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/VectorSimilarityTask.ts
+++ b/packages/ai/src/task/VectorSimilarityTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { CreateWorkflow, GraphAsTask, Workflow } from "@workglow/task-graph";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import {
   cosineSimilarity,
   DataPortSchema,
@@ -148,9 +148,10 @@ export class VectorSimilarityTask extends GraphAsTask<
 
 export const similarity = (
   input: VectorSimilarityTaskInput,
-  config?: VectorSimilarityTaskConfig
+  config?: VectorSimilarityTaskConfig,
+  runConfig?: Partial<IRunConfig>
 ) => {
-  return new VectorSimilarityTask(config).run(input);
+  return new VectorSimilarityTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/generation/ImageEditTask.ts
+++ b/packages/ai/src/task/generation/ImageEditTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { ImageValueSchema } from "@workglow/util/media";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
@@ -76,8 +76,11 @@ export class ImageEditTask extends AiImageOutputTask<ImageEditTaskInput, ImageEd
   }
 }
 
-export const imageEdit = (input: ImageEditTaskInput, config?: ImageEditTaskConfig) =>
-  new ImageEditTask(config).run(input);
+export const imageEdit = (
+  input: ImageEditTaskInput,
+  config?: ImageEditTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => new ImageEditTask(config).run(input, runConfig);
 
 declare module "@workglow/task-graph" {
   interface Workflow {

--- a/packages/ai/src/task/generation/ImageGenerateTask.ts
+++ b/packages/ai/src/task/generation/ImageGenerateTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskConfig } from "@workglow/task-graph";
+import type { TaskConfig, IRunConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
@@ -62,8 +62,11 @@ export class ImageGenerateTask extends AiImageOutputTask<
   }
 }
 
-export const imageGenerate = (input: ImageGenerateTaskInput, config?: ImageGenerateTaskConfig) =>
-  new ImageGenerateTask(config).run(input);
+export const imageGenerate = (
+  input: ImageGenerateTaskInput,
+  config?: ImageGenerateTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => new ImageGenerateTask(config).run(input, runConfig);
 
 declare module "@workglow/task-graph" {
   interface Workflow {

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -169,7 +169,7 @@ export class Workflow<
       this: Workflow<any, any>,
       input: Partial<I> = {},
       config: Partial<C> = {},
-      runConfig: Partial<IRunConfig> = {}
+      runConfig?: Partial<IRunConfig>
     ) {
       this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config, runConfig);
       // Preserve input type from the start of the chain
@@ -576,7 +576,7 @@ export class Workflow<
   >(
     taskClass: ITaskConstructor<I, O, C>,
     config: Partial<C> = {},
-    runConfig: Partial<IRunConfig> = {}
+    runConfig?: Partial<IRunConfig>
   ): Workflow<I, O> {
     return this._builder.addLoopTask<I, O, C>(taskClass, config, runConfig);
   }

--- a/packages/task-graph/src/task-graph/Workflow.ts
+++ b/packages/task-graph/src/task-graph/Workflow.ts
@@ -9,7 +9,7 @@ import { EventEmitter, ServiceRegistry } from "@workglow/util";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
-import type { ITask, ITaskConstructor } from "../task/ITask";
+import type { IRunConfig, ITask, ITaskConstructor } from "../task/ITask";
 import type { StreamEvent } from "../task/StreamTypes";
 import { Task } from "../task/Task";
 import type { TaskEntitlements } from "../task/TaskEntitlements";
@@ -168,9 +168,10 @@ export class Workflow<
     const helper = function (
       this: Workflow<any, any>,
       input: Partial<I> = {},
-      config: Partial<C> = {}
+      config: Partial<C> = {},
+      runConfig: Partial<IRunConfig> = {}
     ) {
-      this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config);
+      this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config, runConfig);
       // Preserve input type from the start of the chain
       // If this is the first task, set both input and output types
       // Otherwise, only update the output type (input type is preserved from 'this')
@@ -545,12 +546,15 @@ export class Workflow<
   public addTask<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I> = TaskConfig<I>>(
     taskClass: ITaskConstructor<I, O, C>,
     input?: Partial<I>,
-    config?: Partial<C>
+    config?: Partial<C>,
+    runConfig?: Partial<IRunConfig>
   ): Workflow<Input, Output> {
-    return this._builder.addTaskWithAutoConnect<I, O, C>(taskClass, input, config) as Workflow<
-      Input,
-      Output
-    >;
+    return this._builder.addTaskWithAutoConnect<I, O, C>(
+      taskClass,
+      input,
+      config,
+      runConfig
+    ) as Workflow<Input, Output>;
   }
 
   // ========================================================================
@@ -569,8 +573,12 @@ export class Workflow<
     I extends DataPorts,
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
-  >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
-    return this._builder.addLoopTask<I, O, C>(taskClass, config);
+  >(
+    taskClass: ITaskConstructor<I, O, C>,
+    config: Partial<C> = {},
+    runConfig: Partial<IRunConfig> = {}
+  ): Workflow<I, O> {
+    return this._builder.addLoopTask<I, O, C>(taskClass, config, runConfig);
   }
 
   /**

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -8,7 +8,7 @@ import { getLogger, ServiceRegistry, uuid4 } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { ConditionFn } from "../task/ConditionalTask";
 import { GraphAsTask } from "../task/GraphAsTask";
-import type { ITask, ITaskConstructor } from "../task/ITask";
+import type { IRunConfig, ITask, ITaskConstructor } from "../task/ITask";
 import { WorkflowError } from "../task/TaskError";
 import type { DataPorts, TaskConfig, TaskInput } from "../task/TaskTypes";
 import { autoConnect } from "./autoConnect";
@@ -95,8 +95,16 @@ export class WorkflowBuilder implements IWorkflowBuilderHandle {
     I extends DataPorts,
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
-  >(taskClass: ITaskConstructor<I, O, C>, config: C): ITask<I, O, C> {
-    const task = new taskClass(config, this._registry ? { registry: this._registry } : undefined);
+  >(
+    taskClass: ITaskConstructor<I, O, C>,
+    config: C,
+    runConfig?: Partial<IRunConfig>
+  ): ITask<I, O, C> {
+    const mergedRunConfig: Partial<IRunConfig> | undefined =
+      runConfig !== undefined || this._registry !== undefined
+        ? { ...runConfig, ...(this._registry ? { registry: this._registry } : {}) }
+        : undefined;
+    const task = new taskClass(config, mergedRunConfig);
     const id = this._facade.graph.addTask(task);
     this._facade.events.emit("changed", id);
     return task;
@@ -115,17 +123,22 @@ export class WorkflowBuilder implements IWorkflowBuilderHandle {
   >(
     taskClass: ITaskConstructor<I, O, C>,
     input: Partial<I> = {},
-    config: Partial<C> = {}
+    config: Partial<C> = {},
+    runConfig?: Partial<IRunConfig>
   ): Workflow<any, any> {
     this._error = "";
 
     const parent = getLastTask(this._facade);
 
-    const task = this.addTaskInstance<I, O, C>(taskClass, {
-      id: uuid4(),
-      ...config,
-      defaults: input,
-    } as C);
+    const task = this.addTaskInstance<I, O, C>(
+      taskClass,
+      {
+        id: uuid4(),
+        ...config,
+        defaults: input,
+      } as C,
+      runConfig
+    );
 
     // Process any pending data flows
     if (this._dataFlows.length > 0) {
@@ -204,7 +217,11 @@ export class WorkflowBuilder implements IWorkflowBuilderHandle {
     I extends DataPorts,
     O extends DataPorts,
     C extends TaskConfig<I> = TaskConfig<I>,
-  >(taskClass: ITaskConstructor<I, O, C>, config: Partial<C> = {}): Workflow<I, O> {
+  >(
+    taskClass: ITaskConstructor<I, O, C>,
+    config: Partial<C> = {},
+    runConfig?: Partial<IRunConfig>
+  ): Workflow<I, O> {
     this._error = "";
 
     const parent = getLastTask(this._facade);
@@ -226,7 +243,11 @@ export class WorkflowBuilder implements IWorkflowBuilderHandle {
         ? ({ ...config, maxIterations: "unbounded" } as Partial<C>)
         : config;
 
-    const task = this.addTaskInstance<I, O, C>(taskClass, { id: uuid4(), ...resolvedConfig } as C);
+    const task = this.addTaskInstance<I, O, C>(
+      taskClass,
+      { id: uuid4(), ...resolvedConfig } as C,
+      runConfig
+    );
 
     // Process any pending data flows (same as addTaskWithAutoConnect)
     if (this._dataFlows.length > 0) {

--- a/packages/task-graph/src/task-graph/WorkflowBuilder.ts
+++ b/packages/task-graph/src/task-graph/WorkflowBuilder.ts
@@ -100,10 +100,10 @@ export class WorkflowBuilder implements IWorkflowBuilderHandle {
     config: C,
     runConfig?: Partial<IRunConfig>
   ): ITask<I, O, C> {
-    const mergedRunConfig: Partial<IRunConfig> | undefined =
-      runConfig !== undefined || this._registry !== undefined
-        ? { ...runConfig, ...(this._registry ? { registry: this._registry } : {}) }
-        : undefined;
+    let mergedRunConfig: Partial<IRunConfig> | undefined = runConfig;
+    if (this._registry !== undefined) {
+      mergedRunConfig = { ...(runConfig ?? {}), registry: this._registry };
+    }
     const task = new taskClass(config, mergedRunConfig);
     const id = this._facade.graph.addTask(task);
     this._facade.events.emit("changed", id);

--- a/packages/task-graph/src/task-graph/WorkflowFactories.ts
+++ b/packages/task-graph/src/task-graph/WorkflowFactories.ts
@@ -62,7 +62,7 @@ export function CreateLoopWorkflow<
   return function (
     this: Workflow<I, O>,
     config: Partial<C> = {},
-    runConfig: Partial<IRunConfig> = {}
+    runConfig?: Partial<IRunConfig>
   ): Workflow<I, O> {
     return this.addLoopTask(taskClass, config, runConfig);
   };
@@ -134,7 +134,7 @@ export function CreateAdaptiveWorkflow<
     this: Workflow<any, any>,
     input: (Partial<IS> & Partial<IV>) | undefined = {},
     config: (Partial<CS> & Partial<CV>) | undefined = {},
-    runConfig: Partial<IRunConfig> | undefined = {}
+    runConfig?: Partial<IRunConfig>
   ): Workflow {
     const parent = getLastTask(this);
     const useVector =

--- a/packages/task-graph/src/task-graph/WorkflowFactories.ts
+++ b/packages/task-graph/src/task-graph/WorkflowFactories.ts
@@ -4,16 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITaskConstructor } from "../task/ITask";
+import type { IRunConfig, ITaskConstructor } from "../task/ITask";
 import type { DataPorts, TaskConfig } from "../task/TaskTypes";
 import { hasVectorLikeInput, hasVectorOutput } from "./GraphSchemaUtils";
 import { Workflow } from "./Workflow";
 import { getLastTask } from "./WorkflowPipe";
 
-// Type definitions for the workflow
+/**
+ * Signature shared by all `Workflow.prototype.<x>` builder methods produced by
+ * {@link CreateWorkflow}.
+ *
+ * The optional `runConfig` is forwarded to the task constructor, so callers can
+ * attach a per-task {@link IRunConfig.resourceScope} (or other runtime knob)
+ * before later invoking `workflow.run(...)`. The workflow's own
+ * {@link WorkflowRunConfig.resourceScope}, if passed to `run()`, still wins
+ * during execution — this third arg primarily exists so that the standalone
+ * convenience wrappers (`chunkRetrieval`, `textEmbedding`, etc.) share a
+ * uniform `(input, config, runConfig)` shape.
+ */
 export type CreateWorkflow<I extends DataPorts, O extends DataPorts, C extends TaskConfig<I>> = (
   input?: Partial<I>,
-  config?: Partial<C>
+  config?: Partial<C>,
+  runConfig?: Partial<IRunConfig>
 ) => Workflow<I, O>;
 
 export function CreateWorkflow<
@@ -33,7 +45,7 @@ export type CreateLoopWorkflow<
   I extends DataPorts,
   O extends DataPorts,
   C extends TaskConfig<I> = TaskConfig<I>,
-> = (this: Workflow<I, O>, config?: Partial<C>) => Workflow<I, O>;
+> = (this: Workflow<I, O>, config?: Partial<C>, runConfig?: Partial<IRunConfig>) => Workflow<I, O>;
 
 /**
  * Factory function that creates a loop workflow method for a given task class.
@@ -47,8 +59,12 @@ export function CreateLoopWorkflow<
   O extends DataPorts,
   C extends TaskConfig<I> = TaskConfig<I>,
 >(taskClass: ITaskConstructor<I, O, C>): CreateLoopWorkflow<I, O, C> {
-  return function (this: Workflow<I, O>, config: Partial<C> = {}): Workflow<I, O> {
-    return this.addLoopTask(taskClass, config);
+  return function (
+    this: Workflow<I, O>,
+    config: Partial<C> = {},
+    runConfig: Partial<IRunConfig> = {}
+  ): Workflow<I, O> {
+    return this.addLoopTask(taskClass, config, runConfig);
   };
 }
 
@@ -86,7 +102,8 @@ export type CreateAdaptiveWorkflow<
 > = (
   this: Workflow,
   input?: Partial<IS> & Partial<IV>,
-  config?: Partial<CS> & Partial<CV>
+  config?: Partial<CS> & Partial<CV>,
+  runConfig?: Partial<IRunConfig>
 ) => Workflow;
 
 /**
@@ -116,14 +133,15 @@ export function CreateAdaptiveWorkflow<
   return function (
     this: Workflow<any, any>,
     input: (Partial<IS> & Partial<IV>) | undefined = {},
-    config: (Partial<CS> & Partial<CV>) | undefined = {}
+    config: (Partial<CS> & Partial<CV>) | undefined = {},
+    runConfig: Partial<IRunConfig> | undefined = {}
   ): Workflow {
     const parent = getLastTask(this);
     const useVector =
       (parent !== undefined && hasVectorOutput(parent)) || hasVectorLikeInput(input);
     if (useVector) {
-      return vectorHelper.call(this, input, config) as Workflow;
+      return vectorHelper.call(this, input, config, runConfig) as Workflow;
     }
-    return scalarHelper.call(this, input, config) as Workflow;
+    return scalarHelper.call(this, input, config, runConfig) as Workflow;
   };
 }

--- a/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
+++ b/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
@@ -91,7 +91,9 @@ const embeddingModel: LlamaCppModelRecord = {
 describe("LlamaCpp Integration (real models, no mocks)", () => {
   let logger = getTestingLogger();
   setLogger(logger);
-  let resourceScope: ResourceScope;
+  // Initialized synchronously up front so `afterAll` always has a scope to
+  // dispose, even if the async setup below throws partway through.
+  const resourceScope = new ResourceScope();
 
   beforeAll(async () => {
     await setTaskQueueRegistry(null);
@@ -102,8 +104,6 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
     const repo = getGlobalModelRepository();
     await repo.addModel(llmModel);
     await repo.addModel(embeddingModel);
-
-    resourceScope = new ResourceScope();
   });
 
   afterAll(async () => {

--- a/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
+++ b/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
@@ -32,11 +32,16 @@ import { ResourceScope, setLogger } from "@workglow/util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
+type MemSnapshot = ReturnType<typeof process.memoryUsage>;
 const mb = (n: number) => (n / 1024 / 1024).toFixed(0) + "MB";
-const reportMem = (label: string) => {
+const signedMb = (n: number) => (n >= 0 ? "+" : "") + (n / 1024 / 1024).toFixed(0) + "MB";
+const snapMem = (): MemSnapshot => process.memoryUsage();
+const reportMem = (label: string, start?: MemSnapshot) => {
   const m = process.memoryUsage();
+  const fmt = (cur: number, base: number | undefined) =>
+    base === undefined ? mb(cur) : `${mb(cur)} (${signedMb(cur - base)})`;
   process.stderr.write(
-    `[${label}] MEM rss=${mb(m.rss)} heap=${mb(m.heapUsed)} ext=${mb(m.external)} ab=${mb(m.arrayBuffers)}\n`
+    `[${label}] MEM rss=${fmt(m.rss, start?.rss)} heap=${fmt(m.heapUsed, start?.heapUsed)} ext=${fmt(m.external, start?.external)} ab=${fmt(m.arrayBuffers, start?.arrayBuffers)}\n`
   );
 };
 const reportTime = (label: string, started: number) => {
@@ -107,12 +112,14 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
   });
 
   afterAll(async () => {
+    reportMem("LlamaCpp before dispose");
+    const beforeDispose = snapMem();
     await resourceScope.disposeAll();
     await disposeLlamaCppResources();
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
-    reportMem("LlamaCpp afterAll");
+    reportMem("LlamaCpp after dispose", beforeDispose);
   });
 
   // ======================================================================
@@ -123,6 +130,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
     "downloads a text generation model and generates a short story",
     async () => {
       const started = Date.now();
+      const startMem = snapMem();
       // Step 1 — download the LLM
       const downloadWorkflow = new Workflow();
       downloadWorkflow.downloadModel({ model: LLM_MODEL_ID });
@@ -146,7 +154,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
       expect(typeof storyResult.text).toBe("string");
       expect((storyResult.text as string).trim().length).toBeGreaterThan(10);
       reportTime("llm download+generate", started);
-      reportMem("llm download+generate");
+      reportMem("llm download+generate", startMem);
     },
     10 * 60 * 1000 // 10 min: download (~85 MB) + inference
   );
@@ -159,6 +167,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
     "downloads an embedding model and embeds text",
     async () => {
       const started = Date.now();
+      const startMem = snapMem();
       // Step 1 — download the embedding model
       const downloadWorkflow = new Workflow();
       downloadWorkflow.downloadModel({ model: EMBED_MODEL_ID });
@@ -187,7 +196,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
       const magnitude = Array.from(vector).reduce((sum, v) => sum + v * v, 0);
       expect(magnitude).toBeGreaterThan(0);
       reportTime("embed download+embed", started);
-      reportMem("embed download+embed");
+      reportMem("embed download+embed", startMem);
     },
     10 * 60 * 1000 // 10 min: download (~34 MB) + inference
   );
@@ -200,6 +209,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
     "generates a story and computes embeddings for each sentence",
     async () => {
       const started = Date.now();
+      const startMem = snapMem();
       // Both models already downloaded by the previous tests; this verifies
       // the full pipeline works end-to-end using cached models.
 
@@ -248,7 +258,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
         }
       }
       reportTime("end-to-end", started);
-      reportMem("end-to-end");
+      reportMem("end-to-end", startMem);
     },
     5 * 60 * 1000 // 5 min: inference only (models already cached)
   );

--- a/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
+++ b/packages/test/src/test/ai-provider/LlamaCppProviderIntegration.integration.test.ts
@@ -28,9 +28,20 @@ import {
   registerLlamaCppInline,
 } from "@workglow/node-llama-cpp/ai-runtime";
 import { getTaskQueueRegistry, setTaskQueueRegistry, Workflow } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
+import { ResourceScope, setLogger } from "@workglow/util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
+
+const mb = (n: number) => (n / 1024 / 1024).toFixed(0) + "MB";
+const reportMem = (label: string) => {
+  const m = process.memoryUsage();
+  process.stderr.write(
+    `[${label}] MEM rss=${mb(m.rss)} heap=${mb(m.heapUsed)} ext=${mb(m.external)} ab=${mb(m.arrayBuffers)}\n`
+  );
+};
+const reportTime = (label: string, started: number) => {
+  process.stderr.write(`[${label}] TIME ${((Date.now() - started) / 1000).toFixed(2)}s\n`);
+};
 
 // ========================================================================
 // Model definitions (tiny models suitable for testing)
@@ -80,6 +91,8 @@ const embeddingModel: LlamaCppModelRecord = {
 describe("LlamaCpp Integration (real models, no mocks)", () => {
   let logger = getTestingLogger();
   setLogger(logger);
+  let resourceScope: ResourceScope;
+
   beforeAll(async () => {
     await setTaskQueueRegistry(null);
     setGlobalModelRepository(new InMemoryModelRepository());
@@ -89,13 +102,17 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
     const repo = getGlobalModelRepository();
     await repo.addModel(llmModel);
     await repo.addModel(embeddingModel);
+
+    resourceScope = new ResourceScope();
   });
 
   afterAll(async () => {
+    await resourceScope.disposeAll();
     await disposeLlamaCppResources();
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
+    reportMem("LlamaCpp afterAll");
   });
 
   // ======================================================================
@@ -105,10 +122,11 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
   it(
     "downloads a text generation model and generates a short story",
     async () => {
+      const started = Date.now();
       // Step 1 — download the LLM
       const downloadWorkflow = new Workflow();
       downloadWorkflow.downloadModel({ model: LLM_MODEL_ID });
-      await downloadWorkflow.run();
+      await downloadWorkflow.run({}, { resourceScope });
 
       // Step 2 — generate a story
       const storyWorkflow = new Workflow();
@@ -119,11 +137,16 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
         temperature: 0.7,
       });
 
-      const storyResult = (await storyWorkflow.run()) as TextGenerationTaskOutput;
+      const storyResult = (await storyWorkflow.run(
+        {},
+        { resourceScope }
+      )) as TextGenerationTaskOutput;
 
       expect(storyResult.text).toBeDefined();
       expect(typeof storyResult.text).toBe("string");
       expect((storyResult.text as string).trim().length).toBeGreaterThan(10);
+      reportTime("llm download+generate", started);
+      reportMem("llm download+generate");
     },
     10 * 60 * 1000 // 10 min: download (~85 MB) + inference
   );
@@ -135,10 +158,11 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
   it(
     "downloads an embedding model and embeds text",
     async () => {
+      const started = Date.now();
       // Step 1 — download the embedding model
       const downloadWorkflow = new Workflow();
       downloadWorkflow.downloadModel({ model: EMBED_MODEL_ID });
-      await downloadWorkflow.run();
+      await downloadWorkflow.run({}, { resourceScope });
 
       // Step 2 — embed a sentence
       const sentence = "A curious robot wandered into an overgrown garden.";
@@ -148,7 +172,10 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
         text: sentence,
       });
 
-      const embedResult = (await embedWorkflow.run()) as TextEmbeddingTaskOutput;
+      const embedResult = (await embedWorkflow.run(
+        {},
+        { resourceScope }
+      )) as TextEmbeddingTaskOutput;
 
       expect(embedResult.vector).toBeDefined();
       expect(embedResult.vector).toBeInstanceOf(Float32Array);
@@ -159,6 +186,8 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
       // Vector should not be all zeros
       const magnitude = Array.from(vector).reduce((sum, v) => sum + v * v, 0);
       expect(magnitude).toBeGreaterThan(0);
+      reportTime("embed download+embed", started);
+      reportMem("embed download+embed");
     },
     10 * 60 * 1000 // 10 min: download (~34 MB) + inference
   );
@@ -170,6 +199,7 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
   it(
     "generates a story and computes embeddings for each sentence",
     async () => {
+      const started = Date.now();
       // Both models already downloaded by the previous tests; this verifies
       // the full pipeline works end-to-end using cached models.
 
@@ -180,7 +210,10 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
         maxTokens: 80,
         temperature: 0.5,
       });
-      const storyResult = (await storyWorkflow.run()) as TextGenerationTaskOutput;
+      const storyResult = (await storyWorkflow.run(
+        {},
+        { resourceScope }
+      )) as TextGenerationTaskOutput;
       const story = (storyResult.text as string)?.trim() ?? "";
 
       expect(story.length).toBeGreaterThan(5);
@@ -197,7 +230,10 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
         text: sentences.length === 1 ? sentences[0] : sentences,
       });
 
-      const embedResult = (await embedWorkflow.run()) as TextEmbeddingTaskOutput;
+      const embedResult = (await embedWorkflow.run(
+        {},
+        { resourceScope }
+      )) as TextEmbeddingTaskOutput;
 
       if (sentences.length === 1) {
         expect(embedResult.vector).toBeInstanceOf(Float32Array);
@@ -211,6 +247,8 @@ describe("LlamaCpp Integration (real models, no mocks)", () => {
           expect(v.length).toBeGreaterThan(0);
         }
       }
+      reportTime("end-to-end", started);
+      reportMem("end-to-end");
     },
     5 * 60 * 1000 // 5 min: inference only (models already cached)
   );

--- a/packages/test/src/test/ai/StreamingAiTaskPhases.test.ts
+++ b/packages/test/src/test/ai/StreamingAiTaskPhases.test.ts
@@ -23,17 +23,33 @@ import {
   TaskOutput,
   TaskQueueRegistry,
 } from "@workglow/task-graph";
-import { setLogger } from "@workglow/util";
-import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ResourceScope, setLogger } from "@workglow/util";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
 const MOCK_PROVIDER = "mock-phase-provider";
+
+const mb = (n: number) => (n / 1024 / 1024).toFixed(0) + "MB";
+const reportMem = (label: string) => {
+  const m = process.memoryUsage();
+  process.stderr.write(
+    `[${label}] MEM rss=${mb(m.rss)} heap=${mb(m.heapUsed)} ext=${mb(m.external)} ab=${mb(m.arrayBuffers)}\n`
+  );
+};
+const reportTime = (label: string, started: number) => {
+  process.stderr.write(`[${label}] TIME ${((Date.now() - started) / 1000).toFixed(2)}s\n`);
+};
 
 describe("StreamingAiTask default phase emissions", () => {
   let server: JobQueueServer<AiJobInput<TaskInput>, TaskOutput>;
   let client: JobQueueClient<AiJobInput<TaskInput>, TaskOutput>;
   let storage: IQueueStorage<AiJobInput<TaskInput>, TaskOutput>;
   let registry: AiProviderRegistry;
+  let resourceScope: ResourceScope;
+
+  beforeAll(() => {
+    resourceScope = new ResourceScope();
+  });
 
   beforeEach(async () => {
     const logger = getTestingLogger();
@@ -75,9 +91,11 @@ describe("StreamingAiTask default phase emissions", () => {
   });
 
   afterAll(async () => {
+    await resourceScope.disposeAll();
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
+    reportMem("StreamingAiTaskPhases afterAll");
   });
 
   const buildModel = (taskType: string) => ({
@@ -91,6 +109,7 @@ describe("StreamingAiTask default phase emissions", () => {
   });
 
   it("emits 'Preparing' before any data event", async () => {
+    const started = Date.now();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "text-delta", port: "text", textDelta: "hi" };
       yield { type: "finish", data: {} };
@@ -101,7 +120,7 @@ describe("StreamingAiTask default phase emissions", () => {
     const task = new TextSummaryTask({ id: "p1" });
     const messages: Array<string | undefined> = [];
     task.subscribe("progress", (_progress, message) => messages.push(message));
-    await task.run({ model: model as any, text: "test" });
+    await task.run({ model: model as any, text: "test" }, { resourceScope });
 
     const idxPreparing = messages.indexOf("Preparing");
     const idxLabel = messages.indexOf("Summarizing");
@@ -113,9 +132,12 @@ describe("StreamingAiTask default phase emissions", () => {
       idxLabel,
       `expected 'Summarizing' after 'Preparing' in messages ${JSON.stringify(messages)}`
     ).toBeGreaterThan(idxPreparing);
+    reportTime("phase: preparing", started);
+    reportMem("phase: preparing");
   });
 
   it("uses the subclass's streamingPhaseLabel on first data event", async () => {
+    const started = Date.now();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "text-delta", port: "text", textDelta: "hi" };
       yield { type: "finish", data: {} };
@@ -126,12 +148,15 @@ describe("StreamingAiTask default phase emissions", () => {
     const task = new TextSummaryTask({ id: "p2" });
     const events: Array<{ progress: number | undefined; message: string | undefined }> = [];
     task.subscribe("progress", (progress, message) => events.push({ progress, message }));
-    await task.run({ model: model as any, text: "test" });
+    await task.run({ model: model as any, text: "test" }, { resourceScope });
 
     expect(events).toContainEqual({ progress: undefined, message: "Summarizing" });
+    reportTime("phase: subclass label", started);
+    reportMem("phase: subclass label");
   });
 
   it("provider-yielded phase overrides the default", async () => {
+    const started = Date.now();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "phase", message: "Calling Anthropic", progress: undefined };
       yield { type: "text-delta", port: "text", textDelta: "hi" };
@@ -143,7 +168,7 @@ describe("StreamingAiTask default phase emissions", () => {
     const task = new TextSummaryTask({ id: "p3" });
     const messages: Array<string | undefined> = [];
     task.subscribe("progress", (_progress, message) => messages.push(message));
-    await task.run({ model: model as any, text: "test" });
+    await task.run({ model: model as any, text: "test" }, { resourceScope });
 
     const idxPreparing = messages.indexOf("Preparing");
     const idxCalling = messages.indexOf("Calling Anthropic");
@@ -160,5 +185,7 @@ describe("StreamingAiTask default phase emissions", () => {
       idxLabel,
       `expected 'Summarizing' after 'Calling Anthropic' in messages ${JSON.stringify(messages)}`
     ).toBeGreaterThan(idxCalling);
+    reportTime("phase: provider override", started);
+    reportMem("phase: provider override");
   });
 });

--- a/packages/test/src/test/ai/StreamingAiTaskPhases.test.ts
+++ b/packages/test/src/test/ai/StreamingAiTaskPhases.test.ts
@@ -29,11 +29,16 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 
 const MOCK_PROVIDER = "mock-phase-provider";
 
+type MemSnapshot = ReturnType<typeof process.memoryUsage>;
 const mb = (n: number) => (n / 1024 / 1024).toFixed(0) + "MB";
-const reportMem = (label: string) => {
+const signedMb = (n: number) => (n >= 0 ? "+" : "") + (n / 1024 / 1024).toFixed(0) + "MB";
+const snapMem = (): MemSnapshot => process.memoryUsage();
+const reportMem = (label: string, start?: MemSnapshot) => {
   const m = process.memoryUsage();
+  const fmt = (cur: number, base: number | undefined) =>
+    base === undefined ? mb(cur) : `${mb(cur)} (${signedMb(cur - base)})`;
   process.stderr.write(
-    `[${label}] MEM rss=${mb(m.rss)} heap=${mb(m.heapUsed)} ext=${mb(m.external)} ab=${mb(m.arrayBuffers)}\n`
+    `[${label}] MEM rss=${fmt(m.rss, start?.rss)} heap=${fmt(m.heapUsed, start?.heapUsed)} ext=${fmt(m.external, start?.external)} ab=${fmt(m.arrayBuffers, start?.arrayBuffers)}\n`
   );
 };
 const reportTime = (label: string, started: number) => {
@@ -91,11 +96,13 @@ describe("StreamingAiTask default phase emissions", () => {
   });
 
   afterAll(async () => {
+    reportMem("StreamingAiTaskPhases before dispose");
+    const beforeDispose = snapMem();
     await resourceScope.disposeAll();
     await getTaskQueueRegistry().stopQueues();
     await getTaskQueueRegistry().clearQueues();
     await setTaskQueueRegistry(null);
-    reportMem("StreamingAiTaskPhases afterAll");
+    reportMem("StreamingAiTaskPhases after dispose", beforeDispose);
   });
 
   const buildModel = (taskType: string) => ({
@@ -110,6 +117,7 @@ describe("StreamingAiTask default phase emissions", () => {
 
   it("emits 'Preparing' before any data event", async () => {
     const started = Date.now();
+    const startMem = snapMem();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "text-delta", port: "text", textDelta: "hi" };
       yield { type: "finish", data: {} };
@@ -133,11 +141,12 @@ describe("StreamingAiTask default phase emissions", () => {
       `expected 'Summarizing' after 'Preparing' in messages ${JSON.stringify(messages)}`
     ).toBeGreaterThan(idxPreparing);
     reportTime("phase: preparing", started);
-    reportMem("phase: preparing");
+    reportMem("phase: preparing", startMem);
   });
 
   it("uses the subclass's streamingPhaseLabel on first data event", async () => {
     const started = Date.now();
+    const startMem = snapMem();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "text-delta", port: "text", textDelta: "hi" };
       yield { type: "finish", data: {} };
@@ -152,11 +161,12 @@ describe("StreamingAiTask default phase emissions", () => {
 
     expect(events).toContainEqual({ progress: undefined, message: "Summarizing" });
     reportTime("phase: subclass label", started);
-    reportMem("phase: subclass label");
+    reportMem("phase: subclass label", startMem);
   });
 
   it("provider-yielded phase overrides the default", async () => {
     const started = Date.now();
+    const startMem = snapMem();
     const streamFn: AiProviderStreamFn = async function* () {
       yield { type: "phase", message: "Calling Anthropic", progress: undefined };
       yield { type: "text-delta", port: "text", textDelta: "hi" };
@@ -186,6 +196,6 @@ describe("StreamingAiTask default phase emissions", () => {
       `expected 'Summarizing' after 'Calling Anthropic' in messages ${JSON.stringify(messages)}`
     ).toBeGreaterThan(idxCalling);
     reportTime("phase: provider override", started);
-    reportMem("phase: provider override");
+    reportMem("phase: provider override", startMem);
   });
 });


### PR DESCRIPTION
Adds an optional third `runConfig?: Partial<IRunConfig>` parameter to
the `CreateWorkflow` / `CreateLoopWorkflow` / `CreateAdaptiveWorkflow`
factories and to every AI convenience wrapper
(`chunkRetrieval`, `textQuestionAnswer`, `textEmbedding`, etc.). This
lets callers share a `ResourceScope` across repeated wrapper calls so
the AI pipeline cache survives between runs — same warm-cache pattern
already supported by `Workflow.run(input, { resourceScope })` and
`Task.run(overrides, { resourceScope })`.

Threaded through `Workflow.addTask`/`addLoopTask` and the underlying
`WorkflowBuilder.addTaskInstance`/`addTaskWithAutoConnect`/`addLoopTask`
so prototype builder methods can accept the same signature uniformly.

https://claude.ai/code/session_013jy9ajzR52tkWnzjz6vvhE