### PR TITLE
fix(ai): rerank candidate floor + KbSearchTask scoreThreshold forwarding

### DIFF
--- a/packages/ai/src/kb/createStandardKbStrategy.ts
+++ b/packages/ai/src/kb/createStandardKbStrategy.ts
@@ -42,10 +42,22 @@ export interface CreateStandardKbStrategyOptions {
    * Multiplier applied to `topK` to size the first-stage candidate pool
    * when `searchMode === "rerank"`. The reranker then narrows the pool
    * back down to `topK`. Defaults to `5`, i.e. first stage fetches
-   * `topK * 5` candidates (with a `topK` floor so it never returns fewer
-   * than `topK`).
+   * `topK * 5` candidates. Used together with `firstStageMinimum` —
+   * the actual first-stage size is `max(topK * firstStageMultiplier,
+   * firstStageMinimum)`, so a tiny `topK` (e.g. `1`) still yields a
+   * meaningful candidate pool for the reranker to choose from instead of
+   * collapsing to a single candidate.
    */
   readonly firstStageMultiplier?: number;
+  /**
+   * Minimum first-stage candidate pool size when `searchMode === "rerank"`.
+   * Defaults to `20`. Prevents the rerank pool from collapsing to
+   * `topK` for very small `topK` values where `topK * firstStageMultiplier`
+   * would still be too few candidates for the reranker to do useful work.
+   * The effective first-stage size is
+   * `max(topK * firstStageMultiplier, firstStageMinimum)`.
+   */
+  readonly firstStageMinimum?: number;
 }
 
 /**
@@ -77,6 +89,7 @@ export function createStandardKbStrategy(
     reservedTokens: options.chunker?.reservedTokens ?? 10,
   } as const;
   const firstStageMultiplier = options.firstStageMultiplier ?? 5;
+  const firstStageMinimum = options.firstStageMinimum ?? 20;
 
   const resolveSearchMode = (kb: IKbStrategyTarget): SearchMode => {
     if (options.searchMode) return options.searchMode;
@@ -212,7 +225,12 @@ export function createStandardKbStrategy(
       }
 
       // mode === "rerank"
-      const firstStageTopK = Math.max(topK * firstStageMultiplier, topK);
+      // First-stage pool is `topK * firstStageMultiplier`, but never
+      // smaller than `firstStageMinimum`. The floor matters for small
+      // `topK`: with `topK=1, multiplier=5` the raw product is 5, which
+      // robs the reranker of any real choice. The minimum keeps the
+      // candidate pool meaningful regardless of how small `topK` is.
+      const firstStageTopK = Math.max(topK * firstStageMultiplier, firstStageMinimum);
       const firstStage: ChunkSearchResult[] = kb.supportsHybridSearch()
         ? await kb.hybridSearch(vector, {
             textQuery: query,

--- a/packages/ai/src/task/KbSearchTask.ts
+++ b/packages/ai/src/task/KbSearchTask.ts
@@ -35,6 +35,13 @@ const inputSchema = {
       title: "Metadata Filter",
       description: "Filter results by chunk metadata fields.",
     },
+    scoreThreshold: {
+      type: "number",
+      title: "Score Threshold",
+      description:
+        "Minimum score to include a result. Honored by similarity and hybrid search modes; ignored by the strategy in rerank mode (cross-encoder logits aren't comparable to cosine/RRF scores).",
+      minimum: 0,
+    },
   },
   required: ["knowledgeBase", "query"],
   additionalProperties: false,
@@ -124,9 +131,14 @@ export class KbSearchTask extends Task<KbSearchTaskInput, KbSearchTaskOutput, Kb
     input: KbSearchTaskInput,
     _context: IExecuteContext
   ): Promise<KbSearchTaskOutput> {
-    const { knowledgeBase, query, topK = 5, filter } = input;
+    const { knowledgeBase, query, topK = 5, filter, scoreThreshold } = input;
     const kb = knowledgeBase as KnowledgeBase;
-    const results = await kb.search(query, { topK, filter });
+    // Forward `scoreThreshold` to the strategy. The standard strategy
+    // honors it in similarity / hybrid modes and intentionally ignores
+    // it in rerank mode (cross-encoder logits aren't on the same scale
+    // as cosine / RRF, so a single numeric threshold would either drop
+    // everything or nothing).
+    const results = await kb.search(query, { topK, filter, scoreThreshold });
     return {
       results,
       // `chunkText` enforces the metadata.text contract — any chunk

--- a/packages/test/src/test/rag/CreateStandardKbStrategyFirstStage.test.ts
+++ b/packages/test/src/test/rag/CreateStandardKbStrategyFirstStage.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createStandardKbStrategy, getAiProviderRegistry, getGlobalModelRepository } from "@workglow/ai";
+import type { ModelRecord } from "@workglow/ai";
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the first-stage candidate-pool sizing in
+ * `createStandardKbStrategy` rerank mode. The pool size is
+ * `max(topK * firstStageMultiplier, firstStageMinimum)`; the minimum
+ * exists so that a very small `topK` (e.g. 1) does not collapse the
+ * reranker's input down to a useless handful of candidates.
+ */
+const TEST_PROVIDER = "test-firststage-provider";
+const TEST_EMBED_MODEL_ID = "test:firststage:embed";
+
+describe("createStandardKbStrategy first-stage sizing (rerank mode)", () => {
+  beforeAll(async () => {
+    const registry = getAiProviderRegistry();
+    registry.registerRunFn(TEST_PROVIDER, "TextEmbeddingTask", async (input) => {
+      const texts = Array.isArray((input as { text: unknown }).text)
+        ? ((input as { text: string[] }).text as string[])
+        : [((input as { text: string }).text as string) ?? ""];
+      const vectors = texts.map(() => new Float32Array([1, 0, 0]));
+      return {
+        vector: vectors.length === 1 ? vectors[0] : vectors,
+      } as unknown as Record<string, unknown>;
+    });
+
+    const modelRepo = getGlobalModelRepository();
+    const existing = await modelRepo.findByName(TEST_EMBED_MODEL_ID).catch(() => undefined);
+    if (!existing) {
+      await modelRepo.addModel({
+        model_id: TEST_EMBED_MODEL_ID,
+        tasks: ["TextEmbeddingTask"],
+        title: "First-stage sizing test embed model",
+        description: "Stub embed model for first-stage sizing tests",
+        provider: TEST_PROVIDER,
+        provider_config: { native_dimensions: 3 },
+        metadata: {},
+      } as ModelRecord);
+    }
+  });
+
+  /**
+   * Set up a rerank-mode KB and spy on the first-stage retrieval call so
+   * we can assert exactly what `topK` the strategy hands down to it.
+   * Heuristic-reranker path (no `rerankerModel`) is used because we only
+   * care about the first-stage `topK`, not the reranker output.
+   */
+  async function captureFirstStageTopK(
+    strategyOptions: Parameters<typeof createStandardKbStrategy>[0],
+    searchTopK: number
+  ): Promise<number> {
+    const kb = await createKnowledgeBase({
+      name: `kb-first-stage-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+      docEmbeddingModel: TEST_EMBED_MODEL_ID,
+      searchMode: "rerank",
+    });
+    kb.setAiStrategy(createStandardKbStrategy(strategyOptions));
+
+    // Spy on whichever first-stage method the strategy will pick. Both
+    // are stubbed to return [] so the rerank path short-circuits and we
+    // don't have to seed real chunks.
+    const hybridSpy = vi
+      .spyOn(kb, "hybridSearch" as never)
+      .mockResolvedValue([] as never);
+    const similaritySpy = vi
+      .spyOn(kb, "similaritySearch" as never)
+      .mockResolvedValue([] as never);
+
+    await kb.search("hi", { topK: searchTopK });
+
+    // Exactly one of the spies should fire (mutually exclusive branches
+    // in the strategy: hybrid if supportsHybridSearch, else similarity).
+    const calls = [...hybridSpy.mock.calls, ...similaritySpy.mock.calls];
+    expect(calls.length).toBe(1);
+    const opts = calls[0][1] as { topK: number };
+    return opts.topK;
+  }
+
+  it("topK=1, multiplier defaults to 5, minimum defaults to 20 → first-stage topK=20", async () => {
+    const firstStage = await captureFirstStageTopK(undefined, 1);
+    expect(firstStage).toBe(20);
+  });
+
+  it("topK=10, multiplier defaults to 5 → first-stage topK=50 (above minimum)", async () => {
+    const firstStage = await captureFirstStageTopK(undefined, 10);
+    expect(firstStage).toBe(50);
+  });
+
+  it("topK=2, multiplier=1, firstStageMinimum=20 → first-stage topK=20 (minimum wins)", async () => {
+    const firstStage = await captureFirstStageTopK(
+      { firstStageMultiplier: 1, firstStageMinimum: 20 },
+      2
+    );
+    expect(firstStage).toBe(20);
+  });
+});

--- a/packages/test/src/test/rag/KbSearchTask.test.ts
+++ b/packages/test/src/test/rag/KbSearchTask.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { kbSearch } from "@workglow/ai";
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests that `KbSearchTask` forwards `scoreThreshold` to `kb.search`.
+ * The task is the public surface that downstream callers wire into a
+ * workflow; if the schema accepts `scoreThreshold` but `execute` drops
+ * it, callers silently get unfiltered results.
+ */
+describe("KbSearchTask scoreThreshold forwarding", () => {
+  /**
+   * Build a KB whose `search` method is replaced with a spy that returns
+   * an empty result list. The spy lets us assert exactly which options
+   * the task hands down.
+   */
+  async function makeKbWithSearchSpy() {
+    const kb = await createKnowledgeBase({
+      name: `kb-search-task-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+    });
+    const searchSpy = vi.spyOn(kb, "search").mockResolvedValue([]);
+    return { kb, searchSpy };
+  }
+
+  it("forwards `scoreThreshold` to kb.search when provided", async () => {
+    const { kb, searchSpy } = await makeKbWithSearchSpy();
+
+    await kbSearch({
+      knowledgeBase: kb,
+      query: "hello",
+      topK: 3,
+      scoreThreshold: 0.42,
+    });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    const [forwardedQuery, forwardedOpts] = searchSpy.mock.calls[0];
+    expect(forwardedQuery).toBe("hello");
+    expect(forwardedOpts).toMatchObject({ topK: 3, scoreThreshold: 0.42 });
+  });
+
+  it("passes `scoreThreshold: undefined` to kb.search when omitted", async () => {
+    const { kb, searchSpy } = await makeKbWithSearchSpy();
+
+    await kbSearch({
+      knowledgeBase: kb,
+      query: "hello",
+      topK: 3,
+    });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    const [, forwardedOpts] = searchSpy.mock.calls[0];
+    // Property may either be absent or explicitly undefined; both
+    // behave identically downstream. What we really care about is
+    // that it's NOT a stale value carried over from a previous call.
+    expect((forwardedOpts as { scoreThreshold?: number }).scoreThreshold).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two High-severity fixes against PR #484 (the KB strategy refactor).

### H1 — `firstStageMultiplier` had a dead `Math.max`, lost candidate floor

`packages/ai/src/kb/createStandardKbStrategy.ts` computed the rerank
first-stage pool as `Math.max(topK * firstStageMultiplier, topK)`,
which is a no-op since `topK * mult >= topK` whenever `mult >= 1`. The
inline comment promised a floor; the code didn't enforce one. For
`topK=1, multiplier=5` (the default), the first-stage pool was 5
candidates — the reranker had almost nothing to choose from.

- Added optional `firstStageMinimum?: number` (default `20`) to
  `CreateStandardKbStrategyOptions`.
- Replaced the no-op with
  `Math.max(topK * firstStageMultiplier, firstStageMinimum)`.
- Updated JSDoc on `firstStageMultiplier` and the new
  `firstStageMinimum` to describe how they interact.

### H2 — `KbSearchTask` silently dropped `scoreThreshold`

`packages/ai/src/task/KbSearchTask.ts` neither declared
`scoreThreshold` on its input schema nor destructured it in `execute`,
so any threshold passed by callers wiring the task into a workflow was
discarded before reaching `kb.search`. Results came back unfiltered
with no warning.

- Added `scoreThreshold?: number` (`{ type: "number", minimum: 0 }`)
  to the task's `inputSchema.properties`, with a description noting
  the strategy intentionally ignores the threshold in rerank mode.
- Destructure `scoreThreshold` in `execute` and forward it:
  `kb.search(query, { topK, filter, scoreThreshold })`.

## Tests

- `packages/test/src/test/rag/CreateStandardKbStrategyFirstStage.test.ts` —
  spies on `hybridSearch` / `similaritySearch` and asserts the
  first-stage `topK` across `{topK=1, mult=5}` -> 20,
  `{topK=10, mult=5}` -> 50, and
  `{topK=2, mult=1, firstStageMinimum=20}` -> 20.
- `packages/test/src/test/rag/KbSearchTask.test.ts` — spies on
  `kb.search` and asserts `scoreThreshold` is forwarded when provided
  and absent (undefined) when omitted.

## Test plan

- [ ] `cd packages/test && bun test src/test/rag/CreateStandardKbStrategyFirstStage.test.ts`
- [ ] `cd packages/test && bun test src/test/rag/KbSearchTask.test.ts`
- [ ] `cd packages/test && bun test src/test/rag/` (regression check on existing RAG suite)
- [ ] `cd packages/ai && bun run build-types` (verify the new option/property typecheck cleanly)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ahj9PynTGUcWpXb2Q2DPr)_