### PR TITLE
fix(ci): skip husky install when $CI is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "publish-all": "bun ./scripts/bunsrc-workspace.ts dist && bun run format && bun run rebuild && bun run test && bun run bunset && bun run publish-login && bun run publish-workspaces",
     "publish-login": "npm login",
     "publish-workspaces": "bun ./scripts/publish-workspaces.ts",
-    "prepare": "husky"
+    "prepare": "[ -n \"$CI\" ] || husky"
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001792"


### PR DESCRIPTION
## Summary

Addresses a High-severity review finding on `package.json:53`: the `"prepare": "husky"` script ran unconditionally, including in CI.

- Installing git hooks on every CI runner is wasted work.
- More importantly, it leaves a `pre-commit` hook in place on runner state. Any future CI-side `git commit` (release bots, changesets, codegen workflows) would silently invoke `lint-staged` against arbitrary runner files.

## Change

`package.json`:
```diff
-    "prepare": "husky"
+    "prepare": "[ -n \"$CI\" ] || husky"
```

This is the Husky 9.1 CI-aware idiom: `$CI` is set by GitHub Actions (and every other major CI provider) automatically, so the `husky` command is skipped there but still runs for local installs. No new dependency required.

The overly-broad `lint-staged` glob is intentionally left for a follow-up.

## Test plan

- [ ] Local `bun install` still installs git hooks (`$CI` unset -> right side of `||` runs).
- [ ] CI `bun install` does not create `.git/hooks/pre-commit` (`$CI=true` -> left side short-circuits, exit 0).


---
_Generated by [Claude Code](https://claude.ai/code/session_018ahj9PynTGUcWpXb2Q2DPr)_