### PR TITLE
Fix critical/high streaming & worker findings on PR #494

### DIFF
--- a/packages/ai/src/capability/AiEmit.ts
+++ b/packages/ai/src/capability/AiEmit.ts
@@ -8,18 +8,28 @@ import type { StreamEvent, TaskOutput } from "@workglow/task-graph";
 
 /**
  * Callback the dispatch layer hands to a run-fn so the run-fn can emit
- * in-flight stream events without ever returning them as a materialized value.
- * Output for one-shot capabilities rides on a single `finish` event; output for
- * streaming capabilities rides on the preceding `text-delta` / `object-delta`
- * / `snapshot` events with a trailing empty `finish`. The accumulator that
- * materializes a single `O` lives only at terminal consumer sites
- * ({@link AiTask.execute}, {@link StreamProcessor}'s `ctx.shouldAccumulate`
- * branch).
+ * in-flight stream events without ever returning them as a materialized
+ * value. Output for one-shot capabilities rides on a single `finish` event;
+ * output for streaming capabilities rides on the preceding `text-delta` /
+ * `object-delta` / `snapshot` events with a trailing empty `finish`. The
+ * accumulator that materializes a single `O` lives only at terminal
+ * consumer sites ({@link AiTask.execute}, {@link StreamProcessor}'s
+ * `ctx.shouldAccumulate` branch).
+ *
+ * Return type is `void | Promise<void>`. Sites that bridge into a bounded
+ * {@link createEmitQueue} pass through that queue's `push()` return value:
+ * producers that `await emit(...)` get backpressure for free. Producers
+ * that don't `await` still work because events are buffered — they just
+ * miss the signal. Synchronous consumers (e.g. {@link accumulatingEmit})
+ * always return `void`.
  */
-export type AiEmit<O extends TaskOutput = TaskOutput> = (event: StreamEvent<O>) => void;
+export type AiEmit<O extends TaskOutput = TaskOutput> = (
+  event: StreamEvent<O>
+) => void | Promise<void>;
 
 /**
- * Discards every event. Used by callers that don't need mid-stream events but
- * still want to drive a run-fn to completion.
+ * Discards every event. Used by callers that don't need mid-stream events
+ * but still want to drive a run-fn to completion. Synchronous — has nothing
+ * to backpressure on.
  */
 export const noopEmit: AiEmit = () => {};

--- a/packages/ai/src/capability/emitQueue.ts
+++ b/packages/ai/src/capability/emitQueue.ts
@@ -5,35 +5,56 @@
  */
 
 /**
- * Bridge between a synchronous `push(event)` producer and a `for await ... of`
- * consumer. Used by {@link StreamingAiTask.executeStream} to forward events
- * from a Promise+emit run-fn to its `AsyncIterable<StreamEvent>` consumer
- * (StreamProcessor / task-graph runner).
+ * Bridge between a `push(event)` producer and a `for await ... of` consumer.
+ * Used by {@link StreamingAiTask.executeStream} and the chat tasks to
+ * forward events from a Promise+emit run-fn to an
+ * `AsyncIterable<StreamEvent>` consumer (StreamProcessor / task-graph
+ * runner / our own per-turn loops).
  *
- * Holds at most the events buffered between an `emit()` and the next iteration
- * step — naturally bounded by consumer pacing. The queue does **not**
- * accumulate beyond that; if the consumer keeps up, the queue is essentially
- * empty at every step. This is not a buffer for materializing `O` — that lives
- * at terminal-consumer sites.
+ * **Bounded.** The queue keeps a configurable `highWaterMark` /
+ * `lowWaterMark` pair (defaults 256 / 64). When the buffered queue
+ * reaches `highWaterMark` events, {@link EmitQueue.push} returns a
+ * Promise instead of `void`; the promise resolves once iteration has
+ * drained the queue back below `lowWaterMark`. Producers that don't
+ * `await` continue to push — the queue still buffers — but they lose the
+ * backpressure signal. Used by callers that want to slow down a fast
+ * producer without dropping events.
  *
- * Termination: `close()` ends the stream cleanly; `fail(err)` makes the next
- * iteration step `throw`. Both are idempotent — later pushes / closes / fails
- * after the first terminal signal are ignored.
+ * Termination: `close()` ends the stream cleanly; `fail(err)` makes the
+ * next iteration step `throw`. Both are idempotent — later pushes /
+ * closes / fails after the first terminal signal are ignored. Both also
+ * release any pending drain-resolvers from `push()` so producers that
+ * were awaiting backpressure don't leak.
  *
- * **Single-consumer.** The waker pattern stores at most one pending resolver,
- * so the `iterable` must be consumed by exactly one `for await` loop. Multiple
- * concurrent iterators are not supported and will hang. This matches the
- * intended use site ({@link StreamingAiTask.executeStream}, which iterates
- * once).
+ * **Single-consumer.** The waker pattern stores at most one pending
+ * resolver, so the `iterable` must be consumed by exactly one `for await`
+ * loop. Multiple concurrent iterators are not supported and will hang.
  */
+export interface EmitQueueOptions {
+  /** Buffered events at or above this length cause `push()` to return a drain promise. Default 256. */
+  highWaterMark?: number;
+  /** Drain promises returned by `push()` resolve once the queue has drained below this length. Default 64. */
+  lowWaterMark?: number;
+}
+
 export interface EmitQueue<E> {
-  push(event: E): void;
+  push(event: E): void | Promise<void>;
   close(): void;
   fail(err: unknown): void;
   readonly iterable: AsyncIterable<E>;
+  /** Current number of buffered events. Exposed for tests / instrumentation. */
+  readonly length: number;
 }
 
-export function createEmitQueue<E>(): EmitQueue<E> {
+export function createEmitQueue<E>(options: EmitQueueOptions = {}): EmitQueue<E> {
+  const highWaterMark = options.highWaterMark ?? 256;
+  const lowWaterMark = options.lowWaterMark ?? Math.max(1, Math.floor(highWaterMark / 4));
+  if (lowWaterMark >= highWaterMark) {
+    throw new RangeError(
+      `emitQueue: lowWaterMark (${lowWaterMark}) must be < highWaterMark (${highWaterMark})`
+    );
+  }
+
   type QueueItem =
     | { kind: "event"; data: E }
     | { kind: "done" }
@@ -43,6 +64,30 @@ export function createEmitQueue<E>(): EmitQueue<E> {
   let waiting: ((value: void) => void) | null = null;
   let terminated = false;
 
+  // Drain resolvers parked by `push()` when the queue is at/above the
+  // high-water mark. Drained by `maybeDrain()` after each shift, or by
+  // `close()` / `fail()`.
+  const drainResolvers: (() => void)[] = [];
+
+  const releaseDrainers = () => {
+    while (drainResolvers.length > 0) {
+      const r = drainResolvers.shift()!;
+      r();
+    }
+  };
+
+  const maybeDrain = () => {
+    if (drainResolvers.length === 0) return;
+    // Only the data-event count matters for backpressure; `done` and
+    // `error` markers are tail-end markers that don't count against the
+    // budget. But `queue.length` already overestimates if a terminator
+    // is queued — which is fine, because once terminated we release every
+    // pending drainer anyway.
+    if (queue.length <= lowWaterMark) {
+      releaseDrainers();
+    }
+  };
+
   const notify = () => {
     if (waiting) {
       const r = waiting;
@@ -51,10 +96,16 @@ export function createEmitQueue<E>(): EmitQueue<E> {
     }
   };
 
-  const push = (event: E) => {
+  const push = (event: E): void | Promise<void> => {
     if (terminated) return;
     queue.push({ kind: "event", data: event });
     notify();
+    if (queue.length >= highWaterMark) {
+      return new Promise<void>((resolve) => {
+        drainResolvers.push(resolve);
+      });
+    }
+    return;
   };
 
   const close = () => {
@@ -62,6 +113,7 @@ export function createEmitQueue<E>(): EmitQueue<E> {
     terminated = true;
     queue.push({ kind: "done" });
     notify();
+    releaseDrainers();
   };
 
   const fail = (error: unknown) => {
@@ -69,6 +121,7 @@ export function createEmitQueue<E>(): EmitQueue<E> {
     terminated = true;
     queue.push({ kind: "error", error });
     notify();
+    releaseDrainers();
   };
 
   const iterable: AsyncIterable<E> = {
@@ -78,6 +131,7 @@ export function createEmitQueue<E>(): EmitQueue<E> {
           while (true) {
             while (queue.length > 0) {
               const item = queue.shift()!;
+              maybeDrain();
               if (item.kind === "event") return { value: item.data, done: false };
               if (item.kind === "done") return { value: undefined, done: true };
               throw item.error;
@@ -91,5 +145,13 @@ export function createEmitQueue<E>(): EmitQueue<E> {
     },
   };
 
-  return { push, close, fail, iterable };
+  return {
+    push,
+    close,
+    fail,
+    iterable,
+    get length() {
+      return queue.length;
+    },
+  };
 }

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, StreamEvent, TaskOutput } from "@workglow/task-graph";
+import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { AiEmit } from "../capability/AiEmit";
 import type { Capability } from "../capability/Capabilities";
-import { createEmitQueue } from "../capability/emitQueue";
 import type { AiJobInput } from "../job/AiJob";
 import type { ModelConfig } from "../model/ModelSchema";
 import { getAiProviderRegistry } from "../provider/AiProviderRegistry";
 import { TypeModel } from "./base/AiTaskSchemas";
 import { buildResponseFormatAddendum } from "./base/responseFormat";
+import { runWithIterable } from "./base/runWithIterable";
 import { StreamingAiTask } from "./base/StreamingAiTask";
 import type { ChatMessage, ContentBlock } from "./ChatMessage";
 import { ChatMessageSchema, ContentBlockSchema } from "./ChatMessage";
@@ -294,30 +294,34 @@ export class AiChatTask extends StreamingAiTask<AiChatTaskInput, AiChatTaskOutpu
       const turnJobInput = await this.getJobInput(perTurnInput);
 
       let assistantText = "";
-      const queue = createEmitQueue<StreamEvent<AiChatTaskOutput>>();
-      const emit: AiEmit<AiChatTaskOutput> = (event) => {
-        if (event.type === "text-delta") {
-          assistantText += (event as any).textDelta;
-          queue.push({
-            ...event,
-            port: (event as any).port ?? "text",
-          } as StreamEvent<AiChatTaskOutput>);
-        } else if (event.type === "finish") {
-          // swallow — we emit our own finish at the end
-        } else {
-          queue.push(event as StreamEvent<AiChatTaskOutput>);
-        }
-      };
-      const runPromise = strategy
-        .execute(turnJobInput as any, context, this.runConfig.runnerId, emit as AiEmit<TaskOutput>)
-        .then(
-          () => queue.close(),
-          (err) => queue.fail(err)
-        );
-      for await (const event of queue.iterable) {
+      // Drive the inner turn through `runWithIterable` so a consumer
+      // break / context abort cancels the provider stream rather than
+      // leaving it running into a closed queue. The emit factory is
+      // where we accumulate per-turn text and swallow inner-turn
+      // `finish` events (the outer `finish` is emitted at the end).
+      const iterable = runWithIterable<AiChatTaskOutput>(
+        strategy,
+        turnJobInput as any,
+        context,
+        this.runConfig.runnerId,
+        (queue): AiEmit<AiChatTaskOutput> =>
+          (event) => {
+            if (event.type === "text-delta") {
+              assistantText += (event as any).textDelta;
+              queue.push({
+                ...event,
+                port: (event as any).port ?? "text",
+              } as StreamEvent<AiChatTaskOutput>);
+            } else if (event.type === "finish") {
+              // swallow — we emit our own finish at the end
+            } else {
+              queue.push(event as StreamEvent<AiChatTaskOutput>);
+            }
+          }
+      );
+      for await (const event of iterable) {
         yield event;
       }
-      await runPromise;
 
       const assistantMsg: ChatMessage = {
         role: "assistant",

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -6,14 +6,13 @@
 
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { getKnowledgeBase, slugifyHeading } from "@workglow/knowledge-base";
-import type { IExecuteContext, StreamEvent, TaskOutput } from "@workglow/task-graph";
+import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { AiEmit } from "../capability/AiEmit";
 import type { Capability } from "../capability/Capabilities";
-import { createEmitQueue } from "../capability/emitQueue";
 import type { AiJobInput } from "../job/AiJob";
 import type { ModelConfig } from "../model/ModelSchema";
 import { getAiProviderRegistry } from "../provider/AiProviderRegistry";
@@ -23,6 +22,7 @@ import {
   KB_INLINE_CITATION_DIRECTIVE,
   type ResponseFormat,
 } from "./base/responseFormat";
+import { runWithIterable } from "./base/runWithIterable";
 import { StreamingAiTask } from "./base/StreamingAiTask";
 import type { ChatMessage, ContentBlock } from "./ChatMessage";
 import { ChatMessageSchema, ContentBlockSchema } from "./ChatMessage";
@@ -559,37 +559,37 @@ export class AiChatWithKbTask extends StreamingAiTask<
         const turnJobInput = await this.getJobInput(perTurnInput);
         const strategy = getAiProviderRegistry().getStrategy(model);
 
-        const queue = createEmitQueue<StreamEvent<AiChatWithKbTaskOutput>>();
-        const emit: AiEmit<AiChatWithKbTaskOutput> = (event) => {
-          if (event.type === "text-delta") {
-            assistantText += (event as any).textDelta;
-            queue.push({
-              ...event,
-              port: (event as any).port ?? "text",
-            } as StreamEvent<AiChatWithKbTaskOutput>);
-          } else if (event.type === "finish") {
-            // Invariant: inner turn run-fns must be text.generation only; finish.data
-            // from inner turns is intentionally discarded. If json-mode capability is
-            // ever added to inner dispatch, this swallow must be revisited.
-          } else {
-            queue.push(event as StreamEvent<AiChatWithKbTaskOutput>);
-          }
-        };
-        const runPromise = strategy
-          .execute(
-            turnJobInput as any,
-            context,
-            this.runConfig.runnerId,
-            emit as AiEmit<TaskOutput>
-          )
-          .then(
-            () => queue.close(),
-            (err) => queue.fail(err)
-          );
-        for await (const event of queue.iterable) {
+        // Drive the inner turn through `runWithIterable` so a consumer
+        // break / context abort cancels the provider stream rather than
+        // leaving it running into a closed queue. The emit factory does
+        // the per-port wrapping and swallows inner-turn `finish` events
+        // (the outer `finish` is emitted at the end).
+        const iterable = runWithIterable<AiChatWithKbTaskOutput>(
+          strategy,
+          turnJobInput as any,
+          context,
+          this.runConfig.runnerId,
+          (queue): AiEmit<AiChatWithKbTaskOutput> =>
+            (event) => {
+              if (event.type === "text-delta") {
+                assistantText += (event as any).textDelta;
+                queue.push({
+                  ...event,
+                  port: (event as any).port ?? "text",
+                } as StreamEvent<AiChatWithKbTaskOutput>);
+              } else if (event.type === "finish") {
+                // Invariant: inner turn run-fns must be text.generation only;
+                // finish.data from inner turns is intentionally discarded. If
+                // json-mode capability is ever added to inner dispatch, this
+                // swallow must be revisited.
+              } else {
+                queue.push(event as StreamEvent<AiChatWithKbTaskOutput>);
+              }
+            }
+        );
+        for await (const event of iterable) {
           yield event;
         }
-        await runPromise;
       }
 
       const assistantMsg: ChatMessage = {

--- a/packages/ai/src/task/base/AiTask.ts
+++ b/packages/ai/src/task/base/AiTask.ts
@@ -171,13 +171,22 @@ export class AiTask<
     }
     const output = result();
 
-    // Register a disposer so the caller can unload the model when done. The
-    // unload path is wired via the "model.download-remove" capability so providers opt
-    // in by registering a run-fn whose `serves` set contains it; bypasses the
-    // task's own `requires` so we don't gate the lifecycle hook on the task.
+    // Register a disposer so the caller can unload the model when done.
+    //
+    // We prefer `model.dispose` (a future capability reserved for a
+    // RAM-only-evict semantic that keeps the on-disk copy) but fall back to
+    // `model.download-remove`, which providers actually register today for
+    // their uncache path. Without the fallback the disposer silently
+    // never runs and worker-resident models leak across the resource
+    // scope's lifetime.
+    //
+    // This intentionally bypasses the task's own `requires` so the
+    // lifecycle hook isn't gated on the task's capability set.
     if (executeContext.resourceScope) {
       const registry = getAiProviderRegistry();
-      const disposeFn = registry.getRunFnFor(model.provider, ["model.dispose"]);
+      const disposeFn =
+        registry.getRunFnFor(model.provider, ["model.dispose"]) ??
+        registry.getRunFnFor(model.provider, ["model.download-remove"]);
       if (disposeFn) {
         const modelPath =
           (model as ModelConfig & { model?: string }).model ??

--- a/packages/ai/src/task/base/StreamingAiTask.ts
+++ b/packages/ai/src/task/base/StreamingAiTask.ts
@@ -16,8 +16,7 @@ import { AiTask } from "./AiTask";
 import type { AiTaskInput } from "./AiTask";
 import { getAiProviderRegistry } from "../../provider/AiProviderRegistry";
 import type { ModelConfig } from "../../model/ModelSchema";
-import type { AiEmit } from "../../capability/AiEmit";
-import { createEmitQueue } from "../../capability/emitQueue";
+import { runWithIterable } from "./runWithIterable";
 
 /**
  * A base class for streaming AI tasks.
@@ -39,11 +38,15 @@ import { createEmitQueue } from "../../capability/emitQueue";
  * (direct or queued), which in turn forwards it to the provider stream function.
  * When the signal fires, the underlying provider SDK tears down its connection
  * and the inner `for await` exits; this generator then returns or throws
- * promptly. Partial accumulated text / object state may still remain in task
- * or runner state after abort (the runner does not clear `runOutputData`) and
- * MUST be treated as invalid unless the final run status is `COMPLETED`.
- * Subclasses overriding `executeStream()` MUST preserve this contract: forward
- * `context.signal`, and either return or throw promptly after abort.
+ * promptly. Consumer-driven cancellation (an early `break` from the
+ * `for await` consuming this generator) is also propagated: see
+ * {@link runWithIterable} for the mechanism that converts a closed
+ * consumer into an aborted provider signal. Partial accumulated text /
+ * object state may still remain in task or runner state after abort (the
+ * runner does not clear `runOutputData`) and MUST be treated as invalid
+ * unless the final run status is `COMPLETED`. Subclasses overriding
+ * `executeStream()` MUST preserve this contract: forward `context.signal`,
+ * and either return or throw promptly after abort.
  */
 export class StreamingAiTask<
   Input extends AiTaskInput = AiTaskInput,
@@ -113,18 +116,20 @@ export class StreamingAiTask<
     // GPU acquisition, provider API connect time.
     yield { type: "phase", message: preparingLabel, progress: undefined } as StreamEvent<Output>;
 
-    const queue = createEmitQueue<StreamEvent<Output>>();
-    const emit: AiEmit<Output> = (event) => queue.push(event);
-
-    const runPromise = strategy
-      .execute(jobInput, context, this.runConfig.runnerId, emit as AiEmit<TaskOutput>)
-      .then(
-        () => queue.close(),
-        (err) => queue.fail(err)
-      );
+    // Drive the strategy through `runWithIterable` so consumer abort
+    // propagates to the provider stream. The factory just forwards events
+    // into the queue verbatim; per-port wrapping happens on the consumer
+    // side below.
+    const iterable = runWithIterable<Output>(
+      strategy,
+      jobInput,
+      context,
+      this.runConfig.runnerId,
+      (queue) => (event) => queue.push(event as StreamEvent<Output>)
+    );
 
     let firstDataSeen = false;
-    for await (const event of queue.iterable) {
+    for await (const event of iterable) {
       if (
         !firstDataSeen &&
         (event.type === "text-delta" || event.type === "object-delta" || event.type === "snapshot")
@@ -145,6 +150,5 @@ export class StreamingAiTask<
         yield event as StreamEvent<Output>;
       }
     }
-    await runPromise;
   }
 }

--- a/packages/ai/src/task/base/runWithIterable.ts
+++ b/packages/ai/src/task/base/runWithIterable.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, StreamEvent, TaskInput, TaskOutput } from "@workglow/task-graph";
+import type { AiEmit } from "../../capability/AiEmit";
+import { createEmitQueue } from "../../capability/emitQueue";
+import type { EmitQueue } from "../../capability/emitQueue";
+import type { IAiExecutionStrategy } from "../../execution/IAiExecutionStrategy";
+import type { AiJobInput } from "../../job/AiJob";
+
+/**
+ * Factory for the emit callback that producers should use. Receives the
+ * queue (already wired) and must return the function the strategy will
+ * call when emitting events. Sites that need to peek at events before they
+ * reach the consumer (e.g. AiChatTask accumulates a per-turn text and
+ * swallows inner-turn `finish` events) use this hook; sites that don't
+ * just `return (event) => queue.push(event as StreamEvent<Output>)`.
+ */
+export type RunWithIterableEmitFactory<Output extends TaskOutput> = (
+  queue: EmitQueue<StreamEvent<Output>>
+) => AiEmit<Output>;
+
+/**
+ * Drive a strategy through an emit-queue and surface its events as an
+ * `AsyncIterable<StreamEvent<Output>>`. Centralises the abort plumbing
+ * shared by every streaming task site:
+ *
+ *   1. Construct a `localAbort` AbortController.
+ *   2. If `context.signal` is already aborted, abort `localAbort` synchronously
+ *      so the strategy sees the cancellation on its first signal check.
+ *      Otherwise wire a `once: true` listener that mirrors parent aborts
+ *      into `localAbort`. The listener is removed when the run settles.
+ *   3. Replace `context.signal` on a shallow wrapper (other context fields
+ *      pass through unchanged) and hand that to `strategy.execute`.
+ *   4. Iterate the queue and yield events to the caller.
+ *   5. In a `finally`, abort `localAbort`, fail the queue, and await the
+ *      run promise. The `await` swallows the post-abort rejection — the
+ *      caller's iteration error (if any) is preserved by the surrounding
+ *      try/finally semantics.
+ *
+ * When a consumer breaks out of the `for await` early (or throws),
+ * step 5 fires `localAbort.abort()` which propagates through the strategy
+ * to the provider, releasing the connection promptly rather than letting
+ * the run keep streaming events into a closed queue.
+ */
+export async function* runWithIterable<Output extends TaskOutput>(
+  strategy: IAiExecutionStrategy,
+  jobInput: AiJobInput<TaskInput>,
+  context: IExecuteContext,
+  runnerId: string | undefined,
+  emitFactory: RunWithIterableEmitFactory<Output>
+): AsyncIterable<StreamEvent<Output>> {
+  const queue = createEmitQueue<StreamEvent<Output>>();
+  const localAbort = new AbortController();
+
+  // Mirror parent aborts onto our localAbort. If the parent is already
+  // aborted, abort synchronously — `addEventListener` on an aborted signal
+  // never fires.
+  const parentSignal: AbortSignal | undefined = context.signal;
+  let parentCleanup: (() => void) | undefined;
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      localAbort.abort(parentSignal.reason);
+    } else {
+      const onParentAbort = () => localAbort.abort(parentSignal.reason);
+      parentSignal.addEventListener("abort", onParentAbort, { once: true });
+      parentCleanup = () => parentSignal.removeEventListener("abort", onParentAbort);
+    }
+  }
+
+  // The strategy reads `signal` off the context; substitute our local one.
+  // Keep every other field (own, registry, updateProgress, resourceScope,
+  // inputStreams, …) referentially identical so behaviour outside cancel
+  // semantics is unchanged.
+  const localContext: IExecuteContext = new Proxy(context, {
+    get(target, prop, receiver) {
+      if (prop === "signal") return localAbort.signal;
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+
+  const emit = emitFactory(queue);
+  const runPromise = strategy
+    .execute(jobInput, localContext, runnerId, emit as AiEmit<TaskOutput>)
+    .then(
+      () => queue.close(),
+      (err) => queue.fail(err)
+    );
+
+  try {
+    for await (const event of queue.iterable) {
+      yield event;
+    }
+    // Stream drained normally — surface any error the run-fn raised after
+    // queue.close()/queue.fail() (no-op when it resolved cleanly).
+    await runPromise;
+  } finally {
+    // Consumer stopped iterating (break / return / throw / completion).
+    // Abort the run, then drain the run-fn so we never leak a dangling
+    // promise. Swallow the expected abort rejection.
+    localAbort.abort(new DOMException("consumer-return", "AbortError"));
+    queue.fail(new DOMException("consumer-return", "AbortError"));
+    try {
+      await runPromise;
+    } catch {
+      // Ignore: abort path always rejects, and the producer-visible
+      // failure has already surfaced via the queue.
+    }
+    parentCleanup?.();
+  }
+}

--- a/packages/ai/src/task/index.ts
+++ b/packages/ai/src/task/index.ts
@@ -13,6 +13,7 @@ export * from "./base/AiImageOutputTask";
 export * from "./base/AiTask";
 export * from "./base/AiTaskSchemas";
 export * from "./base/responseFormat";
+export * from "./base/runWithIterable";
 export * from "./base/StreamingAiTask";
 export * from "./ChatMessage";
 export * from "./ChunkRetrievalTask";

--- a/packages/test/src/test/ai/AiTask.dispose.test.ts
+++ b/packages/test/src/test/ai/AiTask.dispose.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, ModelConfig } from "@workglow/ai";
+import {
+  AiProviderRegistry,
+  TextSummaryTask,
+  setAiProviderRegistry,
+} from "@workglow/ai";
+import { ResourceScope } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const MOCK_PROVIDER = "mock-dispose-fallback-provider";
+
+function buildModel(): ModelConfig {
+  return {
+    model_id: `${MOCK_PROVIDER}:test-model:v1`,
+    title: "test-model",
+    description: "test",
+    capabilities: ["text.summary"],
+    provider: MOCK_PROVIDER,
+    provider_config: {},
+    metadata: {},
+  };
+}
+
+describe("AiTask resourceScope disposer fallback", () => {
+  let registry: AiProviderRegistry;
+  let scope: ResourceScope;
+
+  beforeEach(() => {
+    registry = new AiProviderRegistry();
+    setAiProviderRegistry(registry);
+    scope = new ResourceScope();
+  });
+
+  afterEach(async () => {
+    await scope.disposeAll();
+  });
+
+  it("falls back to model.download-remove when no model.dispose run-fn is registered", async () => {
+    let disposeCalls = 0;
+    const summaryFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      emit({ type: "finish", data: { text: "summary" } });
+    };
+    const downloadRemoveFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      disposeCalls += 1;
+      emit({ type: "finish", data: {} });
+    };
+    registry.registerRunFn(MOCK_PROVIDER, { serves: ["text.summary"], runFn: summaryFn });
+    registry.registerRunFn(MOCK_PROVIDER, {
+      serves: ["model.download-remove"],
+      runFn: downloadRemoveFn,
+    });
+
+    const model = buildModel();
+    const task = new TextSummaryTask({ id: "dispose-1" });
+    await task.run({ model, text: "hello" }, { resourceScope: scope });
+    expect(disposeCalls).toBe(0);
+
+    await scope.disposeAll();
+    expect(disposeCalls).toBe(1);
+  });
+
+  it("does not throw when the provider registers no dispose run-fn (cloud-style)", async () => {
+    const summaryFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      emit({ type: "finish", data: { text: "summary" } });
+    };
+    registry.registerRunFn(MOCK_PROVIDER, { serves: ["text.summary"], runFn: summaryFn });
+
+    const model = buildModel();
+    const task = new TextSummaryTask({ id: "dispose-2" });
+    await task.run({ model, text: "hello" }, { resourceScope: scope });
+    await scope.disposeAll();
+    // Reaching here means dispose path was a no-op (the registry has no
+    // model.download-remove run-fn for this provider).
+    expect(true).toBe(true);
+  });
+
+  it("prefers model.dispose when registered", async () => {
+    let disposeCalls = 0;
+    let downloadRemoveCalls = 0;
+    const summaryFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      emit({ type: "finish", data: { text: "summary" } });
+    };
+    const disposeFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      disposeCalls += 1;
+      emit({ type: "finish", data: {} });
+    };
+    const downloadRemoveFn: AiProviderRunFn = async (_input, _model, _signal, emit) => {
+      downloadRemoveCalls += 1;
+      emit({ type: "finish", data: {} });
+    };
+    registry.registerRunFn(MOCK_PROVIDER, { serves: ["text.summary"], runFn: summaryFn });
+    registry.registerRunFn(MOCK_PROVIDER, { serves: ["model.dispose"], runFn: disposeFn });
+    registry.registerRunFn(MOCK_PROVIDER, {
+      serves: ["model.download-remove"],
+      runFn: downloadRemoveFn,
+    });
+
+    const model = buildModel();
+    const task = new TextSummaryTask({ id: "dispose-3" });
+    await task.run({ model, text: "hello" }, { resourceScope: scope });
+    await scope.disposeAll();
+
+    expect(disposeCalls).toBe(1);
+    expect(downloadRemoveCalls).toBe(0);
+  });
+});

--- a/packages/test/src/test/ai/emitQueue.backpressure.test.ts
+++ b/packages/test/src/test/ai/emitQueue.backpressure.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createEmitQueue } from "@workglow/ai";
+import { describe, expect, it } from "vitest";
+
+describe("emitQueue backpressure", () => {
+  it("push() returns void below high-water and Promise at/above it", () => {
+    const q = createEmitQueue<number>({ highWaterMark: 4, lowWaterMark: 2 });
+    expect(q.push(1)).toBeUndefined();
+    expect(q.push(2)).toBeUndefined();
+    expect(q.push(3)).toBeUndefined();
+    const fourth = q.push(4); // length === 4 → at high-water
+    expect(fourth).toBeInstanceOf(Promise);
+  });
+
+  it("resolves the drain promise after the queue drops below low-water", async () => {
+    const q = createEmitQueue<number>({ highWaterMark: 4, lowWaterMark: 2 });
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    const drain = q.push(4) as Promise<void>;
+    expect(drain).toBeInstanceOf(Promise);
+
+    // Drain via an explicit iterator so we don't loop forever — we want to
+    // observe the drain promise resolving partway through.
+    const iter = q.iterable[Symbol.asyncIterator]();
+    expect((await iter.next()).value).toBe(1);
+    expect((await iter.next()).value).toBe(2);
+    // Now length === 2 (== lowWaterMark). Per spec we resolve when
+    // length <= lowWaterMark.
+    await drain;
+    // Finish draining.
+    expect((await iter.next()).value).toBe(3);
+    expect((await iter.next()).value).toBe(4);
+  });
+
+  it("resolves drain promises cleanly on close()", async () => {
+    const q = createEmitQueue<number>({ highWaterMark: 2, lowWaterMark: 1 });
+    q.push(1);
+    const drain = q.push(2) as Promise<void>;
+    expect(drain).toBeInstanceOf(Promise);
+    q.close();
+    await drain; // must not hang
+  });
+
+  it("resolves drain promises cleanly on fail()", async () => {
+    const q = createEmitQueue<number>({ highWaterMark: 2, lowWaterMark: 1 });
+    q.push(1);
+    const drain = q.push(2) as Promise<void>;
+    expect(drain).toBeInstanceOf(Promise);
+    q.fail(new Error("boom"));
+    await drain; // must not hang
+
+    // Subsequent iteration surfaces the error.
+    const iter = q.iterable[Symbol.asyncIterator]();
+    // Drain the buffered events first (these were pushed before fail).
+    expect((await iter.next()).value).toBe(1);
+    expect((await iter.next()).value).toBe(2);
+    await expect(iter.next()).rejects.toThrow(/boom/);
+  });
+
+  it("rejects nonsensical watermarks", () => {
+    expect(() =>
+      createEmitQueue<number>({ highWaterMark: 4, lowWaterMark: 4 })
+    ).toThrow(/lowWaterMark/);
+    expect(() =>
+      createEmitQueue<number>({ highWaterMark: 1, lowWaterMark: 5 })
+    ).toThrow(/lowWaterMark/);
+  });
+
+  it("buffered length keeps growing if the producer ignores backpressure", () => {
+    const q = createEmitQueue<number>({ highWaterMark: 8, lowWaterMark: 2 });
+    for (let i = 0; i < 1000; i++) q.push(i);
+    // No iteration → all 1000 buffered. We confirm push didn't *drop*
+    // anything (the queue does not throttle producers that ignore the
+    // returned drain promise).
+    expect(q.length).toBe(1000);
+  });
+});

--- a/packages/test/src/test/ai/streaming-abort.test.ts
+++ b/packages/test/src/test/ai/streaming-abort.test.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {
+  AiEmit,
+  IAiExecutionStrategy,
+} from "@workglow/ai";
+import { runWithIterable } from "@workglow/ai";
 import type { IExecuteContext, StreamEvent, TaskInput, TaskOutput } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
-
-import type { AiEmit, IAiExecutionStrategy } from "@workglow/ai";
-import { runWithIterable } from "../../../../ai/src/task/base/runWithIterable";
 
 interface CapturedRun {
   signal: AbortSignal;
@@ -21,13 +23,13 @@ interface CapturedRun {
 
 function createCapturingStrategy(): { strategy: IAiExecutionStrategy; runs: CapturedRun[] } {
   const runs: CapturedRun[] = [];
-  let enteredResolver: (() => void) | undefined;
   const strategy: IAiExecutionStrategy = {
     async execute(_jobInput, context, _runnerId, emit) {
       let resolve!: () => void;
       const blocker = new Promise<void>((r) => {
         resolve = r;
       });
+      let enteredResolver: (() => void) | undefined;
       const entered = new Promise<void>((r) => (enteredResolver = r));
       runs.push({ signal: context.signal, emit, resolveRun: resolve, entered });
       enteredResolver?.();

--- a/packages/test/src/test/ai/streaming-abort.test.ts
+++ b/packages/test/src/test/ai/streaming-abort.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IExecuteContext, StreamEvent, TaskInput, TaskOutput } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+import type { AiEmit, IAiExecutionStrategy } from "@workglow/ai";
+import { runWithIterable } from "../../../../ai/src/task/base/runWithIterable";
+
+interface CapturedRun {
+  signal: AbortSignal;
+  emit: AiEmit<TaskOutput>;
+  /** Resolves the strategy's `execute()` promise (use to simulate normal completion). */
+  resolveRun: () => void;
+  /** Resolves once the strategy has been entered (so the test knows abort can fire). */
+  entered: Promise<void>;
+}
+
+function createCapturingStrategy(): { strategy: IAiExecutionStrategy; runs: CapturedRun[] } {
+  const runs: CapturedRun[] = [];
+  let enteredResolver: (() => void) | undefined;
+  const strategy: IAiExecutionStrategy = {
+    async execute(_jobInput, context, _runnerId, emit) {
+      let resolve!: () => void;
+      const blocker = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const entered = new Promise<void>((r) => (enteredResolver = r));
+      runs.push({ signal: context.signal, emit, resolveRun: resolve, entered });
+      enteredResolver?.();
+      // Emit one event so the consumer can `break`.
+      emit({ type: "text-delta", port: "text", textDelta: "x" } as StreamEvent<TaskOutput>);
+      // Block until either the test resolves us OR the signal aborts.
+      await Promise.race([
+        blocker,
+        new Promise<void>((_resolve, reject) => {
+          context.signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true }
+          );
+        }),
+      ]);
+    },
+    abort() {},
+  };
+  return { strategy, runs };
+}
+
+function makeContext(parentSignal?: AbortSignal): IExecuteContext {
+  return {
+    signal: parentSignal ?? new AbortController().signal,
+    updateProgress: async () => {},
+    own: ((t: unknown) => t) as IExecuteContext["own"],
+    registry: undefined as unknown as IExecuteContext["registry"],
+  };
+}
+
+describe("runWithIterable consumer abort propagation", () => {
+  it("aborts the strategy signal when the consumer breaks out", async () => {
+    const { strategy, runs } = createCapturingStrategy();
+    const context = makeContext();
+
+    const iterable = runWithIterable<TaskOutput>(
+      strategy,
+      { taskType: "Test", requires: [], aiProvider: "fake", taskInput: {} as TaskInput },
+      context,
+      undefined,
+      (queue) => (event) => queue.push(event as StreamEvent<TaskOutput>)
+    );
+
+    let firstEvent: StreamEvent<TaskOutput> | undefined;
+    for await (const event of iterable) {
+      firstEvent = event;
+      break; // Consumer-side abort: this is the trigger we want to verify.
+    }
+
+    expect(firstEvent?.type).toBe("text-delta");
+    // Wait microtasks for the finally block in runWithIterable to fire.
+    await Promise.resolve();
+    expect(runs.length).toBe(1);
+    expect(runs[0]?.signal.aborted).toBe(true);
+  });
+
+  it("aborts the strategy when the parent context signal aborts", async () => {
+    const { strategy, runs } = createCapturingStrategy();
+    const parent = new AbortController();
+    const context = makeContext(parent.signal);
+
+    const iterable = runWithIterable<TaskOutput>(
+      strategy,
+      { taskType: "Test", requires: [], aiProvider: "fake", taskInput: {} as TaskInput },
+      context,
+      undefined,
+      (queue) => (event) => queue.push(event as StreamEvent<TaskOutput>)
+    );
+
+    const collected: StreamEvent<TaskOutput>[] = [];
+    const consumer = (async () => {
+      try {
+        for await (const event of iterable) {
+          collected.push(event);
+          if (collected.length === 1) {
+            // Trigger parent abort after the first event.
+            parent.abort();
+          }
+        }
+      } catch {
+        // Expected — the queue.fail bubbles a rejection up.
+      }
+    })();
+    await consumer;
+
+    expect(runs.length).toBe(1);
+    expect(runs[0]?.signal.aborted).toBe(true);
+  });
+
+  it("settles cleanly when the run-fn completes normally", async () => {
+    const { strategy, runs } = createCapturingStrategy();
+    const context = makeContext();
+
+    const iterable = runWithIterable<TaskOutput>(
+      strategy,
+      { taskType: "Test", requires: [], aiProvider: "fake", taskInput: {} as TaskInput },
+      context,
+      undefined,
+      (queue) => (event) => queue.push(event as StreamEvent<TaskOutput>)
+    );
+
+    // Consume until the run-fn is unblocked, then drain.
+    const events: StreamEvent<TaskOutput>[] = [];
+    const consumer = (async () => {
+      for await (const event of iterable) {
+        events.push(event);
+        if (events.length === 1) {
+          await runs[0]?.entered;
+          runs[0]?.resolveRun();
+        }
+      }
+    })();
+    await consumer;
+
+    // Normal completion: parent signal must remain intact even though
+    // localAbort fires on the finally-block exit path.
+    expect(context.signal.aborted).toBe(false);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/test/src/test/util/WorkerServerBase.race.test.ts
+++ b/packages/test/src/test/util/WorkerServerBase.race.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { WorkerServerBase } from "@workglow/util/worker";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface PostedMessage {
+  readonly type: string;
+  readonly id?: string;
+  readonly data?: unknown;
+}
+
+// Stubs `postMessage` so we can capture every reply the server tries to send.
+// WorkerServerBase calls the global `postMessage` directly, so we replace it
+// for the duration of each test and restore on teardown.
+function installPostMessageStub(): {
+  readonly captured: PostedMessage[];
+  restore(): void;
+} {
+  const captured: PostedMessage[] = [];
+  const original = (globalThis as { postMessage?: unknown }).postMessage;
+  (globalThis as unknown as { postMessage: (m: PostedMessage) => void }).postMessage = (m) => {
+    captured.push(m);
+  };
+  return {
+    captured,
+    restore() {
+      if (typeof original === "function") {
+        (globalThis as { postMessage?: unknown }).postMessage = original;
+      } else {
+        delete (globalThis as { postMessage?: unknown }).postMessage;
+      }
+    },
+  };
+}
+
+describe("WorkerServerBase abort-before-call race", () => {
+  let stub: { captured: PostedMessage[]; restore(): void };
+
+  beforeEach(() => {
+    stub = installPostMessageStub();
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+
+  it("aborts a run-fn whose abort message arrived before the call", async () => {
+    const server = new WorkerServerBase();
+    const seenAborted: boolean[] = [];
+    server.registerRunFunction("dummyRun", async (_input, _model, signal) => {
+      // Record whether the signal is already aborted at the moment the
+      // run-fn starts. The fix should make this `true`.
+      seenAborted.push(signal.aborted);
+    });
+
+    // Abort first, then call. The handler must not lose the abort.
+    await server.handleMessage({ type: "message", data: { type: "abort", id: "req-1" } });
+    await server.handleMessage({
+      type: "message",
+      data: {
+        type: "call",
+        id: "req-1",
+        functionName: "dummyRun",
+        run: true,
+        args: [{}, undefined, undefined, undefined],
+      },
+    });
+
+    expect(seenAborted).toEqual([true]);
+    // The abort path should produce exactly one error reply (no result/complete).
+    const errorReplies = stub.captured.filter((m) => m.id === "req-1" && m.type === "error");
+    const completeReplies = stub.captured.filter((m) => m.id === "req-1" && m.type === "complete");
+    expect(errorReplies.length).toBe(1);
+    expect(completeReplies.length).toBe(0);
+  });
+
+  it("aborts a regular call whose abort arrived before the call", async () => {
+    const server = new WorkerServerBase();
+    const seenAborted: boolean[] = [];
+    server.registerFunction("dummyCall", async (_input, _model, _progress, signal: AbortSignal) => {
+      seenAborted.push(signal.aborted);
+      return "result";
+    });
+
+    await server.handleMessage({ type: "message", data: { type: "abort", id: "req-2" } });
+    await server.handleMessage({
+      type: "message",
+      data: {
+        type: "call",
+        id: "req-2",
+        functionName: "dummyCall",
+        args: [{}, undefined],
+      },
+    });
+
+    expect(seenAborted).toEqual([true]);
+    const errorReplies = stub.captured.filter((m) => m.id === "req-2" && m.type === "error");
+    expect(errorReplies.length).toBe(1);
+  });
+
+  it("aborts a stream call whose abort arrived before the call", async () => {
+    const server = new WorkerServerBase();
+    const seenAborted: boolean[] = [];
+    server.registerStreamFunction("dummyStream", async function* (_input, _model, signal) {
+      seenAborted.push(signal.aborted);
+      // Even though the signal is aborted, we still yield so the test can
+      // verify that the abort was visible on entry. (The real wrapper would
+      // return promptly when seeing signal.aborted; the worker layer's job
+      // here is just to plumb the abort.)
+      yield { type: "noop" };
+    });
+
+    await server.handleMessage({ type: "message", data: { type: "abort", id: "req-3" } });
+    await server.handleMessage({
+      type: "message",
+      data: {
+        type: "call",
+        id: "req-3",
+        functionName: "dummyStream",
+        stream: true,
+        args: [{}, undefined],
+      },
+    });
+
+    expect(seenAborted).toEqual([true]);
+  });
+});

--- a/packages/util/src/worker/WorkerServerBase.ts
+++ b/packages/util/src/worker/WorkerServerBase.ts
@@ -104,6 +104,11 @@ export class WorkerServerBase {
   private requestControllers = new Map<string, AbortController>();
   // Keep track of requests that have already been responded to
   private completedRequests = new Set<string>();
+  // Track abort messages that arrived before the corresponding call started so
+  // the imminent handler can apply them immediately. Bounded to prevent
+  // unbounded growth from buggy clients that send aborts for ids that never
+  // arrive (see {@link scheduleCompletedRequestCleanup} for the matching cap).
+  private pendingAborts = new Set<string>();
 
   private postResult = (id: string, result: any) => {
     if (this.completedRequests.has(id)) {
@@ -232,6 +237,43 @@ export class WorkerServerBase {
       // Send error response back to main thread so the promise rejects
       this.postError(id, "Operation aborted");
       this.scheduleCompletedRequestCleanup(id);
+      return;
+    }
+    // Abort arrived before the call started running (race on the message
+    // port). Record the id so the imminent handle*Call can abort its
+    // controller as soon as it's constructed, and surface the rejection
+    // to the caller immediately.
+    this.recordPendingAbort(id);
+    this.postError(id, "Operation aborted");
+    this.scheduleCompletedRequestCleanup(id);
+  }
+
+  /**
+   * If a prior `abort` arrived for `id` before the call started, abort the
+   * supplied controller immediately and drop the pending marker. Returns
+   * `true` when an abort was consumed so callers may exit fast.
+   */
+  private consumePendingAbort(id: string, controller: AbortController): boolean {
+    if (!this.pendingAborts.delete(id)) return false;
+    controller.abort();
+    return true;
+  }
+
+  /**
+   * Records `id` as having received an abort that has not yet been matched to
+   * a controller. Bounded at 1000 entries; oldest are dropped first so a
+   * misbehaving client cannot leak memory by sending aborts for ids that
+   * never arrive.
+   */
+  private recordPendingAbort(id: string): void {
+    this.pendingAborts.add(id);
+    if (this.pendingAborts.size > 1000) {
+      const iter = this.pendingAborts.values();
+      for (let i = 0; i < 500; i++) {
+        const entry = iter.next();
+        if (entry.done) break;
+        this.pendingAborts.delete(entry.value);
+      }
     }
   }
 
@@ -262,6 +304,8 @@ export class WorkerServerBase {
     try {
       const abortController = new AbortController();
       this.requestControllers.set(id, abortController);
+      // Honour any abort message that beat the call to the worker.
+      this.consumePendingAbort(id, abortController);
 
       const fn = this.functions[functionName];
       const postProgress = (progress: number, message?: string, details?: any) => {
@@ -291,6 +335,7 @@ export class WorkerServerBase {
       try {
         const abortController = new AbortController();
         this.requestControllers.set(id, abortController);
+        this.consumePendingAbort(id, abortController);
 
         const fn = this.streamFunctions[functionName];
         const iterable = fn(input, model, abortController.signal);
@@ -312,6 +357,7 @@ export class WorkerServerBase {
       try {
         const abortController = new AbortController();
         this.requestControllers.set(id, abortController);
+        this.consumePendingAbort(id, abortController);
 
         const fn = this.functions[functionName];
         const noopProgress = () => {};
@@ -346,6 +392,7 @@ export class WorkerServerBase {
     }
     const abortController = new AbortController();
     this.requestControllers.set(id, abortController);
+    this.consumePendingAbort(id, abortController);
     const fn = this.runFunctions[functionName];
 
     const emit = (event: unknown) => {


### PR DESCRIPTION
## Summary

Addresses the four Critical/High findings on PR #494 in plan order
(H2 → H1 → C1 → H3), with tests covering each one.

### H2 — Worker abort race in `WorkerServerBase`

`handleAbort` silently dropped abort messages whose ids had no
`AbortController` yet, so an `abort` racing ahead of its `call` over the
message port would be lost and the run-fn would execute with an
un-aborted signal. Now we record pending aborts in a bounded set and
consume them as soon as `handleCall` / `handleStreamCall` /
`handleRunCall` constructs its controller. Bounded at 1000 entries with
LRU-style eviction.

Test: `packages/test/src/test/util/WorkerServerBase.race.test.ts` —
abort-then-call drives the three handler shapes and verifies the run
sees `signal.aborted === true` and that exactly one error reply is
posted.

### H1 — Dead `resourceScope` disposer for `model.dispose`

The disposer lookup for `model.dispose` never resolved (no provider
registers that capability today), so models cached in worker memory
leaked across the resource scope's lifetime. Added a fallback to
`model.download-remove`, which providers do register for the existing
uncache path. `model.dispose` is preserved for a future RAM-only-evict
semantic and still wins when registered.

Test: `packages/test/src/test/ai/AiTask.dispose.test.ts` covers (a) the
fallback path, (b) the cloud-style provider that registers neither
(no-op, no throw), and (c) that an explicit `model.dispose` registration
wins.

### C1 — Streaming consumer abort doesn't propagate (Critical)

Previously, a `break` from the consuming `for await` only closed the
local emit queue; the strategy kept running and the parent
`context.signal` was never linked to the inner dispatch. A caller-side
abort was invisible to the provider stream.

Introduced `packages/ai/src/task/base/runWithIterable.ts`: dispatches
`strategy.execute(...)` with a derived context whose `signal` is a
`localAbort` controller. The local signal mirrors parent aborts and is
fired in a `finally` block when the consumer exits. Reused at three
sites:

  - `packages/ai/src/task/base/StreamingAiTask.ts`
  - `packages/ai/src/task/AiChatTask.ts`
  - `packages/ai/src/task/AiChatWithKbTask.ts`

Each site previously inlined the queue+runPromise pattern.

Tests: `packages/test/src/test/ai/streaming-abort.test.ts` drives the
helper directly with a fake strategy that blocks until aborted; verifies
consumer-break, parent-abort, and clean completion paths.

### H3 — `emitQueue` unbounded; backpressure

`createEmitQueue` is now bounded by `highWaterMark` (default 256) and
`lowWaterMark` (default 64). `push()` returns `void | Promise<void>` —
producers that `await` get backpressure for free; producers that don't
still push (events are buffered, not dropped). `close()` / `fail()`
release any pending drain-resolvers. `AiEmit` is widened to
`(event) => void | Promise<void>`; existing `void`-returning producers
remain source-compatible.

Test: `packages/test/src/test/ai/emitQueue.backpressure.test.ts` covers
threshold transitions, drain-after-close, drain-after-fail, and
guard-rails on watermark validation.

## Commits

  1. `fix(util/worker): apply aborts that arrive before the call starts` (H2)
  2. `fix(ai/task): fall back to model.download-remove for resourceScope disposer` (H1)
  3. `test(ai/task): cover resourceScope disposer fallback to model.download-remove` (H1 test)
  4. `feat(ai/task): runWithIterable helper that propagates consumer abort` (C1 helper)
  5. `fix(ai/task): propagate consumer abort through StreamingAiTask via runWithIterable` (C1)
  6. `fix(ai/chat): route per-turn dispatch through runWithIterable` (C1)
  7. `fix(ai/chat-kb): route per-turn dispatch through runWithIterable` (C1)
  8. `test(ai/task): streaming consumer abort propagates to provider strategy` (C1 test)
  9. `chore(ai): export runWithIterable from the task barrel for tests / external use`
  10. `feat(ai/capability): bound emitQueue with high/low watermark backpressure` (H3)
  11. `feat(ai/capability): allow AiEmit to return void | Promise<void> for backpressure` (H3)
  12. `test(ai/capability): emitQueue high/low watermark backpressure` (H3 test)

## Test plan

  - [ ] `bun scripts/test.ts vitest unit util` — runs the new
    `WorkerServerBase.race.test.ts`.
  - [ ] `bun scripts/test.ts vitest unit ai` — runs the new
    `AiTask.dispose.test.ts`, `streaming-abort.test.ts`,
    `emitQueue.backpressure.test.ts`, plus the existing
    `emitQueue.test.ts` (verifies the bounded queue still satisfies the
    pre-existing test suite).
  - [ ] Manual smoke: type-check the full repo to confirm the widened
    `AiEmit` type does not introduce regressions in provider run-fns or
    strategies.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ahj9PynTGUcWpXb2Q2DPr)_