### PR TITLE
Fix sqlite-vector ESM module resolution with platform-specific packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "caniuse-lite": "^1.0.30001792",
       },
       "devDependencies": {
+        "@sqliteai/sqlite-vector": "catalog:",
         "@types/bun": "^1.3.13",
         "@types/node": "^24.12.3",
         "@typescript-eslint/eslint-plugin": "^8.59.2",
@@ -29,6 +30,15 @@
         "turbo": "^2.9.12",
         "typescript": "6.0.3",
         "vitest": "^4.1.5",
+      },
+      "optionalDependencies": {
+        "@sqliteai/sqlite-vector-darwin-arm64": "^0.9.95",
+        "@sqliteai/sqlite-vector-darwin-x86_64": "^0.9.95",
+        "@sqliteai/sqlite-vector-linux-arm64": "^0.9.95",
+        "@sqliteai/sqlite-vector-linux-arm64-musl": "^0.9.95",
+        "@sqliteai/sqlite-vector-linux-x86_64": "^0.9.95",
+        "@sqliteai/sqlite-vector-linux-x86_64-musl": "^0.9.95",
+        "@sqliteai/sqlite-vector-win32-x86_64": "^0.9.95",
       },
     },
     "examples/cli": {
@@ -264,6 +274,7 @@
       "devDependencies": {
         "@electric-sql/pglite": "catalog:",
         "@modelcontextprotocol/sdk": "catalog:",
+        "@sqliteai/sqlite-vector": "catalog:",
         "@supabase/supabase-js": "catalog:",
         "@types/pg": "^8.18.0",
         "@workglow/ai": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,17 @@
     "@sqliteai/sqlite-vector": "^0.9.95",
     "better-sqlite3": "^12.9.0"
   },
+  "optionalDependencies": {
+    "@sqliteai/sqlite-vector-darwin-arm64": "^0.9.95",
+    "@sqliteai/sqlite-vector-darwin-x86_64": "^0.9.95",
+    "@sqliteai/sqlite-vector-linux-arm64": "^0.9.95",
+    "@sqliteai/sqlite-vector-linux-arm64-musl": "^0.9.95",
+    "@sqliteai/sqlite-vector-linux-x86_64": "^0.9.95",
+    "@sqliteai/sqlite-vector-linux-x86_64-musl": "^0.9.95",
+    "@sqliteai/sqlite-vector-win32-x86_64": "^0.9.95"
+  },
   "devDependencies": {
+    "@sqliteai/sqlite-vector": "catalog:",
     "@types/bun": "^1.3.13",
     "@types/node": "^24.12.3",
     "@typescript-eslint/eslint-plugin": "^8.59.2",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -23,6 +23,7 @@
     "test-concurrently": "bash -c 'cmds=(); for d in ./src/test/*/; do cmds+=(\"cd $d && bun test\"); done; concurrently \"${cmds[@]}\"'"
   },
   "devDependencies": {
+    "@sqliteai/sqlite-vector": "catalog:",
     "@electric-sql/pglite": "catalog:",
     "@modelcontextprotocol/sdk": "catalog:",
     "@supabase/supabase-js": "catalog:",

--- a/packages/test/src/test/vector/SqliteAiVectorStorage.integration.test.ts
+++ b/packages/test/src/test/vector/SqliteAiVectorStorage.integration.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createRequire } from "node:module";
 import { SqliteAiVectorStorage } from "@workglow/sqlite/storage";
 import { Sqlite } from "@workglow/sqlite/storage";
 import { setLogger } from "@workglow/util";
@@ -11,9 +12,13 @@ import type { DataPortSchemaObject } from "@workglow/util/schema";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
+const _require = createRequire(import.meta.url);
+
 let sqliteVectorAvailable = false;
 try {
-  const mod = await import("@sqliteai/sqlite-vector");
+  // Use CJS require so the platform-specific sub-package resolves correctly in ESM contexts
+  const mod = _require("@sqliteai/sqlite-vector");
+  await Sqlite.init();
   const db = new Sqlite.Database(":memory:");
   db.loadExtension(mod.getExtensionPath());
   db.exec("SELECT vector_version()");

--- a/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createRequire } from "node:module";
 import { Sqlite } from "@workglow/sqlite/storage";
 import type {
   DataPortSchemaObject,
@@ -179,8 +180,9 @@ export class SqliteAiVectorStorage<
     // Try to load the sqlite-vector extension if not already loaded
     if (!this.extensionLoaded) {
       try {
-        // Try to load the extension - the caller may have already loaded it
-        const { getExtensionPath } = await import("@sqliteai/sqlite-vector");
+        // Use CJS require so the platform-specific sub-package resolves correctly in ESM contexts
+        const _require = createRequire(import.meta.url);
+        const { getExtensionPath } = _require("@sqliteai/sqlite-vector");
         this.database.loadExtension(getExtensionPath());
         this.extensionLoaded = true;
       } catch {
@@ -483,7 +485,7 @@ export class SqliteAiVectorStorage<
         ORDER BY v.distance ASC
       `;
       const stmt = db.prepare(sql);
-      const rows = stmt.all(tableName, vectorCol, queryBlob.v, topK) as Array<
+      const rows = stmt.all(tableName, vectorCol, queryBlob.v, topK | 0) as Array<
         Record<string, unknown> & { distance: number }
       >;
 


### PR DESCRIPTION
## Summary

Fixes module resolution issues with `@sqliteai/sqlite-vector` in ESM contexts by switching from dynamic `import()` to CommonJS `require()` via `createRequire()`. This ensures platform-specific sub-packages (darwin-arm64, linux-x86_64, etc.) resolve correctly.

## Changes

- **package.json**: Added optional dependencies for all platform-specific `sqlite-vector` variants (darwin-arm64, darwin-x86_64, linux-arm64, linux-arm64-musl, linux-x86_64, linux-x86_64-musl, win32-x86_64) and added `@sqliteai/sqlite-vector` to devDependencies in both root and test packages using catalog references
- **SqliteAiVectorStorage.ts**: Replaced dynamic `import("@sqliteai/sqlite-vector")` with `createRequire(import.meta.url)` to properly resolve platform-specific sub-packages in ESM contexts
- **SqliteAiVectorStorage.ts**: Fixed potential integer overflow in `topK` parameter by applying bitwise OR with 0 (`topK | 0`) to ensure it's treated as a 32-bit integer
- **SqliteAiVectorStorage.integration.test.ts**: Updated test setup to use `createRequire()` instead of dynamic import for consistent module resolution and added `await Sqlite.init()` call before database operations

## Implementation Details

The core issue was that ESM's dynamic `import()` doesn't properly resolve the conditional exports that `sqlite-vector` uses to load platform-specific native bindings. By using CommonJS `require()` via `createRequire()`, the module resolution falls back to Node's standard package resolution algorithm, which correctly handles the platform-specific sub-package selection.

The optional dependencies declaration ensures all platform variants are available during installation, allowing the correct one to be selected at runtime based on the current platform.

https://claude.ai/code/session_01N1fkmMs9nv3rooEjrwuLQ9