### PR TITLE
feat: thread IRunConfig through KB operations and add document tasks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -199,10 +199,12 @@
       "version": "0.2.35",
       "devDependencies": {
         "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",
       },
       "peerDependencies": {
         "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",
       },
     },

--- a/docs/superpowers/plans/2026-05-15-kb-runconfig-threading.md
+++ b/docs/superpowers/plans/2026-05-15-kb-runconfig-threading.md
@@ -1,0 +1,1154 @@
+# KB RunConfig Threading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread `IRunConfig` (signal, resourceScope, registry) through `KnowledgeBase.upsert/delete/search/reindex` and their `IKbAiStrategy` implementations, and add `KbAddDocumentTask` + `KbDeleteTask`.
+
+**Architecture:** Add `@workglow/task-graph` as a peer dep to `@workglow/knowledge-base`; the dep graph in CLAUDE.md already places `task-graph → dataset`, so this is valid. `IKbAiStrategy` methods gain an optional `runConfig?: Partial<IRunConfig>` trailing param (backward-compatible). KB tasks extract `{signal, resourceScope, registry}` from `IExecuteContext` and pass them to the KB call. New tasks `KbAddDocumentTask` and `KbDeleteTask` follow the same pattern as `KbReindexTask`.
+
+**Tech Stack:** TypeScript, Bun workspaces, Vitest
+
+---
+
+## File Map
+
+**Modified:**
+- `packages/knowledge-base/package.json` — add `@workglow/task-graph` peer + dev dep
+- `packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts` — add `runConfig?` to interface methods
+- `packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts` — add `runConfig?` to `upsert`, `delete`, `search`, `reindex`
+- `packages/ai/src/kb/createStandardKbStrategy.ts` — thread `runConfig` through `embedTexts`, `ingest`, `search`
+- `packages/ai/src/task/KbSearchTask.ts` — use `context` (not `_context`), pass run context to `kb.search`, trim what-explaining comments
+- `packages/ai/src/task/KbReindexTask.ts` — use `context`, pass run context to `kb.reindex`
+- `packages/ai/src/task/index.ts` — export two new tasks
+- `packages/ai/src/task/registerAiTasks.ts` — register two new tasks
+- `packages/test/src/test/rag/KbSearchTask.test.ts` — add runConfig threading test
+
+**Created:**
+- `packages/ai/src/task/KbAddDocumentTask.ts`
+- `packages/ai/src/task/KbDeleteTask.ts`
+- `packages/test/src/test/rag/KbAddDocumentTask.test.ts`
+- `packages/test/src/test/rag/KbDeleteTask.test.ts`
+
+---
+
+## Task 1: Add `@workglow/task-graph` peer dep to `@workglow/knowledge-base`
+
+**Files:**
+- Modify: `packages/knowledge-base/package.json`
+
+- [ ] **Step 1: Add task-graph to peerDependencies, peerDependenciesMeta, and devDependencies**
+
+In `packages/knowledge-base/package.json`, make these three targeted edits:
+
+Replace:
+```json
+  "peerDependencies": {
+    "@workglow/storage": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+```
+With:
+```json
+  "peerDependencies": {
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+```
+
+Replace:
+```json
+  "peerDependenciesMeta": {
+    "@workglow/storage": {
+      "optional": false
+    },
+    "@workglow/util": {
+      "optional": false
+    }
+  },
+```
+With:
+```json
+  "peerDependenciesMeta": {
+    "@workglow/storage": {
+      "optional": false
+    },
+    "@workglow/task-graph": {
+      "optional": false
+    },
+    "@workglow/util": {
+      "optional": false
+    }
+  },
+```
+
+Replace:
+```json
+  "devDependencies": {
+    "@workglow/storage": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+```
+With:
+```json
+  "devDependencies": {
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+```
+
+- [ ] **Step 2: Verify bun install still resolves**
+
+```bash
+bun install
+```
+Expected: No errors. The workspace symlink for `@workglow/task-graph` should appear in `node_modules`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/knowledge-base/package.json
+git commit -m "feat: add task-graph peer dep to knowledge-base"
+```
+
+---
+
+## Task 2: Add `runConfig` to `IKbAiStrategy` interface
+
+**Files:**
+- Modify: `packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts`
+
+- [ ] **Step 1: Write the failing build check**
+
+The build will fail on Task 3 when KnowledgeBase.ts tries to import IRunConfig (if this task is skipped). Confirm now that there's no existing import of `task-graph` in this file:
+
+```bash
+grep -n "task-graph" packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts
+```
+Expected: no output.
+
+- [ ] **Step 2: Add the import**
+
+At the top of `packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts`, after the license header, add the import for `IRunConfig`. The file currently begins its imports with:
+```ts
+import type { TypedArray } from "@workglow/util/schema";
+```
+
+Insert before that line:
+```ts
+import type { IRunConfig } from "@workglow/task-graph";
+```
+
+- [ ] **Step 3: Update `ingest` signature**
+
+Find:
+```ts
+  ingest(kb: IKbStrategyTarget, doc: Document): Promise<Document>;
+```
+Replace with:
+```ts
+  ingest(kb: IKbStrategyTarget, doc: Document, runConfig?: Partial<IRunConfig>): Promise<Document>;
+```
+
+- [ ] **Step 4: Update `delete` signature**
+
+Find:
+```ts
+  delete(kb: IKbStrategyTarget, doc_id: string): Promise<void>;
+```
+Replace with:
+```ts
+  delete(kb: IKbStrategyTarget, doc_id: string, runConfig?: Partial<IRunConfig>): Promise<void>;
+```
+
+- [ ] **Step 5: Update `search` signature**
+
+Find:
+```ts
+  search(
+    kb: IKbStrategyTarget,
+    query: string,
+    options?: ISearchOptions
+  ): Promise<ChunkSearchResult[]>;
+```
+Replace with:
+```ts
+  search(
+    kb: IKbStrategyTarget,
+    query: string,
+    options?: ISearchOptions,
+    runConfig?: Partial<IRunConfig>
+  ): Promise<ChunkSearchResult[]>;
+```
+
+- [ ] **Step 6: Verify type-check compiles**
+
+```bash
+cd packages/knowledge-base && bun run build-types 2>&1 | tail -5
+```
+Expected: no errors (existing strategy implementations tolerate the new optional param).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts
+git commit -m "feat: add optional runConfig to IKbAiStrategy methods"
+```
+
+---
+
+## Task 3: Thread `runConfig` through `KnowledgeBase` public API
+
+**Files:**
+- Modify: `packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts`
+
+- [ ] **Step 1: Add the import**
+
+`KnowledgeBase.ts` currently imports from `"./IKbAiStrategy"`. Add `IRunConfig` import after the license header — before any other imports (or alongside related type imports). Find the first import block and add:
+```ts
+import type { IRunConfig } from "@workglow/task-graph";
+```
+
+- [ ] **Step 2: Update `upsert`**
+
+Find:
+```ts
+  async upsert(doc: Document): Promise<Document> {
+    const strategy = this.requireStrategy("upsert");
+    return strategy.ingest(this, doc);
+  }
+```
+Replace with:
+```ts
+  async upsert(doc: Document, runConfig?: Partial<IRunConfig>): Promise<Document> {
+    const strategy = this.requireStrategy("upsert");
+    return strategy.ingest(this, doc, runConfig);
+  }
+```
+
+- [ ] **Step 3: Update `delete`**
+
+Find:
+```ts
+  async delete(doc_id: string): Promise<void> {
+    const strategy = this.requireStrategy("delete");
+    return strategy.delete(this, doc_id);
+  }
+```
+Replace with:
+```ts
+  async delete(doc_id: string, runConfig?: Partial<IRunConfig>): Promise<void> {
+    const strategy = this.requireStrategy("delete");
+    return strategy.delete(this, doc_id, runConfig);
+  }
+```
+
+- [ ] **Step 4: Update `search`**
+
+Find:
+```ts
+  async search(query: string, options?: ISearchOptions): Promise<ChunkSearchResult[]> {
+    const strategy = this.requireStrategy("search");
+    return strategy.search(this, query, options);
+  }
+```
+Replace with:
+```ts
+  async search(query: string, options?: ISearchOptions, runConfig?: Partial<IRunConfig>): Promise<ChunkSearchResult[]> {
+    const strategy = this.requireStrategy("search");
+    return strategy.search(this, query, options, runConfig);
+  }
+```
+
+- [ ] **Step 5: Update `reindex`**
+
+Find:
+```ts
+  async reindex(): Promise<number> {
+    const strategy = this.requireStrategy("reindex");
+    const docIds = await this.listDocuments();
+    let count = 0;
+    for (const doc_id of docIds) {
+      const doc = await this.getDocument(doc_id);
+      if (!doc) continue;
+      await strategy.ingest(this, doc);
+      count++;
+    }
+    return count;
+  }
+```
+Replace with:
+```ts
+  async reindex(runConfig?: Partial<IRunConfig>): Promise<number> {
+    const strategy = this.requireStrategy("reindex");
+    const docIds = await this.listDocuments();
+    let count = 0;
+    for (const doc_id of docIds) {
+      const doc = await this.getDocument(doc_id);
+      if (!doc) continue;
+      await strategy.ingest(this, doc, runConfig);
+      count++;
+    }
+    return count;
+  }
+```
+
+- [ ] **Step 6: Verify type-check**
+
+```bash
+cd packages/knowledge-base && bun run build-types 2>&1 | tail -5
+```
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+git commit -m "feat: add optional runConfig param to KnowledgeBase upsert/delete/search/reindex"
+```
+
+---
+
+## Task 4: Thread `runConfig` through `createStandardKbStrategy`
+
+**Files:**
+- Modify: `packages/ai/src/kb/createStandardKbStrategy.ts`
+
+- [ ] **Step 1: Write a failing test first**
+
+Run the existing strategy tests to confirm they pass before any changes:
+```bash
+bun scripts/test.ts rag vitest 2>&1 | tail -20
+```
+Expected: all pass.
+
+- [ ] **Step 2: Add the `IRunConfig` import**
+
+In `packages/ai/src/kb/createStandardKbStrategy.ts`, the imports currently end with:
+```ts
+import { TextRerankerTask } from "../task/TextRerankerTask";
+```
+
+Add before that block:
+```ts
+import type { IRunConfig } from "@workglow/task-graph";
+```
+
+- [ ] **Step 3: Update `embedTexts` to accept and thread `runConfig`**
+
+Find:
+```ts
+  const embedTexts = async (texts: readonly string[], modelId: string): Promise<TypedArray[]> => {
+    if (texts.length === 0) return [];
+    const result = await new TextEmbeddingTask().run({ text: texts as string[], model: modelId });
+    const vector = result.vector;
+    return Array.isArray(vector) ? (vector as TypedArray[]) : [vector as TypedArray];
+  };
+```
+Replace with:
+```ts
+  const embedTexts = async (
+    texts: readonly string[],
+    modelId: string,
+    runConfig?: Partial<IRunConfig>
+  ): Promise<TypedArray[]> => {
+    if (texts.length === 0) return [];
+    const result = await new TextEmbeddingTask().run(
+      { text: texts as string[], model: modelId },
+      runConfig
+    );
+    const vector = result.vector;
+    return Array.isArray(vector) ? (vector as TypedArray[]) : [vector as TypedArray];
+  };
+```
+
+- [ ] **Step 4: Update `ingest` to accept and thread `runConfig`**
+
+Find:
+```ts
+    async ingest(kb, doc): Promise<Document> {
+```
+Replace with:
+```ts
+    async ingest(kb, doc, runConfig): Promise<Document> {
+```
+
+Then within `ingest`, find the chunker run call:
+```ts
+      const chunkResult = await chunker.run({
+        doc_id: docId,
+        documentTree: stored.root as never,
+        strategy: resolveChunkStrategy(kb),
+        ...chunkerDefaults,
+      });
+```
+Replace with:
+```ts
+      const chunkResult = await chunker.run(
+        {
+          doc_id: docId,
+          documentTree: stored.root as never,
+          strategy: resolveChunkStrategy(kb),
+          ...chunkerDefaults,
+        },
+        runConfig
+      );
+```
+
+Then find the `embedTexts` call inside `ingest`:
+```ts
+      const vectors = await embedTexts(
+        chunks.map((c) => c.text),
+        requireDocEmbedModel(kb)
+      );
+```
+Replace with:
+```ts
+      const vectors = await embedTexts(
+        chunks.map((c) => c.text),
+        requireDocEmbedModel(kb),
+        runConfig
+      );
+```
+
+- [ ] **Step 5: Update `search` to accept and thread `runConfig`**
+
+Find:
+```ts
+    async search(kb, query, options?: ISearchOptions): Promise<ChunkSearchResult[]> {
+```
+Replace with:
+```ts
+    async search(kb, query, options?: ISearchOptions, runConfig?: Partial<IRunConfig>): Promise<ChunkSearchResult[]> {
+```
+
+Within `search`, find the `embedTexts` call (it appears once for similarity/hybrid/rerank):
+```ts
+      const queryVec = await embedTexts([query], requireQueryEmbedModel(kb));
+```
+Replace with:
+```ts
+      const queryVec = await embedTexts([query], requireQueryEmbedModel(kb), runConfig);
+```
+
+Find the `TextRerankerTask` run call in the rerank branch:
+```ts
+        const result = await new TextRerankerTask().run({
+          query,
+          documents: docs,
+          model: kb.rerankerModel,
+          topK,
+        });
+```
+Replace with:
+```ts
+        const result = await new TextRerankerTask().run(
+          {
+            query,
+            documents: docs,
+            model: kb.rerankerModel,
+            topK,
+          },
+          runConfig
+        );
+```
+
+Find the heuristic `RerankerTask` run call:
+```ts
+      const heuristic = await new RerankerTask().run({
+        query,
+        chunks: docs,
+        scores: firstStage.map((c) => c.score),
+        metadata: firstStage.map((c) => c.metadata as Record<string, unknown>),
+        topK,
+        method: "simple",
+      });
+```
+Replace with:
+```ts
+      const heuristic = await new RerankerTask().run(
+        {
+          query,
+          chunks: docs,
+          scores: firstStage.map((c) => c.score),
+          metadata: firstStage.map((c) => c.metadata as Record<string, unknown>),
+          topK,
+          method: "simple",
+        },
+        runConfig
+      );
+```
+
+- [ ] **Step 6: Verify tests still pass**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | tail -20
+```
+Expected: all pass (runConfig is optional, so existing call sites without it are unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ai/src/kb/createStandardKbStrategy.ts
+git commit -m "feat: thread runConfig through createStandardKbStrategy sub-task calls"
+```
+
+---
+
+## Task 5: Update `KbSearchTask` — thread context, trim comments
+
+**Files:**
+- Modify: `packages/ai/src/task/KbSearchTask.ts`
+- Modify: `packages/test/src/test/rag/KbSearchTask.test.ts`
+
+- [ ] **Step 1: Write the new failing test**
+
+Add to `packages/test/src/test/rag/KbSearchTask.test.ts`, inside the `describe` block, after the existing two tests:
+
+```ts
+  it("threads run context (signal) to kb.search", async () => {
+    const { kb, searchSpy } = await makeKbWithSearchSpy();
+
+    await kbSearch({ knowledgeBase: kb, query: "hello" });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    const call = searchSpy.mock.calls[0];
+    // Third argument is the runConfig extracted from IExecuteContext.
+    const forwardedRunConfig = call[2];
+    expect(forwardedRunConfig).toBeDefined();
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+```
+
+- [ ] **Step 2: Run the new test to confirm it currently fails**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | grep -A 5 "threads run context"
+```
+Expected: FAIL — `forwardedRunConfig` is `undefined` because the current implementation doesn't pass it.
+
+- [ ] **Step 3: Update `KbSearchTask.execute`**
+
+In `packages/ai/src/task/KbSearchTask.ts`, replace the entire `execute` method:
+
+```ts
+  override async execute(
+    input: KbSearchTaskInput,
+    _context: IExecuteContext
+  ): Promise<KbSearchTaskOutput> {
+    const { knowledgeBase, query, topK = 5, filter, scoreThreshold } = input;
+    const kb = knowledgeBase as KnowledgeBase;
+    // Forward `scoreThreshold` to the strategy. The standard strategy
+    // honors it in similarity / hybrid modes and intentionally ignores
+    // it in rerank mode (cross-encoder logits aren't on the same scale
+    // as cosine / RRF, so a single numeric threshold would either drop
+    // everything or nothing).
+    const results = await kb.search(query, { topK, filter, scoreThreshold });
+    return {
+      results,
+      // `chunkText` enforces the metadata.text contract — any chunk
+      // missing text throws with its chunk_id rather than silently
+      // emitting `JSON.stringify(metadata)` (which would surface as
+      // garbage to downstream consumers).
+      chunks: results.map(chunkText),
+      chunk_ids: results.map((r) => r.chunk_id),
+      scores: results.map((r) => r.score),
+      count: results.length,
+    };
+  }
+```
+
+With:
+
+```ts
+  override async execute(
+    input: KbSearchTaskInput,
+    context: IExecuteContext
+  ): Promise<KbSearchTaskOutput> {
+    const { knowledgeBase, query, topK = 5, filter, scoreThreshold } = input;
+    const kb = knowledgeBase as KnowledgeBase;
+    const results = await kb.search(query, { topK, filter, scoreThreshold }, {
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return {
+      results,
+      chunks: results.map(chunkText),
+      chunk_ids: results.map((r) => r.chunk_id),
+      scores: results.map((r) => r.score),
+      count: results.length,
+    };
+  }
+```
+
+- [ ] **Step 4: Run all three tests**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | grep -E "PASS|FAIL|KbSearch"
+```
+Expected: all three `KbSearchTask` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai/src/task/KbSearchTask.ts packages/test/src/test/rag/KbSearchTask.test.ts
+git commit -m "feat: thread IExecuteContext through KbSearchTask to kb.search"
+```
+
+---
+
+## Task 6: Update `KbReindexTask` — thread context
+
+**Files:**
+- Modify: `packages/ai/src/task/KbReindexTask.ts`
+
+- [ ] **Step 1: Update the `execute` method**
+
+In `packages/ai/src/task/KbReindexTask.ts`, replace:
+
+```ts
+  override async execute(
+    input: KbReindexTaskInput,
+    _context: IExecuteContext
+  ): Promise<KbReindexTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    const count = await kb.reindex();
+    return { count };
+  }
+```
+
+With:
+
+```ts
+  override async execute(
+    input: KbReindexTaskInput,
+    context: IExecuteContext
+  ): Promise<KbReindexTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    const count = await kb.reindex({
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return { count };
+  }
+```
+
+- [ ] **Step 2: Verify tests still pass**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | tail -10
+```
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ai/src/task/KbReindexTask.ts
+git commit -m "feat: thread IExecuteContext through KbReindexTask to kb.reindex"
+```
+
+---
+
+## Task 7: Create `KbAddDocumentTask`
+
+**Files:**
+- Create: `packages/ai/src/task/KbAddDocumentTask.ts`
+- Create: `packages/test/src/test/rag/KbAddDocumentTask.test.ts`
+
+- [ ] **Step 1: Write the tests first**
+
+Create `packages/test/src/test/rag/KbAddDocumentTask.test.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { kbAddDocument } from "@workglow/ai";
+import { Document, createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { describe, expect, it, vi } from "vitest";
+
+describe("KbAddDocumentTask", () => {
+  function makeDoc(docId?: string): Document {
+    const doc = new Document(
+      { type: "root", title: "T", children: [] } as never,
+      { title: "Test" }
+    );
+    if (docId) doc.setDocId(docId);
+    return doc;
+  }
+
+  async function makeKbWithUpsertSpy() {
+    const kb = await createKnowledgeBase({
+      name: `kb-add-doc-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+    });
+    const doc = makeDoc("returned-id");
+    const upsertSpy = vi.spyOn(kb, "upsert").mockResolvedValue(doc);
+    return { kb, doc, upsertSpy };
+  }
+
+  it("calls kb.upsert with the provided document", async () => {
+    const { kb, doc, upsertSpy } = await makeKbWithUpsertSpy();
+
+    await kbAddDocument({ knowledgeBase: kb, document: doc });
+
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSpy.mock.calls[0][0]).toBe(doc);
+  });
+
+  it("returns the doc_id from the upserted document", async () => {
+    const { kb, doc } = await makeKbWithUpsertSpy();
+
+    const result = await kbAddDocument({ knowledgeBase: kb, document: doc });
+
+    expect(result.doc_id).toBe("returned-id");
+  });
+
+  it("threads run context (signal) to kb.upsert", async () => {
+    const { kb, upsertSpy } = await makeKbWithUpsertSpy();
+
+    await kbAddDocument({ knowledgeBase: kb, document: makeDoc("x") });
+
+    const forwardedRunConfig = upsertSpy.mock.calls[0][1];
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | grep -A 3 "KbAddDocumentTask"
+```
+Expected: FAIL — `kbAddDocument` does not exist yet.
+
+- [ ] **Step 3: Create the task file**
+
+Create `packages/ai/src/task/KbAddDocumentTask.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { KnowledgeBase } from "@workglow/knowledge-base";
+import { Document, TypeKnowledgeBase } from "@workglow/knowledge-base";
+import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import type { Capability } from "../capability/Capabilities";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    knowledgeBase: TypeKnowledgeBase({
+      title: "Knowledge Base",
+      description: "Knowledge base to add the document to.",
+    }),
+    document: {
+      title: "Document",
+      description: "The Document instance to chunk, embed, and store.",
+      additionalProperties: true,
+    },
+  },
+  required: ["knowledgeBase", "document"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "The stored document ID.",
+    },
+  },
+  required: ["doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type KbAddDocumentTaskInput = Omit<FromSchema<typeof inputSchema>, "document"> & {
+  readonly document: Document;
+};
+export type KbAddDocumentTaskOutput = FromSchema<typeof outputSchema>;
+export type KbAddDocumentTaskConfig = TaskConfig<KbAddDocumentTaskInput>;
+
+/**
+ * Ingest a document into a knowledge base end-to-end: chunk, embed, and
+ * store via the KB's installed strategy. Threads the task's execution
+ * context (signal, resourceScope, registry) into the KB call so model
+ * resources are shared and abort signals propagate.
+ */
+export class KbAddDocumentTask extends Task<
+  KbAddDocumentTaskInput,
+  KbAddDocumentTaskOutput,
+  KbAddDocumentTaskConfig
+> {
+  public static override type = "KbAddDocumentTask";
+  public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
+  public static override category = "RAG";
+  public static override title = "KB Add Document";
+  public static override description =
+    "Ingest a document into a knowledge base: chunk, embed, and store via the KB's installed strategy.";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: KbAddDocumentTaskInput,
+    context: IExecuteContext
+  ): Promise<KbAddDocumentTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    const stored = await kb.upsert(input.document as Document, {
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return { doc_id: stored.doc_id! };
+  }
+}
+
+export const kbAddDocument = (
+  input: KbAddDocumentTaskInput,
+  config?: KbAddDocumentTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbAddDocumentTask(config).run(input, runConfig);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    kbAddDocument: CreateWorkflow<
+      KbAddDocumentTaskInput,
+      KbAddDocumentTaskOutput,
+      KbAddDocumentTaskConfig
+    >;
+  }
+}
+
+Workflow.prototype.kbAddDocument = CreateWorkflow(KbAddDocumentTask);
+```
+
+- [ ] **Step 4: Run tests (they will still fail — not exported yet)**
+
+Registration happens in Task 9. For now, confirm the file compiles:
+
+```bash
+cd packages/ai && bun run build-types 2>&1 | tail -5
+```
+Expected: no errors from the new file itself (TypeScript can see it even before it's re-exported).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai/src/task/KbAddDocumentTask.ts packages/test/src/test/rag/KbAddDocumentTask.test.ts
+git commit -m "feat: add KbAddDocumentTask"
+```
+
+---
+
+## Task 8: Create `KbDeleteTask`
+
+**Files:**
+- Create: `packages/ai/src/task/KbDeleteTask.ts`
+- Create: `packages/test/src/test/rag/KbDeleteTask.test.ts`
+
+- [ ] **Step 1: Write the tests first**
+
+Create `packages/test/src/test/rag/KbDeleteTask.test.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { kbDelete } from "@workglow/ai";
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { describe, expect, it, vi } from "vitest";
+
+describe("KbDeleteTask", () => {
+  async function makeKbWithDeleteSpy() {
+    const kb = await createKnowledgeBase({
+      name: `kb-delete-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+    });
+    const deleteSpy = vi.spyOn(kb, "delete").mockResolvedValue(undefined);
+    return { kb, deleteSpy };
+  }
+
+  it("calls kb.delete with the given doc_id", async () => {
+    const { kb, deleteSpy } = await makeKbWithDeleteSpy();
+
+    await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy.mock.calls[0][0]).toBe("my-doc");
+  });
+
+  it("echoes doc_id in the output", async () => {
+    const { kb } = await makeKbWithDeleteSpy();
+
+    const result = await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    expect(result.doc_id).toBe("my-doc");
+  });
+
+  it("threads run context (signal) to kb.delete", async () => {
+    const { kb, deleteSpy } = await makeKbWithDeleteSpy();
+
+    await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    const forwardedRunConfig = deleteSpy.mock.calls[0][1];
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | grep -A 3 "KbDeleteTask"
+```
+Expected: FAIL — `kbDelete` does not exist yet.
+
+- [ ] **Step 3: Create the task file**
+
+Create `packages/ai/src/task/KbDeleteTask.ts`:
+
+```ts
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { KnowledgeBase } from "@workglow/knowledge-base";
+import { TypeKnowledgeBase } from "@workglow/knowledge-base";
+import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import type { Capability } from "../capability/Capabilities";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    knowledgeBase: TypeKnowledgeBase({
+      title: "Knowledge Base",
+      description: "Knowledge base to delete the document from.",
+    }),
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "ID of the document to delete.",
+    },
+  },
+  required: ["knowledgeBase", "doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "ID of the deleted document (echoed for pipeline composability).",
+    },
+  },
+  required: ["doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type KbDeleteTaskInput = FromSchema<typeof inputSchema>;
+export type KbDeleteTaskOutput = FromSchema<typeof outputSchema>;
+export type KbDeleteTaskConfig = TaskConfig<KbDeleteTaskInput>;
+
+/**
+ * Delete a document and its chunks from a knowledge base via the KB's
+ * installed strategy. Echoes `doc_id` so the task is composable in
+ * pipelines that need to pass the id to a downstream step.
+ */
+export class KbDeleteTask extends Task<KbDeleteTaskInput, KbDeleteTaskOutput, KbDeleteTaskConfig> {
+  public static override type = "KbDeleteTask";
+  public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
+  public static override category = "RAG";
+  public static override title = "KB Delete Document";
+  public static override description =
+    "Delete a document and its chunks from a knowledge base.";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: KbDeleteTaskInput,
+    context: IExecuteContext
+  ): Promise<KbDeleteTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    await kb.delete(input.doc_id, {
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return { doc_id: input.doc_id };
+  }
+}
+
+export const kbDelete = (
+  input: KbDeleteTaskInput,
+  config?: KbDeleteTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbDeleteTask(config).run(input, runConfig);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    kbDelete: CreateWorkflow<KbDeleteTaskInput, KbDeleteTaskOutput, KbDeleteTaskConfig>;
+  }
+}
+
+Workflow.prototype.kbDelete = CreateWorkflow(KbDeleteTask);
+```
+
+- [ ] **Step 4: Verify TypeScript**
+
+```bash
+cd packages/ai && bun run build-types 2>&1 | tail -5
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai/src/task/KbDeleteTask.ts packages/test/src/test/rag/KbDeleteTask.test.ts
+git commit -m "feat: add KbDeleteTask"
+```
+
+---
+
+## Task 9: Register and export new tasks
+
+**Files:**
+- Modify: `packages/ai/src/task/index.ts`
+- Modify: `packages/ai/src/task/registerAiTasks.ts`
+
+- [ ] **Step 1: Export new tasks from `index.ts`**
+
+In `packages/ai/src/task/index.ts`, find the KB task export block:
+```ts
+export * from "./KbReindexTask";
+export * from "./KbSearchTask";
+export * from "./KbToDocumentsTask";
+```
+
+Replace with:
+```ts
+export * from "./KbAddDocumentTask";
+export * from "./KbDeleteTask";
+export * from "./KbReindexTask";
+export * from "./KbSearchTask";
+export * from "./KbToDocumentsTask";
+```
+
+- [ ] **Step 2: Register new tasks in `registerAiTasks.ts`**
+
+In `packages/ai/src/task/registerAiTasks.ts`, find the existing KB imports:
+```ts
+import { KbReindexTask } from "./KbReindexTask";
+import { KbSearchTask } from "./KbSearchTask";
+import { KbToDocumentsTask } from "./KbToDocumentsTask";
+```
+
+Replace with:
+```ts
+import { KbAddDocumentTask } from "./KbAddDocumentTask";
+import { KbDeleteTask } from "./KbDeleteTask";
+import { KbReindexTask } from "./KbReindexTask";
+import { KbSearchTask } from "./KbSearchTask";
+import { KbToDocumentsTask } from "./KbToDocumentsTask";
+```
+
+Then in the `tasks` array, find the block:
+```ts
+    KbSearchTask,
+    KbToDocumentsTask,
+```
+
+Replace with:
+```ts
+    KbAddDocumentTask,
+    KbDeleteTask,
+    KbSearchTask,
+    KbToDocumentsTask,
+```
+
+- [ ] **Step 3: Run all rag tests**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | tail -30
+```
+Expected: all tests pass, including the new `KbAddDocumentTask` and `KbDeleteTask` suites.
+
+- [ ] **Step 4: Run full build to catch any type errors**
+
+```bash
+bun run build:packages 2>&1 | tail -20
+```
+Expected: clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ai/src/task/index.ts packages/ai/src/task/registerAiTasks.ts
+git commit -m "feat: register and export KbAddDocumentTask and KbDeleteTask"
+```
+
+---
+
+## Task 10: Final verification and push
+
+- [ ] **Step 1: Run the full rag test suite**
+
+```bash
+bun scripts/test.ts rag vitest 2>&1 | tail -30
+```
+Expected: all tests green.
+
+- [ ] **Step 2: Run full build**
+
+```bash
+bun run build:packages 2>&1 | tail -10
+```
+Expected: no errors.
+
+- [ ] **Step 3: Push to feature branch**
+
+```bash
+git push -u origin claude/thread-resource-scope-U8rTa
+```
+Expected: push succeeds.

--- a/docs/superpowers/specs/2026-05-15-kb-runconfig-threading-design.md
+++ b/docs/superpowers/specs/2026-05-15-kb-runconfig-threading-design.md
@@ -1,0 +1,141 @@
+# KB RunConfig Threading + New Tasks
+
+**Date:** 2026-05-15  
+**Packages affected:** `@workglow/knowledge-base`, `@workglow/ai`
+
+## Problem
+
+`KnowledgeBase.search()`, `.upsert()`, `.delete()`, and `.reindex()` call their installed `IKbAiStrategy`, which in turn spawns AI sub-tasks (`TextEmbeddingTask`, `HierarchicalChunkerTask`, `TextRerankerTask`, etc.) without any `runConfig`. This means:
+
+- No `resourceScope` — model resources aren't registered for cleanup; every call may load the embedding model fresh.
+- No `registry` — service registry isn't shared across the subtask tree.
+- No `signal` — abort signals don't propagate into AI sub-tasks.
+
+KB tasks (`KbSearchTask`, `KbReindexTask`) receive an `IExecuteContext` but currently ignore it for the KB call.
+
+No task-level wrappers exist for adding or deleting a document, so callers either call the KB directly (losing runConfig) or wire up `ChunkVectorUpsertTask` manually (which is lower-level and doesn't drive the full strategy).
+
+## Design
+
+### 1. Package dependency
+
+Add `@workglow/task-graph` as a peer dep (and dev dep) in `packages/knowledge-base/package.json`. The dep graph in CLAUDE.md already places `task-graph → dataset` (dataset may import from task-graph), so this is architecturally valid. All imports will be type-only.
+
+### 2. `IKbAiStrategy` interface
+
+Each method gains an optional trailing `runConfig` parameter. Optional keeps existing custom strategy implementations backward-compatible.
+
+```ts
+interface IKbAiStrategy {
+  ingest(kb: IKbStrategyTarget, doc: Document,
+         runConfig?: Partial<IRunConfig>): Promise<Document>;
+  delete(kb: IKbStrategyTarget, doc_id: string,
+         runConfig?: Partial<IRunConfig>): Promise<void>;
+  search(kb: IKbStrategyTarget, query: string,
+         options?: ISearchOptions,
+         runConfig?: Partial<IRunConfig>): Promise<ChunkSearchResult[]>;
+}
+```
+
+File: `packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts`
+
+### 3. `KnowledgeBase` public API
+
+Four methods grow an optional `runConfig` parameter. Each delegates straight to the strategy unchanged otherwise.
+
+```ts
+async upsert(doc: Document,    runConfig?: Partial<IRunConfig>): Promise<Document>
+async delete(doc_id: string,   runConfig?: Partial<IRunConfig>): Promise<void>
+async search(query: string,    options?: ISearchOptions, runConfig?: Partial<IRunConfig>): Promise<ChunkSearchResult[]>
+async reindex(                 runConfig?: Partial<IRunConfig>): Promise<number>
+```
+
+File: `packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts`
+
+### 4. `createStandardKbStrategy`
+
+The private `embedTexts` helper gains a `runConfig` param and passes it to `TextEmbeddingTask.run()`.
+
+Threading points:
+- `ingest`: `HierarchicalChunkerTask().run({...}, runConfig)` + `embedTexts([...], model, runConfig)`
+- `search`: `embedTexts([query], model, runConfig)` + `TextRerankerTask().run({...}, runConfig)` + `RerankerTask().run({...}, runConfig)`
+- `delete`: pure storage, no sub-tasks, no change needed.
+
+File: `packages/ai/src/kb/createStandardKbStrategy.ts`
+
+### 5. KB tasks
+
+#### `KbSearchTask` (updated)
+
+- Rename `_context` → `context`; pass `context.runConfig` to `kb.search(query, {topK, filter, scoreThreshold}, context.runConfig)`.
+- Trim the what-explaining comment blocks inside `execute()` per project style (only non-obvious *why* survives).
+
+File: `packages/ai/src/task/KbSearchTask.ts`
+
+#### `KbReindexTask` (updated)
+
+Thread `context.runConfig` to `kb.reindex(context.runConfig)`.
+
+File: `packages/ai/src/task/KbReindexTask.ts`
+
+#### `KbAddDocumentTask` (new)
+
+```ts
+// Input
+{ knowledgeBase: KnowledgeBase, document: Document }
+
+// Output
+{ doc_id: string }
+
+// Behaviour
+cacheable = false
+execute: const stored = await kb.upsert(input.document as Document, context.runConfig);
+          return { doc_id: stored.doc_id! };
+```
+
+- Follows the same task/factory/Workflow-augmentation structure as `KbReindexTask`.
+- Exports `kbAddDocument` standalone helper and `Workflow.prototype.kbAddDocument`.
+
+File: `packages/ai/src/task/KbAddDocumentTask.ts`
+
+#### `KbDeleteTask` (new)
+
+```ts
+// Input
+{ knowledgeBase: KnowledgeBase, doc_id: string }
+
+// Output
+{ doc_id: string }   // echoes input — composable in pipelines
+
+// Behaviour
+cacheable = false
+execute: await kb.delete(input.doc_id, context.runConfig);
+          return { doc_id: input.doc_id };
+```
+
+- Exports `kbDelete` standalone helper and `Workflow.prototype.kbDelete`.
+
+File: `packages/ai/src/task/KbDeleteTask.ts`
+
+### 6. Exports
+
+Both new task files must be:
+- Imported and registered in `packages/ai/src/common.ts` (or the appropriate barrel file where other KB tasks are exported).
+- Re-exported from the `@workglow/ai` package entry points (browser/node/bun).
+
+### 7. `KbToDocumentsTask`
+
+No change — it performs only storage reads, no AI sub-tasks, no runConfig needed.
+
+## Non-goals
+
+- No changes to `IKbStrategyTarget` (the strategy-facing KB surface).
+- No changes to `ScopedKnowledgeBase` (virtual dispatch handles scoping transparently).
+- No new runConfig threading for the low-level building-block methods (`upsertChunk`, `similaritySearch`, etc.) — those are pure storage ops.
+- No removal of `ChunkRetrievalTask` or other existing tasks.
+
+## Testing
+
+- Existing KB strategy tests should pass unchanged (all new params are optional).
+- Add unit tests for `KbAddDocumentTask` and `KbDeleteTask` mirroring `KbReindexTask`'s test pattern.
+- Verify that `KbSearchTask` threads `runConfig.signal` by running a search with an already-aborted signal and confirming propagation.

--- a/packages/ai/src/kb/createStandardKbStrategy.ts
+++ b/packages/ai/src/kb/createStandardKbStrategy.ts
@@ -14,6 +14,7 @@ import type {
   SearchMode,
 } from "@workglow/knowledge-base";
 import { chunkText, toInsertChunkEntities } from "@workglow/knowledge-base";
+import type { IRunConfig } from "@workglow/task-graph";
 import type { TypedArray } from "@workglow/util/schema";
 
 import { HierarchicalChunkerTask } from "../task/HierarchicalChunkerTask";
@@ -120,15 +121,22 @@ export function createStandardKbStrategy(
     return m;
   };
 
-  const embedTexts = async (texts: readonly string[], modelId: string): Promise<TypedArray[]> => {
+  const embedTexts = async (
+    texts: readonly string[],
+    modelId: string,
+    runConfig?: Partial<IRunConfig>
+  ): Promise<TypedArray[]> => {
     if (texts.length === 0) return [];
-    const result = await new TextEmbeddingTask().run({ text: texts as string[], model: modelId });
+    const result = await new TextEmbeddingTask().run(
+      { text: texts as string[], model: modelId },
+      runConfig
+    );
     const vector = result.vector;
     return Array.isArray(vector) ? (vector as TypedArray[]) : [vector as TypedArray];
   };
 
   return {
-    async ingest(kb, doc): Promise<Document> {
+    async ingest(kb, doc, runConfig): Promise<Document> {
       // Order matters: delete old chunks BEFORE rewriting the document.
       // If upsertDocument or any later step fails partway through, the
       // worst the KB can be left in is "doc row preserved, chunks
@@ -153,18 +161,22 @@ export function createStandardKbStrategy(
       }
 
       const chunker = new HierarchicalChunkerTask();
-      const chunkResult = await chunker.run({
-        doc_id: docId,
-        documentTree: stored.root as never,
-        strategy: resolveChunkStrategy(kb),
-        ...chunkerDefaults,
-      });
+      const chunkResult = await chunker.run(
+        {
+          doc_id: docId,
+          documentTree: stored.root as never,
+          strategy: resolveChunkStrategy(kb),
+          ...chunkerDefaults,
+        },
+        runConfig
+      );
       const chunks = chunkResult.chunks ?? [];
       if (chunks.length === 0) return stored;
 
       const vectors = await embedTexts(
         chunks.map((c) => c.text),
-        requireDocEmbedModel(kb)
+        requireDocEmbedModel(kb),
+        runConfig
       );
       const inserts = toInsertChunkEntities(
         { chunks, vectors },
@@ -178,7 +190,12 @@ export function createStandardKbStrategy(
       await kb.deleteDocument(doc_id);
     },
 
-    async search(kb, query, options?: ISearchOptions): Promise<ChunkSearchResult[]> {
+    async search(
+      kb,
+      query,
+      options?: ISearchOptions,
+      runConfig?: Partial<IRunConfig>
+    ): Promise<ChunkSearchResult[]> {
       const mode = resolveSearchMode(kb);
       const topK = options?.topK ?? 5;
       const filter = options?.filter;
@@ -204,7 +221,7 @@ export function createStandardKbStrategy(
         });
       }
 
-      const queryVec = await embedTexts([query], requireQueryEmbedModel(kb));
+      const queryVec = await embedTexts([query], requireQueryEmbedModel(kb), runConfig);
       const vector = queryVec[0];
 
       if (mode === "similarity") {
@@ -258,12 +275,15 @@ export function createStandardKbStrategy(
       // Callers wanting a rerank-relative cutoff should clip on the
       // returned `score` themselves after inspecting `scoreType`.
       if (kb.rerankerModel) {
-        const result = await new TextRerankerTask().run({
-          query,
-          documents: docs,
-          model: kb.rerankerModel,
-          topK,
-        });
+        const result = await new TextRerankerTask().run(
+          {
+            query,
+            documents: docs,
+            model: kb.rerankerModel,
+            topK,
+          },
+          runConfig
+        );
         const indices = (result.indices as number[]) ?? [];
         const scores = (result.scores as number[]) ?? [];
         return indices.map((idx) => {
@@ -281,14 +301,17 @@ export function createStandardKbStrategy(
       // local heuristic so callers still get a usable ordering. We still
       // tag the result with scoreType: "rerank" because callers asked for
       // rerank semantics; the score scale isn't comparable to cosine/RRF.
-      const heuristic = await new RerankerTask().run({
-        query,
-        chunks: docs,
-        scores: firstStage.map((c) => c.score),
-        metadata: firstStage.map((c) => c.metadata as Record<string, unknown>),
-        topK,
-        method: "simple",
-      });
+      const heuristic = await new RerankerTask().run(
+        {
+          query,
+          chunks: docs,
+          scores: firstStage.map((c) => c.score),
+          metadata: firstStage.map((c) => c.metadata as Record<string, unknown>),
+          topK,
+          method: "simple",
+        },
+        runConfig
+      );
       const indices = (heuristic.originalIndices as number[]) ?? [];
       const newScores = (heuristic.scores as number[]) ?? [];
       return indices.map((idx, rank) => {

--- a/packages/ai/src/task/KbAddDocumentTask.ts
+++ b/packages/ai/src/task/KbAddDocumentTask.ts
@@ -78,7 +78,7 @@ export class KbAddDocumentTask extends Task<
     context: IExecuteContext
   ): Promise<KbAddDocumentTaskOutput> {
     const kb = input.knowledgeBase as KnowledgeBase;
-    const stored = await kb.upsert(input.document as Document, {
+    const stored = await kb.upsert(input.document, {
       signal: context.signal,
       resourceScope: context.resourceScope,
       registry: context.registry,

--- a/packages/ai/src/task/KbAddDocumentTask.ts
+++ b/packages/ai/src/task/KbAddDocumentTask.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { KnowledgeBase } from "@workglow/knowledge-base";
+import { Document, TypeKnowledgeBase } from "@workglow/knowledge-base";
+import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import type { Capability } from "../capability/Capabilities";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    knowledgeBase: TypeKnowledgeBase({
+      title: "Knowledge Base",
+      description: "Knowledge base to add the document to.",
+    }),
+    document: {
+      title: "Document",
+      description: "The Document instance to chunk, embed, and store.",
+      additionalProperties: true,
+    },
+  },
+  required: ["knowledgeBase", "document"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "The stored document ID.",
+    },
+  },
+  required: ["doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type KbAddDocumentTaskInput = Omit<FromSchema<typeof inputSchema>, "document"> & {
+  readonly document: Document;
+};
+export type KbAddDocumentTaskOutput = FromSchema<typeof outputSchema>;
+export type KbAddDocumentTaskConfig = TaskConfig<KbAddDocumentTaskInput>;
+
+/**
+ * Ingest a document into a knowledge base end-to-end: chunk, embed, and
+ * store via the KB's installed strategy. Threads the task's execution
+ * context (signal, resourceScope, registry) into the KB call so model
+ * resources are shared and abort signals propagate.
+ */
+export class KbAddDocumentTask extends Task<
+  KbAddDocumentTaskInput,
+  KbAddDocumentTaskOutput,
+  KbAddDocumentTaskConfig
+> {
+  public static override type = "KbAddDocumentTask";
+  public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
+  public static override category = "RAG";
+  public static override title = "KB Add Document";
+  public static override description =
+    "Ingest a document into a knowledge base: chunk, embed, and store via the KB's installed strategy.";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: KbAddDocumentTaskInput,
+    context: IExecuteContext
+  ): Promise<KbAddDocumentTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    const stored = await kb.upsert(input.document as Document, {
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return { doc_id: stored.doc_id! };
+  }
+}
+
+export const kbAddDocument = (
+  input: KbAddDocumentTaskInput,
+  config?: KbAddDocumentTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbAddDocumentTask(config).run(input, runConfig);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    kbAddDocument: CreateWorkflow<
+      KbAddDocumentTaskInput,
+      KbAddDocumentTaskOutput,
+      KbAddDocumentTaskConfig
+    >;
+  }
+}
+
+Workflow.prototype.kbAddDocument = CreateWorkflow(KbAddDocumentTask);

--- a/packages/ai/src/task/KbDeleteTask.ts
+++ b/packages/ai/src/task/KbDeleteTask.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { KnowledgeBase } from "@workglow/knowledge-base";
+import { TypeKnowledgeBase } from "@workglow/knowledge-base";
+import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
+import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
+import type { Capability } from "../capability/Capabilities";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    knowledgeBase: TypeKnowledgeBase({
+      title: "Knowledge Base",
+      description: "Knowledge base to delete the document from.",
+    }),
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "ID of the document to delete.",
+    },
+  },
+  required: ["knowledgeBase", "doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+const outputSchema = {
+  type: "object",
+  properties: {
+    doc_id: {
+      type: "string",
+      title: "Document ID",
+      description: "ID of the deleted document (echoed for pipeline composability).",
+    },
+  },
+  required: ["doc_id"],
+  additionalProperties: false,
+} as const satisfies DataPortSchema;
+
+export type KbDeleteTaskInput = FromSchema<typeof inputSchema>;
+export type KbDeleteTaskOutput = FromSchema<typeof outputSchema>;
+export type KbDeleteTaskConfig = TaskConfig<KbDeleteTaskInput>;
+
+/**
+ * Delete a document and its chunks from a knowledge base via the KB's
+ * installed strategy. Echoes `doc_id` so the task is composable in
+ * pipelines that need to pass the id to a downstream step.
+ */
+export class KbDeleteTask extends Task<KbDeleteTaskInput, KbDeleteTaskOutput, KbDeleteTaskConfig> {
+  public static override type = "KbDeleteTask";
+  public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
+  public static override category = "RAG";
+  public static override title = "KB Delete Document";
+  public static override description = "Delete a document and its chunks from a knowledge base.";
+  public static override cacheable = false;
+
+  public static override inputSchema(): DataPortSchema {
+    return inputSchema as DataPortSchema;
+  }
+  public static override outputSchema(): DataPortSchema {
+    return outputSchema as DataPortSchema;
+  }
+
+  override async execute(
+    input: KbDeleteTaskInput,
+    context: IExecuteContext
+  ): Promise<KbDeleteTaskOutput> {
+    const kb = input.knowledgeBase as KnowledgeBase;
+    await kb.delete(input.doc_id, {
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
+    return { doc_id: input.doc_id };
+  }
+}
+
+export const kbDelete = (
+  input: KbDeleteTaskInput,
+  config?: KbDeleteTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbDeleteTask(config).run(input, runConfig);
+};
+
+declare module "@workglow/task-graph" {
+  interface Workflow {
+    kbDelete: CreateWorkflow<KbDeleteTaskInput, KbDeleteTaskOutput, KbDeleteTaskConfig>;
+  }
+}
+
+Workflow.prototype.kbDelete = CreateWorkflow(KbDeleteTask);

--- a/packages/ai/src/task/KbReindexTask.ts
+++ b/packages/ai/src/task/KbReindexTask.ts
@@ -6,7 +6,7 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { TaskConfig } from "@workglow/task-graph";
+import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -79,8 +79,12 @@ export class KbReindexTask extends Task<
   }
 }
 
-export const kbReindex = async (input: KbReindexTaskInput, config?: KbReindexTaskConfig) => {
-  return new KbReindexTask(config).run(input);
+export const kbReindex = async (
+  input: KbReindexTaskInput,
+  config?: KbReindexTaskConfig,
+  runConfig?: Partial<IRunConfig>
+) => {
+  return new KbReindexTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/ai/src/task/KbReindexTask.ts
+++ b/packages/ai/src/task/KbReindexTask.ts
@@ -67,10 +67,14 @@ export class KbReindexTask extends Task<
 
   override async execute(
     input: KbReindexTaskInput,
-    _context: IExecuteContext
+    context: IExecuteContext
   ): Promise<KbReindexTaskOutput> {
     const kb = input.knowledgeBase as KnowledgeBase;
-    const count = await kb.reindex();
+    const count = await kb.reindex({
+      signal: context.signal,
+      resourceScope: context.resourceScope,
+      registry: context.registry,
+    });
     return { count };
   }
 }

--- a/packages/ai/src/task/KbSearchTask.ts
+++ b/packages/ai/src/task/KbSearchTask.ts
@@ -129,22 +129,21 @@ export class KbSearchTask extends Task<KbSearchTaskInput, KbSearchTaskOutput, Kb
 
   override async execute(
     input: KbSearchTaskInput,
-    _context: IExecuteContext
+    context: IExecuteContext
   ): Promise<KbSearchTaskOutput> {
     const { knowledgeBase, query, topK = 5, filter, scoreThreshold } = input;
     const kb = knowledgeBase as KnowledgeBase;
-    // Forward `scoreThreshold` to the strategy. The standard strategy
-    // honors it in similarity / hybrid modes and intentionally ignores
-    // it in rerank mode (cross-encoder logits aren't on the same scale
-    // as cosine / RRF, so a single numeric threshold would either drop
-    // everything or nothing).
-    const results = await kb.search(query, { topK, filter, scoreThreshold });
+    const results = await kb.search(
+      query,
+      { topK, filter, scoreThreshold },
+      {
+        signal: context.signal,
+        resourceScope: context.resourceScope,
+        registry: context.registry,
+      }
+    );
     return {
       results,
-      // `chunkText` enforces the metadata.text contract — any chunk
-      // missing text throws with its chunk_id rather than silently
-      // emitting `JSON.stringify(metadata)` (which would surface as
-      // garbage to downstream consumers).
       chunks: results.map(chunkText),
       chunk_ids: results.map((r) => r.chunk_id),
       scores: results.map((r) => r.score),

--- a/packages/ai/src/task/index.ts
+++ b/packages/ai/src/task/index.ts
@@ -36,6 +36,8 @@ export * from "./ImageClassificationTask";
 export * from "./ImageEmbeddingTask";
 export * from "./ImageSegmentationTask";
 export * from "./ImageToTextTask";
+export * from "./KbAddDocumentTask";
+export * from "./KbDeleteTask";
 export * from "./KbReindexTask";
 export * from "./KbSearchTask";
 export * from "./KbToDocumentsTask";

--- a/packages/ai/src/task/registerAiTasks.ts
+++ b/packages/ai/src/task/registerAiTasks.ts
@@ -26,6 +26,8 @@ import { ImageClassificationTask } from "./ImageClassificationTask";
 import { ImageEmbeddingTask } from "./ImageEmbeddingTask";
 import { ImageSegmentationTask } from "./ImageSegmentationTask";
 import { ImageToTextTask } from "./ImageToTextTask";
+import { KbAddDocumentTask } from "./KbAddDocumentTask";
+import { KbDeleteTask } from "./KbDeleteTask";
 import { KbReindexTask } from "./KbReindexTask";
 import { KbSearchTask } from "./KbSearchTask";
 import { KbToDocumentsTask } from "./KbToDocumentsTask";
@@ -79,6 +81,8 @@ export const registerAiTasks = () => {
     HandLandmarkerTask,
     HierarchicalChunkerTask,
     HierarchyJoinTask,
+    KbAddDocumentTask,
+    KbDeleteTask,
     KbSearchTask,
     KbToDocumentsTask,
     ImageClassificationTask,

--- a/packages/knowledge-base/package.json
+++ b/packages/knowledge-base/package.json
@@ -27,10 +27,14 @@
   },
   "peerDependencies": {
     "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
     "@workglow/util": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@workglow/storage": {
+      "optional": false
+    },
+    "@workglow/task-graph": {
       "optional": false
     },
     "@workglow/util": {
@@ -39,6 +43,7 @@
   },
   "devDependencies": {
     "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
     "@workglow/util": "workspace:*"
   },
   "exports": {

--- a/packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts
+++ b/packages/knowledge-base/src/knowledge-base/IKbAiStrategy.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IRunConfig } from "@workglow/task-graph";
 import type { TypedArray } from "@workglow/util/schema";
 import type { ChunkRecord } from "../chunk/ChunkSchema";
 import type {
@@ -50,13 +51,13 @@ export interface IKbAiStrategy {
    * embedding model, etc. Returns the stored document (possibly with a
    * newly-assigned doc_id).
    */
-  ingest(kb: IKbStrategyTarget, doc: Document): Promise<Document>;
+  ingest(kb: IKbStrategyTarget, doc: Document, runConfig?: Partial<IRunConfig>): Promise<Document>;
 
   /**
    * Remove a document and its chunks. The default cascading delete works
    * for most cases; override to add audit logging, soft delete, etc.
    */
-  delete(kb: IKbStrategyTarget, doc_id: string): Promise<void>;
+  delete(kb: IKbStrategyTarget, doc_id: string, runConfig?: Partial<IRunConfig>): Promise<void>;
 
   /**
    * Run a text query and return matching chunks. The strategy picks the
@@ -75,7 +76,8 @@ export interface IKbAiStrategy {
   search(
     kb: IKbStrategyTarget,
     query: string,
-    options?: ISearchOptions
+    options?: ISearchOptions,
+    runConfig?: Partial<IRunConfig>
   ): Promise<ChunkSearchResult[]>;
 }
 

--- a/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+++ b/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ITextIndex, TextFields, VectorSearchOptions } from "@workglow/storage";
+import type { IRunConfig } from "@workglow/task-graph";
 import type { TypedArray } from "@workglow/util/schema";
 import type { ChunkRecord } from "../chunk/ChunkSchema";
 import type {
@@ -418,18 +419,18 @@ export class KnowledgeBase {
    * during the upsert won't redirect the in-flight call to the new
    * strategy. See {@link setAiStrategy}.
    */
-  async upsert(doc: Document): Promise<Document> {
+  async upsert(doc: Document, runConfig?: Partial<IRunConfig>): Promise<Document> {
     const strategy = this.requireStrategy("upsert");
-    return strategy.ingest(this, doc);
+    return strategy.ingest(this, doc, runConfig);
   }
 
   /**
    * Remove a document and its chunks. Delegates to the installed strategy
    * (snapshotted at entry — see {@link setAiStrategy}).
    */
-  async delete(doc_id: string): Promise<void> {
+  async delete(doc_id: string, runConfig?: Partial<IRunConfig>): Promise<void> {
     const strategy = this.requireStrategy("delete");
-    return strategy.delete(this, doc_id);
+    return strategy.delete(this, doc_id, runConfig);
   }
 
   /**
@@ -441,9 +442,13 @@ export class KnowledgeBase {
    * during the search won't redirect the in-flight call. See
    * {@link setAiStrategy}.
    */
-  async search(query: string, options?: ISearchOptions): Promise<ChunkSearchResult[]> {
+  async search(
+    query: string,
+    options?: ISearchOptions,
+    runConfig?: Partial<IRunConfig>
+  ): Promise<ChunkSearchResult[]> {
     const strategy = this.requireStrategy("search");
-    return strategy.search(this, query, options);
+    return strategy.search(this, query, options, runConfig);
   }
 
   // ===========================================================================
@@ -780,14 +785,14 @@ export class KnowledgeBase {
    * partway through the loop. The next `reindex()` call would pick up
    * the new strategy. See {@link setAiStrategy}.
    */
-  async reindex(): Promise<number> {
+  async reindex(runConfig?: Partial<IRunConfig>): Promise<number> {
     const strategy = this.requireStrategy("reindex");
     const docIds = await this.listDocuments();
     let count = 0;
     for (const doc_id of docIds) {
       const doc = await this.getDocument(doc_id);
       if (!doc) continue;
-      await strategy.ingest(this, doc);
+      await strategy.ingest(this, doc, runConfig);
       count++;
     }
     return count;

--- a/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+++ b/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
@@ -790,7 +790,7 @@ export class KnowledgeBase {
     const docIds = await this.listDocuments();
     let count = 0;
     for (const doc_id of docIds) {
-      runConfig?.signal?.throwIfAborted();
+      if (runConfig?.signal?.aborted) throw runConfig.signal.reason;
       const doc = await this.getDocument(doc_id);
       if (!doc) continue;
       await strategy.ingest(this, doc, runConfig);

--- a/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+++ b/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
@@ -790,6 +790,7 @@ export class KnowledgeBase {
     const docIds = await this.listDocuments();
     let count = 0;
     for (const doc_id of docIds) {
+      runConfig?.signal?.throwIfAborted();
       const doc = await this.getDocument(doc_id);
       if (!doc) continue;
       await strategy.ingest(this, doc, runConfig);

--- a/packages/test/src/test/rag/KbAddDocumentTask.test.ts
+++ b/packages/test/src/test/rag/KbAddDocumentTask.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { kbAddDocument } from "@workglow/ai";
+import { Document, createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { describe, expect, it, vi } from "vitest";
+
+describe("KbAddDocumentTask", () => {
+  function makeDoc(docId?: string): Document {
+    const doc = new Document({ type: "root", title: "T", children: [] } as never, {
+      title: "Test",
+    });
+    if (docId) doc.setDocId(docId);
+    return doc;
+  }
+
+  async function makeKbWithUpsertSpy() {
+    const kb = await createKnowledgeBase({
+      name: `kb-add-doc-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+    });
+    const doc = makeDoc("returned-id");
+    const upsertSpy = vi.spyOn(kb, "upsert").mockResolvedValue(doc);
+    return { kb, doc, upsertSpy };
+  }
+
+  it("calls kb.upsert with the provided document", async () => {
+    const { kb, doc, upsertSpy } = await makeKbWithUpsertSpy();
+
+    await kbAddDocument({ knowledgeBase: kb, document: doc });
+
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSpy.mock.calls[0][0]).toBe(doc);
+  });
+
+  it("returns the doc_id from the upserted document", async () => {
+    const { kb, doc } = await makeKbWithUpsertSpy();
+
+    const result = await kbAddDocument({ knowledgeBase: kb, document: doc });
+
+    expect(result.doc_id).toBe("returned-id");
+  });
+
+  it("threads run context (signal) to kb.upsert", async () => {
+    const { kb, upsertSpy } = await makeKbWithUpsertSpy();
+
+    await kbAddDocument({ knowledgeBase: kb, document: makeDoc("x") });
+
+    const forwardedRunConfig = upsertSpy.mock.calls[0][1];
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+});

--- a/packages/test/src/test/rag/KbDeleteTask.test.ts
+++ b/packages/test/src/test/rag/KbDeleteTask.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { kbDelete } from "@workglow/ai";
+import { createKnowledgeBase } from "@workglow/knowledge-base";
+import { uuid4 } from "@workglow/util";
+import { describe, expect, it, vi } from "vitest";
+
+describe("KbDeleteTask", () => {
+  async function makeKbWithDeleteSpy() {
+    const kb = await createKnowledgeBase({
+      name: `kb-delete-${uuid4()}`,
+      vectorDimensions: 3,
+      register: false,
+    });
+    const deleteSpy = vi.spyOn(kb, "delete").mockResolvedValue(undefined);
+    return { kb, deleteSpy };
+  }
+
+  it("calls kb.delete with the given doc_id", async () => {
+    const { kb, deleteSpy } = await makeKbWithDeleteSpy();
+
+    await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy.mock.calls[0][0]).toBe("my-doc");
+  });
+
+  it("echoes doc_id in the output", async () => {
+    const { kb } = await makeKbWithDeleteSpy();
+
+    const result = await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    expect(result.doc_id).toBe("my-doc");
+  });
+
+  it("threads run context (signal) to kb.delete", async () => {
+    const { kb, deleteSpy } = await makeKbWithDeleteSpy();
+
+    await kbDelete({ knowledgeBase: kb, doc_id: "my-doc" });
+
+    const forwardedRunConfig = deleteSpy.mock.calls[0][1];
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
+});

--- a/packages/test/src/test/rag/KbSearchTask.test.ts
+++ b/packages/test/src/test/rag/KbSearchTask.test.ts
@@ -63,4 +63,17 @@ describe("KbSearchTask scoreThreshold forwarding", () => {
     // that it's NOT a stale value carried over from a previous call.
     expect((forwardedOpts as { scoreThreshold?: number }).scoreThreshold).toBeUndefined();
   });
+
+  it("threads run context (signal) to kb.search", async () => {
+    const { kb, searchSpy } = await makeKbWithSearchSpy();
+
+    await kbSearch({ knowledgeBase: kb, query: "hello" });
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    const call = searchSpy.mock.calls[0];
+    // Third argument is the runConfig extracted from IExecuteContext.
+    const forwardedRunConfig = call[2];
+    expect(forwardedRunConfig).toBeDefined();
+    expect(forwardedRunConfig).toMatchObject({ signal: expect.any(AbortSignal) });
+  });
 });


### PR DESCRIPTION
## Summary

Thread `IRunConfig` (signal, resourceScope, registry) through `KnowledgeBase.upsert/delete/search/reindex` and their `IKbAiStrategy` implementations. Add two new high-level KB tasks (`KbAddDocumentTask`, `KbDeleteTask`) that wrap the KB API and forward execution context to enable resource sharing and abort signal propagation through the AI sub-task tree.

## Key Changes

- **Package dependency**: Add `@workglow/task-graph` as peer + dev dep to `@workglow/knowledge-base` (architecturally valid per CLAUDE.md dependency graph)

- **`IKbAiStrategy` interface**: Add optional trailing `runConfig?: Partial<IRunConfig>` parameter to `ingest()`, `delete()`, and `search()` methods for backward compatibility

- **`KnowledgeBase` public API**: Thread `runConfig` through `upsert()`, `delete()`, `search()`, and `reindex()` methods; each delegates to the strategy unchanged

- **`createStandardKbStrategy`**: 
  - Private `embedTexts()` helper now accepts and forwards `runConfig` to `TextEmbeddingTask.run()`
  - `ingest()` threads `runConfig` to `HierarchicalChunkerTask` and `embedTexts()`
  - `search()` threads `runConfig` to `embedTexts()`, `TextRerankerTask`, and `RerankerTask`

- **KB task updates**:
  - `KbSearchTask`: Rename `_context` → `context`; extract and forward `{signal, resourceScope, registry}` to `kb.search()`; trim explanatory comments per project style
  - `KbReindexTask`: Extract and forward run context to `kb.reindex()`

- **New tasks**:
  - `KbAddDocumentTask`: Ingest a document end-to-end (chunk, embed, store) via KB strategy; returns `doc_id`
  - `KbDeleteTask`: Delete a document and its chunks; echoes `doc_id` for pipeline composability

- **Registration**: Export and register both new tasks in `packages/ai/src/task/index.ts` and `registerAiTasks.ts`

- **Tests**: Add comprehensive test suites for both new tasks verifying KB method calls, output contracts, and run context threading

## Implementation Details

- All `runConfig` parameters are optional to maintain backward compatibility with existing custom strategy implementations
- KB tasks extract `{signal, resourceScope, registry}` from `IExecuteContext` and pass as a partial `IRunConfig` object to KB methods
- New tasks follow the same pattern as existing KB tasks (`KbSearchTask`, `KbReindexTask`) with proper schema definitions and Workflow integration
- Both new tasks are marked `cacheable = false` since document mutations should not be cached

https://claude.ai/code/session_01DXrRHot1DqLhmbbyuhmLWE