### PR TITLE
ci: re-enable bun-test jobs and pin bun to 1.3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - run: bun run build
       - name: Upload build artifacts
@@ -40,140 +40,140 @@ jobs:
             examples/*/dist/**
           retention-days: 1
 
-  # test-bun-unit:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run unit tests via bun
-  #       run: bun run test:bun:unit
+  test-bun-unit:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run unit tests via bun
+        run: bun run test:bun:unit
 
-  # test-bun-integration:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run integration tests via bun
-  #       env:
-  #         WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
-  #       run: bun run test:bun:integration
+  test-bun-integration:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run integration tests via bun
+        env:
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
+        run: bun run test:bun:integration
 
-  # test-bun-rag:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   timeout-minutes: 25
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Cache ONNX / Hugging Face model downloads
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: |
-  #           ~/.cache/huggingface
-  #         key: libs-hf-models-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-  #         restore-keys: |
-  #           libs-hf-models-${{ runner.os }}-
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run rag tests via bun
-  #       env:
-  #         WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
-  #       run: bun run test:bun:rag
+  test-bun-rag:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Cache ONNX / Hugging Face model downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface
+          key: libs-hf-models-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            libs-hf-models-${{ runner.os }}-
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run rag tests via bun
+        env:
+            WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
+        run: bun run test:bun:rag
 
-  # test-bun-ai-provider-hft:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run HuggingFace Transformers provider tests via bun
-  #       run: bun run test:bun:ai-provider-hft
+  test-bun-ai-provider-hft:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run HuggingFace Transformers provider tests via bun
+        run: bun run test:bun:ai-provider-hft
 
-  # test-bun-ai-provider-llamacpp:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run LlamaCpp provider tests via bun
-  #       run: bun run test:bun:ai-provider-llamacpp
+  test-bun-ai-provider-llamacpp:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run LlamaCpp provider tests via bun
+        run: bun run test:bun:ai-provider-llamacpp
 
-  # test-bun-ai-provider-api:
-  #   runs-on: ubuntu-latest
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 24
-  #     - uses: oven-sh/setup-bun@v2
-  #       with:
-  #         bun-version: latest
-  #     - run: bun i
-  #     - name: Download build artifacts
-  #       uses: actions/download-artifact@v8
-  #       with:
-  #         name: build-output
-  #         path: .
-  #     - name: Run API provider tests via bun
-  #       env:
-  #         WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
-  #       run: bun run test:bun:ai-provider-api
+  test-bun-ai-provider-api:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+      - run: bun i
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: build-output
+          path: .
+      - name: Run API provider tests via bun
+        env:
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
+        run: bun run test:bun:ai-provider-api
 
   test-vitest-unit:
     runs-on: ubuntu-latest
@@ -185,7 +185,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -213,7 +213,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -244,7 +244,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -274,7 +274,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -302,7 +302,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -330,7 +330,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -366,7 +366,7 @@ jobs:
           node-version: 24
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       - run: bun i
       - name: Download Vitest coverage fragments
         run: mkdir -p coverage-parts
@@ -413,12 +413,12 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     needs: [
-        # test-bun-unit,
-        # test-bun-integration,
-        # test-bun-rag,
-        # test-bun-ai-provider-hft,
-        # test-bun-ai-provider-llamacpp,
-        # test-bun-ai-provider-api,
+        test-bun-unit,
+        test-bun-integration,
+        test-bun-rag,
+        test-bun-ai-provider-hft,
+        test-bun-ai-provider-llamacpp,
+        test-bun-ai-provider-api,
         test-vitest-unit,
         test-vitest-integration,
         test-vitest-rag,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
           path: .
       - name: Run rag tests via bun
         env:
-            WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:bun:rag
 
   test-bun-ai-provider-hft:


### PR DESCRIPTION
## Why

Disabling the bun test jobs in `f4ead3b5` (commit body: "Commented out test jobs in GitHub Actions workflow for future reference.") left our canonical runtime ungated. Bun-specific runtime bugs — memory behavior, async scheduling, native bindings, worker semantics — are currently uncovered by CI because only the vitest-on-node path is exercised.

The root cause that triggered the original drive-by comment-out was almost certainly `bun-version: latest` regressing against the dependency bumps landed in the same commit. We have repeatedly been bitten by this:
- `0fa87bdd` — "bun 1.3.13 panics often"
- `6e434871` — "pin bun-version to 1.3.11"

`package.json` already declares the canonical version (`"packageManager": "bun@1.3.11"` and `"engines": { "bun": "^1.3.11" }`), so CI was the only place still riding `latest`.

## What

- Pin every `oven-sh/setup-bun@v2` block in `.github/workflows/test.yml` from `bun-version: latest` to `bun-version: 1.3.11` — covers `build`, all six `test-vitest-*`, all six restored `test-bun-*`, and `merge-vitest-coverage`.
- Uncomment the six previously-disabled `test-bun-*` jobs: `test-bun-unit`, `test-bun-integration`, `test-bun-rag`, `test-bun-ai-provider-hft`, `test-bun-ai-provider-llamacpp`, `test-bun-ai-provider-api`.
- Uncomment the six matching entries in `cleanup.needs` so cleanup waits on the bun jobs.

Job-specific settings were preserved:
- `timeout-minutes: 25` on `test-bun-rag`
- `WORKGLOW_SECRETS_PASSPHRASE` env on `test-bun-integration`, `test-bun-rag`, `test-bun-ai-provider-api`
- HuggingFace model cache step on `test-bun-rag`

## Verification

- After this PR's CI run, confirm six new `test-bun-*` checks appear alongside the existing `test-vitest-*` checks and all are green.
- If any `test-bun-*` job genuinely fails on bun 1.3.11 with current deps, **do not** re-comment the whole job. Open a tracking issue and quarantine that single job with `continue-on-error: true` plus a `TODO(#xxx)` referencing the issue. Nothing has been pre-emptively quarantined here.

## Risks

- `better-sqlite3` 12.10 may require a native rebuild step under bun; if the rebuild fails on first install on a clean runner, integration/rag jobs will surface it.
- The RAG suite has historically been OOM-prone — the 25-minute timeout from the original definition has been preserved.
- CI minutes on this workflow roughly double (six new parallel jobs); concurrency cancellation in the workflow header should keep PR churn bounded.

## Rollback

Single `git revert` of this commit restores prior CI behavior.

https://claude.ai/code/session_01LkKCHC8q6b5e7Nwvc8L3M6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkKCHC8q6b5e7Nwvc8L3M6)_