### PR TITLE
ci: switch API key injection to WORKGLOW_SECRETS_PASSPHRASE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,9 +87,7 @@ jobs:
           path: .
       - name: Run integration tests via bun
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:bun:integration
 
   test-bun-rag:
@@ -115,9 +113,7 @@ jobs:
           path: .
       - name: Run rag tests via bun
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:bun:rag
 
   test-bun-ai-provider-hft:
@@ -191,9 +187,7 @@ jobs:
           path: .
       - name: Run API provider tests via bun
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:bun:ai-provider-api
 
   test-vitest-unit:
@@ -251,9 +245,7 @@ jobs:
           path: .
       - name: Run integration tests via vitest
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:vitest:integration
       - name: Copy Vitest coverage fragment
         run: cp coverage/coverage-final.json vitest-integration-coverage.json
@@ -287,9 +279,7 @@ jobs:
           path: .
       - name: Run rag tests via vitest
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:vitest:rag
       - name: Copy Vitest coverage fragment
         run: cp coverage/coverage-final.json vitest-rag-coverage.json
@@ -387,9 +377,7 @@ jobs:
           path: .
       - name: Run API provider tests via vitest
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:vitest:ai-provider-api
       - name: Copy Vitest coverage fragment
         run: cp coverage/coverage-final.json vitest-ai-provider-api-coverage.json


### PR DESCRIPTION
Replace the three direct GitHub secrets (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY) with a single WORKGLOW_SECRETS_PASSPHRASE secret, letting the preload-credentials mechanism decrypt and hydrate all API keys from the committed encrypted credential store at test runtime.

https://claude.ai/code/session_012hS3h7A87rugLmSxcAU1kQ