### PR TITLE
fix(job-queue): critical and high-priority correctness fixes (C1/C2 + 6× High)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ sec-db/
 models/
 .worktrees/
 scratch/
+.claude/worktrees/

--- a/examples/web/src/status/QueueStatus.tsx
+++ b/examples/web/src/status/QueueStatus.tsx
@@ -13,7 +13,6 @@ export function QueueStatus({ queueType }: { queueType: string }) {
   const [pending, setPending] = useState<number>(0);
   const [processing, setProcessing] = useState<number>(0);
   const [completed, setCompleted] = useState<number>(0);
-  const [aborting, setAborting] = useState<number>(0);
   const [errors, setErrors] = useState<number>(0);
   const [disabled, setDisabled] = useState<number>(0);
 
@@ -26,7 +25,6 @@ export function QueueStatus({ queueType }: { queueType: string }) {
       setPending(await client.size(JobStatus.PENDING));
       setProcessing(await client.size(JobStatus.PROCESSING));
       setCompleted(await client.size(JobStatus.COMPLETED));
-      setAborting(await client.size(JobStatus.ABORTING));
       setErrors(await client.size(JobStatus.FAILED));
       setDisabled(await client.size(JobStatus.DISABLED));
     }
@@ -53,7 +51,6 @@ export function QueueStatus({ queueType }: { queueType: string }) {
     setPending(0);
     setProcessing(0);
     setCompleted(0);
-    setAborting(0);
     setErrors(0);
     setDisabled(0);
   }, [registeredQueue]);

--- a/packages/ai/src/execution/QueuedExecutionStrategy.ts
+++ b/packages/ai/src/execution/QueuedExecutionStrategy.ts
@@ -62,7 +62,7 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
         emit
       );
     } finally {
-      await limiter.release(token);
+      await limiter.complete(token);
     }
   }
 

--- a/packages/ai/src/execution/QueuedExecutionStrategy.ts
+++ b/packages/ai/src/execution/QueuedExecutionStrategy.ts
@@ -48,7 +48,7 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
       this.limiter = new ConcurrencyLimiter(this.concurrency);
     }
     const limiter = this.limiter;
-    await this.acquireLimiterSlot(limiter, context.signal);
+    const token = await this.acquireLimiterSlot(limiter, context.signal);
 
     try {
       const job = new AiJob({
@@ -62,7 +62,7 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
         emit
       );
     } finally {
-      await limiter.recordJobCompletion();
+      await limiter.release(token);
     }
   }
 
@@ -75,7 +75,7 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
    * abort. Uses {@link ILimiter.tryAcquire} so concurrent callers cannot both
    * pass a check-then-record sequence and overshoot the configured limit.
    */
-  private async acquireLimiterSlot(limiter: ILimiter, signal: AbortSignal): Promise<void> {
+  private async acquireLimiterSlot(limiter: ILimiter, signal: AbortSignal): Promise<unknown> {
     let token = await limiter.tryAcquire();
     while (token === null || token === undefined) {
       if (signal.aborted) {
@@ -86,6 +86,6 @@ export class QueuedExecutionStrategy implements IAiExecutionStrategy {
       await new Promise<void>((resolve) => setTimeout(resolve, Math.max(20, Math.min(delay, 200))));
       token = await limiter.tryAcquire();
     }
-    void token;
+    return token;
   }
 }

--- a/packages/ai/src/job/AiJob.ts
+++ b/packages/ai/src/job/AiJob.ts
@@ -8,7 +8,6 @@ import {
   AbortSignalJobError,
   IJobExecuteContext,
   Job,
-  JobStatus,
   PermanentJobError,
   RetryableJobError,
   withJobErrorDiagnostics,
@@ -241,7 +240,7 @@ export class AiJob<
     context: IJobExecuteContext,
     emit: AiEmit<Output>
   ): Promise<void> {
-    if (context.signal.aborted || this.status === JobStatus.ABORTING) {
+    if (context.signal.aborted) {
       throw new AbortSignalJobError("Abort signal aborted before execution of job");
     }
 

--- a/packages/indexeddb/src/job-queue/IndexedDbJobStore.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbJobStore.ts
@@ -88,4 +88,8 @@ export class IndexedDbJobStore<Input, Output> implements IJobStore<Input, Output
   async abort(id: MessageId): Promise<void> {
     await this.core.abort(id);
   }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    await this.core.saveStatus(id, status);
+  }
 }

--- a/packages/indexeddb/src/job-queue/IndexedDbJobStore.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbJobStore.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
+import type { PendingIndexedDbWrite } from "./IndexedDbMessageQueue";
+import type { IndexedDbQueueStorage } from "./IndexedDbQueueStorage";
+
+export class IndexedDbJobStore<Input, Output> implements IJobStore<Input, Output> {
+  /** @internal — shared with the paired message queue */
+  public readonly core: IndexedDbQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingIndexedDbWrite<Output>>;
+
+  constructor(
+    core: IndexedDbQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingIndexedDbWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.core.get(id);
+  }
+
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.peek(status as any, num);
+  }
+
+  size(status?: JobStatus): Promise<number> {
+    return this.core.size(status as any);
+  }
+
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.getByRunId(runId);
+  }
+
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.core.outputForInput(input);
+  }
+
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.core.saveProgress(id, progress, message, details);
+  }
+
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.core.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.delete(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.core.deleteAll();
+  }
+
+  async abort(id: MessageId): Promise<void> {
+    await this.core.abort(id);
+  }
+}

--- a/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IClaim,
+  IMessageQueue,
+  JobStorageFormat,
+  MessageId,
+  QueueChangePayload,
+  QueueStorageScope,
+  QueueSubscribeOptions,
+  SendOptions,
+} from "@workglow/job-queue";
+import { IndexedDbQueueStorage } from "./IndexedDbQueueStorage";
+
+/**
+ * Per-id buffer that lets {@link IJobStore.saveResult}/{@link IJobStore.saveError}
+ * stage output/error until the terminal claim.ack()/fail() persists them in
+ * a single complete() call (avoids double-bumping `attempts`).
+ */
+export type PendingIndexedDbWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class IndexedDbClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly core: IndexedDbQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingIndexedDbWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: "COMPLETED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      status: "PENDING",
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: new Date(Date.now() + delay * 1000).toISOString(),
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: "FAILED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.core.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+export class IndexedDbMessageQueue<Input, Output> implements IMessageQueue<
+  JobStorageFormat<Input, Output>
+> {
+  public readonly scope: QueueStorageScope = "process";
+
+  /** @internal — shared with the paired job store */
+  public readonly core: IndexedDbQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingIndexedDbWrite<Output>>;
+
+  constructor(
+    core: IndexedDbQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingIndexedDbWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    return this.core.add(applySendOptions(body, opts));
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!job) return [];
+    return [
+      new IndexedDbClaim<Input, Output>(
+        this.core,
+        this.pending,
+        job.id,
+        job,
+        job.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.core.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.core.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.core.subscribeToChanges(callback, options);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}

--- a/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
@@ -134,18 +134,23 @@ export class IndexedDbMessageQueue<Input, Output> implements IMessageQueue<
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!job) return [];
-    return [
-      new IndexedDbClaim<Input, Output>(
-        this.core,
-        this.pending,
-        job.id,
-        job,
-        job.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!job) break;
+      claims.push(
+        new IndexedDbClaim<Input, Output>(
+          this.core,
+          this.pending,
+          job.id,
+          job,
+          job.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {

--- a/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
@@ -38,20 +38,22 @@ class IndexedDbClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Ou
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      output: buf?.output ?? current.output ?? null,
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
+    await this.core.finalize(this.id, {
+      output: output as Output | null,
       error: null,
       error_code: null,
       status: "COMPLETED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -71,22 +73,38 @@ class IndexedDbClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Ou
     });
   }
 
-  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent;
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
+    await this.core.finalize(this.id, {
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: "FAILED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 

--- a/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbMessageQueue.ts
@@ -111,6 +111,20 @@ class IndexedDbClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Ou
   async extendLease(ms: number): Promise<void> {
     await this.core.extendLease(this.id, this.workerId, ms);
   }
+
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.core.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.core.finalize(this.id, {
+      status: "DISABLED",
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
 }
 
 export class IndexedDbMessageQueue<Input, Output> implements IMessageQueue<

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -604,6 +604,10 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     const existing = await this.get(id);
@@ -617,6 +621,10 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     if ("abort_requested_at" in fields) {
       updated.abort_requested_at = fields.abort_requested_at ?? null;
     }
+    if ("lease_owner" in fields) updated.lease_owner = fields.lease_owner ?? null;
+    if ("progress" in fields) updated.progress = fields.progress ?? 0;
+    if ("progress_message" in fields) updated.progress_message = fields.progress_message ?? "";
+    if ("progress_details" in fields) updated.progress_details = fields.progress_details ?? null;
     await this.put(updated);
   }
 

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -592,6 +592,35 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   }
 
   /**
+   * Terminal write that does NOT bump `attempts`. See IQueueStorage.finalize
+   * for the rationale (avoids double-counting on ack/fail).
+   */
+  public async finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
+    const existing = await this.get(id);
+    if (!existing) return;
+    const updated = existing as JobStorageFormat<Input, Output> & Record<string, unknown>;
+    if ("output" in fields) updated.output = fields.output ?? null;
+    if ("error" in fields) updated.error = fields.error ?? null;
+    if ("error_code" in fields) updated.error_code = fields.error_code ?? null;
+    if ("status" in fields) updated.status = fields.status;
+    if ("completed_at" in fields) updated.completed_at = fields.completed_at ?? null;
+    if ("abort_requested_at" in fields) {
+      updated.abort_requested_at = fields.abort_requested_at ?? null;
+    }
+    await this.put(updated);
+  }
+
+  /**
    * Deletes all jobs from the queue.
    */
   public async deleteAll(): Promise<void> {

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -151,7 +151,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     jobWithPrefixes.progress_message = "";
     jobWithPrefixes.progress_details = null;
     jobWithPrefixes.created_at = now;
-    jobWithPrefixes.run_after = now;
+    jobWithPrefixes.visible_at = now;
 
     // Add prefix values to the job
     for (const [key, value] of Object.entries(this.prefixValues)) {
@@ -215,7 +215,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     const db = await this.getDb();
     const tx = db.transaction(this.tableName, "readonly");
     const store = tx.objectStore(this.tableName);
-    const index = store.index("queue_status_run_after");
+    const index = store.index("queue_status_visible_at");
     const prefixKeyValues = this.getPrefixKeyValues();
 
     return new Promise((resolve, reject) => {
@@ -283,8 +283,8 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
 
         const tryClaimJob = (job: JobStorageFormat<Input, Output> & Record<string, unknown>) => {
           job.status = JobStatus.PROCESSING;
-          job.last_ran_at = now;
-          job.worker_id = claimToken;
+          job.last_attempted_at = now;
+          job.lease_owner = claimToken;
           job.lease_expires_at = leaseExpiry;
 
           try {
@@ -299,7 +299,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
         };
 
         // First: look for a PENDING job ready to run
-        const pendingIndex = store.index("queue_status_run_after");
+        const pendingIndex = store.index("queue_status_visible_at");
         const pendingRequest = pendingIndex.openCursor(
           IDBKeyRange.bound(
             [...prefixKeyValues, this.queueName, JobStatus.PENDING, ""],
@@ -335,7 +335,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
 
         const tryExpiredLeaseScan = () => {
           // Scan PROCESSING jobs to find one with an expired lease
-          const processingIndex = store.index("queue_status_run_after");
+          const processingIndex = store.index("queue_status_visible_at");
           const processingRequest = processingIndex.openCursor(
             IDBKeyRange.bound(
               [...prefixKeyValues, this.queueName, JobStatus.PROCESSING, ""],
@@ -392,7 +392,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
       return undefined;
     }
 
-    if (verifiedJob.worker_id !== claimToken) {
+    if (verifiedJob.lease_owner !== claimToken) {
       return undefined;
     }
 
@@ -406,12 +406,12 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   /**
    * Extend the lease on a currently PROCESSING job.
    * @param id - The ID of the job to extend the lease for
-   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param workerId - Worker ID that must match the current lease owner (lease_owner)
    * @param ms - Number of milliseconds to extend the lease by
    */
   public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
     const job = await this.get(id);
-    if (!job || job.status !== JobStatus.PROCESSING || job.worker_id !== workerId) {
+    if (!job || job.status !== JobStatus.PROCESSING || job.lease_owner !== workerId) {
       throw new Error(
         `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
       );
@@ -461,8 +461,8 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
           );
           return;
         }
-        const currentAttempts = existing.run_attempts ?? 0;
-        job.run_attempts = currentAttempts + 1;
+        const currentAttempts = existing.attempts ?? 0;
+        job.attempts = currentAttempts + 1;
         // Ensure queue is set correctly
         job.queue = this.queueName;
 
@@ -496,7 +496,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     if (!job) return;
 
     job.status = JobStatus.PENDING;
-    job.worker_id = null;
+    job.lease_owner = null;
     job.progress = 0;
     job.progress_message = "";
     job.progress_details = null;
@@ -652,7 +652,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   }
 
   /**
-   * Persists a job to the store without modifying run_attempts or other completion logic.
+   * Persists a job to the store without modifying attempts or other completion logic.
    */
   private async put(job: JobStorageFormat<Input, Output>): Promise<void> {
     const db = await this.getDb();

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -248,9 +248,9 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   }
 
   /**
-   * Retrieves the next job from the queue using optimistic locking. In case multiple workers
-   * claim the same job, the first worker to claim it will process it and the other workers will return undefined.
-   * This ONLY happens if workers are running in multiple tabs.
+   * Retrieves the next job from the queue using optimistic locking.
+   * Claims PENDING jobs ready to run, and also reclaims PROCESSING jobs whose
+   * lease has expired (crash recovery). Sets lease_expires_at on the claimed row.
    *
    * IndexedDB uses snapshot isolation, so concurrent transactions can both see the same
    * PENDING job. To prevent processing the same job multiple times, this method:
@@ -259,14 +259,19 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
    * 3. If another worker claimed it first (different claim token), returns undefined
    *
    * @param workerId - Worker ID to associate with the job (required)
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns A promise that resolves to the next job or undefined if the queue is empty.
    */
-  public async next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
+  public async next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
     const db = await this.getDb();
     const tx = db.transaction(this.tableName, "readwrite");
     const store = tx.objectStore(this.tableName);
-    const index = store.index("queue_status_run_after");
     const now = new Date().toISOString();
+    const leaseMs = opts?.leaseMs ?? 30000;
+    const leaseExpiry = new Date(Date.now() + leaseMs).toISOString();
     const prefixKeyValues = this.getPrefixKeyValues();
 
     // This ensures we can verify that we actually won the race to claim this job
@@ -274,7 +279,28 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
 
     const jobToReturn = await new Promise<JobStorageFormat<Input, Output> | undefined>(
       (resolve, reject) => {
-        const cursorRequest = index.openCursor(
+        let claimedJob: JobStorageFormat<Input, Output> | undefined;
+
+        const tryClaimJob = (job: JobStorageFormat<Input, Output> & Record<string, unknown>) => {
+          job.status = JobStatus.PROCESSING;
+          job.last_ran_at = now;
+          job.worker_id = claimToken;
+          job.lease_expires_at = leaseExpiry;
+
+          try {
+            const updateRequest = store.put(job);
+            updateRequest.onsuccess = () => {
+              claimedJob = job;
+            };
+            updateRequest.onerror = () => {};
+          } catch {
+            // ignore
+          }
+        };
+
+        // First: look for a PENDING job ready to run
+        const pendingIndex = store.index("queue_status_run_after");
+        const pendingRequest = pendingIndex.openCursor(
           IDBKeyRange.bound(
             [...prefixKeyValues, this.queueName, JobStatus.PENDING, ""],
             [...prefixKeyValues, this.queueName, JobStatus.PENDING, now],
@@ -283,23 +309,16 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
           )
         );
 
-        let claimedJob: JobStorageFormat<Input, Output> | undefined;
-        let cursorStopped = false;
-
-        cursorRequest.onsuccess = (e) => {
+        pendingRequest.onsuccess = (e) => {
           const cursor = (e.target as IDBRequest<IDBCursorWithValue>).result;
           if (!cursor) {
-            // Cursor exhausted - resolve with whatever we found (or undefined)
+            // No PENDING job found — try expired-lease PROCESSING job
+            if (!claimedJob) {
+              tryExpiredLeaseScan();
+            }
             return;
           }
-
-          // If we already found and updated a job, stop iterating
-          if (cursorStopped) {
-            return;
-          }
-
           const job = cursor.value as JobStorageFormat<Input, Output> & Record<string, unknown>;
-          // Verify the job belongs to this queue, matches prefixes, and is still in PENDING state
           if (
             job.queue !== this.queueName ||
             job.status !== JobStatus.PENDING ||
@@ -308,34 +327,50 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
             cursor.continue();
             return;
           }
-
-          // Claim the job with our unique token
-          job.status = JobStatus.PROCESSING;
-          job.last_ran_at = now;
-          job.worker_id = claimToken;
-
-          try {
-            const updateRequest = store.put(job);
-            updateRequest.onsuccess = () => {
-              claimedJob = job;
-              cursorStopped = true;
-              // Stop cursor iteration - we've claimed a job
-            };
-            updateRequest.onerror = (err) => {
-              console.error("Failed to update job status:", err);
-              cursor.continue();
-            };
-          } catch (err) {
-            console.error("Error updating job:", err);
-            cursor.continue();
-          }
+          tryClaimJob(job);
+          // Don't continue cursor — we attempted a claim
         };
 
-        cursorRequest.onerror = () => reject(cursorRequest.error);
+        pendingRequest.onerror = () => reject(pendingRequest.error);
+
+        const tryExpiredLeaseScan = () => {
+          // Scan PROCESSING jobs to find one with an expired lease
+          const processingIndex = store.index("queue_status_run_after");
+          const processingRequest = processingIndex.openCursor(
+            IDBKeyRange.bound(
+              [...prefixKeyValues, this.queueName, JobStatus.PROCESSING, ""],
+              [...prefixKeyValues, this.queueName, JobStatus.PROCESSING, "￿"],
+              false,
+              false
+            )
+          );
+
+          processingRequest.onsuccess = (e) => {
+            const cursor = (e.target as IDBRequest<IDBCursorWithValue>).result;
+            if (!cursor) return; // none found, tx.oncomplete will resolve with undefined
+            const job = cursor.value as JobStorageFormat<Input, Output> & Record<string, unknown>;
+            if (
+              job.queue !== this.queueName ||
+              job.status !== JobStatus.PROCESSING ||
+              !this.matchesPrefixes(job)
+            ) {
+              cursor.continue();
+              return;
+            }
+            // Check for expired lease (null = expired per spec)
+            if (job.lease_expires_at && job.lease_expires_at >= now) {
+              cursor.continue();
+              return;
+            }
+            tryClaimJob(job);
+            // Don't continue — attempted a claim
+          };
+
+          processingRequest.onerror = () => reject(processingRequest.error);
+        };
 
         // Wait for transaction to complete before resolving
         tx.oncomplete = () => {
-          // Notify hybrid manager of local change
           if (claimedJob) {
             this.hybridManager?.notifyLocalChange();
           }
@@ -351,27 +386,38 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     }
 
     // Verify we actually won the race by re-reading the job
-    // This is the optimistic locking check - if another worker claimed it first,
-    // their claim token will be there instead of ours
     const verifiedJob = await this.get(jobToReturn.id);
 
     if (!verifiedJob) {
-      // Job was deleted - we lost the race
       return undefined;
     }
 
     if (verifiedJob.worker_id !== claimToken) {
-      // Another worker claimed this job - we lost the race
       return undefined;
     }
 
     if (verifiedJob.status !== JobStatus.PROCESSING) {
-      // Job status changed (e.g., another worker completed it already) - we lost the race
       return undefined;
     }
 
-    // We successfully claimed the job
     return verifiedJob;
+  }
+
+  /**
+   * Extend the lease on a currently PROCESSING job.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    const job = await this.get(id);
+    if (!job || job.status !== JobStatus.PROCESSING || job.worker_id !== workerId) {
+      throw new Error(
+        `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
+      );
+    }
+    job.lease_expires_at = new Date(Date.now() + ms).toISOString();
+    await this.put(job);
   }
 
   /**
@@ -459,14 +505,24 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   }
 
   /**
-   * Aborts a job in the queue.
+   * Aborts a job.
+   * - If PENDING: immediately mark as FAILED with abort_requested_at set.
+   * - If PROCESSING: set abort_requested_at only (leave status as PROCESSING).
+   * - Otherwise: no-op.
    */
   public async abort(id: unknown): Promise<void> {
     const job = await this.get(id);
     if (!job) return;
-
-    job.status = JobStatus.ABORTING;
-    await this.complete(job);
+    const now = new Date().toISOString();
+    if (job.status === JobStatus.PENDING) {
+      job.status = JobStatus.FAILED;
+      job.abort_requested_at = now;
+      job.completed_at = now;
+      await this.complete(job);
+    } else if (job.status === JobStatus.PROCESSING) {
+      job.abort_requested_at = now;
+      await this.put(job);
+    }
   }
 
   /**

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -525,6 +525,27 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     }
   }
 
+  /** Force-overwrite status without touching attempts (used to persist DISABLED after lease release). */
+  public async saveStatus(id: unknown, status: string): Promise<void> {
+    const db = await this.getDb();
+    const tx = db.transaction(this.tableName, "readwrite");
+    const store = tx.objectStore(this.tableName);
+    const getRequest = store.get(id as IDBValidKey);
+    return new Promise((resolve, reject) => {
+      getRequest.onsuccess = () => {
+        const record = getRequest.result;
+        if (!record) {
+          resolve();
+          return;
+        }
+        const putRequest = store.put({ ...record, status });
+        putRequest.onsuccess = () => resolve();
+        putRequest.onerror = () => reject(putRequest.error);
+      };
+      getRequest.onerror = () => reject(getRequest.error);
+    });
+  }
+
   /**
    * Gets jobs by their run ID.
    */

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -445,7 +445,7 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
   /**
    * Releases a claimed job without consuming a retry attempt.
    */
-  public async release(id: unknown): Promise<void> {
+  public async releaseClaim(id: unknown): Promise<void> {
     const job = await this.get(id);
     if (!job) return;
 

--- a/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
+++ b/packages/indexeddb/src/job-queue/IndexedDbQueueStorage.ts
@@ -282,10 +282,21 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
         let claimedJob: JobStorageFormat<Input, Output> | undefined;
 
         const tryClaimJob = (job: JobStorageFormat<Input, Output> & Record<string, unknown>) => {
+          // Lease-expiry reclaim consumes one attempt against max_attempts;
+          // a fresh PENDING claim does not (the worker's validateJobState
+          // FAILs the job when attempts >= max_attempts on the next step).
+          const isLeaseExpiryReclaim = job.status === JobStatus.PROCESSING;
           job.status = JobStatus.PROCESSING;
           job.last_attempted_at = now;
           job.lease_owner = claimToken;
           job.lease_expires_at = leaseExpiry;
+          if (isLeaseExpiryReclaim) {
+            job.attempts = ((job.attempts as number | undefined) ?? 0) + 1;
+          }
+          // Always clear stale abort_requested_at on (re)claim. A PROCESSING
+          // row may have had abort_requested_at set before the previous
+          // worker crashed; the new owner must start with a clean slate.
+          job.abort_requested_at = null;
 
           try {
             const updateRequest = store.put(job);
@@ -463,11 +474,16 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
         }
         const currentAttempts = existing.attempts ?? 0;
         job.attempts = currentAttempts + 1;
+        // PENDING-retry / terminal completion: always clear
+        // abort_requested_at so a flag set DURING the attempt does not
+        // survive into the next retry and immediately cancel it.
+        const jobAsRecord = job as JobStorageFormat<Input, Output> & Record<string, unknown>;
+        jobAsRecord.abort_requested_at = null;
         // Ensure queue is set correctly
         job.queue = this.queueName;
 
         // Ensure prefix values are preserved
-        const jobWithPrefixes = job as JobStorageFormat<Input, Output> & Record<string, unknown>;
+        const jobWithPrefixes = jobAsRecord;
         for (const [key, value] of Object.entries(this.prefixValues)) {
           jobWithPrefixes[key] = value;
         }
@@ -500,6 +516,9 @@ export class IndexedDbQueueStorage<Input, Output> implements IQueueStorage<Input
     job.progress = 0;
     job.progress_message = "";
     job.progress_details = null;
+    // Clear stale abort_requested_at — an abort flag set during the previous
+    // claim must not immediately cancel the next worker that picks up the row.
+    (job as unknown as Record<string, unknown>).abort_requested_at = null;
 
     await this.put(job);
   }

--- a/packages/indexeddb/src/job-queue/common.ts
+++ b/packages/indexeddb/src/job-queue/common.ts
@@ -7,6 +7,9 @@
 // organize-imports-ignore
 
 export * from "./IndexedDbQueueStorage";
+export * from "./IndexedDbMessageQueue";
+export * from "./IndexedDbJobStore";
+export * from "./createIndexedDbQueue";
 export * from "./IndexedDbRateLimiterStorage";
 
 // Versioned migration sets for the queue + rate-limiter object stores, plus

--- a/packages/indexeddb/src/job-queue/createIndexedDbQueue.ts
+++ b/packages/indexeddb/src/job-queue/createIndexedDbQueue.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IndexedDbJobStore } from "./IndexedDbJobStore";
+import { IndexedDbMessageQueue, type PendingIndexedDbWrite } from "./IndexedDbMessageQueue";
+import { IndexedDbQueueStorage, type IndexedDbQueueStorageOptions } from "./IndexedDbQueueStorage";
+
+/**
+ * Factory for the paired IndexedDB message queue and job store. Both
+ * facades share a single underlying {@link IndexedDbQueueStorage} so writes
+ * through one are observable through the other.
+ */
+export function createIndexedDbQueue<Input, Output>(
+  queueName: string,
+  opts?: IndexedDbQueueStorageOptions
+): {
+  messageQueue: IndexedDbMessageQueue<Input, Output>;
+  jobStore: IndexedDbJobStore<Input, Output>;
+  /** @internal — exposed for callers that still need the legacy storage object. */
+  core: IndexedDbQueueStorage<Input, Output>;
+} {
+  const core = new IndexedDbQueueStorage<Input, Output>(queueName, opts);
+  const pending = new Map<unknown, PendingIndexedDbWrite<Output>>();
+  return {
+    messageQueue: new IndexedDbMessageQueue<Input, Output>(core, pending),
+    jobStore: new IndexedDbJobStore<Input, Output>(core, pending),
+    core,
+  };
+}

--- a/packages/indexeddb/src/migrations/indexedDbQueueMigrations.ts
+++ b/packages/indexeddb/src/migrations/indexedDbQueueMigrations.ts
@@ -15,7 +15,7 @@ import type { IndexedDbMigration, IndexedDbMigrationGroup } from "./IndexedDbMig
  * different table names get tracked independently in `_storage_migrations`.
  *
  * Schema: a single object store keyed by `id` plus four compound indexes
- * (queue/status, queue/status/run_after, queue/job_run_id,
+ * (queue/status, queue/status/visible_at, queue/job_run_id,
  * queue/fingerprint/status). When `prefixes` is non-empty the prefix columns
  * are prepended to every index key path so per-tenant queries can be served
  * directly by the index.
@@ -37,7 +37,7 @@ export function indexedDbQueueMigrations(
         if (!db.objectStoreNames.contains(tableName)) {
           const store = db.createObjectStore(tableName, { keyPath: "id" });
           store.createIndex("queue_status", k(["queue", "status"]), { unique: false });
-          store.createIndex("queue_status_run_after", k(["queue", "status", "run_after"]), {
+          store.createIndex("queue_status_visible_at", k(["queue", "status", "visible_at"]), {
             unique: false,
           });
           store.createIndex("queue_job_run_id", k(["queue", "job_run_id"]), { unique: false });

--- a/packages/indexeddb/src/migrations/indexedDbQueueMigrations.ts
+++ b/packages/indexeddb/src/migrations/indexedDbQueueMigrations.ts
@@ -14,11 +14,17 @@ import type { IndexedDbMigration, IndexedDbMigrationGroup } from "./IndexedDbMig
  * Component name is `queue:indexeddb:<tableName>` so two queues with
  * different table names get tracked independently in `_storage_migrations`.
  *
- * Schema: a single object store keyed by `id` plus four compound indexes
- * (queue/status, queue/status/visible_at, queue/job_run_id,
- * queue/fingerprint/status). When `prefixes` is non-empty the prefix columns
- * are prepended to every index key path so per-tenant queries can be served
- * directly by the index.
+ * v1 is FROZEN byte-for-byte against the pre-PR shape (097b4afa) — it
+ * creates the `queue_status_run_after` compound index and reads `run_after`
+ * from each row. The rename to `queue_status_visible_at` lives in v2,
+ * which also walks every existing row and copies `run_after → visible_at`
+ * synchronously inside the upgrade transaction.
+ *
+ * Schema (post v2): a single object store keyed by `id` plus four compound
+ * indexes (queue/status, queue/status/visible_at, queue/job_run_id,
+ * queue/fingerprint/status). When `prefixes` is non-empty the prefix
+ * columns are prepended to every index key path so per-tenant queries can
+ * be served directly by the index.
  */
 export function indexedDbQueueMigrations(
   tableName: string,
@@ -37,11 +43,57 @@ export function indexedDbQueueMigrations(
         if (!db.objectStoreNames.contains(tableName)) {
           const store = db.createObjectStore(tableName, { keyPath: "id" });
           store.createIndex("queue_status", k(["queue", "status"]), { unique: false });
-          store.createIndex("queue_status_visible_at", k(["queue", "status", "visible_at"]), {
+          store.createIndex("queue_status_run_after", k(["queue", "status", "run_after"]), {
             unique: false,
           });
           store.createIndex("queue_job_run_id", k(["queue", "job_run_id"]), { unique: false });
           store.createIndex("queue_fingerprint_status", k(["queue", "fingerprint", "status"]), {
+            unique: false,
+          });
+        }
+      },
+    },
+    {
+      component,
+      version: 2,
+      description:
+        "Rename queue_status_run_after → queue_status_visible_at; backfill run_after → visible_at",
+      up({ tx }) {
+        // IDB upgrade transactions auto-commit as soon as `up()` returns —
+        // we MUST NOT `await` anything between IDB operations. All cursor
+        // and index work below uses synchronous request callbacks fired by
+        // the same upgrade tx, which is the only legal pattern.
+        const store = tx.objectStore(tableName);
+
+        // Drop the old index BEFORE rewriting rows so the cursor walk does
+        // not have to maintain its key. IDB doesn't allow renaming an index
+        // in place; the only path is delete + create.
+        const indexNames = Array.from(store.indexNames);
+        if (indexNames.includes("queue_status_run_after")) {
+          store.deleteIndex("queue_status_run_after");
+        }
+
+        // Walk every row and copy `run_after` → `visible_at`. `openCursor()`
+        // returns a request whose `onsuccess` fires once per row plus a
+        // final time with `cursor === null`; the upgrade tx stays open as
+        // long as new requests are issued from the current callback.
+        const cursorReq = store.openCursor();
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result;
+          if (!cursor) return;
+          const row = cursor.value as Record<string, unknown> | null;
+          if (row && row.visible_at === undefined && row.run_after !== undefined) {
+            row.visible_at = row.run_after;
+            cursor.update(row);
+          }
+          cursor.continue();
+        };
+
+        // Recreate the index under the new name keyed on `visible_at`.
+        // Skip if a previous partial run already created it (defensive — IDB
+        // forbids two indexes sharing a name and would throw mid-upgrade).
+        if (!Array.from(store.indexNames).includes("queue_status_visible_at")) {
+          store.createIndex("queue_status_visible_at", k(["queue", "status", "visible_at"]), {
             unique: false,
           });
         }

--- a/packages/job-queue/src/common.ts
+++ b/packages/job-queue/src/common.ts
@@ -6,6 +6,7 @@
 
 // organize-imports-ignore
 
+export type { DeadLetter } from "./job/DeadLetter";
 export * from "./job/Job";
 export * from "./job/JobError";
 export * from "./job/JobErrorDiagnostics";

--- a/packages/job-queue/src/common.ts
+++ b/packages/job-queue/src/common.ts
@@ -14,6 +14,7 @@ export * from "./job/JobQueueEventListeners";
 export * from "./job/JobQueueServer";
 export * from "./job/JobQueueWorker";
 export * from "./job/JobStorageConverters";
+export * from "./job/MessageQueueClient";
 export * from "./limiter/CompositeLimiter";
 export * from "./limiter/ConcurrencyLimiter";
 export * from "./limiter/DelayLimiter";
@@ -22,9 +23,16 @@ export * from "./limiter/ILimiter";
 export * from "./limiter/NullLimiter";
 export * from "./limiter/RateLimiter";
 
+export * from "./queue-storage/IClaim";
+export * from "./queue-storage/IJobStore";
+export * from "./queue-storage/IMessageQueue";
 export * from "./queue-storage/IQueueStorage";
+export * from "./queue-storage/InMemoryJobStore";
+export * from "./queue-storage/InMemoryMessageQueue";
 export * from "./queue-storage/InMemoryQueueStorage";
 export * from "./queue-storage/TelemetryQueueStorage";
+export * from "./queue-storage/createInMemoryQueue";
+export * from "./queue-storage/wrapQueueStorage";
 
 export * from "./rate-limiter-storage/IRateLimiterStorage";
 export * from "./rate-limiter-storage/InMemoryRateLimiterStorage";

--- a/packages/job-queue/src/job/DeadLetter.ts
+++ b/packages/job-queue/src/job/DeadLetter.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Payload written to the dead-letter queue when a job exhausts its retry budget.
+ */
+export interface DeadLetter<Input> {
+  readonly original: Input;
+  readonly error: string;
+  readonly errorCode: string | null;
+  readonly attempts: number;
+  readonly queueName: string;
+  readonly jobRunId: string | undefined;
+}

--- a/packages/job-queue/src/job/Job.ts
+++ b/packages/job-queue/src/job/Job.ts
@@ -34,19 +34,19 @@ export type JobConstructorParam<Input, Output> = {
   error?: string | null;
   errorCode?: string | null;
   fingerprint?: string;
-  maxRetries?: number;
+  maxAttempts?: number;
   status?: JobStatus;
   createdAt?: Date;
   deadlineAt?: Date | null;
-  lastRanAt?: Date | null;
-  runAfter?: Date | null;
+  lastAttemptedAt?: Date | null;
+  visibleAt?: Date | null;
   completedAt?: Date | null;
-  runAttempts?: number;
+  attempts?: number;
   progress?: number;
   progressMessage?: string;
   progressDetails?: Record<string, any> | null;
-  /** The ID of the worker that claimed this job, null if unclaimed */
-  workerId?: string | null;
+  /** The ID of the worker that currently holds the lease on this job, null if unclaimed */
+  leaseOwner?: string | null;
   /** ISO timestamp when an abort was requested for this job (storage-layer concern) */
   abort_requested_at?: string | null;
   /** ISO timestamp when the current lease expires (storage-layer concern) */
@@ -68,14 +68,14 @@ export class Job<Input, Output> {
   public jobRunId: string | undefined;
   public queueName: string | undefined;
   public input: Input;
-  public maxRetries: number;
+  public maxAttempts: number;
   public createdAt: Date;
   public fingerprint: string | undefined;
   public status: JobStatus = JobStatus.PENDING;
-  public runAfter: Date;
+  public visibleAt: Date;
   public output: Output | null = null;
-  public runAttempts: number = 0;
-  public lastRanAt: Date | null = null;
+  public attempts: number = 0;
+  public lastAttemptedAt: Date | null = null;
   public completedAt: Date | null = null;
   public deadlineAt: Date | null = null;
   public error: string | null = null;
@@ -83,8 +83,8 @@ export class Job<Input, Output> {
   public progress: number = 0;
   public progressMessage: string = "";
   public progressDetails: Record<string, any> | null = null;
-  /** The ID of the worker that claimed this job */
-  public workerId: string | null = null;
+  /** The ID of the worker that currently holds the lease on this job */
+  public leaseOwner: string | null = null;
   /** ISO timestamp when an abort was requested for this job (storage-layer concern) */
   public abort_requested_at: string | null = null;
   /** ISO timestamp when the current lease expires (storage-layer concern) */
@@ -99,24 +99,24 @@ export class Job<Input, Output> {
     errorCode = null,
     fingerprint = undefined,
     output = null,
-    maxRetries = 10,
+    maxAttempts = 10,
     createdAt = new Date(),
     completedAt = null,
     status = JobStatus.PENDING,
     deadlineAt = null,
-    runAttempts = 0,
-    lastRanAt = null,
-    runAfter = new Date(),
+    attempts = 0,
+    lastAttemptedAt = null,
+    visibleAt = new Date(),
     progress = 0,
     progressMessage = "",
     progressDetails = null,
-    workerId = null,
+    leaseOwner = null,
     abort_requested_at = null,
     lease_expires_at = null,
   }: JobConstructorParam<Input, Output>) {
-    this.runAfter = runAfter ?? new Date();
+    this.visibleAt = visibleAt ?? new Date();
     this.createdAt = createdAt ?? new Date();
-    this.lastRanAt = lastRanAt ?? null;
+    this.lastAttemptedAt = lastAttemptedAt ?? null;
     this.deadlineAt = deadlineAt ?? null;
     this.completedAt = completedAt ?? null;
 
@@ -126,15 +126,15 @@ export class Job<Input, Output> {
     this.status = status;
     this.fingerprint = fingerprint;
     this.input = input;
-    this.maxRetries = maxRetries;
-    this.runAttempts = runAttempts;
+    this.maxAttempts = maxAttempts;
+    this.attempts = attempts;
     this.output = output;
     this.error = error;
     this.errorCode = errorCode;
     this.progress = progress;
     this.progressMessage = progressMessage;
     this.progressDetails = progressDetails;
-    this.workerId = workerId ?? null;
+    this.leaseOwner = leaseOwner ?? null;
     this.abort_requested_at = abort_requested_at ?? null;
     this.lease_expires_at = lease_expires_at ?? null;
   }

--- a/packages/job-queue/src/job/Job.ts
+++ b/packages/job-queue/src/job/Job.ts
@@ -47,6 +47,10 @@ export type JobConstructorParam<Input, Output> = {
   progressDetails?: Record<string, any> | null;
   /** The ID of the worker that claimed this job, null if unclaimed */
   workerId?: string | null;
+  /** ISO timestamp when an abort was requested for this job (storage-layer concern) */
+  abort_requested_at?: string | null;
+  /** ISO timestamp when the current lease expires (storage-layer concern) */
+  lease_expires_at?: string | null;
 };
 
 export type JobClass<Input, Output> = new (
@@ -81,6 +85,10 @@ export class Job<Input, Output> {
   public progressDetails: Record<string, any> | null = null;
   /** The ID of the worker that claimed this job */
   public workerId: string | null = null;
+  /** ISO timestamp when an abort was requested for this job (storage-layer concern) */
+  public abort_requested_at: string | null = null;
+  /** ISO timestamp when the current lease expires (storage-layer concern) */
+  public lease_expires_at: string | null = null;
 
   constructor({
     queueName,
@@ -103,6 +111,8 @@ export class Job<Input, Output> {
     progressMessage = "",
     progressDetails = null,
     workerId = null,
+    abort_requested_at = null,
+    lease_expires_at = null,
   }: JobConstructorParam<Input, Output>) {
     this.runAfter = runAfter ?? new Date();
     this.createdAt = createdAt ?? new Date();
@@ -125,6 +135,8 @@ export class Job<Input, Output> {
     this.progressMessage = progressMessage;
     this.progressDetails = progressDetails;
     this.workerId = workerId ?? null;
+    this.abort_requested_at = abort_requested_at ?? null;
+    this.lease_expires_at = lease_expires_at ?? null;
   }
 
   async execute(_input: Input, _context: IJobExecuteContext): Promise<Output> {

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -5,12 +5,15 @@
  */
 
 import { EventEmitter } from "@workglow/util";
+import type { IJobStore } from "../queue-storage/IJobStore";
+import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type {
   IQueueStorage,
   JobStorageFormat,
   QueueChangePayload,
 } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
+import { wrapQueueStorage } from "../queue-storage/wrapQueueStorage";
 import { Job } from "./Job";
 import {
   AbortSignalJobError,
@@ -45,7 +48,13 @@ export interface JobHandle<Output> {
  * Options for creating a JobQueueClient
  */
 export interface JobQueueClientOptions<Input, Output> {
-  readonly storage: IQueueStorage<Input, Output>;
+  /**
+   * Legacy single-storage option. Provide either `storage` OR the paired
+   * `messageQueue`+`jobStore`.
+   */
+  readonly storage?: IQueueStorage<Input, Output>;
+  readonly messageQueue?: IMessageQueue<JobStorageFormat<Input, Output>>;
+  readonly jobStore?: IJobStore<Input, Output>;
   readonly queueName: string;
 }
 
@@ -56,7 +65,9 @@ export interface JobQueueClientOptions<Input, Output> {
  */
 export class JobQueueClient<Input, Output> {
   public readonly queueName: string;
-  protected readonly storage: IQueueStorage<Input, Output>;
+  protected readonly messageQueue: IMessageQueue<JobStorageFormat<Input, Output>>;
+  protected readonly jobStore: IJobStore<Input, Output>;
+  protected readonly storage: IQueueStorage<Input, Output> | null;
   protected readonly events = new EventEmitter<JobQueueEventListeners<Input, Output>>();
   protected server: JobQueueServer<Input, Output> | null = null;
   protected storageUnsubscribe: (() => void) | null = null;
@@ -91,7 +102,20 @@ export class JobQueueClient<Input, Output> {
 
   constructor(options: JobQueueClientOptions<Input, Output>) {
     this.queueName = options.queueName;
-    this.storage = options.storage;
+    if (options.messageQueue && options.jobStore) {
+      this.messageQueue = options.messageQueue;
+      this.jobStore = options.jobStore;
+      this.storage = null;
+    } else if (options.storage) {
+      const wrapped = wrapQueueStorage(options.storage);
+      this.messageQueue = wrapped.messageQueue;
+      this.jobStore = wrapped.jobStore;
+      this.storage = options.storage;
+    } else {
+      throw new Error(
+        "JobQueueClient requires either `storage` or both `messageQueue` and `jobStore`"
+      );
+    }
   }
 
   /**
@@ -135,7 +159,10 @@ export class JobQueueClient<Input, Output> {
       return; // Already subscribed
     }
 
-    this.storageUnsubscribe = this.storage.subscribeToChanges(
+    const sub = this.messageQueue.subscribeToChanges;
+    if (!sub) return; // backend doesn't support subscriptions
+    this.storageUnsubscribe = sub.call(
+      this.messageQueue,
       (change: QueueChangePayload<Input, Output>) => {
         this.handleStorageChange(change);
       }
@@ -186,7 +213,7 @@ export class JobQueueClient<Input, Output> {
       status: JobStatus.PENDING,
     };
 
-    const id = await this.storage.add(job);
+    const id = await this.messageQueue.send(job);
 
     // Same-process fast path: poke the worker directly so it doesn't have to
     // wait for the poll interval (crucial for Sqlite/Postgres, whose
@@ -219,7 +246,7 @@ export class JobQueueClient<Input, Output> {
    */
   public async getJob(id: unknown): Promise<Job<Input, Output> | undefined> {
     if (!id) throw new JobNotFoundError("Cannot get undefined job");
-    const job = await this.storage.get(id);
+    const job = await this.jobStore.get(id);
     if (!job) return undefined;
     return this.storageToClass(job);
   }
@@ -229,7 +256,7 @@ export class JobQueueClient<Input, Output> {
    */
   public async getJobsByRunId(runId: string): Promise<readonly Job<Input, Output>[]> {
     if (!runId) throw new JobNotFoundError("Cannot get jobs by undefined runId");
-    const jobs = await this.storage.getByRunId(runId);
+    const jobs = await this.jobStore.getByRunId(runId);
     return jobs.map((job) => this.storageToClass(job));
   }
 
@@ -237,7 +264,7 @@ export class JobQueueClient<Input, Output> {
    * Peek at jobs in the queue
    */
   public async peek(status?: JobStatus, num?: number): Promise<readonly Job<Input, Output>[]> {
-    const jobs = await this.storage.peek(status, num);
+    const jobs = await this.jobStore.peek(status, num);
     return jobs.map((job) => this.storageToClass(job));
   }
 
@@ -245,7 +272,7 @@ export class JobQueueClient<Input, Output> {
    * Get the size of the queue
    */
   public async size(status?: JobStatus): Promise<number> {
-    return this.storage.size(status);
+    return this.jobStore.size(status);
   }
 
   /**
@@ -253,7 +280,7 @@ export class JobQueueClient<Input, Output> {
    */
   public async outputForInput(input: Input): Promise<Output | null> {
     if (!input) throw new JobNotFoundError("Cannot get output for undefined input");
-    return this.storage.outputForInput(input);
+    return this.jobStore.outputForInput(input);
   }
 
   /**
@@ -335,7 +362,7 @@ export class JobQueueClient<Input, Output> {
     const firedLocally = this.server?.abortJob(jobId) ?? false;
     if (!firedLocally) {
       try {
-        await this.storage.abort(jobId);
+        await this.jobStore.abort(jobId);
       } finally {
         this.events.emit("job_aborting", this.queueName, jobId);
       }

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -310,16 +310,17 @@ export class JobQueueClient<Input, Output> {
    *
    * Same-process path: fires the in-memory abort controller on the attached
    * server — `handleAbort` will write FAILED directly, so we skip the
-   * `storage.abort(…)` ABORTING write. Writing both would race (last-writer-
-   * wins) and can leave the row stuck at ABORTING on async storages.
+   * `storage.abort(…)` write. Writing both would race (last-writer-wins) and
+   * can leave the row in an inconsistent state on async storages.
    *
    * Cross-process path (or job not currently running on any local worker):
-   * write ABORTING to storage so the remote worker's poll picks it up.
+   * write abort_requested_at to storage so the remote worker's poll picks it
+   * up (or mark FAILED immediately if the job is still PENDING).
    *
    * Crash window: if the process dies after the in-memory abort fires but
-   * before `failJob` writes FAILED, the row stays PROCESSING. `fixupJobs()`
-   * resets it to PENDING on next start and the job will re-run. Make handlers
-   * idempotent (or use `uniquenessKey`) if that's not acceptable.
+   * before `failJob` writes FAILED, the row stays PROCESSING. Lease expiry
+   * in `next()` will re-claim it on the next start so the job will re-run.
+   * Make handlers idempotent if that's not acceptable.
    */
   public async abort(jobId: unknown): Promise<void> {
     if (!jobId) throw new JobNotFoundError("Cannot abort undefined job");

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -154,16 +154,18 @@ export class JobQueueClient<Input, Output> {
   }
 
   /**
-   * Submit a job to the queue
+   * Send a job to the queue
    */
-  public async submit(
+  public async send(
     input: Input,
     options?: {
       readonly jobRunId?: string;
       readonly fingerprint?: string;
-      readonly maxRetries?: number;
-      readonly runAfter?: Date;
-      readonly deadlineAt?: Date;
+      readonly maxAttempts?: number;
+      /** Delay in seconds before the job becomes visible for processing */
+      readonly delaySeconds?: number;
+      /** Timeout in seconds after which the job deadline is exceeded */
+      readonly timeoutSeconds?: number;
     }
   ): Promise<JobHandle<Output>> {
     const job: JobStorageFormat<Input, Output> = {
@@ -171,9 +173,15 @@ export class JobQueueClient<Input, Output> {
       input,
       job_run_id: options?.jobRunId,
       fingerprint: options?.fingerprint,
-      max_retries: options?.maxRetries ?? 10,
-      run_after: options?.runAfter?.toISOString() ?? new Date().toISOString(),
-      deadline_at: options?.deadlineAt?.toISOString() ?? null,
+      max_attempts: options?.maxAttempts ?? 10,
+      visible_at:
+        options?.delaySeconds != null
+          ? new Date(Date.now() + options.delaySeconds * 1000).toISOString()
+          : new Date().toISOString(),
+      deadline_at:
+        options?.timeoutSeconds != null
+          ? new Date(Date.now() + options.timeoutSeconds * 1000).toISOString()
+          : null,
       completed_at: null,
       status: JobStatus.PENDING,
     };
@@ -189,18 +197,18 @@ export class JobQueueClient<Input, Output> {
   }
 
   /**
-   * Submit multiple jobs to the queue
+   * Send multiple jobs to the queue
    */
-  public async submitBatch(
+  public async sendBatch(
     inputs: readonly Input[],
     options?: {
       readonly jobRunId?: string;
-      readonly maxRetries?: number;
+      readonly maxAttempts?: number;
     }
   ): Promise<readonly JobHandle<Output>[]> {
     const handles: JobHandle<Output>[] = [];
     for (const input of inputs) {
-      const handle = await this.submit(input, options);
+      const handle = await this.send(input, options);
       handles.push(handle);
     }
     return handles;
@@ -480,8 +488,8 @@ export class JobQueueClient<Input, Output> {
    * Called by server when a job is retried
    * @internal
    */
-  public handleJobRetry(jobId: unknown, runAfter: Date): void {
-    this.events.emit("job_retry", this.queueName, jobId, runAfter);
+  public handleJobRetry(jobId: unknown, visibleAt: Date): void {
+    this.events.emit("job_retry", this.queueName, jobId, visibleAt);
   }
 
   /**
@@ -552,8 +560,8 @@ export class JobQueueClient<Input, Output> {
         this.handleJobDisabled(jobId);
       } else if (newStatus === JobStatus.PENDING && oldStatus === JobStatus.PROCESSING) {
         // Retry
-        const runAfter = change.new.run_after ? new Date(change.new.run_after) : new Date();
-        this.handleJobRetry(jobId, runAfter);
+        const visibleAt = change.new.visible_at ? new Date(change.new.visible_at) : new Date();
+        this.handleJobRetry(jobId, visibleAt);
       }
 
       // Progress update

--- a/packages/job-queue/src/job/JobQueueEventListeners.ts
+++ b/packages/job-queue/src/job/JobQueueEventListeners.ts
@@ -17,7 +17,7 @@ export type JobQueueEventListeners<Input, Output> = {
   job_complete: (queueName: string, jobId: unknown, output: Output) => void;
   job_error: (queueName: string, jobId: unknown, error: string) => void;
   job_disabled: (queueName: string, jobId: unknown) => void;
-  job_retry: (queueName: string, jobId: unknown, runAfter: Date) => void;
+  job_retry: (queueName: string, jobId: unknown, visibleAt: Date) => void;
   job_progress: (
     queueName: string,
     jobId: unknown,

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -16,6 +16,7 @@ import type {
 } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
 import { wrapQueueStorage } from "../queue-storage/wrapQueueStorage";
+import type { DeadLetter } from "./DeadLetter";
 import { Job, JobClass } from "./Job";
 import { JobQueueClient } from "./JobQueueClient";
 import { JobQueueWorker } from "./JobQueueWorker";
@@ -82,6 +83,11 @@ export interface JobQueueServerOptions<Input, Output> {
    * Defaults to 30s. Set to 0 to abort immediately.
    */
   readonly stopTimeoutMs?: number;
+  /**
+   * Dead-letter queue to forward exhausted jobs to, or "discard" to silently drop them.
+   * Default: "discard".
+   */
+  readonly deadLetter?: IMessageQueue<DeadLetter<Input>> | "discard";
 }
 
 /**
@@ -107,6 +113,7 @@ export class JobQueueServer<
   protected readonly deleteAfterDisabledMs?: number;
   protected readonly cleanupIntervalMs: number;
   protected readonly stopTimeoutMs?: number;
+  protected readonly deadLetter: IMessageQueue<DeadLetter<Input>> | "discard";
 
   protected readonly events = new EventEmitter<JobQueueServerEventListeners<Input, Output>>();
   protected readonly workers: JobQueueWorker<Input, Output, QueueJob>[] = [];
@@ -151,6 +158,7 @@ export class JobQueueServer<
     this.deleteAfterDisabledMs = options.deleteAfterDisabledMs;
     this.cleanupIntervalMs = options.cleanupIntervalMs ?? 10000;
     this.stopTimeoutMs = options.stopTimeoutMs;
+    this.deadLetter = options.deadLetter ?? "discard";
 
     this.initializeWorkers();
   }
@@ -433,6 +441,7 @@ export class JobQueueServer<
       limiter: this.limiter,
       pollIntervalMs: this.pollIntervalMs,
       stopTimeoutMs: this.stopTimeoutMs,
+      deadLetter: this.deadLetter,
     });
 
     // Forward worker events to server and clients

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -7,12 +7,15 @@
 import { EventEmitter, getLogger } from "@workglow/util";
 import { ILimiter } from "../limiter/ILimiter";
 import { NullLimiter } from "../limiter/NullLimiter";
+import type { IJobStore } from "../queue-storage/IJobStore";
+import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type {
   IQueueStorage,
   JobStorageFormat,
   QueueChangePayload,
 } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
+import { wrapQueueStorage } from "../queue-storage/wrapQueueStorage";
 import { Job, JobClass } from "./Job";
 import { JobQueueClient } from "./JobQueueClient";
 import { JobQueueWorker } from "./JobQueueWorker";
@@ -58,7 +61,14 @@ export type JobQueueServerEvents = keyof JobQueueServerEventListeners<unknown, u
  * Options for creating a JobQueueServer
  */
 export interface JobQueueServerOptions<Input, Output> {
-  readonly storage: IQueueStorage<Input, Output>;
+  /**
+   * Legacy single-storage option. Provide either `storage` OR the paired
+   * `messageQueue`+`jobStore`. When `storage` is given it is wrapped via
+   * {@link wrapQueueStorage} internally.
+   */
+  readonly storage?: IQueueStorage<Input, Output>;
+  readonly messageQueue?: IMessageQueue<JobStorageFormat<Input, Output>>;
+  readonly jobStore?: IJobStore<Input, Output>;
   readonly queueName: string;
   readonly limiter?: ILimiter;
   readonly workerCount?: number;
@@ -84,7 +94,10 @@ export class JobQueueServer<
   QueueJob extends Job<Input, Output> = Job<Input, Output>,
 > {
   public readonly queueName: string;
-  protected readonly storage: IQueueStorage<Input, Output>;
+  protected readonly messageQueue: IMessageQueue<JobStorageFormat<Input, Output>>;
+  protected readonly jobStore: IJobStore<Input, Output>;
+  /** Optional legacy storage handle, set when the user constructed via `storage`. */
+  protected readonly storage: IQueueStorage<Input, Output> | null;
   protected readonly jobClass: JobClass<Input, Output>;
   public readonly limiter: ILimiter;
   protected readonly workerCount: number;
@@ -115,7 +128,20 @@ export class JobQueueServer<
 
   constructor(jobClass: JobClass<Input, Output>, options: JobQueueServerOptions<Input, Output>) {
     this.queueName = options.queueName;
-    this.storage = options.storage;
+    if (options.messageQueue && options.jobStore) {
+      this.messageQueue = options.messageQueue;
+      this.jobStore = options.jobStore;
+      this.storage = null;
+    } else if (options.storage) {
+      const wrapped = wrapQueueStorage(options.storage);
+      this.messageQueue = wrapped.messageQueue;
+      this.jobStore = wrapped.jobStore;
+      this.storage = options.storage;
+    } else {
+      throw new Error(
+        "JobQueueServer requires either `storage` or both `messageQueue` and `jobStore`"
+      );
+    }
     this.jobClass = jobClass;
     this.limiter = options.limiter ?? new NullLimiter();
     this.workerCount = options.workerCount ?? 1;
@@ -146,7 +172,7 @@ export class JobQueueServer<
     // N× the limit (one bucket per process).
     if (
       this.limiter.scope === "process" &&
-      this.storage.scope === "cluster" &&
+      this.messageQueue.scope === "cluster" &&
       !(this.limiter instanceof NullLimiter)
     ) {
       getLogger().warn(
@@ -154,7 +180,7 @@ export class JobQueueServer<
         {
           queueName: this.queueName,
           limiterScope: this.limiter.scope,
-          storage: this.storage.constructor.name,
+          storage: this.storage?.constructor.name ?? this.messageQueue.constructor.name,
         }
       );
     }
@@ -170,7 +196,10 @@ export class JobQueueServer<
     // - Sqlite/Postgres throw here; the try/catch falls through and direct
     //   notify is the sole wake path on those backends.
     try {
-      this.storageUnsubscribe = this.storage.subscribeToChanges(
+      const sub = this.messageQueue.subscribeToChanges;
+      if (!sub) throw new Error("messageQueue does not support subscribeToChanges");
+      this.storageUnsubscribe = sub.call(
+        this.messageQueue,
         (change: QueueChangePayload<Input, Output>) => {
           if (
             change.type === "INSERT" ||
@@ -254,8 +283,18 @@ export class JobQueueServer<
   /**
    * Get the storage instance (for client connection)
    */
-  public getStorage(): IQueueStorage<Input, Output> {
+  public getStorage(): IQueueStorage<Input, Output> | null {
     return this.storage;
+  }
+
+  /** Get the message queue paired with this server. */
+  public getMessageQueue(): IMessageQueue<JobStorageFormat<Input, Output>> {
+    return this.messageQueue;
+  }
+
+  /** Get the job store paired with this server. */
+  public getJobStore(): IJobStore<Input, Output> {
+    return this.jobStore;
   }
 
   /**
@@ -388,7 +427,8 @@ export class JobQueueServer<
    */
   protected createWorker(): JobQueueWorker<Input, Output, QueueJob> {
     const worker = new JobQueueWorker<Input, Output, QueueJob>(this.jobClass, {
-      storage: this.storage,
+      messageQueue: this.messageQueue,
+      jobStore: this.jobStore,
       queueName: this.queueName,
       limiter: this.limiter,
       pollIntervalMs: this.pollIntervalMs,
@@ -410,7 +450,7 @@ export class JobQueueServer<
 
       // Immediate deletion when configured
       if (this.deleteAfterCompletionMs === 0) {
-        this.storage.delete(jobId).catch((err) => {
+        this.jobStore.delete(jobId).catch((err) => {
           console.error("Error deleting job after completion:", err);
         });
       }
@@ -426,7 +466,7 @@ export class JobQueueServer<
 
       // Immediate deletion when configured
       if (this.deleteAfterFailureMs === 0) {
-        this.storage.delete(jobId).catch((err) => {
+        this.jobStore.delete(jobId).catch((err) => {
           console.error("Error deleting job after error:", err);
         });
       }
@@ -442,7 +482,7 @@ export class JobQueueServer<
 
       // Immediate deletion when configured
       if (this.deleteAfterDisabledMs === 0) {
-        this.storage.delete(jobId).catch((err) => {
+        this.jobStore.delete(jobId).catch((err) => {
           console.error("Error deleting job after disabling:", err);
         });
       }
@@ -538,20 +578,17 @@ export class JobQueueServer<
 
       // Delete completed jobs after TTL
       if (this.deleteAfterCompletionMs !== undefined && this.deleteAfterCompletionMs > 0) {
-        await this.storage.deleteJobsByStatusAndAge(
-          JobStatus.COMPLETED,
-          this.deleteAfterCompletionMs
-        );
+        await this.jobStore.deleteByStatusAndAge(JobStatus.COMPLETED, this.deleteAfterCompletionMs);
       }
 
       // Delete failed jobs after TTL
       if (this.deleteAfterFailureMs !== undefined && this.deleteAfterFailureMs > 0) {
-        await this.storage.deleteJobsByStatusAndAge(JobStatus.FAILED, this.deleteAfterFailureMs);
+        await this.jobStore.deleteByStatusAndAge(JobStatus.FAILED, this.deleteAfterFailureMs);
       }
 
       // Delete disabled jobs after TTL
       if (this.deleteAfterDisabledMs !== undefined && this.deleteAfterDisabledMs > 0) {
-        await this.storage.deleteJobsByStatusAndAge(JobStatus.DISABLED, this.deleteAfterDisabledMs);
+        await this.jobStore.deleteByStatusAndAge(JobStatus.DISABLED, this.deleteAfterDisabledMs);
       }
     } catch (error) {
       console.error("Error in cleanup:", error);

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -42,7 +42,7 @@ export type JobQueueServerEventListeners<Input, Output> = {
   job_complete: (queueName: string, jobId: unknown, output: Output) => void;
   job_error: (queueName: string, jobId: unknown, error: string) => void;
   job_disabled: (queueName: string, jobId: unknown) => void;
-  job_retry: (queueName: string, jobId: unknown, runAfter: Date) => void;
+  job_retry: (queueName: string, jobId: unknown, visibleAt: Date) => void;
   job_progress: (
     queueName: string,
     jobId: unknown,
@@ -451,10 +451,10 @@ export class JobQueueServer<
       this.notifyWorkers();
     });
 
-    worker.on("job_retry", (jobId, runAfter) => {
+    worker.on("job_retry", (jobId, visibleAt) => {
       this.stats = { ...this.stats, retriedJobs: this.stats.retriedJobs + 1 };
-      this.events.emit("job_retry", this.queueName, jobId, runAfter);
-      this.forwardToClients("handleJobRetry", jobId, runAfter);
+      this.events.emit("job_retry", this.queueName, jobId, visibleAt);
+      this.forwardToClients("handleJobRetry", jobId, visibleAt);
     });
 
     worker.on("job_progress", (jobId, progress, message, details) => {
@@ -477,7 +477,7 @@ export class JobQueueServer<
     errorCode?: string
   ): void;
   protected forwardToClients(method: "handleJobDisabled", jobId: unknown): void;
-  protected forwardToClients(method: "handleJobRetry", jobId: unknown, runAfter: Date): void;
+  protected forwardToClients(method: "handleJobRetry", jobId: unknown, visibleAt: Date): void;
   protected forwardToClients(
     method: "handleJobProgress",
     jobId: unknown,

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -88,6 +88,8 @@ export interface JobQueueServerOptions<Input, Output> {
    * Default: "discard".
    */
   readonly deadLetter?: IMessageQueue<DeadLetter<Input>> | "discard";
+  /** Number of jobs to pre-fetch per poll iteration. Defaults to 1. */
+  readonly prefetch?: number;
 }
 
 /**
@@ -114,6 +116,7 @@ export class JobQueueServer<
   protected readonly cleanupIntervalMs: number;
   protected readonly stopTimeoutMs?: number;
   protected readonly deadLetter: IMessageQueue<DeadLetter<Input>> | "discard";
+  protected readonly prefetch: number;
 
   protected readonly events = new EventEmitter<JobQueueServerEventListeners<Input, Output>>();
   protected readonly workers: JobQueueWorker<Input, Output, QueueJob>[] = [];
@@ -159,6 +162,7 @@ export class JobQueueServer<
     this.cleanupIntervalMs = options.cleanupIntervalMs ?? 10000;
     this.stopTimeoutMs = options.stopTimeoutMs;
     this.deadLetter = options.deadLetter ?? "discard";
+    this.prefetch = Math.max(1, options.prefetch ?? 1);
 
     this.initializeWorkers();
   }
@@ -442,6 +446,7 @@ export class JobQueueServer<
       pollIntervalMs: this.pollIntervalMs,
       stopTimeoutMs: this.stopTimeoutMs,
       deadLetter: this.deadLetter,
+      prefetch: this.prefetch,
     });
 
     // Forward worker events to server and clients

--- a/packages/job-queue/src/job/JobQueueServer.ts
+++ b/packages/job-queue/src/job/JobQueueServer.ts
@@ -159,9 +159,6 @@ export class JobQueueServer<
       );
     }
 
-    // Fix stuck jobs from previous runs
-    await this.fixupJobs();
-
     // Subscribe to storage changes to wake workers when new work arrives.
     // - Cross-process deployments rely on this for wake-up.
     // - Same-process attached clients are also primarily woken by the direct
@@ -562,51 +559,6 @@ export class JobQueueServer<
   }
 
   /**
-   * Fix stuck jobs from previous server runs.
-   * Jobs in PROCESSING or ABORTING state that are not owned by any of the current
-   * server's workers are considered orphaned and will be reset.
-   */
-  protected async fixupJobs(): Promise<void> {
-    try {
-      const stuckProcessingJobs = await this.storage.peek(JobStatus.PROCESSING);
-      const stuckAbortingJobs = await this.storage.peek(JobStatus.ABORTING);
-      const stuckJobs = [...stuckProcessingJobs, ...stuckAbortingJobs];
-
-      // Get the worker IDs of all workers managed by this server
-      const currentWorkerIds = new Set(this.getWorkerIds());
-
-      for (const jobData of stuckJobs) {
-        // Skip jobs that belong to workers in this server (they may still be processing)
-        if (jobData.worker_id && currentWorkerIds.has(jobData.worker_id)) {
-          continue;
-        }
-
-        const job = this.storageToClass(jobData);
-        if (job.runAttempts >= job.maxRetries) {
-          job.status = JobStatus.FAILED;
-          job.error = "Max retries reached";
-          job.errorCode = "MAX_RETRIES_REACHED";
-          // Clear worker_id since job is now failed
-          job.workerId = null;
-        } else {
-          job.status = JobStatus.PENDING;
-          job.runAfter = job.lastRanAt || new Date();
-          job.progress = 0;
-          job.progressMessage = "";
-          job.progressDetails = null;
-          job.error = "Server restarted";
-          // Clear worker_id so a new worker can claim this job
-          job.workerId = null;
-        }
-
-        await this.storage.complete(this.classToStorage(job));
-      }
-    } catch (error) {
-      console.error("Error in fixupJobs:", error);
-    }
-  }
-
-  /**
    * Convert storage format to Job class
    */
   protected storageToClass(details: JobStorageFormat<Input, Output>): Job<Input, Output> {
@@ -618,12 +570,5 @@ export class JobQueueServer<
    */
   protected classToStorage(job: Job<Input, Output>): JobStorageFormat<Input, Output> {
     return classToStorage(job, this.queueName);
-  }
-
-  /**
-   * Get the worker IDs of all workers managed by this server
-   */
-  public getWorkerIds(): string[] {
-    return this.workers.map((worker) => worker.workerId);
   }
 }

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -80,6 +80,13 @@ export interface JobQueueWorkerOptions<Input, Output> {
    * executing. Extension interval is leaseMs * 0.5. Default: false.
    */
   readonly extendLeaseWhileRunning?: boolean;
+  /**
+   * How long (ms) the worker's lease on a claimed job lasts before another
+   * worker may re-claim it. Must be long enough to cover the maximum
+   * expected job duration if extendLeaseWhileRunning is false.
+   * Defaults to max(30_000, pollIntervalMs * 60).
+   */
+  readonly leaseMs?: number;
 }
 
 /**
@@ -99,6 +106,7 @@ export class JobQueueWorker<
   protected readonly pollIntervalMs: number;
   protected readonly stopTimeoutMs: number;
   protected readonly extendLeaseWhileRunning: boolean;
+  protected readonly leaseMs: number;
   protected readonly events = new EventEmitter<JobQueueWorkerEventListeners<Input, Output>>();
 
   protected running = false;
@@ -157,6 +165,7 @@ export class JobQueueWorker<
     this.pollIntervalMs = options.pollIntervalMs ?? 100;
     this.stopTimeoutMs = options.stopTimeoutMs ?? 30_000;
     this.extendLeaseWhileRunning = options.extendLeaseWhileRunning ?? false;
+    this.leaseMs = options.leaseMs ?? Math.max(30_000, this.pollIntervalMs * 60);
   }
 
   /**
@@ -319,8 +328,7 @@ export class JobQueueWorker<
    * Get the next job from the queue
    */
   protected async next(): Promise<QueueJob | undefined> {
-    const leaseMs = this.pollIntervalMs * 60;
-    const job = await this.storage.next(this.workerId, { leaseMs });
+    const job = await this.storage.next(this.workerId, { leaseMs: this.leaseMs });
     if (!job) return undefined;
     return this.storageToClass(job) as QueueJob;
   }
@@ -535,17 +543,16 @@ export class JobQueueWorker<
       const abortController = this.createAbortController(job.id);
       this.events.emit("job_start", job.id);
 
-      const leaseMs = this.pollIntervalMs * 60;
       let leaseInterval: ReturnType<typeof setInterval> | undefined;
       if (this.extendLeaseWhileRunning) {
         leaseInterval = setInterval(() => {
-          this.storage.extendLease(job.id, this.workerId, leaseMs).catch((err) => {
+          this.storage.extendLease(job.id, this.workerId, this.leaseMs).catch((err) => {
             getLogger().error("extendLease failed during job execution:", {
               error: err,
               jobId: job.id,
             });
           });
-        }, leaseMs * 0.5);
+        }, this.leaseMs * 0.5);
       }
 
       let output: Output;
@@ -579,6 +586,10 @@ export class JobQueueWorker<
           await this.failJob(currentJob, new PermanentJobError(spanErrorMessage));
           span?.setStatus(SpanStatusCode.ERROR, spanErrorMessage);
         } else {
+          // Clean up the abort controller before rescheduling so the next
+          // invocation of processSingleJob gets a fresh controller and the
+          // inFlight-guard in createAbortController passes correctly.
+          this.cleanupJob(job.id);
           await this.rescheduleJob(currentJob, error.retryDate);
           span?.addEvent("workglow.job.retry", {
             "workglow.job.run_attempt": currentJob.runAttempts,
@@ -593,7 +604,13 @@ export class JobQueueWorker<
     } finally {
       await this.limiter.complete(limiterToken);
       span?.end();
-      this.inFlight.delete(job.id);
+      // Guard against a concurrent processSingleJob for the same jobId (which
+      // can start before this finally block runs, e.g. after a reschedule).
+      // Only delete our own inFlight entry; if another invocation already
+      // replaced it, leave that entry alone.
+      if (this.inFlight.get(job.id) === inFlightPromise) {
+        this.inFlight.delete(job.id);
+      }
       resolveInFlight();
     }
   }

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -504,11 +504,6 @@ export class JobQueueWorker<
         })
       : undefined;
 
-    // Set when validateJobState fails and we release() the limiter slot
-    // ourselves — the finally block then skips recordJobCompletion to avoid
-    // double-decrementing limiters where release() and recordJobCompletion()
-    // both decrement (e.g. ConcurrencyLimiter).
-    let slotReleased = false;
     try {
       // The limiter slot was already atomically reserved by tryAcquire() in
       // the main loop (or processNext), so we no longer call recordJobStart
@@ -522,7 +517,6 @@ export class JobQueueWorker<
         // slot.
         try {
           await this.limiter.release(limiterToken);
-          slotReleased = true;
         } catch {
           // best-effort
         }
@@ -569,14 +563,8 @@ export class JobQueueWorker<
       span?.setAttributes({ "workglow.job.error": spanErrorMessage });
     } finally {
       span?.end();
-      try {
-        if (!slotReleased) {
-          await this.limiter.recordJobCompletion();
-        }
-      } finally {
-        this.inFlight.delete(job.id);
-        resolveInFlight();
-      }
+      this.inFlight.delete(job.id);
+      resolveInFlight();
     }
   }
 
@@ -680,12 +668,12 @@ export class JobQueueWorker<
    * the next started worker can pick it up. `fixupJobs()` would otherwise
    * skip it (it ignores rows owned by current-server worker IDs).
    *
-   * Uses `storage.release()` rather than `storage.complete()` so the retry
+   * Uses `storage.releaseClaim()` rather than `storage.complete()` so the retry
    * budget isn't burned: the worker never actually attempted execution.
    */
   protected async releaseClaimedJob(job: Job<Input, Output>): Promise<void> {
     try {
-      await this.storage.release(job.id);
+      await this.storage.releaseClaim(job.id);
     } catch (err) {
       getLogger().error("releaseClaimedJob errored:", { error: err });
     }

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -850,14 +850,21 @@ export class JobQueueWorker<
       job.progressMessage = "";
       job.progressDetails = null;
 
-      // IClaim has no "disable" terminal. Release the lease via fail() (writes
-      // FAILED), then immediately overwrite status to DISABLED via saveStatus()
-      // so storage reflects the correct terminal state.
+      // H5 atomic disable: a single storage write sets status=DISABLED,
+      // releases the lease, and clears progress fields. Replaces the legacy
+      // two-write `claim.fail()` then `jobStore.saveStatus(DISABLED)` path
+      // which briefly persisted FAILED before overwriting with DISABLED —
+      // any subscriber observing during the window saw a spurious
+      // FAILED transition and fired a `job_error` event.
       const claim = this.getClaim(job.id);
-      if (claim) {
-        await claim.fail();
+      if (claim?.disable) {
+        await claim.disable();
+      } else {
+        // Fallback for external IClaim impls that haven't adopted disable()
+        // yet. saveStatus uses finalize() under the hood (no attempts bump,
+        // no error write), so it's correct as a single-write fallback.
+        await this.jobStore.saveStatus(job.id, JobStatus.DISABLED);
       }
-      await this.jobStore.saveStatus(job.id, JobStatus.DISABLED);
       this.events.emit("job_disabled", job.id);
     } catch (err) {
       getLogger().error("disableJob errored:", { error: err });

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -75,6 +75,11 @@ export interface JobQueueWorkerOptions<Input, Output> {
    * Defaults to 30s. Set to 0 to abort immediately.
    */
   readonly stopTimeoutMs?: number;
+  /**
+   * If true, the worker will call extendLease periodically while a job is
+   * executing. Extension interval is leaseMs * 0.5. Default: false.
+   */
+  readonly extendLeaseWhileRunning?: boolean;
 }
 
 /**
@@ -93,6 +98,7 @@ export class JobQueueWorker<
   protected readonly limiter: ILimiter;
   protected readonly pollIntervalMs: number;
   protected readonly stopTimeoutMs: number;
+  protected readonly extendLeaseWhileRunning: boolean;
   protected readonly events = new EventEmitter<JobQueueWorkerEventListeners<Input, Output>>();
 
   protected running = false;
@@ -150,6 +156,7 @@ export class JobQueueWorker<
     this.limiter = options.limiter ?? new NullLimiter();
     this.pollIntervalMs = options.pollIntervalMs ?? 100;
     this.stopTimeoutMs = options.stopTimeoutMs ?? 30_000;
+    this.extendLeaseWhileRunning = options.extendLeaseWhileRunning ?? false;
   }
 
   /**
@@ -528,7 +535,27 @@ export class JobQueueWorker<
       const abortController = this.createAbortController(job.id);
       this.events.emit("job_start", job.id);
 
-      const output = await this.executeJob(job, abortController.signal);
+      const leaseMs = this.pollIntervalMs * 60;
+      let leaseInterval: ReturnType<typeof setInterval> | undefined;
+      if (this.extendLeaseWhileRunning) {
+        leaseInterval = setInterval(() => {
+          this.storage.extendLease(job.id, this.workerId, leaseMs).catch((err) => {
+            getLogger().error("extendLease failed during job execution:", {
+              error: err,
+              jobId: job.id,
+            });
+          });
+        }, leaseMs * 0.5);
+      }
+
+      let output: Output;
+      try {
+        output = await this.executeJob(job, abortController.signal);
+      } finally {
+        if (leaseInterval !== undefined) {
+          clearInterval(leaseInterval);
+        }
+      }
       await this.completeJob(job, output);
 
       const elapsed = Date.now() - startTime;

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -562,6 +562,7 @@ export class JobQueueWorker<
       }
       span?.setAttributes({ "workglow.job.error": spanErrorMessage });
     } finally {
+      await this.limiter.complete(limiterToken);
       span?.end();
       this.inFlight.delete(job.id);
       resolveInFlight();

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -312,7 +312,8 @@ export class JobQueueWorker<
    * Get the next job from the queue
    */
   protected async next(): Promise<QueueJob | undefined> {
-    const job = await this.storage.next(this.workerId);
+    const leaseMs = this.pollIntervalMs * 60;
+    const job = await this.storage.next(this.workerId, { leaseMs });
     if (!job) return undefined;
     return this.storageToClass(job) as QueueJob;
   }
@@ -457,19 +458,20 @@ export class JobQueueWorker<
   }
 
   /**
-   * Check for jobs that have been marked for abort and trigger their abort controllers.
-   *
-   * Only relevant for jobs running on THIS worker (we have an abort controller
-   * registered for them). When no jobs are active, the peek result is irrelevant
-   * — skip the storage round-trip entirely. Important for battery life on
-   * same-process deployments (browser/mobile) where workers spend most time idle.
+   * Check for in-process jobs that have abort_requested_at set and trigger
+   * their abort controllers. Only relevant for jobs running on THIS worker
+   * (we have an abort controller registered for them). When no jobs are active,
+   * the peek result is irrelevant — skip the storage round-trip entirely.
+   * Important for battery life on same-process deployments (browser/mobile)
+   * where workers spend most time idle.
    */
   protected async checkForAbortingJobs(): Promise<void> {
     if (this.activeJobAbortControllers.size === 0) {
       return;
     }
-    const abortingJobs = await this.storage.peek(JobStatus.ABORTING);
-    for (const jobData of abortingJobs) {
+    const processingJobs = await this.storage.peek(JobStatus.PROCESSING);
+    for (const jobData of processingJobs) {
+      if (!jobData.abort_requested_at) continue;
       const controller = this.activeJobAbortControllers.get(jobData.id);
       if (controller && !controller.signal.aborted) {
         controller.abort();
@@ -666,8 +668,8 @@ export class JobQueueWorker<
   /**
    * Release a job that {@link next} just claimed but that we won't process
    * because the worker was stopped mid-claim. Resets the row to PENDING so
-   * the next started worker can pick it up. `fixupJobs()` would otherwise
-   * skip it (it ignores rows owned by current-server worker IDs).
+   * the next started worker can pick it up. Lease expiry in `next()` would
+   * otherwise reclaim it after the lease expires.
    *
    * Uses `storage.releaseClaim()` rather than `storage.complete()` so the retry
    * budget isn't burned: the worker never actually attempted execution.
@@ -746,7 +748,7 @@ export class JobQueueWorker<
    * `completeJob` that won the race (the COMPLETED→FAILED overwrite bug).
    *
    * If the job is no longer in flight here, it has already settled — recheck
-   * storage and only write FAILED for non-terminal states (i.e. an ABORTING
+   * storage and only write FAILED for non-terminal states (i.e. a PROCESSING
    * row left over from a cross-process abort that this worker never picked up).
    */
   protected async handleAbort(jobId: unknown): Promise<void> {
@@ -787,10 +789,7 @@ export class JobQueueWorker<
     if (job.status === JobStatus.FAILED) {
       throw new PermanentJobError(`Job ${job.id} has failed`);
     }
-    if (
-      job.status === JobStatus.ABORTING ||
-      this.activeJobAbortControllers.get(job.id)?.signal.aborted
-    ) {
+    if (this.activeJobAbortControllers.get(job.id)?.signal.aborted) {
       throw new AbortSignalJobError(`Job ${job.id} is being aborted`);
     }
     if (job.deadlineAt && job.deadlineAt < new Date()) {

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -768,10 +768,22 @@ export class JobQueueWorker<
       job.error = null;
       job.errorCode = null;
 
+      // H2 atomic ack: hand the result directly to claim.ack() so result +
+      // COMPLETED status land in a single storage write. If we crash here
+      // — anywhere between this call site and the storage layer's commit —
+      // the row stays PROCESSING, the lease expires, the next worker
+      // reclaims it, and no `job_complete` is ever emitted. Before this
+      // change we issued `saveResult` then `ack`: a crash between the two
+      // left a PROCESSING row with the output already written, no
+      // `job_complete`, and a redelivery that overwrote the previously-
+      // saved output.
       const claim = this.getClaim(job.id);
-      await this.jobStore.saveResult(job.id, (output ?? null) as Output);
       if (claim) {
-        await claim.ack();
+        await claim.ack(output ?? null);
+      } else {
+        // No active claim (rare path — e.g. abort beat us to it). Fall back
+        // to the legacy two-step so the result is still persisted.
+        await this.jobStore.saveResult(job.id, (output ?? null) as Output);
       }
       this.events.emit("job_complete", job.id, output as Output);
     } catch (err) {
@@ -794,10 +806,30 @@ export class JobQueueWorker<
       job.error = error.message;
       job.errorCode = error?.constructor?.name ?? null;
 
+      // H2 atomic fail: hand error/errorCode/abortRequested directly to
+      // claim.fail() so they land in a single storage write together with
+      // status=FAILED. Eliminates the saveError-then-fail two-write window
+      // where a crash could leave the row PROCESSING with an `error`
+      // already written.
+      const abortRequested = error instanceof AbortSignalJobError;
       const claim = this.getClaim(job.id);
-      await this.jobStore.saveError(job.id, error.message, error.constructor.name ?? null, false);
       if (claim) {
-        await claim.fail();
+        await claim.fail({
+          error: error.message,
+          errorCode: error.constructor.name ?? null,
+          abortRequested,
+        });
+      } else {
+        // Fallback — no active claim (e.g. lease lost or abort path). The
+        // legacy two-step is still correct here because we're writing
+        // straight to the job store; the atomicity loss only matters when
+        // ack/fail and the result write are split across claim and store.
+        await this.jobStore.saveError(
+          job.id,
+          error.message,
+          error.constructor.name ?? null,
+          abortRequested
+        );
       }
       this.events.emit("job_error", job.id, error.message, error.constructor.name);
     } catch (err) {

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -622,15 +622,9 @@ export class JobQueueWorker<
       try {
         await this.validateJobState(job);
       } catch (validationErr) {
-        // Validation failed before we ran any actual work — release THIS
-        // limiter slot (by token, not by recency) so it doesn't count toward
-        // the rate limit and we don't accidentally release another worker's
-        // slot.
-        try {
-          await this.limiter.release(limiterToken);
-        } catch {
-          // best-effort
-        }
+        // Throw — the outer finally block's limiter.complete() will release
+        // the slot. Do NOT call limiter.release() here too; that would
+        // double-decrement the counter and admit one extra concurrent job.
         throw validationErr;
       }
 
@@ -680,7 +674,7 @@ export class JobQueueWorker<
         if (currentJob.attempts + 1 >= currentJob.maxAttempts) {
           spanErrorMessage = "Max attempts reached";
           // Forward to dead-letter queue before marking as failed
-          if (this.deadLetter && this.deadLetter !== "discard") {
+          if (this.deadLetter !== "discard") {
             try {
               await this.deadLetter.send({
                 original: currentJob.input,
@@ -756,7 +750,7 @@ export class JobQueueWorker<
   }
 
   /** Internal — resolve the active claim for a job id, throw if missing. */
-  private requireClaim(jobId: unknown): IClaim<JobStorageFormat<Input, Output>> | undefined {
+  private getClaim(jobId: unknown): IClaim<JobStorageFormat<Input, Output>> | undefined {
     return this.activeClaims.get(jobId);
   }
 
@@ -774,7 +768,7 @@ export class JobQueueWorker<
       job.error = null;
       job.errorCode = null;
 
-      const claim = this.requireClaim(job.id);
+      const claim = this.getClaim(job.id);
       await this.jobStore.saveResult(job.id, (output ?? null) as Output);
       if (claim) {
         await claim.ack();
@@ -800,7 +794,7 @@ export class JobQueueWorker<
       job.error = error.message;
       job.errorCode = error?.constructor?.name ?? null;
 
-      const claim = this.requireClaim(job.id);
+      const claim = this.getClaim(job.id);
       await this.jobStore.saveError(job.id, error.message, error.constructor.name ?? null, false);
       if (claim) {
         await claim.fail();
@@ -824,21 +818,14 @@ export class JobQueueWorker<
       job.progressMessage = "";
       job.progressDetails = null;
 
-      // DISABLED isn't first-class on IClaim. Use the legacy escape hatch on
-      // the underlying record by re-reading and writing through the jobStore
-      // helpers we have, then settle the claim via fail() so the lease/owner
-      // are released. Status is then re-flipped to DISABLED in a follow-up
-      // saveError-like write below.
-      const existing = await this.jobStore.get(job.id);
-      const claim = this.requireClaim(job.id);
+      // IClaim has no "disable" terminal. Release the lease via fail() (writes
+      // FAILED), then immediately overwrite status to DISABLED via saveStatus()
+      // so storage reflects the correct terminal state.
+      const claim = this.getClaim(job.id);
       if (claim) {
         await claim.fail();
       }
-      if (existing) {
-        // Direct write would be ideal; lacking an IJobStore.saveStatus we
-        // re-fetch and emit a logger note. JobQueueServer downstream tracks
-        // DISABLED via stats from the event.
-      }
+      await this.jobStore.saveStatus(job.id, JobStatus.DISABLED);
       this.events.emit("job_disabled", job.id);
     } catch (err) {
       getLogger().error("disableJob errored:", { error: err });
@@ -888,8 +875,8 @@ export class JobQueueWorker<
       // The storage layer will read from DB and increment, so this keeps them aligned
       job.attempts = (job.attempts ?? 0) + 1;
 
-      const claim = this.requireClaim(job.id);
-      const delaySeconds = Math.max(0, Math.floor((job.visibleAt.getTime() - Date.now()) / 1000));
+      const claim = this.getClaim(job.id);
+      const delaySeconds = Math.max(0, (job.visibleAt.getTime() - Date.now()) / 1000);
       if (claim) {
         await claim.retry({ delaySeconds });
       }

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -44,7 +44,7 @@ export type JobQueueWorkerEventListeners<Input, Output> = {
   job_complete: (jobId: unknown, output: Output) => void;
   job_error: (jobId: unknown, error: string, errorCode?: string) => void;
   job_disabled: (jobId: unknown) => void;
-  job_retry: (jobId: unknown, runAfter: Date) => void;
+  job_retry: (jobId: unknown, visibleAt: Date) => void;
   job_progress: (
     jobId: unknown,
     progress: number,
@@ -427,15 +427,15 @@ export class JobQueueWorker<
   /**
    * Determine how long to sleep when idle.
    *
-   * Peeks at the earliest PENDING job: if it has a future `run_after`,
+   * Peeks at the earliest PENDING job: if it has a future `visible_at`,
    * returns the time until it becomes ready (clamped to `pollIntervalMs`);
    * otherwise returns `pollIntervalMs`.
    */
   private async getIdleDelay(): Promise<number> {
     try {
       const pending = await this.storage.peek(JobStatus.PENDING, 1);
-      if (pending.length > 0 && pending[0].run_after) {
-        const delay = new Date(pending[0].run_after).getTime() - Date.now();
+      if (pending.length > 0 && pending[0].visible_at) {
+        const delay = new Date(pending[0].visible_at).getTime() - Date.now();
         if (delay > 0) {
           return Math.min(delay, this.pollIntervalMs);
         }
@@ -514,9 +514,9 @@ export class JobQueueWorker<
           attributes: {
             "workglow.job.id": String(job.id),
             "workglow.job.queue": this.queueName,
-            "workglow.job.worker_id": this.workerId,
-            "workglow.job.run_attempt": job.runAttempts,
-            "workglow.job.max_retries": job.maxRetries,
+            "workglow.job.lease_owner": this.workerId,
+            "workglow.job.attempt": job.attempts,
+            "workglow.job.max_attempts": job.maxAttempts,
           },
         })
       : undefined;
@@ -581,8 +581,8 @@ export class JobQueueWorker<
           throw new JobNotFoundError(`Job ${job.id} not found`);
         }
 
-        if (currentJob.runAttempts >= currentJob.maxRetries) {
-          spanErrorMessage = "Max retries reached";
+        if (currentJob.attempts + 1 >= currentJob.maxAttempts) {
+          spanErrorMessage = "Max attempts reached";
           await this.failJob(currentJob, new PermanentJobError(spanErrorMessage));
           span?.setStatus(SpanStatusCode.ERROR, spanErrorMessage);
         } else {
@@ -592,7 +592,7 @@ export class JobQueueWorker<
           this.cleanupJob(job.id);
           await this.rescheduleJob(currentJob, error.retryDate);
           span?.addEvent("workglow.job.retry", {
-            "workglow.job.run_attempt": currentJob.runAttempts,
+            "workglow.job.attempt": currentJob.attempts,
           });
           span?.setStatus(SpanStatusCode.UNSET);
         }
@@ -733,16 +733,16 @@ export class JobQueueWorker<
     try {
       job.status = JobStatus.PENDING;
       const nextAvailableTime = await this.limiter.getNextAvailableTime();
-      job.runAfter = retryDate instanceof Date ? retryDate : nextAvailableTime;
+      job.visibleAt = retryDate instanceof Date ? retryDate : nextAvailableTime;
       job.progress = 0;
       job.progressMessage = "";
       job.progressDetails = null;
-      // Increment runAttempts to keep in-memory object in sync with storage
+      // Increment attempts to keep in-memory object in sync with storage
       // The storage layer will read from DB and increment, so this keeps them aligned
-      job.runAttempts = (job.runAttempts ?? 0) + 1;
+      job.attempts = (job.attempts ?? 0) + 1;
 
       await this.storage.complete(this.classToStorage(job));
-      this.events.emit("job_retry", job.id, job.runAfter);
+      this.events.emit("job_retry", job.id, job.visibleAt);
     } catch (err) {
       getLogger().error("rescheduleJob errored:", { error: err });
     }

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -20,6 +20,7 @@ import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type { IQueueStorage, JobStorageFormat } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
 import { wrapQueueStorage } from "../queue-storage/wrapQueueStorage";
+import type { DeadLetter } from "./DeadLetter";
 import { Job, JobClass } from "./Job";
 import {
   AbortSignalJobError,
@@ -98,6 +99,18 @@ export interface JobQueueWorkerOptions<Input, Output> {
    * Defaults to max(30_000, pollIntervalMs * 60).
    */
   readonly leaseMs?: number;
+  /**
+   * Dead-letter queue to forward exhausted jobs to, or "discard" to drop them.
+   * Default: "discard".
+   */
+  readonly deadLetter?: IMessageQueue<DeadLetter<Input>> | "discard";
+  /**
+   * Number of claims to fetch per loop iteration. Default: 1.
+   * With prefetch > 1, claims that cannot immediately acquire a limiter slot
+   * are released back to PENDING via retry, so concurrency is still governed
+   * by the limiter.
+   */
+  readonly prefetch?: number;
 }
 
 /**
@@ -120,6 +133,8 @@ export class JobQueueWorker<
   protected readonly extendLeaseWhileRunning: boolean;
   protected readonly leaseMs: number;
   protected readonly events = new EventEmitter<JobQueueWorkerEventListeners<Input, Output>>();
+  protected readonly deadLetter: IMessageQueue<DeadLetter<Input>> | "discard";
+  protected readonly prefetch: number;
 
   protected running = false;
 
@@ -195,6 +210,8 @@ export class JobQueueWorker<
     this.stopTimeoutMs = options.stopTimeoutMs ?? 30_000;
     this.extendLeaseWhileRunning = options.extendLeaseWhileRunning ?? false;
     this.leaseMs = options.leaseMs ?? Math.max(30_000, this.pollIntervalMs * 60);
+    this.deadLetter = options.deadLetter ?? "discard";
+    this.prefetch = Math.max(1, options.prefetch ?? 1);
   }
 
   /**
@@ -354,7 +371,8 @@ export class JobQueueWorker<
   // ========================================================================
 
   /**
-   * Get the next job from the queue
+   * Get the next job from the queue (always fetches a single claim).
+   * Used by {@link processNext} and the single-claim path of {@link processJobs}.
    */
   protected async next(): Promise<QueueJob | undefined> {
     const claims = await this.messageQueue.receive({
@@ -369,6 +387,27 @@ export class JobQueueWorker<
       this.activeClaims.set(job.id, claim);
     }
     return job;
+  }
+
+  /**
+   * Fetch up to `this.prefetch` claims from the queue and register them in
+   * {@link activeClaims}. Returns an array of jobs ready to be dispatched.
+   */
+  private async nextBatch(): Promise<QueueJob[]> {
+    const claims = await this.messageQueue.receive({
+      workerId: this.workerId,
+      leaseMs: this.leaseMs,
+      max: this.prefetch,
+    });
+    const jobs: QueueJob[] = [];
+    for (const claim of claims) {
+      const job = this.storageToClass(claim.body) as QueueJob;
+      if (job.id != null) {
+        this.activeClaims.set(job.id, claim);
+      }
+      jobs.push(job);
+    }
+    return jobs;
   }
 
   /**
@@ -396,8 +435,13 @@ export class JobQueueWorker<
         // overshooting the configured limit by exactly the worker concurrency.
         // The atomic tryAcquire guarantees only one of N concurrent acquirers
         // succeeds when there's one slot left.
-        const job = await this.next();
-        if (!job) {
+        //
+        // With prefetch > 1, we claim up to `prefetch` jobs at once and do a
+        // non-blocking tryAcquire for each. Jobs that can't immediately get a
+        // limiter slot are released back to PENDING so other workers can pick
+        // them up. With prefetch == 1 the behavior is identical to before.
+        const jobs = await this.nextBatch();
+        if (jobs.length === 0) {
           // Queue is empty — sleep until notified of new work or until the
           // next deferred job becomes ready.
           const delay = await this.getIdleDelay();
@@ -405,38 +449,50 @@ export class JobQueueWorker<
           continue;
         }
 
-        if (!this.running) {
-          // Stopped during the await. Release the job back to PENDING.
-          await this.releaseClaimedJob(job);
-          return;
-        }
+        let anyDispatched = false;
+        let limiterFull = false;
 
-        const limiterToken = await this.limiter.tryAcquire();
-        if (limiterToken === null || limiterToken === undefined) {
-          // Lost the race for the last slot, or hit the rate-limit window.
-          // Give the job back and wait for capacity.
-          await this.releaseClaimedJob(job);
-          await this.waitForWakeOrTimeout(await this.getLimiterWakeDelay());
-          continue;
-        }
-
-        if (!this.running) {
-          // Stop fired while tryAcquire was in flight. Undo both the limiter
-          // reservation (release THIS token, not "the most recent") and the
-          // job claim so we don't start processing on a worker that's about
-          // to exit.
-          try {
-            await this.limiter.release(limiterToken);
-          } catch {
-            // best-effort
+        for (const job of jobs) {
+          if (!this.running) {
+            // Stopped during the batch. Release all remaining jobs back to PENDING.
+            await this.releaseClaimedJob(job);
+            continue;
           }
-          await this.releaseClaimedJob(job);
+
+          const limiterToken = await this.limiter.tryAcquire();
+          if (limiterToken === null || limiterToken === undefined) {
+            // No limiter slot available — release the claim back so another
+            // worker (or this one on a later iteration) can pick it up.
+            await this.releaseClaimedJob(job);
+            limiterFull = true;
+            continue;
+          }
+
+          if (!this.running) {
+            // Stop fired while tryAcquire was in flight.
+            try {
+              await this.limiter.release(limiterToken);
+            } catch {
+              // best-effort
+            }
+            await this.releaseClaimedJob(job);
+            continue;
+          }
+
+          // Don't await - process in background to allow concurrent jobs.
+          this.processSingleJob(job, limiterToken);
+          anyDispatched = true;
+        }
+
+        if (!this.running) {
           return;
         }
 
-        // Don't await - process in background to allow concurrent jobs.
-        // The loop will claim+acquire on the next iteration.
-        this.processSingleJob(job, limiterToken);
+        // If the limiter was full for every claim we fetched, back off before
+        // retrying so we don't busy-loop hammering the queue.
+        if (!anyDispatched && limiterFull) {
+          await this.waitForWakeOrTimeout(await this.getLimiterWakeDelay());
+        }
       } catch {
         // Don't let transient errors kill the loop
         await sleep(this.pollIntervalMs);
@@ -623,13 +679,28 @@ export class JobQueueWorker<
 
         if (currentJob.attempts + 1 >= currentJob.maxAttempts) {
           spanErrorMessage = "Max attempts reached";
+          // Forward to dead-letter queue before marking as failed
+          if (this.deadLetter && this.deadLetter !== "discard") {
+            try {
+              await this.deadLetter.send({
+                original: currentJob.input,
+                error: error.message,
+                errorCode: error.constructor.name ?? null,
+                attempts: currentJob.attempts,
+                queueName: this.queueName,
+                jobRunId: currentJob.jobRunId,
+              });
+            } catch (dlqErr) {
+              getLogger().error("Dead-letter queue send failed:", { error: dlqErr });
+            }
+          }
           await this.failJob(currentJob, new PermanentJobError(spanErrorMessage));
           span?.setStatus(SpanStatusCode.ERROR, spanErrorMessage);
         } else {
-          // Clean up the abort controller before rescheduling so the next
-          // invocation of processSingleJob gets a fresh controller and the
-          // inFlight-guard in createAbortController passes correctly.
-          this.cleanupJob(job.id);
+          // Only delete the abort controller (not the claim) so rescheduleJob
+          // can still call claim.retry(). rescheduleJob's finally block drops
+          // the claim from activeClaims after it has been settled.
+          this.activeJobAbortControllers.delete(job.id);
           await this.rescheduleJob(currentJob, error.retryDate);
           span?.addEvent("workglow.job.retry", {
             "workglow.job.attempt": currentJob.attempts,

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -14,8 +14,12 @@ import {
 } from "@workglow/util";
 import { ILimiter } from "../limiter/ILimiter";
 import { NullLimiter } from "../limiter/NullLimiter";
+import type { IClaim } from "../queue-storage/IClaim";
+import type { IJobStore } from "../queue-storage/IJobStore";
+import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type { IQueueStorage, JobStorageFormat } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
+import { wrapQueueStorage } from "../queue-storage/wrapQueueStorage";
 import { Job, JobClass } from "./Job";
 import {
   AbortSignalJobError,
@@ -61,7 +65,14 @@ export type JobQueueWorkerEvents = keyof JobQueueWorkerEventListeners<unknown, u
  * Options for creating a JobQueueWorker
  */
 export interface JobQueueWorkerOptions<Input, Output> {
-  readonly storage: IQueueStorage<Input, Output>;
+  /**
+   * Legacy single-storage option. Provide either `storage` OR the paired
+   * `messageQueue`+`jobStore`. When `storage` is given it is wrapped via
+   * {@link wrapQueueStorage} internally.
+   */
+  readonly storage?: IQueueStorage<Input, Output>;
+  readonly messageQueue?: IMessageQueue<JobStorageFormat<Input, Output>>;
+  readonly jobStore?: IJobStore<Input, Output>;
   readonly queueName: string;
   readonly limiter?: ILimiter;
   readonly pollIntervalMs?: number;
@@ -100,7 +111,8 @@ export class JobQueueWorker<
 > {
   public readonly queueName: string;
   public readonly workerId: string;
-  protected readonly storage: IQueueStorage<Input, Output>;
+  protected readonly messageQueue: IMessageQueue<JobStorageFormat<Input, Output>>;
+  protected readonly jobStore: IJobStore<Input, Output>;
   protected readonly jobClass: JobClass<Input, Output>;
   protected readonly limiter: ILimiter;
   protected readonly pollIntervalMs: number;
@@ -117,6 +129,12 @@ export class JobQueueWorker<
    * (complete / fail / retry / abort).
    */
   private readonly inFlight: Map<unknown, Promise<void>> = new Map();
+
+  /**
+   * Active claims for jobs currently being processed. Used to drive
+   * ack/retry/fail/extendLease in completion paths.
+   */
+  private readonly activeClaims: Map<unknown, IClaim<JobStorageFormat<Input, Output>>> = new Map();
 
   /**
    * Resolve function for the idle wait promise.
@@ -159,7 +177,18 @@ export class JobQueueWorker<
   constructor(jobClass: JobClass<Input, Output>, options: JobQueueWorkerOptions<Input, Output>) {
     this.queueName = options.queueName;
     this.workerId = options.workerId ?? uuid4();
-    this.storage = options.storage;
+    if (options.messageQueue && options.jobStore) {
+      this.messageQueue = options.messageQueue;
+      this.jobStore = options.jobStore;
+    } else if (options.storage) {
+      const wrapped = wrapQueueStorage(options.storage);
+      this.messageQueue = wrapped.messageQueue;
+      this.jobStore = wrapped.jobStore;
+    } else {
+      throw new Error(
+        "JobQueueWorker requires either `storage` or both `messageQueue` and `jobStore`"
+      );
+    }
     this.jobClass = jobClass;
     this.limiter = options.limiter ?? new NullLimiter();
     this.pollIntervalMs = options.pollIntervalMs ?? 100;
@@ -328,9 +357,18 @@ export class JobQueueWorker<
    * Get the next job from the queue
    */
   protected async next(): Promise<QueueJob | undefined> {
-    const job = await this.storage.next(this.workerId, { leaseMs: this.leaseMs });
-    if (!job) return undefined;
-    return this.storageToClass(job) as QueueJob;
+    const claims = await this.messageQueue.receive({
+      workerId: this.workerId,
+      leaseMs: this.leaseMs,
+      max: 1,
+    });
+    const claim = claims[0];
+    if (!claim) return undefined;
+    const job = this.storageToClass(claim.body) as QueueJob;
+    if (job.id != null) {
+      this.activeClaims.set(job.id, claim);
+    }
+    return job;
   }
 
   /**
@@ -433,7 +471,7 @@ export class JobQueueWorker<
    */
   private async getIdleDelay(): Promise<number> {
     try {
-      const pending = await this.storage.peek(JobStatus.PENDING, 1);
+      const pending = await this.jobStore.peek(JobStatus.PENDING, 1);
       if (pending.length > 0 && pending[0].visible_at) {
         const delay = new Date(pending[0].visible_at).getTime() - Date.now();
         if (delay > 0) {
@@ -484,7 +522,7 @@ export class JobQueueWorker<
     if (this.activeJobAbortControllers.size === 0) {
       return;
     }
-    const processingJobs = await this.storage.peek(JobStatus.PROCESSING);
+    const processingJobs = await this.jobStore.peek(JobStatus.PROCESSING);
     for (const jobData of processingJobs) {
       if (!jobData.abort_requested_at) continue;
       const controller = this.activeJobAbortControllers.get(jobData.id);
@@ -546,7 +584,9 @@ export class JobQueueWorker<
       let leaseInterval: ReturnType<typeof setInterval> | undefined;
       if (this.extendLeaseWhileRunning) {
         leaseInterval = setInterval(() => {
-          this.storage.extendLease(job.id, this.workerId, this.leaseMs).catch((err) => {
+          const claim = this.activeClaims.get(job.id);
+          if (!claim) return;
+          claim.extendLease(this.leaseMs).catch((err) => {
             getLogger().error("extendLease failed during job execution:", {
               error: err,
               jobId: job.id,
@@ -644,6 +684,11 @@ export class JobQueueWorker<
     this.events.emit("job_progress", jobId, progress, message, details);
   }
 
+  /** Internal — resolve the active claim for a job id, throw if missing. */
+  private requireClaim(jobId: unknown): IClaim<JobStorageFormat<Input, Output>> | undefined {
+    return this.activeClaims.get(jobId);
+  }
+
   /**
    * Mark a job as completed
    */
@@ -658,7 +703,11 @@ export class JobQueueWorker<
       job.error = null;
       job.errorCode = null;
 
-      await this.storage.complete(this.classToStorage(job));
+      const claim = this.requireClaim(job.id);
+      await this.jobStore.saveResult(job.id, (output ?? null) as Output);
+      if (claim) {
+        await claim.ack();
+      }
       this.events.emit("job_complete", job.id, output as Output);
     } catch (err) {
       getLogger().error("completeJob errored:", { error: err });
@@ -680,7 +729,11 @@ export class JobQueueWorker<
       job.error = error.message;
       job.errorCode = error?.constructor?.name ?? null;
 
-      await this.storage.complete(this.classToStorage(job));
+      const claim = this.requireClaim(job.id);
+      await this.jobStore.saveError(job.id, error.message, error.constructor.name ?? null, false);
+      if (claim) {
+        await claim.fail();
+      }
       this.events.emit("job_error", job.id, error.message, error.constructor.name);
     } catch (err) {
       getLogger().error("failJob errored:", { error: err });
@@ -700,7 +753,21 @@ export class JobQueueWorker<
       job.progressMessage = "";
       job.progressDetails = null;
 
-      await this.storage.complete(this.classToStorage(job));
+      // DISABLED isn't first-class on IClaim. Use the legacy escape hatch on
+      // the underlying record by re-reading and writing through the jobStore
+      // helpers we have, then settle the claim via fail() so the lease/owner
+      // are released. Status is then re-flipped to DISABLED in a follow-up
+      // saveError-like write below.
+      const existing = await this.jobStore.get(job.id);
+      const claim = this.requireClaim(job.id);
+      if (claim) {
+        await claim.fail();
+      }
+      if (existing) {
+        // Direct write would be ideal; lacking an IJobStore.saveStatus we
+        // re-fetch and emit a logger note. JobQueueServer downstream tracks
+        // DISABLED via stats from the event.
+      }
       this.events.emit("job_disabled", job.id);
     } catch (err) {
       getLogger().error("disableJob errored:", { error: err });
@@ -720,9 +787,18 @@ export class JobQueueWorker<
    */
   protected async releaseClaimedJob(job: Job<Input, Output>): Promise<void> {
     try {
-      await this.storage.releaseClaim(job.id);
+      // Prefer driving the claim's release path so any per-claim cleanup
+      // (e.g. transient buffers) is consistent with regular settlement.
+      const claim = this.activeClaims.get(job.id);
+      if (claim) {
+        await this.messageQueue.releaseClaim(claim.id);
+      } else {
+        await this.messageQueue.releaseClaim(job.id);
+      }
     } catch (err) {
       getLogger().error("releaseClaimedJob errored:", { error: err });
+    } finally {
+      this.activeClaims.delete(job.id);
     }
   }
 
@@ -741,10 +817,19 @@ export class JobQueueWorker<
       // The storage layer will read from DB and increment, so this keeps them aligned
       job.attempts = (job.attempts ?? 0) + 1;
 
-      await this.storage.complete(this.classToStorage(job));
+      const claim = this.requireClaim(job.id);
+      const delaySeconds = Math.max(0, Math.floor((job.visibleAt.getTime() - Date.now()) / 1000));
+      if (claim) {
+        await claim.retry({ delaySeconds });
+      }
       this.events.emit("job_retry", job.id, job.visibleAt);
     } catch (err) {
       getLogger().error("rescheduleJob errored:", { error: err });
+    } finally {
+      // rescheduleJob is called from the catch branch in processSingleJob,
+      // which already calls cleanupJob via this method's path; ensure the
+      // claim ref is dropped too.
+      this.activeClaims.delete(job.id);
     }
   }
 
@@ -818,7 +903,7 @@ export class JobQueueWorker<
    * Get a job by ID
    */
   protected async getJob(id: unknown): Promise<Job<Input, Output> | undefined> {
-    const job = await this.storage.get(id);
+    const job = await this.jobStore.get(id);
     if (!job) return undefined;
     return this.storageToClass(job);
   }
@@ -862,6 +947,7 @@ export class JobQueueWorker<
    */
   protected cleanupJob(jobId: unknown): void {
     this.activeJobAbortControllers.delete(jobId);
+    this.activeClaims.delete(jobId);
   }
 
   /**

--- a/packages/job-queue/src/job/JobStorageConverters.ts
+++ b/packages/job-queue/src/job/JobStorageConverters.ts
@@ -32,11 +32,12 @@ export function storageToClass<Input, Output>(
   details: JobStorageFormat<Input, Output>,
   jobClass: JobClass<Input, Output>,
   options?: {
-    /** @deprecated renamed to includeLeaseOwner; both names accepted */
+    /** @deprecated use includeLeaseOwner instead */
     readonly includeWorkerId?: boolean;
+    readonly includeLeaseOwner?: boolean;
   }
 ): Job<Input, Output> {
-  const includeLeaseOwner = options?.includeWorkerId ?? true;
+  const includeLeaseOwner = options?.includeLeaseOwner ?? options?.includeWorkerId ?? true;
   return new jobClass({
     id: details.id,
     jobRunId: details.job_run_id,

--- a/packages/job-queue/src/job/JobStorageConverters.ts
+++ b/packages/job-queue/src/job/JobStorageConverters.ts
@@ -57,6 +57,8 @@ export function storageToClass<Input, Output>(
     runAttempts: details.run_attempts ?? 0,
     maxRetries: details.max_retries ?? 10,
     ...(includeWorkerId ? { workerId: details.worker_id ?? null } : {}),
+    abort_requested_at: details.abort_requested_at ?? null,
+    lease_expires_at: details.lease_expires_at ?? null,
   });
 }
 
@@ -89,5 +91,7 @@ export function classToStorage<Input, Output>(
     progress_message: job.progressMessage ?? "",
     progress_details: job.progressDetails ?? null,
     worker_id: job.workerId ?? null,
+    abort_requested_at: job.abort_requested_at ?? null,
+    lease_expires_at: job.lease_expires_at ?? null,
   };
 }

--- a/packages/job-queue/src/job/JobStorageConverters.ts
+++ b/packages/job-queue/src/job/JobStorageConverters.ts
@@ -32,10 +32,11 @@ export function storageToClass<Input, Output>(
   details: JobStorageFormat<Input, Output>,
   jobClass: JobClass<Input, Output>,
   options?: {
+    /** @deprecated renamed to includeLeaseOwner; both names accepted */
     readonly includeWorkerId?: boolean;
   }
 ): Job<Input, Output> {
-  const includeWorkerId = options?.includeWorkerId ?? true;
+  const includeLeaseOwner = options?.includeWorkerId ?? true;
   return new jobClass({
     id: details.id,
     jobRunId: details.job_run_id,
@@ -43,10 +44,10 @@ export function storageToClass<Input, Output>(
     fingerprint: details.fingerprint,
     input: details.input as Input,
     output: details.output as Output,
-    runAfter: toDate(details.run_after),
+    visibleAt: toDate(details.visible_at),
     createdAt: toDate(details.created_at)!,
     deadlineAt: toDate(details.deadline_at),
-    lastRanAt: toDate(details.last_ran_at),
+    lastAttemptedAt: toDate(details.last_attempted_at),
     completedAt: toDate(details.completed_at),
     progress: details.progress || 0,
     progressMessage: details.progress_message || "",
@@ -54,9 +55,9 @@ export function storageToClass<Input, Output>(
     status: details.status as JobStatus,
     error: details.error ?? null,
     errorCode: details.error_code ?? null,
-    runAttempts: details.run_attempts ?? 0,
-    maxRetries: details.max_retries ?? 10,
-    ...(includeWorkerId ? { workerId: details.worker_id ?? null } : {}),
+    attempts: details.attempts ?? 0,
+    maxAttempts: details.max_attempts ?? 10,
+    ...(includeLeaseOwner ? { leaseOwner: details.lease_owner ?? null } : {}),
     abort_requested_at: details.abort_requested_at ?? null,
     lease_expires_at: details.lease_expires_at ?? null,
   });
@@ -80,17 +81,17 @@ export function classToStorage<Input, Output>(
     output: job.output ?? null,
     error: job.error === null ? null : String(job.error),
     error_code: job.errorCode || null,
-    run_attempts: job.runAttempts ?? 0,
-    max_retries: job.maxRetries ?? 10,
-    run_after: dateToISOString(job.runAfter) ?? now,
+    attempts: job.attempts ?? 0,
+    max_attempts: job.maxAttempts ?? 10,
+    visible_at: dateToISOString(job.visibleAt) ?? now,
     created_at: dateToISOString(job.createdAt) ?? now,
     deadline_at: dateToISOString(job.deadlineAt),
-    last_ran_at: dateToISOString(job.lastRanAt),
+    last_attempted_at: dateToISOString(job.lastAttemptedAt),
     completed_at: dateToISOString(job.completedAt),
     progress: job.progress ?? 0,
     progress_message: job.progressMessage ?? "",
     progress_details: job.progressDetails ?? null,
-    worker_id: job.workerId ?? null,
+    lease_owner: job.leaseOwner ?? null,
     abort_requested_at: job.abort_requested_at ?? null,
     lease_expires_at: job.lease_expires_at ?? null,
   };

--- a/packages/job-queue/src/job/MessageQueueClient.ts
+++ b/packages/job-queue/src/job/MessageQueueClient.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMessageQueue, MessageId, SendOptions } from "../queue-storage/IMessageQueue";
+
+/**
+ * Thin producer-only client over an {@link IMessageQueue}. Use for
+ * fire-and-forget message production where you don't need the {@link Job}
+ * lifecycle abstractions in {@link JobQueueClient}.
+ */
+export class MessageQueueClient<Body> {
+  private readonly messageQueue: IMessageQueue<Body>;
+
+  constructor(opts: { readonly messageQueue: IMessageQueue<Body> }) {
+    this.messageQueue = opts.messageQueue;
+  }
+
+  async send(body: Body, opts?: SendOptions): Promise<MessageId> {
+    return this.messageQueue.send(body, opts);
+  }
+
+  async sendBatch(bodies: readonly Body[], opts?: SendOptions): Promise<readonly MessageId[]> {
+    return this.messageQueue.sendBatch(bodies, opts);
+  }
+}

--- a/packages/job-queue/src/limiter/CompositeLimiter.ts
+++ b/packages/job-queue/src/limiter/CompositeLimiter.ts
@@ -27,15 +27,6 @@ export class CompositeLimiter implements ILimiter {
     this.limiters.push(limiter);
   }
 
-  async canProceed(): Promise<boolean> {
-    for (const limiter of this.limiters) {
-      if (!(await limiter.canProceed())) {
-        return false; // If any limiter says "no", proceed no further
-      }
-    }
-    return true; // All limiters agree
-  }
-
   /**
    * Atomic against the composite: acquires children sequentially and rolls
    * back any successfully-acquired prefix if a later child rejects, so the
@@ -69,14 +60,6 @@ export class CompositeLimiter implements ILimiter {
   async release(token: unknown): Promise<void> {
     if (!Array.isArray(token)) return;
     await Promise.all(this.limiters.map((l, i) => l.release(token[i]).catch(() => {})));
-  }
-
-  async recordJobStart(): Promise<void> {
-    await Promise.all(this.limiters.map((limiter) => limiter.recordJobStart()));
-  }
-
-  async recordJobCompletion(): Promise<void> {
-    await Promise.all(this.limiters.map((limiter) => limiter.recordJobCompletion()));
   }
 
   async getNextAvailableTime(): Promise<Date> {

--- a/packages/job-queue/src/limiter/CompositeLimiter.ts
+++ b/packages/job-queue/src/limiter/CompositeLimiter.ts
@@ -62,6 +62,11 @@ export class CompositeLimiter implements ILimiter {
     await Promise.all(this.limiters.map((l, i) => l.release(token[i]).catch(() => {})));
   }
 
+  async complete(token: unknown): Promise<void> {
+    if (!Array.isArray(token)) return;
+    await Promise.all(this.limiters.map((l, i) => l.complete(token[i]).catch(() => {})));
+  }
+
   async getNextAvailableTime(): Promise<Date> {
     let maxDate = new Date(); // Assume now as the default
     for (const limiter of this.limiters) {

--- a/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
+++ b/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
@@ -46,6 +46,10 @@ export class ConcurrencyLimiter implements ILimiter {
     this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
   }
 
+  async complete(_token: unknown): Promise<void> {
+    this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
+  }
+
   async getNextAvailableTime(): Promise<Date> {
     return this.currentRunningJobs > this.maxConcurrentJobs ? new Date() : new Date(Date.now() - 1);
   }

--- a/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
+++ b/packages/job-queue/src/limiter/ConcurrencyLimiter.ts
@@ -23,13 +23,6 @@ export class ConcurrencyLimiter implements ILimiter {
     this.maxConcurrentJobs = maxConcurrentJobs;
   }
 
-  async canProceed(): Promise<boolean> {
-    return (
-      this.currentRunningJobs < this.maxConcurrentJobs &&
-      Date.now() >= this.nextAllowedStartTime.getTime()
-    );
-  }
-
   /** Sentinel token; ConcurrencyLimiter has no per-row identity, just a counter. */
   private static readonly SENTINEL = Symbol("ConcurrencyLimiter.acquired");
 
@@ -50,14 +43,6 @@ export class ConcurrencyLimiter implements ILimiter {
 
   async release(token: unknown): Promise<void> {
     if (token !== ConcurrencyLimiter.SENTINEL) return;
-    this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
-  }
-
-  async recordJobStart(): Promise<void> {
-    this.currentRunningJobs++;
-  }
-
-  async recordJobCompletion(): Promise<void> {
     this.currentRunningJobs = Math.max(0, this.currentRunningJobs - 1);
   }
 

--- a/packages/job-queue/src/limiter/DelayLimiter.ts
+++ b/packages/job-queue/src/limiter/DelayLimiter.ts
@@ -39,6 +39,10 @@ export class DelayLimiter implements ILimiter {
     }
   }
 
+  async complete(_token: unknown): Promise<void> {
+    // No-op — the delay window reservation must persist until the window expires.
+  }
+
   async getNextAvailableTime(): Promise<Date> {
     return this.nextAvailableTime;
   }

--- a/packages/job-queue/src/limiter/DelayLimiter.ts
+++ b/packages/job-queue/src/limiter/DelayLimiter.ts
@@ -14,10 +14,6 @@ export class DelayLimiter implements ILimiter {
   private lastAcquireBaseline: number = 0;
   constructor(private delayInMilliseconds: number = 50) {}
 
-  async canProceed(): Promise<boolean> {
-    return Date.now() >= this.nextAvailableTime.getTime();
-  }
-
   /**
    * Token records the previous nextAvailableTime so release can roll back to
    * exactly the state before this acquire — even if other acquires (or
@@ -41,14 +37,6 @@ export class DelayLimiter implements ILimiter {
     if (this.nextAvailableTime.getTime() === this.lastAcquireBaseline + this.delayInMilliseconds) {
       this.nextAvailableTime = new Date(token);
     }
-  }
-
-  async recordJobStart(): Promise<void> {
-    this.nextAvailableTime = new Date(Date.now() + this.delayInMilliseconds);
-  }
-
-  async recordJobCompletion(): Promise<void> {
-    // No action needed.
   }
 
   async getNextAvailableTime(): Promise<Date> {

--- a/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
+++ b/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
@@ -23,7 +23,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
   private readonly windowSizeMs: number;
   private readonly idealInterval: number;
   private nextAvailableTime: number = Date.now();
-  private lastStartTime: number = 0;
   private durations: number[] = [];
   /** Promise chain used to serialize concurrent {@link tryAcquire} callers. */
   private acquireChain: Promise<unknown> = Promise.resolve();
@@ -63,7 +62,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
       const priorNextAvailable = this.nextAvailableTime;
       // Reserve the slot by advancing nextAvailableTime now (recordJobStart-style)
       // so a follow-up tryAcquire from another caller in the same tick blocks.
-      this.lastStartTime = now;
       if (this.durations.length === 0) {
         this.nextAvailableTime = now + this.idealInterval;
       } else {
@@ -97,6 +95,13 @@ export class EvenlySpacedRateLimiter implements ILimiter {
     }
   }
 
+  /**
+   * No-op — rate window reservations must persist until the window expires.
+   */
+  async complete(_token: unknown): Promise<void> {
+    return Promise.resolve();
+  }
+
   async getNextAvailableTime(): Promise<Date> {
     return new Date(this.nextAvailableTime);
   }
@@ -111,6 +116,5 @@ export class EvenlySpacedRateLimiter implements ILimiter {
   async clear(): Promise<void> {
     this.durations = [];
     this.nextAvailableTime = Date.now();
-    this.lastStartTime = 0;
   }
 }

--- a/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
+++ b/packages/job-queue/src/limiter/EvenlySpacedRateLimiter.ts
@@ -41,12 +41,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
     this.idealInterval = this.windowSizeMs / this.maxExecutions;
   }
 
-  /** Can we start a new job right now? */
-  async canProceed(): Promise<boolean> {
-    const now = Date.now();
-    return now >= this.nextAvailableTime;
-  }
-
   /**
    * Atomic acquire: serialized by an internal promise chain so two concurrent
    * acquirers cannot both observe `now >= nextAvailableTime` and both proceed.
@@ -100,38 +94,6 @@ export class EvenlySpacedRateLimiter implements ILimiter {
     const t = token as { priorNextAvailable: number; advancedTo: number };
     if (this.nextAvailableTime === t.advancedTo) {
       this.nextAvailableTime = t.priorNextAvailable;
-    }
-  }
-
-  /** Record that a job is starting now. */
-  async recordJobStart(): Promise<void> {
-    const now = Date.now();
-    this.lastStartTime = now;
-
-    // If no timing data yet, assume zero run-time (ideal interval)
-    if (this.durations.length === 0) {
-      this.nextAvailableTime = now + this.idealInterval;
-    } else {
-      // Compute average run duration
-      const sum = this.durations.reduce((a, b) => a + b, 0);
-      const avgDuration = sum / this.durations.length;
-      // Schedule next start: ideal spacing minus average duration
-      const waitMs = Math.max(0, this.idealInterval - avgDuration);
-      this.nextAvailableTime = now + waitMs;
-    }
-  }
-
-  /**
-   * Call this when a job finishes.
-   * We measure its duration, update our running-average,
-   * and then compute how long to wait before the next job start.
-   */
-  async recordJobCompletion(): Promise<void> {
-    const now = Date.now();
-    const duration = now - this.lastStartTime;
-    this.durations.push(duration);
-    if (this.durations.length > this.maxExecutions) {
-      this.durations.shift();
     }
   }
 

--- a/packages/job-queue/src/limiter/ILimiter.ts
+++ b/packages/job-queue/src/limiter/ILimiter.ts
@@ -25,9 +25,8 @@ export type LimiterScope = "process" | "cluster";
  *
  * The atomic primitive is {@link tryAcquire}: it both checks whether a job may
  * proceed and reserves the slot in a single uninterruptible step. Callers
- * MUST use {@link tryAcquire}/{@link release} (not the legacy
- * {@link canProceed}/{@link recordJobStart} pair) when correctness matters
- * under concurrency.
+ * MUST use {@link tryAcquire}/{@link release} when correctness matters under
+ * concurrency.
  */
 export interface ILimiter {
   /**
@@ -62,21 +61,6 @@ export interface ILimiter {
    */
   release(token: unknown): Promise<void>;
 
-  /**
-   * Legacy non-binding "would tryAcquire succeed?" probe. SUBJECT TO RACES —
-   * do not use this followed by {@link recordJobStart} in production code; use
-   * {@link tryAcquire} instead. Retained for observability and tests.
-   */
-  canProceed(): Promise<boolean>;
-
-  /**
-   * Legacy "force-record an execution" hook. SUBJECT TO RACES when paired with
-   * {@link canProceed} — use {@link tryAcquire} instead. Retained for tests
-   * and external bookkeeping.
-   */
-  recordJobStart(): Promise<void>;
-
-  recordJobCompletion(): Promise<void>;
   getNextAvailableTime(): Promise<Date>;
   setNextAvailableTime(date: Date): Promise<void>;
   clear(): Promise<void>;

--- a/packages/job-queue/src/limiter/ILimiter.ts
+++ b/packages/job-queue/src/limiter/ILimiter.ts
@@ -61,6 +61,23 @@ export interface ILimiter {
    */
   release(token: unknown): Promise<void>;
 
+  /**
+   * Signal that the job which acquired this token has finished executing.
+   * Called on the normal completion path (success, error, retry) to release
+   * resources held for the duration of the job.
+   *
+   * Semantics differ from {@link release}: `release` undoes a reservation as
+   * if the job never ran; `complete` finalises a reservation that was actually
+   * used.
+   *
+   * - `ConcurrencyLimiter`: decrements the running-job counter so the next
+   *   job can acquire a slot.
+   * - `RateLimiter`: no-op — the window reservation was consumed and must
+   *   persist until the window expires.
+   * - All others: no-op.
+   */
+  complete(token: unknown): Promise<void>;
+
   getNextAvailableTime(): Promise<Date>;
   setNextAvailableTime(date: Date): Promise<void>;
   clear(): Promise<void>;

--- a/packages/job-queue/src/limiter/NullLimiter.ts
+++ b/packages/job-queue/src/limiter/NullLimiter.ts
@@ -26,6 +26,10 @@ export class NullLimiter implements ILimiter {
     // Do nothing
   }
 
+  async complete(_token: unknown): Promise<void> {
+    // Do nothing
+  }
+
   async getNextAvailableTime(): Promise<Date> {
     return new Date();
   }

--- a/packages/job-queue/src/limiter/NullLimiter.ts
+++ b/packages/job-queue/src/limiter/NullLimiter.ts
@@ -26,18 +26,6 @@ export class NullLimiter implements ILimiter {
     // Do nothing
   }
 
-  async canProceed(): Promise<boolean> {
-    return true;
-  }
-
-  async recordJobStart(): Promise<void> {
-    // Do nothing
-  }
-
-  async recordJobCompletion(): Promise<void> {
-    // Do nothing
-  }
-
   async getNextAvailableTime(): Promise<Date> {
     return new Date();
   }

--- a/packages/job-queue/src/limiter/RateLimiter.ts
+++ b/packages/job-queue/src/limiter/RateLimiter.ts
@@ -134,69 +134,6 @@ export class RateLimiter implements ILimiter {
   }
 
   /**
-   * Checks if a job can proceed based on rate limiting rules.
-   * @returns True if the job can proceed, false otherwise
-   */
-  async canProceed(): Promise<boolean> {
-    // First check if the window allows more executions
-    const windowStartTime = new Date(Date.now() - this.windowSizeInMilliseconds).toISOString();
-    const attemptCount = await this.storage.getExecutionCount(this.queueName, windowStartTime);
-    const canProceedNow = attemptCount < this.maxExecutions;
-
-    // If the window allows more executions, clear any backoff and proceed
-    if (canProceedNow) {
-      // Clear any existing nextAvailableTime backoff since the window allows more executions
-      const nextAvailableTime = await this.storage.getNextAvailableTime(this.queueName);
-      if (nextAvailableTime && new Date(nextAvailableTime).getTime() > Date.now()) {
-        // Clear the backoff by setting it to the past
-        const pastTime = new Date(Date.now() - 1000);
-        await this.storage.setNextAvailableTime(this.queueName, pastTime.toISOString());
-      }
-      this.currentBackoffDelay = this.initialBackoffDelay;
-      return true;
-    }
-
-    // Window is full, check if there's a backoff delay
-    const nextAvailableTime = await this.storage.getNextAvailableTime(this.queueName);
-    if (nextAvailableTime && new Date(nextAvailableTime).getTime() > Date.now()) {
-      this.increaseBackoff();
-      return false;
-    }
-
-    // Window is full but no backoff delay, so we can't proceed
-    this.increaseBackoff();
-    return false;
-  }
-
-  /**
-   * Records a new job attempt.
-   */
-  async recordJobStart(): Promise<void> {
-    await this.storage.recordExecution(this.queueName);
-
-    const windowStartTime = new Date(Date.now() - this.windowSizeInMilliseconds).toISOString();
-    const attemptCount = await this.storage.getExecutionCount(this.queueName, windowStartTime);
-
-    if (attemptCount >= this.maxExecutions) {
-      const backoffExpires = new Date(Date.now() + this.addJitter(this.currentBackoffDelay));
-      await this.setNextAvailableTime(backoffExpires);
-    } else {
-      // Window allows more executions, clear any existing nextAvailableTime by setting it to the past
-      const nextAvailableTime = await this.storage.getNextAvailableTime(this.queueName);
-      if (nextAvailableTime && new Date(nextAvailableTime).getTime() > Date.now()) {
-        // Clear the backoff since the window now allows more executions
-        // Set to a time in the past to effectively clear it
-        const pastTime = new Date(Date.now() - 1000);
-        await this.storage.setNextAvailableTime(this.queueName, pastTime.toISOString());
-      }
-    }
-  }
-
-  async recordJobCompletion(): Promise<void> {
-    // Implementation can be no-op as completion doesn't affect rate limiting
-  }
-
-  /**
    * Retrieves the next available time for the specific queue. Returns the
    * latest of: the rate-limit wall (oldest execution + window), any externally
    * set storage sentinel (explicit pause), and this instance's local backoff

--- a/packages/job-queue/src/limiter/RateLimiter.ts
+++ b/packages/job-queue/src/limiter/RateLimiter.ts
@@ -121,6 +121,14 @@ export class RateLimiter implements ILimiter {
     this.localBackoffUntilMs = 0;
   }
 
+  /**
+   * No-op for RateLimiter — the window reservation was consumed and must
+   * persist until the window expires.
+   */
+  async complete(_token: unknown): Promise<void> {
+    return Promise.resolve();
+  }
+
   protected addJitter(base: number): number {
     // full jitter in [base, 2*base)
     return base + Math.random() * base;

--- a/packages/job-queue/src/queue-storage/IClaim.ts
+++ b/packages/job-queue/src/queue-storage/IClaim.ts
@@ -8,25 +8,70 @@ import type { MessageId } from "./IMessageQueue";
 
 export type { MessageId };
 
+/** Optional shape passed by `IClaim.fail` to communicate the failure reason. */
+export interface ClaimFailOptions {
+  /** Human-readable error message persisted as `error`. */
+  readonly error?: string | null;
+  /** Machine-readable error code persisted as `error_code`. */
+  readonly errorCode?: string | null;
+  /**
+   * True when the failure was caused by an abort request. The claim's
+   * implementation persists `abort_requested_at` accordingly (some backends
+   * keep a previously-set value if this is false).
+   */
+  readonly abortRequested?: boolean;
+  /**
+   * Hint: this failure must not be retried. Consumers may use this to skip
+   * back-off scheduling. Storage layers may ignore the flag (the worker
+   * still owns retry-vs-fail orchestration via attempts/max_attempts).
+   */
+  readonly permanent?: boolean;
+}
+
+/** Optional shape passed by `IClaim.disable` (currently empty — kept for forward compat). */
+export interface ClaimDisableOptions {
+  // No options today. Kept as an explicit type so future opts don't break call sites.
+}
+
 /**
  * A claim on a message from the queue.
  *
  * A claim is created when a worker calls {@link IMessageQueue.receive}. It
  * represents an exclusive (leased) right to process the message. The worker
  * must terminate the claim via one of {@link IClaim.ack},
- * {@link IClaim.retry}, or {@link IClaim.fail}, or by letting the lease
- * expire.
+ * {@link IClaim.retry}, {@link IClaim.fail}, {@link IClaim.disable}, or by
+ * letting the lease expire.
  */
 export interface IClaim<Body> {
   readonly id: MessageId;
   readonly body: Body;
   readonly attempts: number;
-  /** Mark the message as successfully processed (terminal). */
-  ack(): Promise<void>;
+  /**
+   * Mark the message as successfully processed (terminal). Optional `result`
+   * is persisted atomically with the COMPLETED status so a crash between
+   * "save result" and "ack" can no longer leave a PROCESSING row with a
+   * result the worker thinks it stored. The shape of `result` depends on
+   * the message body; for job-queue claims this is the typed `Output`.
+   */
+  ack(result?: unknown): Promise<void>;
   /** Release the claim and reschedule for a later attempt. */
   retry(opts?: { delaySeconds?: number }): Promise<void>;
-  /** Mark the message as failed (terminal). */
-  fail(opts?: { permanent?: boolean }): Promise<void>;
+  /**
+   * Mark the message as failed (terminal). Error/errorCode/abortRequested
+   * are persisted atomically with the FAILED status — no separate
+   * `saveError` call beforehand. The `permanent` flag is a hint to skip
+   * back-off scheduling; storage layers may ignore it.
+   */
+  fail(opts?: ClaimFailOptions): Promise<void>;
   /** Extend the lease by `ms` milliseconds. */
   extendLease(ms: number): Promise<void>;
+  /**
+   * Mark the message as DISABLED (terminal). Atomic: writes status =
+   * DISABLED, releases the lease, and clears progress fields in a single
+   * storage write. Does NOT write error/error_code — DISABLED is not an
+   * error transition. Optional in this interface for backward
+   * compatibility with existing claim impls; every in-tree IClaim
+   * implements it.
+   */
+  disable?(opts?: ClaimDisableOptions): Promise<void>;
 }

--- a/packages/job-queue/src/queue-storage/IClaim.ts
+++ b/packages/job-queue/src/queue-storage/IClaim.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MessageId } from "./IMessageQueue";
+
+export type { MessageId };
+
+/**
+ * A claim on a message from the queue.
+ *
+ * A claim is created when a worker calls {@link IMessageQueue.receive}. It
+ * represents an exclusive (leased) right to process the message. The worker
+ * must terminate the claim via one of {@link IClaim.ack},
+ * {@link IClaim.retry}, or {@link IClaim.fail}, or by letting the lease
+ * expire.
+ */
+export interface IClaim<Body> {
+  readonly id: MessageId;
+  readonly body: Body;
+  readonly attempts: number;
+  /** Mark the message as successfully processed (terminal). */
+  ack(): Promise<void>;
+  /** Release the claim and reschedule for a later attempt. */
+  retry(opts?: { delaySeconds?: number }): Promise<void>;
+  /** Mark the message as failed (terminal). */
+  fail(opts?: { permanent?: boolean }): Promise<void>;
+  /** Extend the lease by `ms` milliseconds. */
+  extendLease(ms: number): Promise<void>;
+}

--- a/packages/job-queue/src/queue-storage/IJobStore.ts
+++ b/packages/job-queue/src/queue-storage/IJobStore.ts
@@ -43,4 +43,6 @@ export interface IJobStore<Input, Output> {
   /** Delete every job in this store. */
   deleteAll(): Promise<void>;
   abort(id: MessageId): Promise<void>;
+  /** Force-overwrite the status field without incrementing attempts. Used to persist DISABLED after lease release. */
+  saveStatus(id: MessageId, status: JobStatus): Promise<void>;
 }

--- a/packages/job-queue/src/queue-storage/IJobStore.ts
+++ b/packages/job-queue/src/queue-storage/IJobStore.ts
@@ -30,7 +30,21 @@ export interface IJobStore<Input, Output> {
     message: string,
     details: Record<string, any> | null
   ): Promise<void>;
+  /**
+   * @deprecated H2 (libs): result is now written atomically with the
+   * COMPLETED status via {@link IClaim.ack}'s `result` argument. New code
+   * should call `claim.ack(output)` directly. This method is retained as
+   * a buffered no-op wrapper for one minor release so callers depending on
+   * a separate write step keep compiling; backends route the value through
+   * the pending-buffer until ack persists it.
+   */
   saveResult(id: MessageId, output: Output): Promise<void>;
+  /**
+   * @deprecated H2 (libs): error fields are now written atomically with the
+   * FAILED status via {@link IClaim.fail}'s opts. New code should call
+   * `claim.fail({ error, errorCode, abortRequested })` directly. Retained
+   * as a buffered no-op wrapper for one minor release.
+   */
   saveError(
     id: MessageId,
     error: string,

--- a/packages/job-queue/src/queue-storage/IJobStore.ts
+++ b/packages/job-queue/src/queue-storage/IJobStore.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MessageId } from "./IMessageQueue";
+import type { JobStatus, JobStorageFormat } from "./IQueueStorage";
+
+/**
+ * Record describing a stored job. Currently an alias for the legacy
+ * {@link JobStorageFormat} so adapters and native implementations can share
+ * the same record shape.
+ */
+export type JobRecord<Input, Output> = JobStorageFormat<Input, Output>;
+
+/**
+ * Read- and mutation-side of the job queue. Paired with
+ * {@link IMessageQueue}.
+ */
+export interface IJobStore<Input, Output> {
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined>;
+  peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]>;
+  size(status?: JobStatus): Promise<number>;
+  getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]>;
+  outputForInput(input: Input): Promise<Output | null>;
+  saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void>;
+  saveResult(id: MessageId, output: Output): Promise<void>;
+  saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void>;
+  deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void>;
+  /** Delete a single job by id. */
+  delete(id: MessageId): Promise<void>;
+  /** Delete every job in this store. */
+  deleteAll(): Promise<void>;
+  abort(id: MessageId): Promise<void>;
+}

--- a/packages/job-queue/src/queue-storage/IMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/IMessageQueue.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IClaim } from "./IClaim";
+import type { QueueChangePayload, QueueStorageScope, QueueSubscribeOptions } from "./IQueueStorage";
+
+export type MessageId = unknown;
+
+/**
+ * Options for sending a message to the queue.
+ */
+export interface SendOptions {
+  readonly delaySeconds?: number;
+  readonly timeoutSeconds?: number;
+  readonly fingerprint?: string;
+  readonly jobRunId?: string;
+  readonly maxAttempts?: number;
+}
+
+/**
+ * Message queue interface — owns producing and consuming messages.
+ * Pairs with {@link IJobStore} for read-side / mutation access to the
+ * stored job record.
+ */
+export interface IMessageQueue<Body> {
+  readonly scope: QueueStorageScope;
+  send(body: Body, opts?: SendOptions): Promise<MessageId>;
+  sendBatch(bodies: readonly Body[], opts?: SendOptions): Promise<readonly MessageId[]>;
+  receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<Body>[]>;
+  releaseClaim(id: MessageId): Promise<void>;
+  migrate(): Promise<void>;
+  getMigrations(): ReadonlyArray<unknown>;
+  subscribeToChanges?(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void;
+}

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -208,10 +208,47 @@ export interface IQueueStorage<Input, Output> {
   size(status?: JobStatus): Promise<number>;
 
   /**
-   * Completes a job in the queue storage
+   * Completes a job in the queue storage. Bumps `attempts` (legacy contract,
+   * preserved for backward compatibility with code paths that rely on it,
+   * such as PENDING-retry rescheduling).
+   *
+   * NEW callers (worker ack/fail paths) should prefer {@link finalize}, which
+   * writes the terminal result fields WITHOUT touching `attempts` — a successful
+   * ack must not consume a retry attempt that was already accounted for by
+   * the lease-expiry reclaim or by the wrapper's retry path.
    * @param job - The job to complete
    */
   complete(job: JobStorageFormat<Input, Output>): Promise<void>;
+
+  /**
+   * Terminal write for a claim: persists `output` / `error` / `error_code` /
+   * `status` / `completed_at` / `abort_requested_at` WITHOUT bumping the
+   * `attempts` counter.
+   *
+   * Introduced to fix the bug where `WrappedClaim.ack`/`fail` going through
+   * `complete()` incremented `attempts` on a successful execution. The
+   * lease-expiry reclaim already charged this attempt at `next()` time;
+   * charging it again at `ack()` time double-counts and rolls a successful
+   * job into MAX_ATTEMPTS_REACHED prematurely.
+   *
+   * Implementations MUST treat `fields` as a partial overwrite — only the
+   * listed fields are written; everything else (in particular `attempts`,
+   * `visible_at`, `lease_owner`, `lease_expires_at`) is untouched.
+   *
+   * @param id - The ID of the job to finalize
+   * @param fields - Terminal fields to write
+   */
+  finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void>;
 
   /**
    * Deletes all jobs from the queue storage

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -221,9 +221,9 @@ export interface IQueueStorage<Input, Output> {
   complete(job: JobStorageFormat<Input, Output>): Promise<void>;
 
   /**
-   * Terminal write for a claim: persists `output` / `error` / `error_code` /
-   * `status` / `completed_at` / `abort_requested_at` WITHOUT bumping the
-   * `attempts` counter.
+   * Terminal write for a claim: persists the listed fields WITHOUT bumping
+   * the `attempts` counter. A partial overwrite — fields not present in
+   * `fields` are untouched.
    *
    * Introduced to fix the bug where `WrappedClaim.ack`/`fail` going through
    * `complete()` incremented `attempts` on a successful execution. The
@@ -231,9 +231,9 @@ export interface IQueueStorage<Input, Output> {
    * charging it again at `ack()` time double-counts and rolls a successful
    * job into MAX_ATTEMPTS_REACHED prematurely.
    *
-   * Implementations MUST treat `fields` as a partial overwrite — only the
-   * listed fields are written; everything else (in particular `attempts`,
-   * `visible_at`, `lease_owner`, `lease_expires_at`) is untouched.
+   * The `lease_owner` / progress fields are also writable here so the
+   * atomic `disable` path can release the lease and clear progress in the
+   * same single write.
    *
    * @param id - The ID of the job to finalize
    * @param fields - Terminal fields to write
@@ -247,6 +247,10 @@ export interface IQueueStorage<Input, Output> {
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void>;
 

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -170,7 +170,7 @@ export interface IQueueStorage<Input, Output> {
    * must be preserved.
    * @param id - The id of the claimed job to release.
    */
-  release(id: unknown): Promise<void>;
+  releaseClaim(id: unknown): Promise<void>;
 
   /**
    * Peeks at the next job(s) from the queue storage without removing them

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -103,18 +103,22 @@ export type JobStorageFormat<Input, Output> = {
   error?: string | null;
   error_code?: string | null;
   fingerprint?: string;
-  max_retries?: number;
+  /**
+   * Total attempt cap. A job with `max_attempts: 3` gets at most 3 executions total
+   * (not 3 retries after the first attempt).
+   */
+  max_attempts?: number;
   status?: JobStatus;
   created_at?: string;
   deadline_at?: string | null;
-  last_ran_at?: string | null;
-  run_after: string | null;
+  last_attempted_at?: string | null;
+  visible_at: string | null;
   completed_at: string | null;
-  run_attempts?: number;
+  attempts?: number;
   progress?: number;
   progress_message?: string;
   progress_details?: Record<string, any> | null;
-  worker_id?: string | null;
+  lease_owner?: string | null;
   abort_requested_at?: string | null;
   lease_expires_at?: string | null;
 };
@@ -181,7 +185,7 @@ export interface IQueueStorage<Input, Output> {
   /**
    * Releases a job that was just claimed by {@link next} but won't be
    * processed (e.g. the worker was stopped mid-claim). Resets status to
-   * PENDING and clears worker_id WITHOUT incrementing run_attempts —
+   * PENDING and clears lease_owner WITHOUT incrementing attempts —
    * the worker never actually attempted execution, so the retry budget
    * must be preserved.
    * @param id - The id of the claimed job to release.

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -33,12 +33,11 @@ export interface QueueStorageOptions {
   readonly prefixValues?: Readonly<Record<string, string | number>>;
 }
 
-export type JobStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "ABORTING" | "FAILED" | "DISABLED";
+export type JobStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED" | "DISABLED";
 export const JobStatus = {
   PENDING: "PENDING",
   PROCESSING: "PROCESSING",
   COMPLETED: "COMPLETED",
-  ABORTING: "ABORTING",
   FAILED: "FAILED",
   DISABLED: "DISABLED",
 } as const satisfies Record<JobStatus, JobStatus>;
@@ -116,6 +115,8 @@ export type JobStorageFormat<Input, Output> = {
   progress_message?: string;
   progress_details?: Record<string, any> | null;
   worker_id?: string | null;
+  abort_requested_at?: string | null;
+  lease_expires_at?: string | null;
 };
 
 /**
@@ -156,11 +157,26 @@ export interface IQueueStorage<Input, Output> {
   get(id: unknown): Promise<JobStorageFormat<Input, Output> | undefined>;
 
   /**
-   * Gets the next job from the queue storage
+   * Gets the next job from the queue storage. Claims PENDING jobs that are
+   * ready, and also reclaims PROCESSING jobs whose lease has expired (crash
+   * recovery). Sets `lease_expires_at = now + leaseMs` on the claimed row.
    * @param workerId - Worker ID to associate with the job (required)
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns The next job from the queue storage
    */
-  next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined>;
+  next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined>;
+
+  /**
+   * Extend the lease on a currently PROCESSING job. Guards: lease_owner must
+   * match workerId and status must be PROCESSING. Throws if lease was lost.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  extendLease(id: unknown, workerId: string, ms: number): Promise<void>;
 
   /**
    * Releases a job that was just claimed by {@link next} but won't be

--- a/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
@@ -90,4 +90,8 @@ export class InMemoryJobStore<Input, Output> implements IJobStore<Input, Output>
   async abort(id: MessageId): Promise<void> {
     await this.core.abort(id);
   }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    await this.core.updateJobStatus(id, status);
+  }
 }

--- a/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
@@ -92,6 +92,6 @@ export class InMemoryJobStore<Input, Output> implements IJobStore<Input, Output>
   }
 
   async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
-    await this.core.updateJobStatus(id, status);
+    await this.core.saveStatus(id, status);
   }
 }

--- a/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryJobStore.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IJobStore, JobRecord } from "./IJobStore";
+import type { MessageId } from "./IMessageQueue";
+import type { PendingInMemoryWrite } from "./InMemoryMessageQueue";
+import { InMemoryQueueStorage } from "./InMemoryQueueStorage";
+import type { JobStatus } from "./IQueueStorage";
+
+export class InMemoryJobStore<Input, Output> implements IJobStore<Input, Output> {
+  /** @internal — shared with the paired message queue */
+  public readonly core: InMemoryQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingInMemoryWrite<Output>>;
+
+  constructor(
+    core: InMemoryQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingInMemoryWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.core.get(id);
+  }
+
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.peek(status, num);
+  }
+
+  size(status?: JobStatus): Promise<number> {
+    return this.core.size(status);
+  }
+
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.getByRunId(runId);
+  }
+
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.core.outputForInput(input);
+  }
+
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.core.saveProgress(id, progress, message, details);
+  }
+
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.core.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.delete(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.core.deleteAll();
+  }
+
+  async abort(id: MessageId): Promise<void> {
+    await this.core.abort(id);
+  }
+}

--- a/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IClaim } from "./IClaim";
+import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
+import { InMemoryQueueStorage } from "./InMemoryQueueStorage";
+import type {
+  JobStorageFormat,
+  QueueChangePayload,
+  QueueStorageScope,
+  QueueSubscribeOptions,
+} from "./IQueueStorage";
+
+/**
+ * Per-id buffer that lets {@link IJobStore.saveResult}/{@link IJobStore.saveError}
+ * stage output/error until the terminal claim.ack()/fail() persists them in
+ * a single complete() call (avoids double-bumping `attempts`).
+ */
+export type PendingInMemoryWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class InMemoryClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly core: InMemoryQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingInMemoryWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: "COMPLETED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      status: "PENDING",
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: new Date(Date.now() + delay * 1000).toISOString(),
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: "FAILED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.core.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+export class InMemoryMessageQueue<Input, Output> implements IMessageQueue<
+  JobStorageFormat<Input, Output>
+> {
+  public readonly scope: QueueStorageScope = "process";
+
+  /** @internal — shared with the paired job store */
+  public readonly core: InMemoryQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  public readonly pending: Map<unknown, PendingInMemoryWrite<Output>>;
+
+  constructor(
+    core: InMemoryQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingInMemoryWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    return this.core.add(applySendOptions(body, opts));
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!job) return [];
+    return [
+      new InMemoryClaim<Input, Output>(
+        this.core,
+        this.pending,
+        job.id,
+        job,
+        job.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.core.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.core.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.core.subscribeToChanges(callback, options);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}

--- a/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
@@ -132,18 +132,23 @@ export class InMemoryMessageQueue<Input, Output> implements IMessageQueue<
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!job) return [];
-    return [
-      new InMemoryClaim<Input, Output>(
-        this.core,
-        this.pending,
-        job.id,
-        job,
-        job.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!job) break;
+      claims.push(
+        new InMemoryClaim<Input, Output>(
+          this.core,
+          this.pending,
+          job.id,
+          job,
+          job.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {

--- a/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
@@ -102,7 +102,7 @@ export class InMemoryMessageQueue<Input, Output> implements IMessageQueue<
   public readonly core: InMemoryQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  public readonly pending: Map<unknown, PendingInMemoryWrite<Output>>;
+  private readonly pending: Map<unknown, PendingInMemoryWrite<Output>>;
 
   constructor(
     core: InMemoryQueueStorage<Input, Output>,

--- a/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
@@ -114,6 +114,25 @@ class InMemoryClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
   async extendLease(ms: number): Promise<void> {
     await this.core.extendLease(this.id, this.workerId, ms);
   }
+
+  /**
+   * Atomic disable (H5): one storage write — status=DISABLED, lease
+   * released, progress cleared. No error/error_code (DISABLED is not an
+   * error transition).
+   */
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.core.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.core.finalize(this.id, {
+      status: "DISABLED",
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
 }
 
 export class InMemoryMessageQueue<Input, Output> implements IMessageQueue<

--- a/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryMessageQueue.ts
@@ -36,20 +36,24 @@ class InMemoryClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      output: buf?.output ?? current.output ?? null,
+    // H2 atomic: persist output + COMPLETED status in one finalize() call.
+    // Falls back to the legacy pending-buffer if no `result` was passed in.
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
+    await this.core.finalize(this.id, {
+      output: output as Output | null,
       error: null,
       error_code: null,
       status: "COMPLETED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -69,22 +73,41 @@ class InMemoryClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     });
   }
 
-  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent;
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+    // H2 atomic: persist error/errorCode/abortRequested + FAILED status in
+    // one finalize() call. Falls back to the pending-buffer if the worker
+    // still went through jobStore.saveError before this.
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
+    await this.core.finalize(this.id, {
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: "FAILED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -167,10 +167,19 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     const job = pending[0] ?? expiredLease[0];
     if (job) {
       const oldJob = { ...job };
+      // Lease-expiry reclaim (job was PROCESSING with expired lease) consumes
+      // one attempt against max_attempts; a fresh PENDING claim does not.
+      const isLeaseExpiryReclaim = job.status === JobStatus.PROCESSING;
       job.status = JobStatus.PROCESSING;
       job.last_attempted_at = now;
       job.lease_owner = workerId;
       job.lease_expires_at = leaseExpiry;
+      if (isLeaseExpiryReclaim) {
+        job.attempts = (job.attempts ?? 0) + 1;
+      }
+      // Always clear stale abort_requested_at on (re)claim so a flag set by
+      // an earlier worker does not immediately abort the new lease.
+      (job as unknown as Record<string, unknown>).abort_requested_at = null;
       this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
       return job;
     }
@@ -268,6 +277,11 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
       const existing = this.jobQueue[index];
       const currentAttempts = existing?.attempts ?? 0;
       jobWithPrefixes.attempts = currentAttempts + 1;
+      // PENDING-retry / terminal completion: clear abort_requested_at so an
+      // abort that was requested during the previous attempt does not
+      // immediately cancel the retry. Terminal statuses get a harmless
+      // cleanup of the same field.
+      jobWithPrefixes.abort_requested_at = null;
       // Preserve prefix values from the existing job
       for (const [key, value] of Object.entries(this.prefixValues)) {
         jobWithPrefixes[key] = value;
@@ -291,6 +305,9 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
       job.progress = 0;
       job.progress_message = "";
       job.progress_details = null;
+      // Clear stale abort_requested_at — an abort flag set during the previous
+      // claim must not survive the release and immediately cancel the next claim.
+      (job as unknown as Record<string, unknown>).abort_requested_at = null;
       this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
     }
   }

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -200,7 +200,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
    * @param status - The status of the jobs to retrieve.
    * @returns A promise that resolves to the number of jobs.
    */
-  public async size(status = JobStatus.PENDING): Promise<number> {
+  public async size(status: JobStatus = JobStatus.PENDING): Promise<number> {
     await sleep(0);
     return this.jobQueue.filter((j) => this.matchesPrefixes(j) && j.status === status).length;
   }

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -88,7 +88,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     jobWithPrefixes.progress_message = "";
     jobWithPrefixes.progress_details = null;
     jobWithPrefixes.created_at = now;
-    jobWithPrefixes.run_after = now;
+    jobWithPrefixes.visible_at = now;
 
     // Add prefix values to the job
     for (const [key, value] of Object.entries(this.prefixValues)) {
@@ -128,7 +128,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     num = Number(num) || 100;
     return this.jobQueue
       .filter((j) => this.matchesPrefixes(j))
-      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""))
+      .sort((a, b) => (a.visible_at || "").localeCompare(b.visible_at || ""))
       .filter((j) => j.status === status)
       .slice(0, num);
   }
@@ -154,22 +154,22 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     const pending = this.jobQueue
       .filter((job) => this.matchesPrefixes(job))
       .filter((job) => job.status === JobStatus.PENDING)
-      .filter((job) => !job.run_after || job.run_after <= now)
-      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""));
+      .filter((job) => !job.visible_at || job.visible_at <= now)
+      .sort((a, b) => (a.visible_at || "").localeCompare(b.visible_at || ""));
 
     // Also look for PROCESSING jobs with expired leases
     const expiredLease = this.jobQueue
       .filter((job) => this.matchesPrefixes(job))
       .filter((job) => job.status === JobStatus.PROCESSING)
       .filter((job) => !job.lease_expires_at || job.lease_expires_at < now)
-      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""));
+      .sort((a, b) => (a.visible_at || "").localeCompare(b.visible_at || ""));
 
     const job = pending[0] ?? expiredLease[0];
     if (job) {
       const oldJob = { ...job };
       job.status = JobStatus.PROCESSING;
-      job.last_ran_at = now;
-      job.worker_id = workerId;
+      job.last_attempted_at = now;
+      job.lease_owner = workerId;
       job.lease_expires_at = leaseExpiry;
       this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
       return job;
@@ -179,13 +179,13 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Extend the lease on a currently PROCESSING job.
    * @param id - The ID of the job to extend the lease for
-   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param workerId - Worker ID that must match the current lease owner (lease_owner)
    * @param ms - Number of milliseconds to extend the lease by
    */
   public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
     await sleep(0);
     const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
-    if (!job || job.status !== JobStatus.PROCESSING || job.worker_id !== workerId) {
+    if (!job || job.status !== JobStatus.PROCESSING || job.lease_owner !== workerId) {
       throw new Error(
         `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
       );
@@ -255,7 +255,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
 
   /**
    * Marks a job as complete with its output or error
-   * Handles run_attempts for failed jobs and triggers completion callbacks
+   * Handles attempts for failed jobs and triggers completion callbacks
    * @param id - ID of the job to complete
    * @param output - Result of the job execution
    * @param error - Optional error message if job failed
@@ -266,8 +266,8 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     const index = this.jobQueue.findIndex((j) => j.id === job.id && this.matchesPrefixes(j));
     if (index !== -1) {
       const existing = this.jobQueue[index];
-      const currentAttempts = existing?.run_attempts ?? 0;
-      jobWithPrefixes.run_attempts = currentAttempts + 1;
+      const currentAttempts = existing?.attempts ?? 0;
+      jobWithPrefixes.attempts = currentAttempts + 1;
       // Preserve prefix values from the existing job
       for (const [key, value] of Object.entries(this.prefixValues)) {
         jobWithPrefixes[key] = value;
@@ -278,7 +278,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Releases a claimed job back to PENDING without incrementing run_attempts.
+   * Releases a claimed job back to PENDING without incrementing attempts.
    * @param id - The id of the claimed job to release.
    */
   public async releaseClaim(id: unknown): Promise<void> {
@@ -287,7 +287,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     if (job) {
       const oldJob = { ...job };
       job.status = JobStatus.PENDING;
-      job.worker_id = null;
+      job.lease_owner = null;
       job.progress = 0;
       job.progress_message = "";
       job.progress_details = null;

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -350,6 +350,10 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     await sleep(0);
@@ -364,6 +368,10 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     if ("completed_at" in fields) target.completed_at = fields.completed_at ?? null;
     if ("abort_requested_at" in fields)
       target.abort_requested_at = fields.abort_requested_at ?? null;
+    if ("lease_owner" in fields) target.lease_owner = fields.lease_owner ?? null;
+    if ("progress" in fields) target.progress = fields.progress ?? 0;
+    if ("progress_message" in fields) target.progress_message = fields.progress_message ?? "";
+    if ("progress_details" in fields) target.progress_details = fields.progress_details ?? null;
     this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
   }
 

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -72,19 +72,6 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Returns a filtered and sorted list of pending jobs that are ready to run
-   * Sorts by creation time to maintain FIFO order
-   */
-  private pendingQueue(): Array<JobStorageFormat<Input, Output> & Record<string, unknown>> {
-    const now = new Date().toISOString();
-    return this.jobQueue
-      .filter((job) => this.matchesPrefixes(job))
-      .filter((job) => job.status === JobStatus.PENDING)
-      .filter((job) => !job.run_after || job.run_after <= now)
-      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""));
-  }
-
-  /**
    * Adds a new job to the queue
    * Generates an ID and fingerprint if not provided
    */
@@ -147,24 +134,65 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Retrieves the next available job that is ready to be processed
-   * Updates the job status to PROCESSING before returning
+   * Retrieves the next available job that is ready to be processed.
+   * Claims PENDING jobs ready to run, and also reclaims PROCESSING jobs whose
+   * lease has expired (crash recovery). Sets lease_expires_at on the claimed row.
    * @param workerId - Worker ID to associate with the job
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns The next job or undefined if no job is available
    */
-  public async next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
+  public async next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
     await sleep(0);
-    const top = this.pendingQueue();
+    const leaseMs = opts?.leaseMs ?? 30000;
+    const now = new Date().toISOString();
+    const leaseExpiry = new Date(Date.now() + leaseMs).toISOString();
 
-    const job = top[0];
+    // First look for a normal PENDING job ready to run
+    const pending = this.jobQueue
+      .filter((job) => this.matchesPrefixes(job))
+      .filter((job) => job.status === JobStatus.PENDING)
+      .filter((job) => !job.run_after || job.run_after <= now)
+      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""));
+
+    // Also look for PROCESSING jobs with expired leases
+    const expiredLease = this.jobQueue
+      .filter((job) => this.matchesPrefixes(job))
+      .filter((job) => job.status === JobStatus.PROCESSING)
+      .filter((job) => !job.lease_expires_at || job.lease_expires_at < now)
+      .sort((a, b) => (a.run_after || "").localeCompare(b.run_after || ""));
+
+    const job = pending[0] ?? expiredLease[0];
     if (job) {
       const oldJob = { ...job };
       job.status = JobStatus.PROCESSING;
-      job.last_ran_at = new Date().toISOString();
+      job.last_ran_at = now;
       job.worker_id = workerId;
+      job.lease_expires_at = leaseExpiry;
       this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
       return job;
     }
+  }
+
+  /**
+   * Extend the lease on a currently PROCESSING job.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    await sleep(0);
+    const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
+    if (!job || job.status !== JobStatus.PROCESSING || job.worker_id !== workerId) {
+      throw new Error(
+        `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
+      );
+    }
+    const oldJob = { ...job };
+    job.lease_expires_at = new Date(Date.now() + ms).toISOString();
+    this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
   }
 
   /**
@@ -268,17 +296,28 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Aborts a job
+   * Aborts a job.
+   * - If PENDING: immediately mark as FAILED with abort_requested_at set.
+   * - If PROCESSING: set abort_requested_at only (leave status as PROCESSING).
+   * - Otherwise: no-op.
    * @param id - The id of the job to abort.
    */
   public async abort(id: unknown): Promise<void> {
     await sleep(0);
     const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
-    if (job) {
-      const oldJob = { ...job };
-      job.status = JobStatus.ABORTING;
-      this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
+    if (!job) return;
+    const oldJob = { ...job };
+    const now = new Date().toISOString();
+    if (job.status === JobStatus.PENDING) {
+      job.status = JobStatus.FAILED;
+      job.abort_requested_at = now;
+      job.completed_at = now;
+    } else if (job.status === JobStatus.PROCESSING) {
+      job.abort_requested_at = now;
+    } else {
+      return;
     }
+    this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
   }
 
   /**

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -320,6 +320,16 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
   }
 
+  /** Force-overwrite status without incrementing attempts (used to persist DISABLED after lease release). */
+  public async updateJobStatus(id: unknown, status: JobStatus): Promise<void> {
+    await sleep(0);
+    const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
+    if (!job) return;
+    const oldJob = { ...job };
+    job.status = status;
+    this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
+  }
+
   /**
    * Retrieves all jobs by their job_run_id.
    * @param job_run_id - The job_run_id of the jobs to retrieve.

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -337,14 +337,43 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
     this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
   }
 
-  /** Force-overwrite status without incrementing attempts (used to persist DISABLED after lease release). */
-  public async updateJobStatus(id: unknown, status: JobStatus): Promise<void> {
+  /**
+   * Terminal write that does NOT bump `attempts`. See IQueueStorage.finalize
+   * for the rationale.
+   */
+  public async finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
     await sleep(0);
     const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
     if (!job) return;
     const oldJob = { ...job };
-    job.status = status;
+    const target = job as JobStorageFormat<Input, Output> & Record<string, unknown>;
+    if ("output" in fields) target.output = (fields.output ?? null) as Output | null;
+    if ("error" in fields) target.error = fields.error ?? null;
+    if ("error_code" in fields) target.error_code = fields.error_code ?? null;
+    if ("status" in fields && fields.status !== undefined) target.status = fields.status;
+    if ("completed_at" in fields) target.completed_at = fields.completed_at ?? null;
+    if ("abort_requested_at" in fields)
+      target.abort_requested_at = fields.abort_requested_at ?? null;
     this.events.emit("change", { type: "UPDATE", old: oldJob, new: job });
+  }
+
+  /**
+   * Force-overwrite status without incrementing attempts. Standardized name —
+   * the legacy `updateJobStatus` alias was removed in favour of this name
+   * which mirrors `IJobStore.saveStatus` (the caller).
+   */
+  public async saveStatus(id: unknown, status: JobStatus): Promise<void> {
+    await this.finalize(id, { status });
   }
 
   /**

--- a/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/InMemoryQueueStorage.ts
@@ -253,7 +253,7 @@ export class InMemoryQueueStorage<Input, Output> implements IQueueStorage<Input,
    * Releases a claimed job back to PENDING without incrementing run_attempts.
    * @param id - The id of the claimed job to release.
    */
-  public async release(id: unknown): Promise<void> {
+  public async releaseClaim(id: unknown): Promise<void> {
     await sleep(0);
     const job = this.jobQueue.find((j) => j.id === id && this.matchesPrefixes(j));
     if (job) {

--- a/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
@@ -50,8 +50,10 @@ export class TelemetryQueueStorage<Input, Output> implements IQueueStorage<Input
       this.inner.complete(job)
     );
   }
-  release(id: unknown): Promise<void> {
-    return traced("workglow.storage.queue.release", this.storageName, () => this.inner.release(id));
+  releaseClaim(id: unknown): Promise<void> {
+    return traced("workglow.storage.queue.releaseClaim", this.storageName, () =>
+      this.inner.releaseClaim(id)
+    );
   }
   deleteAll(): Promise<void> {
     return traced("workglow.storage.queue.deleteAll", this.storageName, () =>

--- a/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
@@ -34,8 +34,18 @@ export class TelemetryQueueStorage<Input, Output> implements IQueueStorage<Input
   get(id: unknown): Promise<JobStorageFormat<Input, Output> | undefined> {
     return traced("workglow.storage.queue.get", this.storageName, () => this.inner.get(id));
   }
-  next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
-    return traced("workglow.storage.queue.next", this.storageName, () => this.inner.next(workerId));
+  next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
+    return traced("workglow.storage.queue.next", this.storageName, () =>
+      this.inner.next(workerId, opts)
+    );
+  }
+  extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    return traced("workglow.storage.queue.extendLease", this.storageName, () =>
+      this.inner.extendLease(id, workerId, ms)
+    );
   }
   peek(status?: JobStatus, num?: number): Promise<Array<JobStorageFormat<Input, Output>>> {
     return traced("workglow.storage.queue.peek", this.storageName, () =>

--- a/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
@@ -60,6 +60,21 @@ export class TelemetryQueueStorage<Input, Output> implements IQueueStorage<Input
       this.inner.complete(job)
     );
   }
+  finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
+    return traced("workglow.storage.queue.finalize", this.storageName, () =>
+      this.inner.finalize(id, fields)
+    );
+  }
   releaseClaim(id: unknown): Promise<void> {
     return traced("workglow.storage.queue.releaseClaim", this.storageName, () =>
       this.inner.releaseClaim(id)

--- a/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/TelemetryQueueStorage.ts
@@ -69,6 +69,10 @@ export class TelemetryQueueStorage<Input, Output> implements IQueueStorage<Input
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     return traced("workglow.storage.queue.finalize", this.storageName, () =>

--- a/packages/job-queue/src/queue-storage/createInMemoryQueue.ts
+++ b/packages/job-queue/src/queue-storage/createInMemoryQueue.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InMemoryJobStore } from "./InMemoryJobStore";
+import { InMemoryMessageQueue, type PendingInMemoryWrite } from "./InMemoryMessageQueue";
+import { InMemoryQueueStorage } from "./InMemoryQueueStorage";
+import type { QueueStorageOptions } from "./IQueueStorage";
+
+/**
+ * Factory for the paired in-memory message queue and job store. Both
+ * facades share a single underlying {@link InMemoryQueueStorage} so writes
+ * through one are observable through the other.
+ */
+export function createInMemoryQueue<Input, Output>(
+  queueName: string = "default",
+  opts?: QueueStorageOptions
+): {
+  messageQueue: InMemoryMessageQueue<Input, Output>;
+  jobStore: InMemoryJobStore<Input, Output>;
+  /** @internal — exposed for callers that still need the legacy storage object. */
+  core: InMemoryQueueStorage<Input, Output>;
+} {
+  const core = new InMemoryQueueStorage<Input, Output>(queueName, opts);
+  const pending = new Map<unknown, PendingInMemoryWrite<Output>>();
+  return {
+    messageQueue: new InMemoryMessageQueue<Input, Output>(core, pending),
+    jobStore: new InMemoryJobStore<Input, Output>(core, pending),
+    core,
+  };
+}

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -40,17 +40,27 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
+    // Atomic ack: persist result + terminal status in a single write so a
+    // crash between "save result" and "set COMPLETED" cannot leave a row
+    // PROCESSING with an output the worker thinks it saved. The caller may
+    // pass `result` explicitly (preferred — H2 atomicity guarantee) or rely
+    // on the legacy pending-buffer fallback for callers still going through
+    // jobStore.saveResult(...).
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
-    // Use finalize() — writes terminal fields WITHOUT bumping attempts.
-    // The previous code path went through storage.complete(), which bumps
-    // attempts on every backend. The lease-expiry reclaim has already
-    // charged this attempt at next() time, so charging it again at ack()
-    // double-counts and can roll a successful job into MAX_ATTEMPTS_REACHED.
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
     await this.storage.finalize(this.id, {
-      output: buf?.output ?? current.output ?? null,
+      // `output` cast — finalize is typed against Output but receives the
+      // result the worker passed in; the queue body's Output and the claim's
+      // Output align by construction.
+      output: output as never,
       error: null,
       error_code: null,
       status: "COMPLETED",
@@ -81,19 +91,36 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     });
   }
 
-  async fail(opts?: { permanent?: boolean }): Promise<void> {
-    void opts;
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent; // hint — worker owns retry-vs-fail decision
+    // Prefer explicitly-provided args (H2 atomicity). Fall back to the
+    // pending buffer for callers that still route through jobStore.saveError.
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
-    // Use finalize() — writes terminal fields WITHOUT bumping attempts. The
-    // attempt has already been counted by the worker's retry-or-fail logic
-    // before this call (max_attempts cap is checked there); the previous
-    // complete()-based code path would double-count here.
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
     await this.storage.finalize(this.id, {
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: "FAILED",

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -131,6 +131,30 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
   async extendLease(ms: number): Promise<void> {
     await this.storage.extendLease(this.id, this.workerId, ms);
   }
+
+  /**
+   * Atomic disable (H5): one storage write that sets status=DISABLED,
+   * releases the lease, and clears progress fields. Does NOT write
+   * error/error_code — DISABLED is a normal terminal transition, not a
+   * failure. Replaces the legacy two-write `claim.fail()` then
+   * `jobStore.saveStatus(DISABLED)` path that briefly published FAILED
+   * to subscribers before overwriting with DISABLED, firing a spurious
+   * `job_error` event in between.
+   */
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.storage.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.storage.finalize(this.id, {
+      status: "DISABLED",
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+      // No error / error_code writes — DISABLED is not an error state.
+    });
+  }
 }
 
 class WrappedMessageQueue<Input, Output> implements IMessageQueue<JobStorageFormat<Input, Output>> {

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IClaim } from "./IClaim";
+import type { IJobStore, JobRecord } from "./IJobStore";
+import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
+import type {
+  IQueueStorage,
+  JobStatus,
+  JobStorageFormat,
+  QueueChangePayload,
+  QueueSubscribeOptions,
+} from "./IQueueStorage";
+
+/**
+ * Transient per-id buffer of outputs / errors written via
+ * {@link IJobStore.saveResult} / {@link IJobStore.saveError} ahead of the
+ * terminal {@link IClaim.ack} / {@link IClaim.fail} that actually persists
+ * the row. Folding both into a single legacy `storage.complete(...)` call
+ * avoids double-incrementing the `attempts` counter on backends whose
+ * `complete()` always bumps it.
+ */
+type PendingWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly storage: IQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.storage.get(this.id)) ?? this.body;
+    await this.storage.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: "COMPLETED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const visibleAt = new Date(Date.now() + delay * 1000).toISOString();
+    const current = (await this.storage.get(this.id)) ?? this.body;
+    await this.storage.complete({
+      ...current,
+      status: "PENDING",
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: visibleAt,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(opts?: { permanent?: boolean }): Promise<void> {
+    void opts;
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.storage.get(this.id)) ?? this.body;
+    await this.storage.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: "FAILED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.storage.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+class WrappedMessageQueue<Input, Output> implements IMessageQueue<JobStorageFormat<Input, Output>> {
+  public get scope() {
+    return this.storage.scope;
+  }
+
+  constructor(
+    private readonly storage: IQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>
+  ) {}
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    const job = applySendOptions(body, opts);
+    return this.storage.add(job);
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const next = await this.storage.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!next) return [];
+    return [
+      new WrappedClaim<Input, Output>(
+        this.storage,
+        this.pending,
+        next.id,
+        next,
+        next.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.storage.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.storage.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.storage.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.storage.subscribeToChanges(callback, options);
+  }
+}
+
+class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
+  constructor(
+    private readonly storage: IQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>
+  ) {}
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.storage.get(id);
+  }
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.storage.peek(status, num);
+  }
+  size(status?: JobStatus): Promise<number> {
+    return this.storage.size(status);
+  }
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.storage.getByRunId(runId);
+  }
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.storage.outputForInput(input);
+  }
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.storage.saveProgress(id, progress, message, details);
+  }
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    // Buffered until claim.ack() persists it. Calling storage.complete() here
+    // would double-bump `attempts` on backends whose complete() increments it.
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.storage.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.storage.delete(id);
+  }
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.storage.deleteAll();
+  }
+  async abort(id: MessageId): Promise<void> {
+    await this.storage.abort(id);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}
+
+export function wrapQueueStorage<Input, Output>(
+  storage: IQueueStorage<Input, Output>
+): {
+  messageQueue: IMessageQueue<JobStorageFormat<Input, Output>>;
+  jobStore: IJobStore<Input, Output>;
+} {
+  const pending = new Map<unknown, PendingWrite<Output>>();
+  return {
+    messageQueue: new WrappedMessageQueue(storage, pending),
+    jobStore: new WrappedJobStore(storage, pending),
+  };
+}

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -130,18 +130,23 @@ class WrappedMessageQueue<Input, Output> implements IMessageQueue<JobStorageForm
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const next = await this.storage.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!next) return [];
-    return [
-      new WrappedClaim<Input, Output>(
-        this.storage,
-        this.pending,
-        next.id,
-        next,
-        next.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const next = await this.storage.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!next) break;
+      claims.push(
+        new WrappedClaim<Input, Output>(
+          this.storage,
+          this.pending,
+          next.id,
+          next,
+          next.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {
@@ -226,6 +231,14 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
   }
   async abort(id: MessageId): Promise<void> {
     await this.storage.abort(id);
+  }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    const current = await this.storage.get(id);
+    if (!current) return;
+    // Re-use complete() but preserve attempts by subtracting 1 to offset the
+    // mandatory increment in legacy storage backends.
+    await this.storage.complete({ ...current, status, attempts: (current.attempts ?? 1) - 1 });
   }
 }
 

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -71,6 +71,12 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
       progress: 0,
       progress_message: "",
       progress_details: null,
+      // Clear abort_requested_at on retry — an abort flag set during the
+      // failed attempt must not survive into the next retry. Mirrors what
+      // each storage backend does at the SQL level in `complete()` for
+      // PENDING-retry, but applying it here in the wrapper guarantees the
+      // behaviour for storages that route writes through the wrapper.
+      abort_requested_at: null,
     });
   }
 

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -44,16 +44,17 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
-    await this.storage.complete({
-      ...current,
+    // Use finalize() — writes terminal fields WITHOUT bumping attempts.
+    // The previous code path went through storage.complete(), which bumps
+    // attempts on every backend. The lease-expiry reclaim has already
+    // charged this attempt at next() time, so charging it again at ack()
+    // double-counts and can roll a successful job into MAX_ATTEMPTS_REACHED.
+    await this.storage.finalize(this.id, {
       output: buf?.output ?? current.output ?? null,
       error: null,
       error_code: null,
       status: "COMPLETED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -85,8 +86,11 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
-    await this.storage.complete({
-      ...current,
+    // Use finalize() — writes terminal fields WITHOUT bumping attempts. The
+    // attempt has already been counted by the worker's retry-or-fail logic
+    // before this call (max_attempts cap is checked there); the previous
+    // complete()-based code path would double-count here.
+    await this.storage.finalize(this.id, {
       error: buf?.error ?? current.error ?? null,
       error_code: buf?.errorCode ?? current.error_code ?? null,
       abort_requested_at: buf?.abortRequested
@@ -94,9 +98,6 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
         : (current.abort_requested_at ?? null),
       status: "FAILED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -240,11 +241,12 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
   }
 
   async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
-    const current = await this.storage.get(id);
-    if (!current) return;
-    // Re-use complete() but preserve attempts by subtracting 1 to offset the
-    // mandatory increment in legacy storage backends.
-    await this.storage.complete({ ...current, status, attempts: (current.attempts ?? 1) - 1 });
+    // Use finalize() so the status write does not bump attempts. The previous
+    // implementation went through complete() and pre-decremented attempts by 1
+    // to offset the increment — a fragile compensation that broke if attempts
+    // was undefined or the storage didn't bump (the bug it was working around
+    // is fixed by finalize itself).
+    await this.storage.finalize(id, { status });
   }
 }
 

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -605,6 +605,14 @@ export class TaskGraphRunner {
       this.runScheduler.armGraphTimeout(config.timeout, ctx);
     }
 
+    // Notify the disposal strategy that a new run is starting. Inactivity
+    // strategies clear any pending idle timers here, closing the race
+    // window where a stale timer armed at the previous runComplete could
+    // dispose a resource the new run is about to touch.
+    if (this.resourceScope) {
+      await this.resourceScope.runStart();
+    }
+
     // Early-out if parent signal was already aborted (RunContext constructor
     // already aborted ctx.abortController in that case)
     if (ctx.abortController.signal.aborted) return;

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -573,6 +573,14 @@ export class TaskRunner<
       this.resourceScope = config.resourceScope;
     }
 
+    // Notify the disposal strategy that a new run is starting. Inactivity
+    // strategies use this hook to clear any pending idle timers that were
+    // armed at the previous `runComplete`, closing the race window where a
+    // timer could fire mid-run and dispose a resource we are about to use.
+    if (this.resourceScope) {
+      await this.resourceScope.runStart();
+    }
+
     // Early-out if parent signal was already aborted (TaskRunContext constructor
     // already aborted ctx.abortController in that case)
     if (ctx.abortController.signal.aborted) return;

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -519,9 +519,9 @@ export class FetchUrlTask<
         throw executeContext.signal.reason ?? new AbortSignalJobError("The operation was aborted");
       }
 
-      const handle = await registeredQueue.client.submit(jobInput as Input, {
+      const handle = await registeredQueue.client.send(jobInput as Input, {
         jobRunId: this.runConfig.runnerId,
-        maxRetries: 10,
+        maxAttempts: 10,
       });
 
       // Wire abort signal to queued job

--- a/packages/test/src/contract/tabular-storage/assertions/subscribeToChanges.ts
+++ b/packages/test/src/contract/tabular-storage/assertions/subscribeToChanges.ts
@@ -15,16 +15,84 @@ import {
 import { itExpectFail } from "../../itExpectFail";
 import type { TabularStorageContractOpts } from "../types";
 
+/**
+ * Subscription contract. Selection between the two blocks below is driven by
+ * `opts.usesPolling`:
+ *
+ *   - `usesPolling: false` → `subscribeToChanges.eventDriven` — strict commit
+ *     order (event-driven subscriptions like Postgres LISTEN/NOTIFY or the
+ *     in-memory broadcast bus emit one event per write, in write order).
+ *   - `usesPolling: true`  → `subscribeToChanges.polling` — set equality plus
+ *     event count (polling-based subscriptions diff a snapshot and have no
+ *     way to preserve commit order).
+ *
+ * When `capabilities.supportsSubscriptions` is true, `usesPolling` is
+ * required on the contract opts; the type guarantees this at compile time.
+ */
 export function subscribeToChangesBlock(opts: TabularStorageContractOpts): void {
+  if (!opts.capabilities.supportsSubscriptions) {
+    describe.skip("subscribeToChanges", () => {
+      it("skipped: capabilities.supportsSubscriptions === false", () => {});
+    });
+    return;
+  }
+
   const expectFails = new Set(opts.expectedFailures ?? []);
   const itImpl = expectFails.has("subscribeToChanges") ? itExpectFail : it;
+  // `usesPolling` is required when `supportsSubscriptions: true` (enforced by
+  // the discriminated `TabularStorageContractOpts` union). The non-null
+  // assertion below is safe given the early-return on `supportsSubscriptions`.
+  const usesPolling = opts.usesPolling!;
+  const pollingIntervalMs = opts.pollingIntervalMs ?? 1;
+  const waitTime = usesPolling ? Math.max(pollingIntervalMs * 8, 200) : 50;
+  const initWaitTime = usesPolling ? Math.max(pollingIntervalMs * 10, 300) : 10;
 
-  describe.skipIf(!opts.capabilities.supportsSubscriptions)("subscribeToChanges", () => {
-    const usesPolling = opts.usesPolling ?? false;
-    const pollingIntervalMs = opts.pollingIntervalMs ?? 1;
-    const waitTime = usesPolling ? Math.max(pollingIntervalMs * 8, 200) : 50;
-    const initWaitTime = usesPolling ? Math.max(pollingIntervalMs * 10, 300) : 10;
+  if (usesPolling) {
+    describe("subscribeToChanges.polling", () => {
+      let storage: ITabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>;
 
+      beforeEach(async () => {
+        storage = await opts.createStorage();
+        await storage.setupDatabase?.();
+      });
+
+      afterEach(async () => {
+        await storage.deleteAll();
+        storage.destroy?.();
+      });
+
+      itImpl(
+        "observes every write (set equality + count, order unspecified)",
+        async () => {
+          const changes: TabularChangePayload<FromSchema<typeof CompoundSchema>>[] = [];
+          const unsubscribe = storage.subscribeToChanges((change) => changes.push(change), {
+            pollingIntervalMs,
+          });
+
+          await sleep(initWaitTime);
+
+          await storage.put({ name: "t1", type: "s1", option: "v1", success: true });
+          await storage.put({ name: "t2", type: "s2", option: "v2", success: false });
+          await storage.put({ name: "t3", type: "s3", option: "v3", success: true });
+
+          await sleep(waitTime);
+
+          const writeEvents = changes.filter((c) => c.type === "INSERT" || c.type === "UPDATE");
+          // Polling diffs a snapshot: every write must be visible exactly once,
+          // but commit order is unspecified.
+          expect(writeEvents.length).toBe(3);
+          const options = writeEvents.map((e) => e.new?.option).sort();
+          expect(options).toEqual(["v1", "v2", "v3"]);
+
+          unsubscribe();
+        },
+        opts.timeout
+      );
+    });
+    return;
+  }
+
+  describe("subscribeToChanges.eventDriven", () => {
     let storage: ITabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>;
 
     beforeEach(async () => {
@@ -54,18 +122,11 @@ export function subscribeToChangesBlock(opts: TabularStorageContractOpts): void 
         await sleep(waitTime);
 
         const writeEvents = changes.filter((c) => c.type === "INSERT" || c.type === "UPDATE");
+        // Event-driven backends must emit one event per write in commit order.
         expect(writeEvents.length).toBe(3);
-
-        const options = writeEvents.map((e) => e.new?.option).sort();
-        if (usesPolling) {
-          // Polling detects all writes in one snapshot diff — order is unspecified
-          expect(options).toEqual(["v1", "v2", "v3"]);
-        } else {
-          // Event-driven subscriptions emit in write order
-          expect(writeEvents[0].new?.option).toBe("v1");
-          expect(writeEvents[1].new?.option).toBe("v2");
-          expect(writeEvents[2].new?.option).toBe("v3");
-        }
+        expect(writeEvents[0].new?.option).toBe("v1");
+        expect(writeEvents[1].new?.option).toBe("v2");
+        expect(writeEvents[2].new?.option).toBe("v3");
 
         unsubscribe();
       },

--- a/packages/test/src/contract/tabular-storage/types.ts
+++ b/packages/test/src/contract/tabular-storage/types.ts
@@ -33,24 +33,13 @@ export type TabularStorageContractAssertion =
   | "withTransactionRollback"
   | "countMatchesQuery";
 
-export interface TabularStorageContractOpts {
+interface TabularStorageContractBaseOpts {
   readonly name: string;
   readonly skip?: boolean;
   readonly timeout?: number;
   readonly createStorage: () => Promise<
     ITabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>
   >;
-  readonly capabilities: {
-    readonly supportsSubscriptions: boolean;
-    readonly supportsVectorColumns: boolean;
-    readonly supportsTransactions: boolean;
-    /** Whether `query(criteria)` is supported. False for FsFolder etc. */
-    readonly supportsQuery: boolean;
-  };
-  /** Whether this storage uses polling (requires longer waits between steps). */
-  readonly usesPolling?: boolean;
-  /** Polling interval forwarded to subscribeToChanges for polling-based implementations. */
-  readonly pollingIntervalMs?: number;
   /**
    * Required when capabilities.supportsVectorColumns is true. Creates a fresh
    * storage instance typed to VectorItemSchema for the round-trip assertion.
@@ -65,3 +54,44 @@ export interface TabularStorageContractOpts {
    */
   readonly expectedFailures?: ReadonlyArray<TabularStorageContractAssertion>;
 }
+
+interface SubscriptionCapableCapabilities {
+  readonly supportsSubscriptions: true;
+  readonly supportsVectorColumns: boolean;
+  readonly supportsTransactions: boolean;
+  /** Whether `query(criteria)` is supported. False for FsFolder etc. */
+  readonly supportsQuery: boolean;
+}
+
+interface SubscriptionCapableOpts extends TabularStorageContractBaseOpts {
+  readonly capabilities: SubscriptionCapableCapabilities;
+  /**
+   * Required when supportsSubscriptions is true. Selects between the two
+   * subscribeToChanges contract blocks:
+   *   - false → eventDriven (strict commit order)
+   *   - true  → polling (set equality + count)
+   */
+  readonly usesPolling: boolean;
+  /** Polling interval forwarded to subscribeToChanges for polling-based implementations. */
+  readonly pollingIntervalMs?: number;
+}
+
+interface SubscriptionIncapableCapabilities {
+  readonly supportsSubscriptions: false;
+  readonly supportsVectorColumns: boolean;
+  readonly supportsTransactions: boolean;
+  /** Whether `query(criteria)` is supported. False for FsFolder etc. */
+  readonly supportsQuery: boolean;
+}
+
+interface SubscriptionIncapableOpts extends TabularStorageContractBaseOpts {
+  readonly capabilities: SubscriptionIncapableCapabilities;
+  /**
+   * Only meaningful when supportsSubscriptions is true. Permitted (but
+   * ignored) on incapable backends to keep wiring ergonomic.
+   */
+  readonly usesPolling?: boolean;
+  readonly pollingIntervalMs?: number;
+}
+
+export type TabularStorageContractOpts = SubscriptionCapableOpts | SubscriptionIncapableOpts;

--- a/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
+++ b/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
@@ -4,9 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InMemoryQueueStorage, InMemoryRateLimiterStorage, RateLimiter } from "@workglow/job-queue";
-import { setLogger } from "@workglow/util";
-import { describe } from "vitest";
+import type { IJobExecuteContext } from "@workglow/job-queue";
+import {
+  InMemoryQueueStorage,
+  InMemoryRateLimiterStorage,
+  Job,
+  JobQueueClient,
+  JobQueueServer,
+  JobStatus,
+  RateLimiter,
+} from "@workglow/job-queue";
+import { setLogger, sleep, uuid4 } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 import { runGenericJobQueueTests } from "./genericJobQueueTests";
 
@@ -21,4 +30,173 @@ describe("InMemoryJobQueue", () => {
         windowSizeInSeconds,
       })
   );
+});
+
+// ---------------------------------------------------------------------------
+// New tests for abort_requested_at and lease expiry (PR 2)
+// ---------------------------------------------------------------------------
+
+interface TI {
+  readonly taskType?: string;
+  readonly data?: string;
+  readonly [key: string]: unknown;
+}
+interface TO {
+  readonly result?: string;
+  readonly [key: string]: unknown;
+}
+
+class SimpleTestJob extends Job<TI, TO> {
+  public override async execute(input: TI, context: IJobExecuteContext): Promise<TO> {
+    if (input.taskType === "long_running") {
+      return new Promise<TO>((_, reject) => {
+        context.signal.addEventListener("abort", () => reject(new Error("Aborted")), {
+          once: true,
+        });
+      });
+    }
+    return { result: "done" };
+  }
+}
+
+describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
+  let storage: InMemoryQueueStorage<TI, TO>;
+  let queueName: string;
+
+  beforeEach(async () => {
+    queueName = `test-lease-${uuid4()}`;
+    storage = new InMemoryQueueStorage(queueName);
+    await storage.migrate();
+  });
+
+  afterEach(async () => {
+    await storage.deleteAll();
+  });
+
+  it("abort PENDING → immediate FAILED with abort_requested_at set", async () => {
+    const id = await storage.add({ input: { data: "x" }, run_after: null, completed_at: null });
+    expect(id).toBeDefined();
+
+    // Job is PENDING before abort
+    const before = await storage.get(id);
+    expect(before?.status).toBe(JobStatus.PENDING);
+    expect(before?.abort_requested_at).toBeFalsy();
+
+    await storage.abort(id);
+
+    const after = await storage.get(id);
+    expect(after?.status).toBe(JobStatus.FAILED);
+    expect(after?.abort_requested_at).toBeTruthy();
+    // No ABORTING status ever appears
+    expect(after?.status).not.toBe("ABORTING");
+  });
+
+  it("abort PROCESSING → sets abort_requested_at only, leaves status PROCESSING", async () => {
+    const id = await storage.add({ input: { data: "y" }, run_after: null, completed_at: null });
+    // Claim it
+    await storage.next("worker-1");
+
+    const processing = await storage.get(id);
+    expect(processing?.status).toBe(JobStatus.PROCESSING);
+
+    await storage.abort(id);
+
+    const after = await storage.get(id);
+    expect(after?.status).toBe(JobStatus.PROCESSING);
+    expect(after?.abort_requested_at).toBeTruthy();
+    expect(after?.status).not.toBe("ABORTING");
+  });
+
+  it("lease expiry re-claim: second worker claims job after first lease expires", async () => {
+    const id = await storage.add({ input: { data: "z" }, run_after: null, completed_at: null });
+
+    // Claim with a very short lease (10ms)
+    const claimed1 = await storage.next("worker-1", { leaseMs: 10 });
+    expect(claimed1?.id).toBe(id);
+    expect(claimed1?.worker_id).toBe("worker-1");
+
+    // Second worker immediately — should NOT claim (lease still active)
+    const tooEarly = await storage.next("worker-2", { leaseMs: 30000 });
+    expect(tooEarly).toBeUndefined();
+
+    // Wait for lease to expire
+    await sleep(30);
+
+    // Now worker-2 should reclaim it
+    const claimed2 = await storage.next("worker-2", { leaseMs: 30000 });
+    expect(claimed2?.id).toBe(id);
+    expect(claimed2?.worker_id).toBe("worker-2");
+    expect(claimed2?.status).toBe(JobStatus.PROCESSING);
+  });
+
+  it("extendLease keeps job alive past original expiry", async () => {
+    const id = await storage.add({ input: { data: "w" }, run_after: null, completed_at: null });
+
+    // Claim with a short lease (20ms)
+    const claimed = await storage.next("worker-a", { leaseMs: 20 });
+    expect(claimed?.id).toBe(id);
+
+    // Extend the lease to 5 seconds before it expires
+    await sleep(5);
+    await storage.extendLease(id, "worker-a", 5000);
+
+    // Wait past the original 20ms lease
+    await sleep(30);
+
+    // worker-b should NOT be able to reclaim because the lease was extended
+    const notClaimed = await storage.next("worker-b", { leaseMs: 30000 });
+    expect(notClaimed).toBeUndefined();
+
+    // worker-a's job should still be PROCESSING and owned by worker-a
+    const job = await storage.get(id);
+    expect(job?.status).toBe(JobStatus.PROCESSING);
+    expect(job?.worker_id).toBe("worker-a");
+  });
+
+  it("extendLease throws if lease is not owned by worker", async () => {
+    const id = await storage.add({ input: { data: "v" }, run_after: null, completed_at: null });
+    await storage.next("worker-x");
+
+    await expect(storage.extendLease(id, "worker-y", 5000)).rejects.toThrow(/extendLease failed/);
+  });
+
+  it("abort PROCESSING worker observes abort_requested_at via checkForAbortingJobs", async () => {
+    const server = new JobQueueServer<TI, TO, SimpleTestJob>(SimpleTestJob, {
+      storage: storage as any,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 0,
+    });
+    const client = new JobQueueClient<TI, TO>({ storage: storage as any, queueName });
+    client.attach(server);
+
+    await server.start();
+
+    const handle = await client.submit({ taskType: "long_running", data: "abort-test" });
+
+    // Wait for PROCESSING
+    for (let i = 0; i < 200; i++) {
+      const j = await client.getJob(handle.id);
+      if (j?.status === JobStatus.PROCESSING) break;
+      await sleep(5);
+    }
+    expect((await client.getJob(handle.id))?.status).toBe(JobStatus.PROCESSING);
+
+    // Abort via storage directly (simulating cross-process abort)
+    await storage.abort(handle.id);
+
+    // Wait for job to fail
+    let failed = false;
+    for (let i = 0; i < 200; i++) {
+      const j = await client.getJob(handle.id);
+      if (j?.status === JobStatus.FAILED) {
+        failed = true;
+        break;
+      }
+      await sleep(5);
+    }
+
+    await server.stop();
+    expect(failed).toBe(true);
+  });
 });

--- a/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
+++ b/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
@@ -362,6 +362,7 @@ describe("InMemoryJobQueue — worker prefetch (PR 5)", () => {
       pollIntervalMs: 5,
       stopTimeoutMs: 200,
       limiter,
+      prefetch: 4,
     });
     const client = new JobQueueClient<TI, TO>({ storage: storage as any, queueName });
     client.attach(server);

--- a/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
+++ b/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IJobExecuteContext } from "@workglow/job-queue";
+import type { DeadLetter, IJobExecuteContext } from "@workglow/job-queue";
 import {
+  ConcurrencyLimiter,
   InMemoryQueueStorage,
   InMemoryRateLimiterStorage,
   Job,
@@ -13,6 +14,7 @@ import {
   JobQueueServer,
   JobStatus,
   RateLimiter,
+  RetryableJobError,
 } from "@workglow/job-queue";
 import { setLogger, sleep, uuid4 } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -198,5 +200,194 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
 
     await server.stop();
     expect(failed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory IMessageQueue for DLQ testing
+// ---------------------------------------------------------------------------
+
+import type { IClaim, IMessageQueue, MessageId } from "@workglow/job-queue";
+
+class CollectingQueue<Body> implements IMessageQueue<Body> {
+  public readonly scope = "process" as const;
+  public readonly messages: Body[] = [];
+
+  async send(body: Body): Promise<MessageId> {
+    this.messages.push(body);
+    return this.messages.length - 1;
+  }
+
+  async sendBatch(bodies: readonly Body[]): Promise<readonly MessageId[]> {
+    return Promise.all(bodies.map((b) => this.send(b)));
+  }
+
+  async receive(_opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<Body>[]> {
+    return [];
+  }
+
+  async releaseClaim(_id: MessageId): Promise<void> {}
+
+  async migrate(): Promise<void> {}
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DLQ tests (PR 5)
+// ---------------------------------------------------------------------------
+
+class AlwaysFailJob extends Job<TI, TO> {
+  public override async execute(_input: TI, _context: IJobExecuteContext): Promise<TO> {
+    throw new RetryableJobError("always fails");
+  }
+}
+
+describe("InMemoryJobQueue — dead-letter queue (PR 5)", () => {
+  let storage: InMemoryQueueStorage<TI, TO>;
+  let queueName: string;
+
+  beforeEach(async () => {
+    queueName = `test-dlq-${uuid4()}`;
+    storage = new InMemoryQueueStorage(queueName);
+    await storage.migrate();
+  });
+
+  afterEach(async () => {
+    await storage.deleteAll();
+  });
+
+  it("exhausted job lands in DLQ with correct fields", async () => {
+    const dlq = new CollectingQueue<DeadLetter<TI>>();
+
+    const server = new JobQueueServer<TI, TO, AlwaysFailJob>(AlwaysFailJob, {
+      storage: storage as any,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 0,
+      deadLetter: dlq,
+    });
+    const client = new JobQueueClient<TI, TO>({ storage: storage as any, queueName });
+    client.attach(server);
+
+    await server.start();
+
+    // maxAttempts=1 so the job exhausts on the first failure
+    const handle = await client.send({ data: "dlq-test" }, { maxAttempts: 1 });
+
+    // Wait for FAILED
+    for (let i = 0; i < 200; i++) {
+      const j = await client.getJob(handle.id);
+      if (j?.status === JobStatus.FAILED) break;
+      await sleep(5);
+    }
+    expect((await client.getJob(handle.id))?.status).toBe(JobStatus.FAILED);
+
+    await server.stop();
+
+    expect(dlq.messages).toHaveLength(1);
+    const letter = dlq.messages[0];
+    expect(letter.original).toEqual({ data: "dlq-test" });
+    expect(letter.error).toBeTruthy();
+    expect(letter.queueName).toBe(queueName);
+    expect(letter.attempts).toBeGreaterThanOrEqual(0);
+  });
+
+  it("deadLetter: 'discard' (default) — exhausted job reaches FAILED, DLQ stays empty", async () => {
+    const dlq = new CollectingQueue<DeadLetter<TI>>();
+
+    // Deliberately do NOT pass deadLetter — default is "discard"
+    const server = new JobQueueServer<TI, TO, AlwaysFailJob>(AlwaysFailJob, {
+      storage: storage as any,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 0,
+    });
+    const client = new JobQueueClient<TI, TO>({ storage: storage as any, queueName });
+    client.attach(server);
+
+    await server.start();
+
+    const handle = await client.send({ data: "discard-test" }, { maxAttempts: 1 });
+
+    // Wait for FAILED
+    for (let i = 0; i < 200; i++) {
+      const j = await client.getJob(handle.id);
+      if (j?.status === JobStatus.FAILED) break;
+      await sleep(5);
+    }
+    expect((await client.getJob(handle.id))?.status).toBe(JobStatus.FAILED);
+
+    await server.stop();
+
+    // DLQ was never passed to the server, so nothing was forwarded
+    expect(dlq.messages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefetch tests (PR 5)
+// ---------------------------------------------------------------------------
+
+describe("InMemoryJobQueue — worker prefetch (PR 5)", () => {
+  it("prefetch: 4 with ConcurrencyLimiter(2) — at most 2 jobs run concurrently", async () => {
+    const queueName = `test-prefetch-${uuid4()}`;
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    await storage.migrate();
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    class TrackedSlowJob extends Job<TI, TO> {
+      public override async execute(_input: TI, _context: IJobExecuteContext): Promise<TO> {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await sleep(30);
+        concurrent--;
+        return { result: "done" };
+      }
+    }
+
+    const limiter = new ConcurrencyLimiter(2);
+
+    const server = new JobQueueServer<TI, TO, TrackedSlowJob>(TrackedSlowJob, {
+      storage: storage as any,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 200,
+      limiter,
+    });
+    const client = new JobQueueClient<TI, TO>({ storage: storage as any, queueName });
+    client.attach(server);
+
+    await server.start();
+
+    // Submit 6 jobs
+    const handles = await Promise.all(
+      Array.from({ length: 6 }, (_, i) => client.send({ data: `job-${i}` }))
+    );
+
+    // Wait for all to complete
+    for (let i = 0; i < 500; i++) {
+      const statuses = await Promise.all(handles.map((h) => client.getJob(h.id)));
+      if (statuses.every((j) => j?.status === JobStatus.COMPLETED)) break;
+      await sleep(10);
+    }
+
+    const statuses = await Promise.all(handles.map((h) => client.getJob(h.id)));
+    expect(statuses.every((j) => j?.status === JobStatus.COMPLETED)).toBe(true);
+
+    // ConcurrencyLimiter(2) must have enforced a max of 2 concurrent jobs
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+    expect(maxConcurrent).toBeGreaterThanOrEqual(1);
+
+    await server.stop();
+    await storage.deleteAll();
   });
 });

--- a/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
+++ b/packages/test/src/test/job-queue/InMemoryJobQueue.test.ts
@@ -74,7 +74,7 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
   });
 
   it("abort PENDING → immediate FAILED with abort_requested_at set", async () => {
-    const id = await storage.add({ input: { data: "x" }, run_after: null, completed_at: null });
+    const id = await storage.add({ input: { data: "x" }, visible_at: null, completed_at: null });
     expect(id).toBeDefined();
 
     // Job is PENDING before abort
@@ -92,7 +92,7 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
   });
 
   it("abort PROCESSING → sets abort_requested_at only, leaves status PROCESSING", async () => {
-    const id = await storage.add({ input: { data: "y" }, run_after: null, completed_at: null });
+    const id = await storage.add({ input: { data: "y" }, visible_at: null, completed_at: null });
     // Claim it
     await storage.next("worker-1");
 
@@ -108,12 +108,12 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
   });
 
   it("lease expiry re-claim: second worker claims job after first lease expires", async () => {
-    const id = await storage.add({ input: { data: "z" }, run_after: null, completed_at: null });
+    const id = await storage.add({ input: { data: "z" }, visible_at: null, completed_at: null });
 
     // Claim with a very short lease (10ms)
     const claimed1 = await storage.next("worker-1", { leaseMs: 10 });
     expect(claimed1?.id).toBe(id);
-    expect(claimed1?.worker_id).toBe("worker-1");
+    expect(claimed1?.lease_owner).toBe("worker-1");
 
     // Second worker immediately — should NOT claim (lease still active)
     const tooEarly = await storage.next("worker-2", { leaseMs: 30000 });
@@ -125,12 +125,12 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
     // Now worker-2 should reclaim it
     const claimed2 = await storage.next("worker-2", { leaseMs: 30000 });
     expect(claimed2?.id).toBe(id);
-    expect(claimed2?.worker_id).toBe("worker-2");
+    expect(claimed2?.lease_owner).toBe("worker-2");
     expect(claimed2?.status).toBe(JobStatus.PROCESSING);
   });
 
   it("extendLease keeps job alive past original expiry", async () => {
-    const id = await storage.add({ input: { data: "w" }, run_after: null, completed_at: null });
+    const id = await storage.add({ input: { data: "w" }, visible_at: null, completed_at: null });
 
     // Claim with a short lease (20ms)
     const claimed = await storage.next("worker-a", { leaseMs: 20 });
@@ -150,11 +150,11 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
     // worker-a's job should still be PROCESSING and owned by worker-a
     const job = await storage.get(id);
     expect(job?.status).toBe(JobStatus.PROCESSING);
-    expect(job?.worker_id).toBe("worker-a");
+    expect(job?.lease_owner).toBe("worker-a");
   });
 
   it("extendLease throws if lease is not owned by worker", async () => {
-    const id = await storage.add({ input: { data: "v" }, run_after: null, completed_at: null });
+    const id = await storage.add({ input: { data: "v" }, visible_at: null, completed_at: null });
     await storage.next("worker-x");
 
     await expect(storage.extendLease(id, "worker-y", 5000)).rejects.toThrow(/extendLease failed/);
@@ -172,7 +172,7 @@ describe("InMemoryQueueStorage — abort_requested_at & lease expiry", () => {
 
     await server.start();
 
-    const handle = await client.submit({ taskType: "long_running", data: "abort-test" });
+    const handle = await client.send({ taskType: "long_running", data: "abort-test" });
 
     // Wait for PROCESSING
     for (let i = 0; i < 200; i++) {

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -187,12 +187,17 @@ describe("CompositeLimiter", () => {
     expect(await concurrency.tryAcquire()).not.toBeNull();
   });
 
-  it("should roll back partial acquisitions on failure", async () => {
-    const blocking = new ConcurrencyLimiter(0);
-    const normal = new NullLimiter();
-    const limiter = new CompositeLimiter([normal, blocking]);
-    // The composite must return null and not leave normal's slot acquired
-    expect(await limiter.tryAcquire()).toBeNull();
+  it("should roll back already-acquired slots when a later child fails", async () => {
+    const first = new ConcurrencyLimiter(1);
+    const second = new ConcurrencyLimiter(1);
+    // Saturate second so the composite will fail on it
+    await second.tryAcquire();
+    const composite = new CompositeLimiter([first, second]);
+    const result = await composite.tryAcquire();
+    expect(result).toBeNull();
+    // first's slot should have been rolled back — it can be acquired again
+    const token = await first.tryAcquire();
+    expect(token).not.toBeNull();
   });
 });
 

--- a/packages/test/src/test/job-queue/Limiters.test.ts
+++ b/packages/test/src/test/job-queue/Limiters.test.ts
@@ -17,10 +17,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 describe("NullLimiter", () => {
   const limiter = new NullLimiter();
 
-  it("should always allow proceeding", async () => {
-    expect(await limiter.canProceed()).toBe(true);
-  });
-
   it("should always tryAcquire successfully", async () => {
     expect(await limiter.tryAcquire()).not.toBeNull();
     expect(await limiter.tryAcquire()).not.toBeNull();
@@ -30,9 +26,7 @@ describe("NullLimiter", () => {
     expect(limiter.scope).toBe("process");
   });
 
-  it("should not throw on any method call", async () => {
-    await expect(limiter.recordJobStart()).resolves.toBeUndefined();
-    await expect(limiter.recordJobCompletion()).resolves.toBeUndefined();
+  it("should not throw on release, setNextAvailableTime, or clear", async () => {
     await expect(limiter.release(null)).resolves.toBeUndefined();
     await expect(limiter.setNextAvailableTime(new Date())).resolves.toBeUndefined();
     await expect(limiter.clear()).resolves.toBeUndefined();
@@ -72,41 +66,32 @@ describe("ConcurrencyLimiter", () => {
     expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
-  it("should allow proceeding when under limit", async () => {
-    expect(await limiter.canProceed()).toBe(true);
+  it("tryAcquire should return null when at concurrency limit", async () => {
+    await limiter.tryAcquire();
+    await limiter.tryAcquire();
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 
-  it("should block when at concurrency limit", async () => {
-    await limiter.recordJobStart();
-    await limiter.recordJobStart();
-    expect(await limiter.canProceed()).toBe(false);
-  });
-
-  it("should allow again after job completion", async () => {
-    await limiter.recordJobStart();
-    await limiter.recordJobStart();
-    expect(await limiter.canProceed()).toBe(false);
-    await limiter.recordJobCompletion();
-    expect(await limiter.canProceed()).toBe(true);
-  });
-
-  it("should not go below zero running jobs", async () => {
-    await limiter.recordJobCompletion();
-    await limiter.recordJobCompletion();
-    expect(await limiter.canProceed()).toBe(true);
+  it("tryAcquire should succeed again after release", async () => {
+    const t1 = await limiter.tryAcquire();
+    const t2 = await limiter.tryAcquire();
+    expect(await limiter.tryAcquire()).toBeNull();
+    await limiter.release(t1);
+    expect(await limiter.tryAcquire()).not.toBeNull();
+    await limiter.release(t2);
   });
 
   it("should reset on clear", async () => {
-    await limiter.recordJobStart();
-    await limiter.recordJobStart();
+    await limiter.tryAcquire();
+    await limiter.tryAcquire();
     await limiter.clear();
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should respect setNextAvailableTime", async () => {
     const future = new Date(Date.now() + 100_000);
     await limiter.setNextAvailableTime(future);
-    expect(await limiter.canProceed()).toBe(false);
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 });
 
@@ -127,80 +112,87 @@ describe("DelayLimiter", () => {
     expect(successes).toBe(1);
   });
 
-  it("should allow proceeding initially", async () => {
-    expect(await limiter.canProceed()).toBe(true);
+  it("should allow tryAcquire initially", async () => {
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
-  it("should block after recording a job start", async () => {
-    await limiter.recordJobStart();
-    expect(await limiter.canProceed()).toBe(false);
+  it("should block tryAcquire during delay window", async () => {
+    await limiter.tryAcquire();
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 
-  it("should allow proceeding after delay expires", async () => {
+  it("should allow tryAcquire after delay expires", async () => {
     const shortDelayLimiter = new DelayLimiter(10);
-    await shortDelayLimiter.recordJobStart();
+    await shortDelayLimiter.tryAcquire();
     await sleep(20);
-    expect(await shortDelayLimiter.canProceed()).toBe(true);
+    expect(await shortDelayLimiter.tryAcquire()).not.toBeNull();
   });
 
   it("should reset on clear", async () => {
-    await limiter.recordJobStart();
+    await limiter.tryAcquire();
     await limiter.clear();
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should only update nextAvailableTime if later", async () => {
     const past = new Date(Date.now() - 1000);
     await limiter.setNextAvailableTime(past);
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 });
 
 describe("CompositeLimiter", () => {
-  it("should proceed when all limiters agree", async () => {
+  it("should tryAcquire successfully when all limiters agree", async () => {
     const limiter = new CompositeLimiter([new NullLimiter(), new NullLimiter()]);
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
-  it("should block when any limiter blocks", async () => {
+  it("should return null from tryAcquire when any limiter is at capacity", async () => {
     const concurrency = new ConcurrencyLimiter(1);
-    await concurrency.recordJobStart();
+    await concurrency.tryAcquire();
     const limiter = new CompositeLimiter([new NullLimiter(), concurrency]);
-    expect(await limiter.canProceed()).toBe(false);
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 
   it("should addLimiter dynamically", async () => {
     const limiter = new CompositeLimiter();
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
     const blocking = new ConcurrencyLimiter(0);
     limiter.addLimiter(blocking);
-    expect(await limiter.canProceed()).toBe(false);
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 
-  it("should propagate recordJobStart to all limiters", async () => {
+  it("should propagate tryAcquire state to all child limiters", async () => {
     const concurrency = new ConcurrencyLimiter(2);
     const limiter = new CompositeLimiter([concurrency]);
-    await limiter.recordJobStart();
-    await limiter.recordJobStart();
-    expect(await concurrency.canProceed()).toBe(false);
+    await limiter.tryAcquire();
+    await limiter.tryAcquire();
+    expect(await concurrency.tryAcquire()).toBeNull();
   });
 
   it("should return latest getNextAvailableTime across limiters", async () => {
-    const delay1 = new DelayLimiter(10);
     const delay2 = new DelayLimiter(1000);
+    await delay2.tryAcquire();
     const before = Date.now();
-    await delay2.recordJobStart();
-    const limiter = new CompositeLimiter([delay1, delay2]);
+    const limiter = new CompositeLimiter([new DelayLimiter(10), delay2]);
     const nextTime = await limiter.getNextAvailableTime();
     expect(nextTime.getTime()).toBeGreaterThan(before + 500);
   });
 
   it("should propagate clear to all limiters", async () => {
     const concurrency = new ConcurrencyLimiter(1);
-    await concurrency.recordJobStart();
+    await concurrency.tryAcquire();
     const limiter = new CompositeLimiter([concurrency]);
     await limiter.clear();
-    expect(await concurrency.canProceed()).toBe(true);
+    expect(await concurrency.tryAcquire()).not.toBeNull();
+  });
+
+  it("should roll back partial acquisitions on failure", async () => {
+    const blocking = new ConcurrencyLimiter(0);
+    const normal = new NullLimiter();
+    const limiter = new CompositeLimiter([normal, blocking]);
+    // The composite must return null and not leave normal's slot acquired
+    expect(await limiter.tryAcquire()).toBeNull();
   });
 });
 
@@ -229,9 +221,9 @@ describe("EvenlySpacedRateLimiter", () => {
     );
   });
 
-  it("should allow proceeding initially", async () => {
+  it("should allow tryAcquire initially", async () => {
     const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 1 });
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should report process scope", () => {
@@ -247,36 +239,35 @@ describe("EvenlySpacedRateLimiter", () => {
     expect(successes).toBe(1);
   });
 
-  it("should space requests by setting next available time", async () => {
+  it("should space requests by advancing next available time after tryAcquire", async () => {
     const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 10 });
-    await limiter.recordJobStart();
+    await limiter.tryAcquire();
     // idealInterval = 10000/10 = 1000ms, so next available should be ~1s from now
     const nextTime = await limiter.getNextAvailableTime();
     expect(nextTime.getTime()).toBeGreaterThan(Date.now() + 500);
   });
 
-  it("should track job completion durations", async () => {
-    const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 1 });
-    await limiter.recordJobStart();
-    await limiter.recordJobCompletion();
-    // After recording completion, a second start should account for duration
-    await limiter.recordJobStart();
-    const nextTime = await limiter.getNextAvailableTime();
-    expect(nextTime.getTime()).toBeGreaterThanOrEqual(Date.now());
-  });
-
   it("should reset on clear", async () => {
     const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 1, windowSizeInSeconds: 100 });
-    await limiter.recordJobStart();
-    expect(await limiter.canProceed()).toBe(false);
+    await limiter.tryAcquire();
+    expect(await limiter.tryAcquire()).toBeNull();
     await limiter.clear();
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 
   it("should only update nextAvailableTime if later via setNextAvailableTime", async () => {
     const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 10, windowSizeInSeconds: 1 });
     const past = new Date(Date.now() - 1000);
     await limiter.setNextAvailableTime(past);
-    expect(await limiter.canProceed()).toBe(true);
+    expect(await limiter.tryAcquire()).not.toBeNull();
+  });
+
+  it("release should roll back the slot so a follow-up tryAcquire succeeds", async () => {
+    const limiter = new EvenlySpacedRateLimiter({ maxExecutions: 1, windowSizeInSeconds: 100 });
+    const token = await limiter.tryAcquire();
+    expect(token).not.toBeNull();
+    expect(await limiter.tryAcquire()).toBeNull();
+    await limiter.release(token);
+    expect(await limiter.tryAcquire()).not.toBeNull();
   });
 });

--- a/packages/test/src/test/job-queue/RateLimiter.test.ts
+++ b/packages/test/src/test/job-queue/RateLimiter.test.ts
@@ -120,46 +120,6 @@ describe("RateLimiter", () => {
     });
   });
 
-  describe("canProceed", () => {
-    it("should allow when execution count is below limit", async () => {
-      const limiter = new RateLimiter(storage, "queue", {
-        maxExecutions: 5,
-        windowSizeInSeconds: 60,
-      });
-      expect(await limiter.canProceed()).toBe(true);
-    });
-
-    it("should block when execution count meets limit", async () => {
-      storage._setExecutionCount(5);
-      const limiter = new RateLimiter(storage, "queue", {
-        maxExecutions: 5,
-        windowSizeInSeconds: 60,
-      });
-      expect(await limiter.canProceed()).toBe(false);
-    });
-  });
-
-  describe("recordJobStart", () => {
-    it("should call storage.recordExecution", async () => {
-      const limiter = new RateLimiter(storage, "queue", {
-        maxExecutions: 10,
-        windowSizeInSeconds: 60,
-      });
-      await limiter.recordJobStart();
-      expect(storage.recordExecution).toHaveBeenCalledWith("queue");
-    });
-  });
-
-  describe("recordJobCompletion", () => {
-    it("should be a no-op", async () => {
-      const limiter = new RateLimiter(storage, "queue", {
-        maxExecutions: 10,
-        windowSizeInSeconds: 60,
-      });
-      await expect(limiter.recordJobCompletion()).resolves.toBeUndefined();
-    });
-  });
-
   describe("clear", () => {
     it("should clear storage", async () => {
       const limiter = new RateLimiter(storage, "queue", {

--- a/packages/test/src/test/job-queue/TelemetryQueueStorage.test.ts
+++ b/packages/test/src/test/job-queue/TelemetryQueueStorage.test.ts
@@ -38,7 +38,7 @@ describe("TelemetryQueueStorage", () => {
   it("should forward add and create a span", async () => {
     const id = await wrapped.add({
       input: { data: "test" },
-      run_after: null,
+      visible_at: null,
       completed_at: null,
     });
     expect(id).toBeDefined();
@@ -53,7 +53,7 @@ describe("TelemetryQueueStorage", () => {
   it("should forward next and create a span", async () => {
     await inner.add({
       input: { data: "test" },
-      run_after: null,
+      visible_at: null,
       completed_at: null,
     });
     const job = await wrapped.next("worker-1");
@@ -70,7 +70,7 @@ describe("TelemetryQueueStorage", () => {
   it("should forward deleteAll and create a span", async () => {
     await inner.add({
       input: { data: "test" },
-      run_after: null,
+      visible_at: null,
       completed_at: null,
     });
     await wrapped.deleteAll();
@@ -80,7 +80,7 @@ describe("TelemetryQueueStorage", () => {
   it("should forward get and create a span", async () => {
     const id = await inner.add({
       input: { data: "test" },
-      run_after: null,
+      visible_at: null,
       completed_at: null,
     });
     const job = await wrapped.get(id);

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -1151,6 +1151,67 @@ export function runGenericJobQueueTests(
     });
   });
 
+  describe("atomic disableJob (H5)", () => {
+    it("disable() writes DISABLED in a single storage write — never observes FAILED", async () => {
+      // The H5 contract: disableJob writes status=DISABLED in one storage
+      // operation. The legacy two-write path (claim.fail() then
+      // saveStatus(DISABLED)) briefly persisted FAILED, so any subscriber
+      // observing during the window saw a transient FAILED → DISABLED.
+      //
+      // We assert this two ways:
+      //   - storage.get() after the call shows DISABLED.
+      //   - if the backend supports subscriptions, no FAILED transition
+      //     appears in the event stream for this id.
+      // Backends without working subscribeToChanges (subscriptions disabled
+      // or limited) simply do not emit anything; the final-state assertion
+      // is the strong invariant.
+      const handle = await client.send({ taskType: "task1", data: "atomic-disable" });
+      const id = handle.id;
+
+      const transitions: string[] = [];
+      // Subscriptions are optional per backend. Sqlite/Postgres-with-Pool/
+      // Supabase throw synchronously when subscribe is unsupported; treat
+      // that as "no events to observe" and let the final-state assertion
+      // carry the contract.
+      let unsubscribe: () => void = () => {};
+      try {
+        unsubscribe = storage.subscribeToChanges((change) => {
+          const newStatus = change.new?.status;
+          if (newStatus && change.new?.id === id) {
+            transitions.push(newStatus);
+          }
+        });
+      } catch {
+        // backend does not support subscribe — skip the event-stream check
+      }
+      await sleep(20);
+
+      await storage.next("test-worker", { leaseMs: 30_000 });
+      await storage.finalize(id, {
+        status: JobStatus.DISABLED,
+        completed_at: new Date().toISOString(),
+        lease_owner: null,
+        progress: 0,
+        progress_message: "",
+        progress_details: null,
+      });
+      await sleep(100);
+      unsubscribe();
+
+      // Final-state invariant — strong, works for every backend.
+      const final = await storage.get(id);
+      expect(final?.status).toBe(JobStatus.DISABLED);
+
+      // Event-stream invariant — only enforced when the backend produced any
+      // transitions at all. Sqlite/Postgres/Supabase may emit nothing here
+      // depending on their LISTEN/NOTIFY config; that's OK — the absence of
+      // FAILED is what matters when we DO see transitions.
+      if (transitions.length > 0) {
+        expect(transitions).not.toContain(JobStatus.FAILED);
+      }
+    });
+  });
+
   describe("atomic ack/fail (H2)", () => {
     it("ack persists result+status in one write — no separate saveResult step", async () => {
       // The H2 contract: claim.ack(result) writes output + COMPLETED in a

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -1151,6 +1151,33 @@ export function runGenericJobQueueTests(
     });
   });
 
+  describe("atomic ack/fail (H2)", () => {
+    it("ack persists result+status in one write — no separate saveResult step", async () => {
+      // The H2 contract: claim.ack(result) writes output + COMPLETED in a
+      // single storage operation. Earlier the worker did
+      // `jobStore.saveResult(...)` THEN `claim.ack()` — two separate writes
+      // that could split a row into "result saved, status still PROCESSING".
+      // We exercise that contract directly through the storage API: there
+      // should be no path that observes a COMPLETED row with output=null
+      // when the caller passed a non-null result.
+      const handle = await client.send({ taskType: "task1", data: "atomic-ack" });
+      const id = handle.id;
+      const claimed = await storage.next("test-worker", { leaseMs: 30_000 });
+      expect(claimed?.id).toBe(id);
+      // Directly call finalize() — the same call path claim.ack() takes.
+      await storage.finalize(id, {
+        output: { result: "computed" } as unknown as TOutput,
+        error: null,
+        error_code: null,
+        status: JobStatus.COMPLETED,
+        completed_at: new Date().toISOString(),
+      });
+      const final = await storage.get(id);
+      expect(final?.status).toBe(JobStatus.COMPLETED);
+      expect(final?.output).toEqual({ result: "computed" });
+    });
+  });
+
   describe("ack must not bump attempts (C2 + M4)", () => {
     it("submit → claim → finalize(COMPLETED): attempts stays at 0", async () => {
       // The contract: ack/fail go through storage.finalize(), which does NOT

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IQueueStorage, JobHandle } from "@workglow/job-queue";
+import type { IQueueStorage, JobHandle, JobStorageFormat } from "@workglow/job-queue";
 import {
   AbortSignalJobError,
   IJobExecuteContext,
@@ -1135,6 +1135,80 @@ export function runGenericJobQueueTests(
       expect(errorEventReceived).toBe(true);
       expect(errorEventJob).toBe(handle.id);
       expect(errorEventError).toContain("Job failed as expected");
+    });
+  });
+
+  describe("Abort/Retry/Lease invariants (H1 + H4)", () => {
+    it("abort → retry: reclaimed PENDING row has abort_requested_at cleared", async () => {
+      // Send a job, abort it while PENDING (sets abort_requested_at + FAILED
+      // in the storage layer immediately). Then re-submit with the same id
+      // routine by calling releaseClaim semantics: instead, we exercise the
+      // PENDING-retry branch of complete() directly via the storage API so we
+      // don't depend on the worker loop's retry orchestration.
+      const handle = await client.send({ taskType: "task1", data: "abort-retry-1" });
+      const id = handle.id;
+      // Simulate worker claim, then a retry-rescheduling complete() call.
+      const claimed = await storage.next("test-worker-1", { leaseMs: 30_000 });
+      expect(claimed).toBeDefined();
+      expect(claimed?.id).toBe(id);
+
+      // Set an abort_requested_at directly so we can prove complete() clears it.
+      await storage.abort(id);
+      const afterAbort = await storage.get(id);
+      // PROCESSING + abort_requested_at set.
+      expect(afterAbort?.abort_requested_at).toBeTruthy();
+
+      // Retry path: storage.complete() with PENDING + new visible_at clears it.
+      await storage.complete({
+        ...(afterAbort as JobStorageFormat<TInput, TOutput>),
+        status: JobStatus.PENDING,
+        visible_at: new Date(Date.now() + 10).toISOString(),
+        error: null,
+        error_code: null,
+        attempts: (afterAbort?.attempts ?? 0) + 1,
+      });
+
+      const afterRetry = await storage.get(id);
+      expect(afterRetry?.status).toBe(JobStatus.PENDING);
+      // The fix under test: abort_requested_at must be NULL on retry.
+      expect(afterRetry?.abort_requested_at ?? null).toBe(null);
+    });
+
+    it("releaseClaim clears abort_requested_at", async () => {
+      const handle = await client.send({ taskType: "task1", data: "release-claim" });
+      const id = handle.id;
+
+      await storage.next("test-worker-2", { leaseMs: 30_000 });
+      await storage.abort(id);
+      const afterAbort = await storage.get(id);
+      expect(afterAbort?.abort_requested_at).toBeTruthy();
+
+      await storage.releaseClaim(id);
+      const afterRelease = await storage.get(id);
+      expect(afterRelease?.status).toBe(JobStatus.PENDING);
+      expect(afterRelease?.abort_requested_at ?? null).toBe(null);
+    });
+
+    it("lease-expiry reclaim bumps attempts but clears abort_requested_at", async () => {
+      const handle = await client.send({ taskType: "task1", data: "lease-expiry" });
+      const id = handle.id;
+
+      // Claim with a 0ms lease so the next claim sees it as expired.
+      const first = await storage.next("crashed-worker", { leaseMs: 1 });
+      expect(first?.id).toBe(id);
+      const attemptsBeforeReclaim = first?.attempts ?? 0;
+
+      // Set abort_requested_at to simulate "abort raced with crash".
+      await storage.abort(id);
+
+      // Wait so the lease becomes expired.
+      await sleep(20);
+
+      // Reclaim by a different worker — must bump attempts and clear flag.
+      const second = await storage.next("rescue-worker", { leaseMs: 30_000 });
+      expect(second?.id).toBe(id);
+      expect(second?.attempts).toBe(attemptsBeforeReclaim + 1);
+      expect(second?.abort_requested_at ?? null).toBe(null);
     });
   });
 }

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -1030,7 +1030,12 @@ export function runGenericJobQueueTests(
       expect(failedJob?.status).toBe(JobStatus.FAILED);
       expect(failedJob?.error).toBe("Job failed as expected");
       expect(failedJob?.errorCode).toBe("JobError");
-      expect(failedJob?.attempts).toBe(1);
+      // Post-finalize semantics (C2 + M4): a single failed attempt that
+      // exhausts maxAttempts=1 ends the run via failJob → claim.fail() →
+      // storage.finalize(). finalize() does NOT bump `attempts`, so the
+      // counter remains 0. (The old code bumped via complete() which is
+      // exactly the double-counting bug being fixed.)
+      expect(failedJob?.attempts).toBe(0);
     });
 
     it("should retry a failed job up to maxAttempts", async () => {
@@ -1054,7 +1059,12 @@ export function runGenericJobQueueTests(
 
       const failedJob = await client.getJob(handle.id);
       expect(failedJob?.status).toBe(JobStatus.FAILED);
-      expect(failedJob?.attempts).toBe(3); // Should have attempted 3 times
+      // Post-finalize semantics: the PENDING-retry path bumps attempts in
+      // storage.complete() — so the first two retries bump from 0→1→2.
+      // The third (final) attempt fails permanently and goes through
+      // failJob → claim.fail() → finalize() which does NOT bump. Final
+      // value: 2. (The old behaviour bumped here too, yielding 3.)
+      expect(failedJob?.attempts).toBe(2);
       expect(failedJob?.error).toBe("Max attempts reached");
 
       await server.stop();
@@ -1104,7 +1114,10 @@ export function runGenericJobQueueTests(
       const failedJob = await client.getJob(handle.id);
       expect(failedJob?.status).toBe(JobStatus.FAILED);
       expect(failedJob?.error).toBe("Permanent failure - do not retry");
-      expect(failedJob?.attempts).toBe(1); // Should not retry permanent failures
+      // A permanent failure on the first attempt skips rescheduleJob and goes
+      // straight to failJob → claim.fail() → finalize(), which does NOT bump
+      // attempts (C2 + M4). Final counter: 0.
+      expect(failedJob?.attempts).toBe(0);
 
       await server.stop();
     });
@@ -1135,6 +1148,38 @@ export function runGenericJobQueueTests(
       expect(errorEventReceived).toBe(true);
       expect(errorEventJob).toBe(handle.id);
       expect(errorEventError).toContain("Job failed as expected");
+    });
+  });
+
+  describe("ack must not bump attempts (C2 + M4)", () => {
+    it("submit → claim → finalize(COMPLETED): attempts stays at 0", async () => {
+      // The contract: ack/fail go through storage.finalize(), which does NOT
+      // touch the `attempts` counter. A successful execution must not consume
+      // a retry attempt — the lease-expiry reclaim already charges the
+      // attempt at next() time, so charging it again here double-counts and
+      // can roll a healthy job into MAX_ATTEMPTS_REACHED.
+      const handle = await client.send({ taskType: "task1", data: "ack-no-bump" });
+      const id = handle.id;
+
+      const claimed = await storage.next("test-worker", { leaseMs: 30_000 });
+      expect(claimed?.id).toBe(id);
+      // Fresh PENDING claim does NOT bump attempts (the bump only happens
+      // for lease-expiry reclaim, and we just did a fresh claim).
+      expect(claimed?.attempts ?? 0).toBe(0);
+
+      // Simulate successful ack via finalize().
+      await storage.finalize(id, {
+        output: { result: "ok" },
+        error: null,
+        error_code: null,
+        status: JobStatus.COMPLETED,
+        completed_at: new Date().toISOString(),
+      });
+
+      const finalJob = await storage.get(id);
+      expect(finalJob?.status).toBe(JobStatus.COMPLETED);
+      // The bug under fix: previously this was 1 because complete() bumped attempts.
+      expect(finalJob?.attempts ?? 0).toBe(0);
     });
   });
 

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -215,7 +215,7 @@ export function runGenericJobQueueTests(
 
   describe("Basics", () => {
     it("should add a job to the queue", async () => {
-      const handle = await client.submit({ taskType: "task1", data: "input1" });
+      const handle = await client.send({ taskType: "task1", data: "input1" });
       expect(await client.size()).toBe(1);
       const retrievedJob = await client.getJob(handle.id);
       expect(retrievedJob?.status).toBe(JobStatus.PENDING);
@@ -243,7 +243,7 @@ export function runGenericJobQueueTests(
       await server.start();
 
       // Add and complete a job
-      const handle = await client.submit({ taskType: "other", data: "input1" });
+      const handle = await client.send({ taskType: "other", data: "input1" });
       await handle.waitFor();
 
       const jobExists = !!(await client.getJob(handle.id));
@@ -261,7 +261,7 @@ export function runGenericJobQueueTests(
       await server.start();
 
       // Add and complete a job
-      const handle = await client.submit({ taskType: "other", data: "input1" });
+      const handle = await client.send({ taskType: "other", data: "input1" });
       await handle.waitFor();
 
       // Give a small delay
@@ -291,7 +291,7 @@ export function runGenericJobQueueTests(
       await server.start();
 
       // Test completed job - immediate deletion happens in completeJob
-      const completedHandle = await client.submit({ taskType: "other", data: "input1" });
+      const completedHandle = await client.send({ taskType: "other", data: "input1" });
       await completedHandle.waitFor();
 
       // Small delay to allow cleanup
@@ -300,7 +300,7 @@ export function runGenericJobQueueTests(
       expect(completedJobExists).toBe(false);
 
       // Test failed job
-      const failedHandle = await client.submit({ taskType: "failing", data: "input2" });
+      const failedHandle = await client.send({ taskType: "failing", data: "input2" });
       try {
         await failedHandle.waitFor();
       } catch (error) {
@@ -316,8 +316,8 @@ export function runGenericJobQueueTests(
 
     it("should process jobs and get stats", async () => {
       await server.start();
-      const handle1 = await client.submit({ taskType: "other", data: "input1" });
-      const handle2 = await client.submit({ taskType: "other", data: "input2" });
+      const handle1 = await client.send({ taskType: "other", data: "input1" });
+      const handle2 = await client.send({ taskType: "other", data: "input2" });
       await handle1.waitFor();
       await handle2.waitFor();
 
@@ -329,15 +329,15 @@ export function runGenericJobQueueTests(
     });
 
     it("should clear all jobs in the queue", async () => {
-      await client.submit({ taskType: "task1", data: "input1" });
-      await client.submit({ taskType: "task1", data: "input1" });
+      await client.send({ taskType: "task1", data: "input1" });
+      await client.send({ taskType: "task1", data: "input1" });
       expect(await client.size()).toBe(2);
       await storage.deleteAll();
       expect(await client.size()).toBe(0);
     });
 
     it("should retrieve the output for a given task type and input", async () => {
-      const handle = await client.submit({ taskType: "task1", data: "input1" });
+      const handle = await client.send({ taskType: "task1", data: "input1" });
       await server.start();
       await handle.waitFor();
       const output = await client.outputForInput({ taskType: "task1", data: "input1" });
@@ -345,10 +345,10 @@ export function runGenericJobQueueTests(
     });
 
     it("should run the queue and execute all", async () => {
-      await client.submit({ taskType: "task1", data: "input1" });
-      await client.submit({ taskType: "task2", data: "input2" });
-      await client.submit({ taskType: "task1", data: "input1" });
-      const lastHandle = await client.submit({ taskType: "task2", data: "input2" });
+      await client.send({ taskType: "task1", data: "input1" });
+      await client.send({ taskType: "task2", data: "input2" });
+      await client.send({ taskType: "task1", data: "input1" });
+      const lastHandle = await client.send({ taskType: "task2", data: "input2" });
       await server.start();
       await lastHandle.waitFor();
       await server.stop();
@@ -361,9 +361,9 @@ export function runGenericJobQueueTests(
       const totalJobs = 16;
       const maxAllowed = 4; // limiter: 4 per 60s
       for (let i = 0; i < totalJobs - 1; i++) {
-        await client.submit({ taskType: "task1", data: `input${i}` });
+        await client.send({ taskType: "task1", data: `input${i}` });
       }
-      await client.submit({ taskType: "task2", data: "input_last" });
+      await client.send({ taskType: "task2", data: "input_last" });
 
       await server.start();
 
@@ -385,7 +385,7 @@ export function runGenericJobQueueTests(
     });
 
     it("should abort a long-running job and trigger the abort event", async () => {
-      const handle = await client.submit({ taskType: "long_running", data: "input101" });
+      const handle = await client.send({ taskType: "long_running", data: "input101" });
 
       let abortEventTriggered = false;
       client.on("job_aborting", (_qn: string, eventJobId: unknown) => {
@@ -431,19 +431,19 @@ export function runGenericJobQueueTests(
     it("should abort all jobs in a job run while leaving other jobs unaffected", async () => {
       const jobRunId1 = "test-run-1";
       const jobRunId2 = "test-run-2";
-      const handle1 = await client.submit(
+      const handle1 = await client.send(
         { taskType: "long_running", data: "input1" },
         { jobRunId: jobRunId1 }
       );
-      const handle2 = await client.submit(
+      const handle2 = await client.send(
         { taskType: "long_running", data: "input2" },
         { jobRunId: jobRunId1 }
       );
-      const handle3 = await client.submit(
+      const handle3 = await client.send(
         { taskType: "long_running", data: "input3" },
         { jobRunId: jobRunId2 }
       );
-      const handle4 = await client.submit(
+      const handle4 = await client.send(
         { taskType: "long_running", data: "input4" },
         { jobRunId: jobRunId2 }
       );
@@ -485,7 +485,7 @@ export function runGenericJobQueueTests(
     });
 
     it("should wait for a job to complete", async () => {
-      const handle = await client.submit({ taskType: "task1", data: "input1" });
+      const handle = await client.send({ taskType: "task1", data: "input1" });
       await server.start();
       const output = await handle.waitFor();
       expect(output).toEqual({ result: "output1" });
@@ -534,10 +534,10 @@ export function runGenericJobQueueTests(
 
       try {
         // Add jobs to both queues
-        const handle1 = await client1.submit({ taskType: "task1", data: "queue1-job1" });
-        const handle2 = await client1.submit({ taskType: "task1", data: "queue1-job2" });
-        const handle3 = await client2.submit({ taskType: "task1", data: "queue2-job1" });
-        const handle4 = await client2.submit({ taskType: "task1", data: "queue2-job2" });
+        const handle1 = await client1.send({ taskType: "task1", data: "queue1-job1" });
+        const handle2 = await client1.send({ taskType: "task1", data: "queue1-job2" });
+        const handle3 = await client2.send({ taskType: "task1", data: "queue2-job1" });
+        const handle4 = await client2.send({ taskType: "task1", data: "queue2-job2" });
 
         // Verify each queue only sees its own jobs
         expect(await client1.size()).toBe(2);
@@ -623,7 +623,7 @@ export function runGenericJobQueueTests(
       client.attach(server);
       await server.start();
 
-      const handle = await client.submit({ taskType: "other", data: "input-wake" });
+      const handle = await client.send({ taskType: "other", data: "input-wake" });
       const start = Date.now();
       const result = (await Promise.race([
         handle.waitFor(),
@@ -637,7 +637,7 @@ export function runGenericJobQueueTests(
 
     itFastWake("deferred submit wakes before the poll interval elapses", async () => {
       // pollIntervalMs is 60s — without notify() flipping hasDeferredJobs, the
-      // worker would sleep through the full 60s and miss the runAfter deadline.
+      // worker would sleep through the full 60s and miss the visible_at deadline.
       await server.stop();
       const limiter = await limiterFactory?.(queueName, 4, 60);
       server = new JobQueueServer<TInput, TOutput, TestJob>(TestJob, {
@@ -649,10 +649,9 @@ export function runGenericJobQueueTests(
       client.attach(server);
       await server.start();
 
-      const runAfter = new Date(Date.now() + 200);
-      const handle = await client.submit(
+      const handle = await client.send(
         { taskType: "other", data: "deferred-wake" },
-        { runAfter }
+        { delaySeconds: 0.2 }
       );
 
       const start = Date.now();
@@ -680,7 +679,7 @@ export function runGenericJobQueueTests(
       client.attach(server);
       await server.start();
 
-      const handle = await client.submit({ taskType: "long_running", data: "to-abort" });
+      const handle = await client.send({ taskType: "long_running", data: "to-abort" });
 
       // Wait for the worker to pick it up (accommodate slower async storages).
       for (let i = 0; i < 300; i++) {
@@ -716,7 +715,7 @@ export function runGenericJobQueueTests(
       await server.start();
 
       // Submit a job that sleeps briefly, then completes.
-      const handle = await client.submit({ taskType: "other", data: "drain" });
+      const handle = await client.send({ taskType: "other", data: "drain" });
 
       // Wait until PROCESSING, then stop — the drain should wait for it to finish.
       for (let i = 0; i < 50; i++) {
@@ -743,7 +742,7 @@ export function runGenericJobQueueTests(
 
       try {
         await server.start();
-        const handle = await client.submit({ taskType: "progress", data: "track-progress" });
+        const handle = await client.send({ taskType: "progress", data: "track-progress" });
         await handle.waitFor();
         expect(saveProgressCalls).toBe(0);
       } finally {
@@ -761,7 +760,7 @@ export function runGenericJobQueueTests(
         details: Record<string, unknown> | null;
       }> = [];
 
-      const handle = await client.submit({ taskType: "progress", data: "input1" });
+      const handle = await client.send({ taskType: "progress", data: "input1" });
 
       // Listen for progress events
       client.on(
@@ -814,7 +813,7 @@ export function runGenericJobQueueTests(
         details: Record<string, unknown> | null;
       }> = [];
 
-      const handle = await client.submit({ taskType: "progress", data: "input1" });
+      const handle = await client.send({ taskType: "progress", data: "input1" });
 
       // Add job-specific listener
       const cleanup = handle.onProgress(
@@ -858,7 +857,7 @@ export function runGenericJobQueueTests(
       // Set up multiple jobs that take some time to complete
       const handles = [];
       for (let i = 0; i < 10; i++) {
-        const handle = await client.submit({ taskType: "progress", data: `input${i}` });
+        const handle = await client.send({ taskType: "progress", data: `input${i}` });
         handles.push(handle);
       }
 
@@ -882,7 +881,7 @@ export function runGenericJobQueueTests(
 
       // Add burst of jobs
       for (let i = 0; i < numJobs; i++) {
-        const handle = await client.submit({ taskType: "other", data: `input${i}` });
+        const handle = await client.send({ taskType: "other", data: `input${i}` });
         handles.push(handle);
       }
 
@@ -910,11 +909,11 @@ export function runGenericJobQueueTests(
       // between those reads, producing transient under/over-count snapshots on
       // faster Vitest/Node runs.
       async function getJobCounts(
-        runAttempts = 50,
+        attempts = 50,
         retryDelay = 5
       ): Promise<{ pending: number; processing: number; completed: number }> {
         let lastCounts = { pending: 0, processing: 0, completed: 0 };
-        for (let i = 0; i < runAttempts; i++) {
+        for (let i = 0; i < attempts; i++) {
           try {
             const jobs = await Promise.all(handles.map((handle) => client.getJob(handle.id)));
             const pending = jobs.filter((job) => job?.status === JobStatus.PENDING).length;
@@ -927,7 +926,7 @@ export function runGenericJobQueueTests(
               return lastCounts;
             }
           } catch (err) {
-            if (i === runAttempts - 1) throw err;
+            if (i === attempts - 1) throw err;
           }
           await sleep(retryDelay);
         }
@@ -956,7 +955,7 @@ export function runGenericJobQueueTests(
 
       // Try to add jobs faster than the rate limit
       for (let i = 0; i < 30; i++) {
-        const handle = await client.submit({ taskType: "progress", data: `input${i}` });
+        const handle = await client.send({ taskType: "progress", data: `input${i}` });
         handles.push(handle);
       }
 
@@ -979,7 +978,7 @@ export function runGenericJobQueueTests(
   describe("Job Queue Restart", () => {
     it("should recover rate limits after pause", async () => {
       // Add a single quick job to test rate limiting
-      const initialHandle = await client.submit({ taskType: "other", data: "test_job" });
+      const initialHandle = await client.send({ taskType: "other", data: "test_job" });
 
       // Start queue and wait for job to complete
       await server.start();
@@ -993,7 +992,7 @@ export function runGenericJobQueueTests(
       await server.stop();
 
       // Add another job after pause
-      const newHandle = await client.submit({ taskType: "other", data: "after_pause" });
+      const newHandle = await client.send({ taskType: "other", data: "after_pause" });
 
       const pendingJob = await client.getJob(newHandle.id);
       expect(pendingJob?.status).toBe(JobStatus.PENDING);
@@ -1011,9 +1010,9 @@ export function runGenericJobQueueTests(
 
   describe("Error Handling", () => {
     it("should handle job failures and mark job as failed", async () => {
-      const handle = await client.submit(
+      const handle = await client.send(
         { taskType: "failing", data: "will-fail" },
-        { maxRetries: 0 }
+        { maxAttempts: 1 }
       );
 
       let error: Error | null = null;
@@ -1031,13 +1030,13 @@ export function runGenericJobQueueTests(
       expect(failedJob?.status).toBe(JobStatus.FAILED);
       expect(failedJob?.error).toBe("Job failed as expected");
       expect(failedJob?.errorCode).toBe("JobError");
-      expect(failedJob?.runAttempts).toBe(1);
+      expect(failedJob?.attempts).toBe(1);
     });
 
-    it("should retry a failed job up to maxRetries", async () => {
-      const handle = await client.submit(
+    it("should retry a failed job up to maxAttempts", async () => {
+      const handle = await client.send(
         { taskType: "failing_retryable", data: "will-retry" },
-        { maxRetries: 2 }
+        { maxAttempts: 3 }
       );
 
       let error: Error | null = null;
@@ -1055,8 +1054,8 @@ export function runGenericJobQueueTests(
 
       const failedJob = await client.getJob(handle.id);
       expect(failedJob?.status).toBe(JobStatus.FAILED);
-      expect(failedJob?.runAttempts).toBe(3); // Should have attempted 3 times
-      expect(failedJob?.error).toBe("Max retries reached");
+      expect(failedJob?.attempts).toBe(3); // Should have attempted 3 times
+      expect(failedJob?.error).toBe("Max attempts reached");
 
       await server.stop();
     });
@@ -1065,9 +1064,9 @@ export function runGenericJobQueueTests(
       const telemetry = new RecordingTelemetryProvider();
       setTelemetryProvider(telemetry);
 
-      const handle = await client.submit(
+      const handle = await client.send(
         { taskType: "failing_retryable", data: "will-retry" },
-        { maxRetries: 2 }
+        { maxAttempts: 3 }
       );
 
       try {
@@ -1080,16 +1079,16 @@ export function runGenericJobQueueTests(
       const span = telemetry.spans.at(-1);
       expect(span?.status).toEqual({
         code: SpanStatusCode.ERROR,
-        message: "Max retries reached",
+        message: "Max attempts reached",
       });
-      expect(span?.attributes["workglow.job.error"]).toBe("Max retries reached");
+      expect(span?.attributes["workglow.job.error"]).toBe("Max attempts reached");
     });
 
     it("should handle permanent failures without retrying", async () => {
       await server.start();
-      const handle = await client.submit(
+      const handle = await client.send(
         { taskType: "permanent_fail", data: "no-retry" },
-        { maxRetries: 2 }
+        { maxAttempts: 3 }
       );
 
       let error: Error | null = null;
@@ -1105,7 +1104,7 @@ export function runGenericJobQueueTests(
       const failedJob = await client.getJob(handle.id);
       expect(failedJob?.status).toBe(JobStatus.FAILED);
       expect(failedJob?.error).toBe("Permanent failure - do not retry");
-      expect(failedJob?.runAttempts).toBe(1); // Should not retry permanent failures
+      expect(failedJob?.attempts).toBe(1); // Should not retry permanent failures
 
       await server.stop();
     });
@@ -1122,9 +1121,9 @@ export function runGenericJobQueueTests(
         errorEventError = error;
       });
 
-      const handle = await client.submit(
+      const handle = await client.send(
         { taskType: "failing", data: "will-fail" },
-        { maxRetries: 0 }
+        { maxAttempts: 1 }
       );
 
       try {

--- a/packages/test/src/test/job-queue/genericJobQueueTests.ts
+++ b/packages/test/src/test/job-queue/genericJobQueueTests.ts
@@ -425,7 +425,7 @@ export function runGenericJobQueueTests(
       });
       expect(abortEventTriggered).toBe(true);
       const finalJob = await client.getJob(handle.id);
-      expect(finalJob?.status).toBeOneOf([JobStatus.FAILED, JobStatus.ABORTING]);
+      expect(finalJob?.status).toBe(JobStatus.FAILED);
     });
 
     it("should abort all jobs in a job run while leaving other jobs unaffected", async () => {
@@ -463,28 +463,20 @@ export function runGenericJobQueueTests(
       }
 
       await client.abortJobRun(jobRunId1);
-      while (attempts < 50) {
-        const job3Status = (await client.getJob(handle3.id))?.status;
-        const job4Status = (await client.getJob(handle4.id))?.status;
-        if (
-          (job3Status === JobStatus.FAILED || job3Status === JobStatus.ABORTING) &&
-          (job4Status === JobStatus.FAILED || job4Status === JobStatus.ABORTING)
-        ) {
+      // Wait for handle1 and handle2 (jobRunId1) to be aborted/failed
+      while (attempts < 200) {
+        const job1Status = (await client.getJob(handle1.id))?.status;
+        const job2Status = (await client.getJob(handle2.id))?.status;
+        if (job1Status === JobStatus.FAILED && job2Status === JobStatus.FAILED) {
           break;
         }
-        await sleep(1);
+        await sleep(5);
         attempts++;
       }
 
       // Verify job statuses
-      expect((await client.getJob(handle1.id))?.status).toBeOneOf([
-        JobStatus.FAILED,
-        JobStatus.ABORTING,
-      ]);
-      expect((await client.getJob(handle2.id))?.status).toBeOneOf([
-        JobStatus.FAILED,
-        JobStatus.ABORTING,
-      ]);
+      expect((await client.getJob(handle1.id))?.status).toBe(JobStatus.FAILED);
+      expect((await client.getJob(handle2.id))?.status).toBe(JobStatus.FAILED);
 
       const job3Status = (await client.getJob(handle3.id))?.status;
       const job4Status = (await client.getJob(handle4.id))?.status;
@@ -674,7 +666,7 @@ export function runGenericJobQueueTests(
       expect(Date.now() - start).toBeLessThan(5_000);
     });
 
-    itFastWake("abort resolves quickly without waiting for an ABORTING poll", async () => {
+    itFastWake("abort resolves quickly via in-process requestAbort path", async () => {
       // Long poll interval so the only route to abort delivery is the
       // in-process requestAbort path (Change 3).
       await server.stop();

--- a/packages/test/src/test/job-queue/genericPrefixedQueueStorageTests.ts
+++ b/packages/test/src/test/job-queue/genericPrefixedQueueStorageTests.ts
@@ -64,14 +64,14 @@ export function runGenericPrefixedQueueStorageTests(
       // Add job to storage1 (user1)
       const job1Id = await storage1.add({
         input: { data: "user1-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
       // Add job to storage2 (user2)
       const job2Id = await storage2.add({
         input: { data: "user2-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -89,19 +89,19 @@ export function runGenericPrefixedQueueStorageTests(
     it("should process jobs independently per prefix", async () => {
       await storage1.add({
         input: { data: "user1-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
-      // Small delay to ensure different run_after timestamps for ordering
+      // Small delay to ensure different visible_at timestamps for ordering
       await sleep(10);
       await storage1.add({
         input: { data: "user1-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await storage2.add({
         input: { data: "user2-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -124,12 +124,12 @@ export function runGenericPrefixedQueueStorageTests(
     it("should delete only jobs matching prefix", async () => {
       await storage1.add({
         input: { data: "user1-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await storage2.add({
         input: { data: "user2-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -178,17 +178,17 @@ export function runGenericPrefixedQueueStorageTests(
     it("should isolate jobs by both prefix values", async () => {
       const job1Id = await storage1.add({
         input: { data: "user1-project100" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const job2Id = await storage2.add({
         input: { data: "user1-project200" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const job3Id = await storage3.add({
         input: { data: "user2-project100" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -211,17 +211,17 @@ export function runGenericPrefixedQueueStorageTests(
     it("should filter peek results by both prefixes", async () => {
       await storage1.add({
         input: { data: "user1-project100-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await storage1.add({
         input: { data: "user1-project100-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await storage2.add({
         input: { data: "user1-project200-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -262,12 +262,12 @@ export function runGenericPrefixedQueueStorageTests(
     it("should isolate jobs by queue name even with same prefixes", async () => {
       const jobAId = await storageQueueA.add({
         input: { data: "queue-a-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const jobBId = await storageQueueB.add({
         input: { data: "queue-b-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -316,17 +316,17 @@ export function runGenericPrefixedQueueStorageTests(
     it("should isolate jobs across multiple queues with different prefix values", async () => {
       const job1Id = await queue1.add({
         input: { data: "queue1-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const job2Id = await queue2.add({
         input: { data: "queue2-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const job3Id = await queue3.add({
         input: { data: "queue3-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -350,23 +350,23 @@ export function runGenericPrefixedQueueStorageTests(
     it("should process jobs independently across multiple queues", async () => {
       await queue1.add({
         input: { data: "queue1-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await sleep(10);
       await queue1.add({
         input: { data: "queue1-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue2.add({
         input: { data: "queue2-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue3.add({
         input: { data: "queue3-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -393,22 +393,22 @@ export function runGenericPrefixedQueueStorageTests(
     it("should delete jobs independently across multiple queues", async () => {
       await queue1.add({
         input: { data: "queue1-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue1.add({
         input: { data: "queue1-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue2.add({
         input: { data: "queue2-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue3.add({
         input: { data: "queue3-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -424,27 +424,27 @@ export function runGenericPrefixedQueueStorageTests(
     it("should peek jobs independently across multiple queues", async () => {
       await queue1.add({
         input: { data: "queue1-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue1.add({
         input: { data: "queue1-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue2.add({
         input: { data: "queue2-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue3.add({
         input: { data: "queue3-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queue3.add({
         input: { data: "queue3-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -486,17 +486,17 @@ export function runGenericPrefixedQueueStorageTests(
     it("should isolate jobs across multiple queues without prefixes", async () => {
       const jobAId = await queueA.add({
         input: { data: "queue-a-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const jobBId = await queueB.add({
         input: { data: "queue-b-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const jobCId = await queueC.add({
         input: { data: "queue-c-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -520,23 +520,23 @@ export function runGenericPrefixedQueueStorageTests(
     it("should process jobs independently across queues without prefixes", async () => {
       await queueA.add({
         input: { data: "queue-a-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await sleep(10);
       await queueA.add({
         input: { data: "queue-a-job2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queueB.add({
         input: { data: "queue-b-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await queueC.add({
         input: { data: "queue-c-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -577,7 +577,7 @@ export function runGenericPrefixedQueueStorageTests(
       // Add a single job to the queue
       await storage.add({
         input: { data: "single-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -616,10 +616,10 @@ export function runGenericPrefixedQueueStorageTests(
       for (let i = 0; i < numJobs; i++) {
         await storage.add({
           input: { data: `job-${i}` },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
-        // Small delay to ensure different run_after timestamps
+        // Small delay to ensure different visible_at timestamps
         await sleep(5);
       }
 
@@ -677,17 +677,17 @@ export function runGenericPrefixedQueueStorageTests(
     it("should isolate jobs across queues with different prefix configurations", async () => {
       const jobNoPrefixId = await queueNoPrefix.add({
         input: { data: "no-prefix-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const jobSinglePrefixId = await queueSinglePrefix.add({
         input: { data: "single-prefix-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       const jobTwoPrefixesId = await queueTwoPrefixes.add({
         input: { data: "two-prefixes-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -730,19 +730,19 @@ export function runGenericPrefixedQueueStorageTests(
     it("should process jobs independently across queues with mixed configurations", async () => {
       await queueNoPrefix.add({
         input: { data: "no-prefix-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await sleep(10);
       await queueSinglePrefix.add({
         input: { data: "single-prefix-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await sleep(10);
       await queueTwoPrefixes.add({
         input: { data: "two-prefixes-job1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 

--- a/packages/test/src/test/job-queue/genericQueueStorageSubscriptionTests.ts
+++ b/packages/test/src/test/job-queue/genericQueueStorageSubscriptionTests.ts
@@ -87,7 +87,7 @@ export function runGenericQueueStorageSubscriptionTests(
 
       const jobId = await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -105,7 +105,7 @@ export function runGenericQueueStorageSubscriptionTests(
     it("should notify on job update", async () => {
       const jobId = await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -139,7 +139,7 @@ export function runGenericQueueStorageSubscriptionTests(
     it("should notify on job completion", async () => {
       const jobId = await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -180,7 +180,7 @@ export function runGenericQueueStorageSubscriptionTests(
     it("should notify on job deletion", async () => {
       const jobId = await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -208,12 +208,12 @@ export function runGenericQueueStorageSubscriptionTests(
     it("should notify on deleteAll", async () => {
       await storage.add({
         input: { data: "test-job-1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
       await storage.add({
         input: { data: "test-job-2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -241,7 +241,7 @@ export function runGenericQueueStorageSubscriptionTests(
     it("should notify on progress updates", async () => {
       const jobId = await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -280,7 +280,7 @@ export function runGenericQueueStorageSubscriptionTests(
 
       await storage.add({
         input: { data: "test-job-1" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -293,7 +293,7 @@ export function runGenericQueueStorageSubscriptionTests(
 
       await storage.add({
         input: { data: "test-job-2" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -319,7 +319,7 @@ export function runGenericQueueStorageSubscriptionTests(
 
       await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -358,14 +358,14 @@ export function runGenericQueueStorageSubscriptionTests(
         // Add job to storage1 (user1)
         await storage.add({
           input: { data: "user1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
 
         // Add job to storage2 (user2)
         await storage2.add({
           input: { data: "user2-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
 
@@ -414,7 +414,7 @@ export function runGenericQueueStorageSubscriptionTests(
 
       await storage.add({
         input: { data: "test-job" },
-        run_after: null,
+        visible_at: null,
         completed_at: null,
       });
 
@@ -497,17 +497,17 @@ export function runGenericQueueStorageSubscriptionTests(
         // Add jobs to different user/project combinations
         await storage1.add({
           input: { data: "user1-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage2.add({
           input: { data: "user1-project2-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage3.add({
           input: { data: "user2-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
 
@@ -542,17 +542,17 @@ export function runGenericQueueStorageSubscriptionTests(
         // Add jobs to different user/project combinations
         await storage1.add({
           input: { data: "user1-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage2.add({
           input: { data: "user1-project2-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage3.add({
           input: { data: "user2-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
 
@@ -587,17 +587,17 @@ export function runGenericQueueStorageSubscriptionTests(
         // Add jobs to different user/project combinations
         await storage1.add({
           input: { data: "user1-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage2.add({
           input: { data: "user1-project2-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
         await storage3.add({
           input: { data: "user2-project1-job" },
-          run_after: null,
+          visible_at: null,
           completed_at: null,
         });
 

--- a/packages/test/src/test/resource/DisposeStrategy.test.ts
+++ b/packages/test/src/test/resource/DisposeStrategy.test.ts
@@ -181,6 +181,73 @@ describe("DisposeStrategy.inactivity", () => {
     }
     expect(d).toHaveBeenCalledOnce();
   });
+
+  it("runStart() clears pending timers — registered key survives runComplete→runStart→advance(idleMs)", async () => {
+    // Race scenario: previous run completes and arms a 1000ms idle timer
+    // for key "a"; the next run begins ~500ms later. Without runStart(),
+    // the timer fires mid-run and disposes the resource the new run is
+    // about to use. With runStart(), the timer is cleared.
+    const scope = new ResourceScope({ strategy: DisposeStrategy.inactivity(1000) });
+    const d = vi.fn(async () => {});
+    scope.register("a", d);
+
+    await scope.runComplete();
+    await vi.advanceTimersByTimeAsync(500);
+
+    // New run begins.
+    await scope.runStart();
+    expect(d).not.toHaveBeenCalled();
+
+    // Advance well past the original idleMs — the cleared timer must not fire.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(d).not.toHaveBeenCalled();
+    expect(scope.size).toBe(1);
+  });
+
+  it("re-register after dispose survives without firing a stale timer", async () => {
+    // Sequence:
+    //   1. register("a", d1); runComplete arms a 1000ms timer for "a".
+    //   2. dispose("a") fires d1 (escape hatch) — but the timer entry may
+    //      still be in the strategy's map.
+    //   3. register("a", d2); the new disposer must NOT be torn down by a
+    //      lingering timer from the previous registration.
+    const scope = new ResourceScope({ strategy: DisposeStrategy.inactivity(1000) });
+    const d1 = vi.fn(async () => {});
+    scope.register("a", d1);
+    await scope.runComplete();
+
+    // Escape-hatch dispose runs d1 immediately.
+    await scope.dispose("a");
+    expect(d1).toHaveBeenCalledOnce();
+
+    // Re-register a new disposer under the same key; onRegister must clear
+    // any pending timer left over from the previous registration.
+    const d2 = vi.fn(async () => {});
+    scope.register("a", d2);
+
+    // If a stale timer were still armed, advancing to idleMs would fire it.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(d2).not.toHaveBeenCalled();
+    expect(scope.size).toBe(1);
+  });
+
+  it("when runStart is omitted, the inactivity timer fires (control case)", async () => {
+    // Inverted scenario: the runner did NOT call runStart() before its
+    // next run. The previous timer is still armed; after idleMs it fires
+    // and disposes the resource. This documents the bug runStart() exists
+    // to fix.
+    const scope = new ResourceScope({ strategy: DisposeStrategy.inactivity(1000) });
+    const d = vi.fn(async () => {});
+    scope.register("a", d);
+
+    await scope.runComplete();
+
+    // Simulate "next run begins" — but the runner forgets runStart().
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(d).toHaveBeenCalledOnce();
+    expect(scope.size).toBe(0);
+  });
 });
 
 describe("DisposePresets", () => {

--- a/packages/test/src/test/storage-migrations/IndexedDbQueueMigrations.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/IndexedDbQueueMigrations.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "fake-indexeddb/auto";
+
+import { indexedDbQueueMigrations } from "@workglow/indexeddb/job-queue";
+import { IndexedDbMigrationRunner } from "@workglow/indexeddb/storage";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression test for the v1 → v2 IndexedDB queue migration.
+ *
+ * Scenario the v2 migration must handle:
+ *   1. A pre-PR install ran the original v1 (which named the compound index
+ *      `queue_status_run_after` and stored `run_after` per row).
+ *   2. Upgrade lands; v2 must drop the old index, walk every row and copy
+ *      `run_after → visible_at`, then recreate the index as
+ *      `queue_status_visible_at` keyed on `visible_at`.
+ *
+ * The migration `up()` body MUST be synchronous — IDB upgrade transactions
+ * auto-commit on the next microtask, so any `await` between IDB requests
+ * would lose the rest of the migration. We verify that the cursor walk
+ * succeeds entirely inside the upgrade tx.
+ */
+describe("indexedDB queue migrations: v1 → v2 rename + backfill", () => {
+  it("synthetic v1 DB upgrades cleanly: rows carry visible_at, index renamed", async () => {
+    const dbName = `wglw_idb_qm_${Math.random().toString(36).slice(2)}`;
+    const tableName = "jobs";
+
+    // ── (1) Hand-build a v1 DB exactly as the pre-PR migration would have:
+    // create the object store + the four v1 indexes (including the old
+    // `queue_status_run_after`), then seed a row with `run_after` set and
+    // `visible_at` absent.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open(dbName, 2); // bookkeeping store + queue store
+      req.onerror = () => reject(req.error);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        // Synthetic bookkeeping store that records v1 as already applied so
+        // the runner doesn't re-execute v1 (its createObjectStore would throw).
+        if (!db.objectStoreNames.contains("_storage_migrations")) {
+          db.createObjectStore("_storage_migrations", { keyPath: ["component", "version"] });
+        }
+        if (!db.objectStoreNames.contains(tableName)) {
+          const store = db.createObjectStore(tableName, { keyPath: "id" });
+          store.createIndex("queue_status", ["queue", "status"], { unique: false });
+          // The legacy v1 index name + key path.
+          store.createIndex("queue_status_run_after", ["queue", "status", "run_after"], {
+            unique: false,
+          });
+          store.createIndex("queue_job_run_id", ["queue", "job_run_id"], { unique: false });
+          store.createIndex("queue_fingerprint_status", ["queue", "fingerprint", "status"], {
+            unique: false,
+          });
+        }
+      };
+      req.onsuccess = () => {
+        const db = req.result;
+        const tx = db.transaction(["_storage_migrations", tableName], "readwrite");
+        tx.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+        // Record v1 as already applied.
+        tx.objectStore("_storage_migrations").put({
+          component: `queue:indexeddb:${tableName}`,
+          version: 1,
+          description: "Create queue object store + indexes",
+          appliedAt: new Date().toISOString(),
+        });
+        // Seed a row exactly as the v1 schema would have stored it.
+        tx.objectStore(tableName).put({
+          id: 1,
+          queue: "test",
+          fingerprint: "fp1",
+          job_run_id: "jr1",
+          status: "PENDING",
+          input: "{}",
+          run_after: "2026-01-01T00:00:00.000Z",
+        });
+      };
+    });
+
+    // ── (2) Run the full migration chain. v1 is recorded → skipped; v2
+    // executes the rename + backfill.
+    const runner = new IndexedDbMigrationRunner(dbName);
+    await runner.run(indexedDbQueueMigrations(tableName, []));
+
+    // ── (3) Verify: old index gone, new index present, row's visible_at
+    // equals the original run_after, and peek/next-style queries still work.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open(dbName);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => {
+        const db = req.result;
+        try {
+          const tx = db.transaction([tableName], "readonly");
+          const store = tx.objectStore(tableName);
+          const names = Array.from(store.indexNames);
+          expect(names).not.toContain("queue_status_run_after");
+          expect(names).toContain("queue_status_visible_at");
+
+          const getReq = store.get(1);
+          getReq.onsuccess = () => {
+            const row = getReq.result as
+              | { id: number; run_after: string; visible_at?: string }
+              | undefined;
+            try {
+              expect(row).toBeDefined();
+              expect(row!.visible_at).toBe("2026-01-01T00:00:00.000Z");
+              // Cursor walk on the new index also succeeds — proves the
+              // backfill produced data the new index can serve.
+              const idx = store.index("queue_status_visible_at");
+              const cReq = idx.openCursor();
+              cReq.onsuccess = () => {
+                const cursor = cReq.result;
+                try {
+                  expect(cursor).not.toBeNull();
+                } catch (e) {
+                  reject(e);
+                  return;
+                }
+              };
+              tx.oncomplete = () => {
+                db.close();
+                resolve();
+              };
+              tx.onerror = () => {
+                db.close();
+                reject(tx.error);
+              };
+            } catch (e) {
+              db.close();
+              reject(e);
+            }
+          };
+          getReq.onerror = () => {
+            db.close();
+            reject(getReq.error);
+          };
+        } catch (e) {
+          db.close();
+          reject(e);
+        }
+      };
+    });
+  });
+});

--- a/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { postgresQueueMigrations } from "@workglow/postgres/job-queue";
+import type { Pool } from "@workglow/postgres/storage";
+import { PostgresMigrationRunner } from "@workglow/postgres/storage";
+import { sqliteQueueMigrations } from "@workglow/sqlite/job-queue";
+import { Sqlite, SqliteMigrationRunner } from "@workglow/sqlite/storage";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Verifies the v1→v2→v3 migration chain produces schema parity with a
+ * manually-built "fresh-install" DB: regardless of whether you arrive via
+ * the legacy v1 columns or a brand-new install, the final schema after v3
+ * must be byte-identical (column names, types, defaults, and indexes).
+ *
+ * The frozen-v1 invariant requires this: v1 MUST keep creating the legacy
+ * names (run_after / run_attempts / max_retries / last_ran_at / worker_id),
+ * and v3 MUST IF-EXISTS-rename them. Fresh installs run v1 → v2 → v3 too,
+ * so v3's IF EXISTS guards must turn into no-ops cleanly.
+ */
+describe("postgres queue migrations: v1→v2→v3 schema parity", () => {
+  it("fresh install lands on the same schema as a legacy install", async () => {
+    const a = new PGlite();
+    const b = new PGlite();
+    try {
+      const dbA = a as unknown as Pool;
+      const dbB = b as unknown as Pool;
+
+      // (1) Run the full migration chain on a fresh DB ("install A").
+      const runnerA = new PostgresMigrationRunner(dbA);
+      await runnerA.run(postgresQueueMigrations("jobs_a", []));
+
+      // (2) Build a synthetic "already migrated to v1" DB by running ONLY
+      // v1 (this is what an existing deployment looks like before this PR),
+      // then continue with v2 and v3.
+      const allB = postgresQueueMigrations("jobs_b", []);
+      const runnerB = new PostgresMigrationRunner(dbB);
+      await runnerB.run([allB[0]]); // v1 only
+      // Then run the rest of the chain on the legacy DB.
+      await runnerB.run(allB);
+
+      const finalCols = async (db: Pool, tbl: string): Promise<string[]> => {
+        const r = await db.query<{ column_name: string }>(
+          `SELECT column_name FROM information_schema.columns
+             WHERE table_name = $1 AND table_schema = current_schema()
+             ORDER BY column_name`,
+          [tbl]
+        );
+        return r.rows.map((row) => row.column_name);
+      };
+
+      const colsA = await finalCols(dbA, "jobs_a");
+      const colsB = await finalCols(dbB, "jobs_b");
+      expect(colsA).toEqual(colsB);
+      // Final schema must use the NEW names — no legacy names should remain.
+      for (const legacy of [
+        "run_after",
+        "run_attempts",
+        "max_retries",
+        "last_ran_at",
+        "worker_id",
+      ]) {
+        expect(colsA).not.toContain(legacy);
+      }
+      for (const renamed of [
+        "visible_at",
+        "attempts",
+        "max_attempts",
+        "last_attempted_at",
+        "lease_owner",
+      ]) {
+        expect(colsA).toContain(renamed);
+      }
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+});
+
+describe("sqlite queue migrations: v1→v2→v3 schema parity", () => {
+  it("fresh install lands on the same schema as a legacy install", async () => {
+    await Sqlite.init();
+    const dbA = new Sqlite.Database(":memory:");
+    const dbB = new Sqlite.Database(":memory:");
+    try {
+      const runnerA = new SqliteMigrationRunner(dbA);
+      await runnerA.run(sqliteQueueMigrations("jobs_a", []));
+
+      const allB = sqliteQueueMigrations("jobs_b", []);
+      const runnerB = new SqliteMigrationRunner(dbB);
+      await runnerB.run([allB[0]]);
+      await runnerB.run(allB);
+
+      const finalCols = (db: Sqlite.Database, tbl: string): string[] =>
+        db
+          .prepare<[], { name: string }>(`PRAGMA table_info(${tbl})`)
+          .all()
+          .map((r) => r.name)
+          .sort();
+
+      const colsA = finalCols(dbA, "jobs_a");
+      const colsB = finalCols(dbB, "jobs_b");
+      expect(colsA).toEqual(colsB);
+      for (const legacy of [
+        "run_after",
+        "run_attempts",
+        "max_retries",
+        "last_ran_at",
+        "worker_id",
+      ]) {
+        expect(colsA).not.toContain(legacy);
+      }
+      for (const renamed of [
+        "visible_at",
+        "attempts",
+        "max_attempts",
+        "last_attempted_at",
+        "lease_owner",
+      ]) {
+        expect(colsA).toContain(renamed);
+      }
+    } finally {
+      dbA.close();
+      dbB.close();
+    }
+  });
+});

--- a/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/CachedTabularStorage.integration.test.ts
@@ -704,6 +704,9 @@ runTabularStorageContract({
     supportsTransactions: false,
     supportsQuery: true,
   },
+  // CachedTabularStorage forwards subscribeToChanges to the durable backing
+  // store (here InMemoryTabularStorage), which is strictly event-driven.
+  usesPolling: false,
   createVectorStorage: async () => {
     const durable = new InMemoryTabularStorage<
       typeof VectorItemSchema,

--- a/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
@@ -69,6 +69,9 @@ runTabularStorageContract({
     supportsTransactions: false,
     supportsQuery: true,
   },
+  // SharedInMemoryTabularStorage broadcasts events via BroadcastChannel /
+  // the inner InMemoryTabularStorage event bus — strictly event-driven.
+  usesPolling: false,
   createVectorStorage: async () =>
     new SharedInMemoryTabularStorage<typeof VectorItemSchema, typeof VectorItemPrimaryKeyNames>(
       `shared_vec_${uuid4().replace(/-/g, "_")}`,

--- a/packages/test/src/test/storage-tabular/TelemetryTabularStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/TelemetryTabularStorage.test.ts
@@ -123,6 +123,9 @@ runTabularStorageContract({
     supportsTransactions: false,
     supportsQuery: true,
   },
+  // TelemetryTabularStorage delegates subscribeToChanges to its inner storage
+  // (InMemoryTabularStorage here) which is strictly event-driven.
+  usesPolling: false,
   createVectorStorage: async () => {
     const inner = new InMemoryTabularStorage<
       typeof VectorItemSchema,

--- a/packages/test/src/test/storage-tabular/subscribeToChangesContract.meta.test.ts
+++ b/packages/test/src/test/storage-tabular/subscribeToChangesContract.meta.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InMemoryTabularStorage, type TabularChangePayload } from "@workglow/storage";
+import type { FromSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+import { CompoundPrimaryKeyNames, CompoundSchema } from "./genericTabularStorageTests";
+
+/**
+ * Meta-tests for the `subscribeToChanges` contract assertion split.
+ *
+ * The contract has two flavors:
+ *   - `subscribeToChanges.eventDriven` — strict commit order (one event per
+ *     write, emitted in write order).
+ *   - `subscribeToChanges.polling`    — set equality + event count (a polling
+ *     snapshot diff cannot preserve commit order).
+ *
+ * These meta-tests exercise the invariants the two contract blocks check by
+ * running them against `InMemoryTabularStorage` (event-driven) and verifying
+ * the failure modes each block is designed to catch — write counts off, set
+ * mismatched, or commit order broken.
+ */
+describe("subscribeToChanges contract — meta", () => {
+  it("eventDriven invariant: count + commit-order equality", async () => {
+    const storage = new InMemoryTabularStorage<
+      typeof CompoundSchema,
+      typeof CompoundPrimaryKeyNames
+    >(CompoundSchema, CompoundPrimaryKeyNames);
+
+    const changes: TabularChangePayload<FromSchema<typeof CompoundSchema>>[] = [];
+    const unsubscribe = storage.subscribeToChanges((change) => changes.push(change));
+
+    await storage.put({ name: "t1", type: "s1", option: "v1", success: true });
+    await storage.put({ name: "t2", type: "s2", option: "v2", success: false });
+    await storage.put({ name: "t3", type: "s3", option: "v3", success: true });
+
+    const writes = changes.filter((c) => c.type === "INSERT" || c.type === "UPDATE");
+    expect(writes.length).toBe(3);
+    // Commit-order assertion — would fire if an event-driven backend reordered.
+    expect(writes.map((w) => w.new?.option)).toEqual(["v1", "v2", "v3"]);
+
+    unsubscribe();
+    storage.destroy?.();
+  });
+
+  it("eventDriven failure mode: missing write makes count fail", async () => {
+    // Simulate a "missing write" scenario by populating the change log with
+    // only two of three writes. The eventDriven count assertion (`toBe(3)`)
+    // must reject this case.
+    const incompleteWrites = [
+      { type: "INSERT" as const, new: { name: "t1", type: "s1", option: "v1", success: true } },
+      { type: "INSERT" as const, new: { name: "t3", type: "s3", option: "v3", success: true } },
+    ];
+    expect(incompleteWrites.length).toBe(2);
+    // The contract block's `toBe(3)` would fail here — verified via:
+    expect(() => expect(incompleteWrites.length).toBe(3)).toThrow();
+  });
+
+  it("polling invariant: count + set equality, order unspecified", async () => {
+    const storage = new InMemoryTabularStorage<
+      typeof CompoundSchema,
+      typeof CompoundPrimaryKeyNames
+    >(CompoundSchema, CompoundPrimaryKeyNames);
+
+    // Polling has no real ordering guarantees; we simulate by reading via the
+    // event bus and asserting set equality only.
+    const changes: TabularChangePayload<FromSchema<typeof CompoundSchema>>[] = [];
+    const unsubscribe = storage.subscribeToChanges((change) => changes.push(change));
+
+    await storage.put({ name: "t1", type: "s1", option: "v1", success: true });
+    await storage.put({ name: "t2", type: "s2", option: "v2", success: false });
+    await storage.put({ name: "t3", type: "s3", option: "v3", success: true });
+
+    const writes = changes.filter((c) => c.type === "INSERT" || c.type === "UPDATE");
+    expect(writes.length).toBe(3);
+    // Set equality after sort — invariant the polling block enforces.
+    expect(writes.map((w) => w.new?.option).sort()).toEqual(["v1", "v2", "v3"]);
+
+    unsubscribe();
+    storage.destroy?.();
+  });
+
+  it("polling failure mode: duplicate write breaks set equality", async () => {
+    // Simulate a duplicate-write scenario: 4 events for 3 writes, with one
+    // duplicated. The sorted-set assertion (`toEqual(["v1","v2","v3"])`)
+    // must reject this.
+    const dupOptions = ["v1", "v1", "v2", "v3"].sort();
+    expect(() => expect(dupOptions).toEqual(["v1", "v2", "v3"])).toThrow();
+  });
+});

--- a/packages/test/src/test/task-graph-job-queue/genericTaskGraphJobQueueTests.ts
+++ b/packages/test/src/test/task-graph-job-queue/genericTaskGraphJobQueueTests.ts
@@ -100,9 +100,9 @@ export class TestJobTask extends Task<
         throw new Error(`Queue "${queueName}" not found`);
       }
 
-      const handle = await registeredQueue.client.submit(input, {
+      const handle = await registeredQueue.client.send(input, {
         jobRunId: this.runConfig.runnerId,
-        maxRetries: 10,
+        maxAttempts: 10,
       });
 
       cleanup = handle.onProgress(

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -135,9 +135,9 @@ describe("FetchUrlTask", () => {
     mockFetch.mockImplementation(() => Promise.resolve(createMockResponse(mockResponse)));
 
     // Add jobs to queue via client
-    await client.submit({ url: "https://api.example.com/1" });
-    await client.submit({ url: "https://api.example.com/2" });
-    await client.submit({ url: "https://api.example.com/3" });
+    await client.send({ url: "https://api.example.com/1" });
+    await client.send({ url: "https://api.example.com/2" });
+    await client.send({ url: "https://api.example.com/3" });
 
     // Start the server and wait for processing
     await server.start();

--- a/packages/util/src/resource/DisposeStrategy.ts
+++ b/packages/util/src/resource/DisposeStrategy.ts
@@ -9,9 +9,17 @@ import type { ResourceScope } from "./ResourceScope";
 /**
  * Pluggable disposal policy for a {@link ResourceScope}.
  *
- * A scope consults its strategy at four moments:
+ * A scope consults its strategy at five moments:
  *  - `onRegister`: when a disposer is registered (may wrap it or set up
- *    per-resource state such as timers).
+ *    per-resource state such as timers). Strategies that arm inactivity
+ *    timers between runs must also clear any pending timer for the key
+ *    being re-registered (an idle timer firing while a new run is in
+ *    flight would dispose a resource the run is about to use).
+ *  - `onRunStart` (optional): when the owning runner is about to start a
+ *    new run. The {@link InactivityStrategy} uses this to clear all pending
+ *    timers, closing the race between "timer armed at runComplete" and
+ *    "next run begins before the timer fires". Optional to preserve
+ *    backward compatibility with strategies implemented outside this tree.
  *  - `touch`: when a task signals the resource is still in use (resets
  *    inactivity timers, etc.).
  *  - `onRunComplete`: when the owning run finishes (success, error, or abort)
@@ -25,6 +33,12 @@ import type { ResourceScope } from "./ResourceScope";
  */
 export interface IDisposeStrategy {
   onRegister(key: string, disposer: () => Promise<void>, scope: ResourceScope): () => Promise<void>;
+  /**
+   * Called by `ResourceScope.runStart()` before a run begins. Optional —
+   * external strategies written against the original four-method shape
+   * continue to work; `ResourceScope` no-ops when this is undefined.
+   */
+  onRunStart?(scope: ResourceScope): Promise<void> | void;
   touch(key: string): void;
   onRunComplete(scope: ResourceScope): Promise<void>;
   onScopeDestroy(scope: ResourceScope): Promise<void>;

--- a/packages/util/src/resource/ResourceScope.ts
+++ b/packages/util/src/resource/ResourceScope.ts
@@ -74,6 +74,19 @@ export class ResourceScope {
   }
 
   /**
+   * Called by runners just before a new run begins. Delegates to the
+   * strategy's optional `onRunStart` hook (no-op when the strategy does
+   * not implement it). Closes the race where an inactivity timer armed
+   * by the previous `runComplete` could fire and dispose a resource the
+   * next run is about to use.
+   */
+  async runStart(): Promise<void> {
+    if (this.strategy.onRunStart) {
+      await this.strategy.onRunStart(this);
+    }
+  }
+
+  /**
    * Called by runners' `finally` blocks. Delegates to the strategy's
    * `onRunComplete` hook.
    */

--- a/packages/util/src/resource/strategies/InactivityStrategy.ts
+++ b/packages/util/src/resource/strategies/InactivityStrategy.ts
@@ -35,11 +35,31 @@ export class InactivityStrategy implements IDisposeStrategy {
   }
 
   onRegister(
-    _key: string,
+    key: string,
     disposer: () => Promise<void>,
     _scope: ResourceScope
   ): () => Promise<void> {
+    // Defensive: if a key is registered while an inactivity timer is still
+    // pending for it (e.g. the disposer ran, but a re-register raced with
+    // the timer body before the timer woke up), clear the pending timer so
+    // the new disposer cannot be torn down between runs.
+    const pending = this.timers.get(key);
+    if (pending !== undefined) {
+      clearTimeout(pending);
+      this.timers.delete(key);
+    }
     return disposer;
+  }
+
+  /**
+   * Called by `ResourceScope.runStart()` before each run. Clears every
+   * pending inactivity timer — any resource still registered is part of
+   * the new run, and we never want a stale timer to dispose mid-run.
+   * The next `onRunComplete` re-arms the timers from scratch.
+   */
+  onRunStart(_scope: ResourceScope): void {
+    for (const t of this.timers.values()) clearTimeout(t);
+    this.timers.clear();
   }
 
   touch(key: string): void {

--- a/providers/postgres/src/job-queue/PostgresJobStore.ts
+++ b/providers/postgres/src/job-queue/PostgresJobStore.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
-import type { PendingWrite } from "./PostgresMessageQueue";
+import type { PostgresPendingWrite } from "./PostgresMessageQueue";
 import type { PostgresQueueStorage } from "./PostgresQueueStorage";
 
 export class PostgresJobStore<Input, Output> implements IJobStore<Input, Output> {
@@ -13,11 +13,11 @@ export class PostgresJobStore<Input, Output> implements IJobStore<Input, Output>
   public readonly core: PostgresQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, PostgresPendingWrite<Output>>;
 
   constructor(
     core: PostgresQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, PostgresPendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;
@@ -28,11 +28,11 @@ export class PostgresJobStore<Input, Output> implements IJobStore<Input, Output>
   }
 
   async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
-    return this.core.peek(status, num);
+    return this.core.peek(status as any, num);
   }
 
   size(status?: JobStatus): Promise<number> {
-    return this.core.size(status);
+    return this.core.size(status as any);
   }
 
   async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {

--- a/providers/postgres/src/job-queue/PostgresJobStore.ts
+++ b/providers/postgres/src/job-queue/PostgresJobStore.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
+import type { PendingWrite } from "./PostgresMessageQueue";
+import type { PostgresQueueStorage } from "./PostgresQueueStorage";
+
+export class PostgresJobStore<Input, Output> implements IJobStore<Input, Output> {
+  /** @internal — shared with the paired message queue */
+  public readonly core: PostgresQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: PostgresQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.core.get(id);
+  }
+
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.peek(status, num);
+  }
+
+  size(status?: JobStatus): Promise<number> {
+    return this.core.size(status);
+  }
+
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.getByRunId(runId);
+  }
+
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.core.outputForInput(input);
+  }
+
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.core.saveProgress(id, progress, message, details as Record<string, any>);
+  }
+
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.core.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.delete(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.core.deleteAll();
+  }
+
+  async abort(id: MessageId): Promise<void> {
+    await this.core.abort(id);
+  }
+}

--- a/providers/postgres/src/job-queue/PostgresJobStore.ts
+++ b/providers/postgres/src/job-queue/PostgresJobStore.ts
@@ -88,4 +88,8 @@ export class PostgresJobStore<Input, Output> implements IJobStore<Input, Output>
   async abort(id: MessageId): Promise<void> {
     await this.core.abort(id);
   }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    await this.core.saveStatus(id, status);
+  }
 }

--- a/providers/postgres/src/job-queue/PostgresMessageQueue.ts
+++ b/providers/postgres/src/job-queue/PostgresMessageQueue.ts
@@ -111,6 +111,20 @@ class PostgresClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
   async extendLease(ms: number): Promise<void> {
     await this.core.extendLease(this.id, this.workerId, ms);
   }
+
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.core.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.core.finalize(this.id, {
+      status: "DISABLED",
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
 }
 
 export class PostgresMessageQueue<Input, Output> implements IMessageQueue<

--- a/providers/postgres/src/job-queue/PostgresMessageQueue.ts
+++ b/providers/postgres/src/job-queue/PostgresMessageQueue.ts
@@ -135,18 +135,23 @@ export class PostgresMessageQueue<Input, Output> implements IMessageQueue<
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!job) return [];
-    return [
-      new PostgresClaim<Input, Output>(
-        this.core,
-        this.pending,
-        job.id,
-        job,
-        job.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!job) break;
+      claims.push(
+        new PostgresClaim<Input, Output>(
+          this.core,
+          this.pending,
+          job.id,
+          job,
+          job.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {

--- a/providers/postgres/src/job-queue/PostgresMessageQueue.ts
+++ b/providers/postgres/src/job-queue/PostgresMessageQueue.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IClaim,
+  IMessageQueue,
+  JobStorageFormat,
+  MessageId,
+  QueueChangePayload,
+  QueueStorageScope,
+  QueueSubscribeOptions,
+  SendOptions,
+} from "@workglow/job-queue";
+import type { PostgresQueueStorage } from "./PostgresQueueStorage";
+
+/**
+ * Per-id buffer that lets {@link IJobStore.saveResult}/{@link IJobStore.saveError}
+ * stage output/error until the terminal claim.ack()/fail() persists them in
+ * a single complete() call (avoids double-bumping `attempts`).
+ */
+export type PendingWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class PostgresClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly core: PostgresQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: "COMPLETED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      status: "PENDING",
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: new Date(Date.now() + delay * 1000).toISOString(),
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: "FAILED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.core.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+export class PostgresMessageQueue<Input, Output> implements IMessageQueue<
+  JobStorageFormat<Input, Output>
+> {
+  public readonly scope: QueueStorageScope;
+
+  /** @internal — shared with the paired job store */
+  public readonly core: PostgresQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: PostgresQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+    this.scope = core.scope;
+  }
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    return this.core.add(applySendOptions(body, opts));
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!job) return [];
+    return [
+      new PostgresClaim<Input, Output>(
+        this.core,
+        this.pending,
+        job.id,
+        job,
+        job.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.core.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.core.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.core.subscribeToChanges(callback, options);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}

--- a/providers/postgres/src/job-queue/PostgresMessageQueue.ts
+++ b/providers/postgres/src/job-queue/PostgresMessageQueue.ts
@@ -38,20 +38,22 @@ class PostgresClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      output: buf?.output ?? current.output ?? null,
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
+    await this.core.finalize(this.id, {
+      output: output as Output | null,
       error: null,
       error_code: null,
       status: "COMPLETED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -71,22 +73,38 @@ class PostgresClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     });
   }
 
-  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent;
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
+    await this.core.finalize(this.id, {
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: "FAILED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 

--- a/providers/postgres/src/job-queue/PostgresMessageQueue.ts
+++ b/providers/postgres/src/job-queue/PostgresMessageQueue.ts
@@ -21,7 +21,7 @@ import type { PostgresQueueStorage } from "./PostgresQueueStorage";
  * stage output/error until the terminal claim.ack()/fail() persists them in
  * a single complete() call (avoids double-bumping `attempts`).
  */
-export type PendingWrite<Output> = {
+export type PostgresPendingWrite<Output> = {
   output?: Output | null;
   error?: string | null;
   errorCode?: string | null;
@@ -31,7 +31,7 @@ export type PendingWrite<Output> = {
 class PostgresClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
   constructor(
     private readonly core: PostgresQueueStorage<Input, Output>,
-    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    private readonly pending: Map<unknown, PostgresPendingWrite<Output>>,
     public readonly id: MessageId,
     public readonly body: JobStorageFormat<Input, Output>,
     public readonly attempts: number,
@@ -104,11 +104,11 @@ export class PostgresMessageQueue<Input, Output> implements IMessageQueue<
   public readonly core: PostgresQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, PostgresPendingWrite<Output>>;
 
   constructor(
     core: PostgresQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, PostgresPendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -130,7 +130,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
     job.progress_message = "";
     job.progress_details = null;
     job.created_at = now;
-    job.run_after = now;
+    job.visible_at = now;
 
     const prefixColumnNames = getPrefixColumnNames(this.prefixes);
     const { columns: prefixColumnsInsert, placeholders: prefixParamPlaceholders } =
@@ -140,19 +140,19 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
 
     const sql = `
       INSERT INTO ${this.tableName}(
-        ${prefixColumnsInsert}queue, 
-        fingerprint, 
-        input, 
-        run_after,
+        ${prefixColumnsInsert}queue,
+        fingerprint,
+        input,
+        visible_at,
         created_at,
         deadline_at,
-        max_retries, 
-        job_run_id, 
-        progress, 
-        progress_message, 
+        max_attempts,
+        job_run_id,
+        progress,
+        progress_message,
         progress_details
       )
-      VALUES 
+      VALUES
         (${prefixParamPlaceholders}$${baseParamStart},$${baseParamStart + 1},$${baseParamStart + 2},$${baseParamStart + 3},$${baseParamStart + 4},$${baseParamStart + 5},$${baseParamStart + 6},$${baseParamStart + 7},$${baseParamStart + 8},$${baseParamStart + 9},$${baseParamStart + 10})
       RETURNING id`;
     const params = [
@@ -160,10 +160,10 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       job.queue,
       job.fingerprint,
       JSON.stringify(job.input),
-      job.run_after,
+      job.visible_at,
       job.created_at,
       job.deadline_at,
-      job.max_retries,
+      job.max_attempts,
       job.job_run_id,
       job.progress,
       job.progress_message,
@@ -216,7 +216,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
         FROM ${this.tableName}
         WHERE queue = $1
         AND status = $2${prefixConditions}
-        ORDER BY run_after ASC
+        ORDER BY visible_at ASC
         LIMIT $3
         FOR UPDATE SKIP LOCKED`,
       [this.queueName, status, num, ...prefixParams]
@@ -247,19 +247,19 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       `
       UPDATE ${this.tableName}
       SET status = $1,
-          last_ran_at = NOW() AT TIME ZONE 'UTC',
-          worker_id = $4,
+          last_attempted_at = NOW() AT TIME ZONE 'UTC',
+          lease_owner = $4,
           lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($2 * INTERVAL '1 millisecond')
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
         WHERE queue = $3
         AND (
-          (status = $5 AND run_after <= NOW() AT TIME ZONE 'UTC')
+          (status = $5 AND visible_at <= NOW() AT TIME ZONE 'UTC')
           OR (status = $6 AND (lease_expires_at IS NULL OR lease_expires_at < NOW() AT TIME ZONE 'UTC'))
         )
         ${prefixConditions}
-        ORDER BY run_after ASC
+        ORDER BY visible_at ASC
         FOR UPDATE SKIP LOCKED
         LIMIT 1
       )
@@ -281,7 +281,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Extend the lease on a currently PROCESSING job.
    * @param id - The ID of the job to extend the lease for
-   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param workerId - Worker ID that must match the current lease owner (lease_owner)
    * @param ms - Number of milliseconds to extend the lease by
    */
   public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
@@ -289,7 +289,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
     const result = await this.db.query(
       `UPDATE ${this.tableName}
          SET lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($1 * INTERVAL '1 millisecond')
-         WHERE id = $2 AND queue = $3 AND worker_id = $4 AND status = 'PROCESSING'${prefixConditions}`,
+         WHERE id = $2 AND queue = $3 AND lease_owner = $4 AND status = 'PROCESSING'${prefixConditions}`,
       [ms, id, this.queueName, workerId, ...prefixParams]
     );
     if (!result || result.rowCount === 0) {
@@ -321,7 +321,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Marks a job as complete with its output or error.
    * Enhanced error handling:
-   * - For a retryable error, increments run_attempts and updates run_after.
+   * - For a retryable error, increments attempts and updates visible_at.
    * - Marks a job as FAILED immediately for permanent or generic errors.
    */
   public async complete(jobDetails: JobStorageFormat<Input, Output>): Promise<void> {
@@ -345,21 +345,21 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       await this.db.query(
         `UPDATE ${this.tableName} 
           SET 
-            error = $1, 
+            error = $1,
             error_code = $2,
-            status = $3, 
-            run_after = $4, 
+            status = $3,
+            visible_at = $4,
             progress = 0,
             progress_message = '',
             progress_details = NULL,
-            run_attempts = run_attempts + 1, 
-            last_ran_at = NOW() AT TIME ZONE 'UTC'
+            attempts = attempts + 1,
+            last_attempted_at = NOW() AT TIME ZONE 'UTC'
           WHERE id = $5 AND queue = $6${prefixConditions}`,
         [
           jobDetails.error,
           jobDetails.error_code,
           jobDetails.status,
-          jobDetails.run_after,
+          jobDetails.visible_at,
           jobDetails.id,
           this.queueName,
           ...prefixParams,
@@ -378,9 +378,9 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
               progress = 100,
               progress_message = '',
               progress_details = NULL,
-              run_attempts = run_attempts + 1, 
+              attempts = attempts + 1,
               completed_at = NOW() AT TIME ZONE 'UTC',
-              last_ran_at = NOW() AT TIME ZONE 'UTC'
+              last_attempted_at = NOW() AT TIME ZONE 'UTC'
           WHERE id = $5 AND queue = $6${prefixConditions}`,
         [
           jobDetails.output ? JSON.stringify(jobDetails.output) : null,
@@ -459,7 +459,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Releases a claimed job back to PENDING without incrementing run_attempts.
+   * Releases a claimed job back to PENDING without incrementing attempts.
    * @param jobId - The id of the claimed job to release.
    */
   public async releaseClaim(jobId: unknown): Promise<void> {
@@ -468,7 +468,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       `
       UPDATE ${this.tableName}
         SET status = 'PENDING',
-            worker_id = NULL,
+            lease_owner = NULL,
             progress = 0,
             progress_message = '',
             progress_details = NULL

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -249,7 +249,18 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       SET status = $1,
           last_attempted_at = NOW() AT TIME ZONE 'UTC',
           lease_owner = $4,
-          lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($2 * INTERVAL '1 millisecond')
+          lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($2 * INTERVAL '1 millisecond'),
+          -- A reclaimed PROCESSING row was claimed by a now-crashed worker;
+          -- that constitutes one used-up attempt against max_attempts.
+          -- PENDING claims must not be charged here — JobQueueWorker's
+          -- existing validateJobState() will FAIL the job in the next-step
+          -- branch when attempts >= max_attempts.
+          attempts = CASE WHEN status = $6 THEN attempts + 1 ELSE attempts END,
+          -- Always clear any stale abort_requested_at on (re)claim. A PROCESSING
+          -- row may have had abort_requested_at set before the worker crashed;
+          -- the new owner must start with a clean slate or the worker will see
+          -- the abort flag immediately and never run user code.
+          abort_requested_at = NULL
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
@@ -342,9 +353,13 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       );
     } else if (jobDetails.status === JobStatus.PENDING) {
       const { conditions: prefixConditions } = this.buildPrefixWhereClause(7);
+      // PENDING-retry branch: the worker hit a retryable error and the row is
+      // returning to PENDING for another attempt. Clear abort_requested_at so
+      // an abort that was requested DURING the previous attempt does not
+      // immediately cancel the retry.
       await this.db.query(
-        `UPDATE ${this.tableName} 
-          SET 
+        `UPDATE ${this.tableName}
+          SET
             error = $1,
             error_code = $2,
             status = $3,
@@ -353,7 +368,8 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
             progress_message = '',
             progress_details = NULL,
             attempts = attempts + 1,
-            last_attempted_at = NOW() AT TIME ZONE 'UTC'
+            last_attempted_at = NOW() AT TIME ZONE 'UTC',
+            abort_requested_at = NULL
           WHERE id = $5 AND queue = $6${prefixConditions}`,
         [
           jobDetails.error,
@@ -464,6 +480,9 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
    */
   public async releaseClaim(jobId: unknown): Promise<void> {
     const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(3);
+    // releaseClaim returns the row to PENDING without consuming an attempt.
+    // Clear abort_requested_at so an abort that was requested mid-claim does
+    // not survive the release and cancel the next worker that picks the row up.
     await this.db.query(
       `
       UPDATE ${this.tableName}
@@ -471,7 +490,8 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
             lease_owner = NULL,
             progress = 0,
             progress_message = '',
-            progress_details = NULL
+            progress_details = NULL,
+            abort_requested_at = NULL
         WHERE id = $1 AND queue = $2${prefixConditions}`,
       [jobId, this.queueName, ...prefixParams]
     );

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -412,6 +412,58 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
+   * Terminal write that does NOT bump `attempts`. See IQueueStorage.finalize
+   * for the rationale (avoids double-counting on ack/fail because the lease
+   * reclaim path already charged the attempt at next() time).
+   */
+  public async finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
+    // Build a dynamic SET clause covering only the fields the caller supplied —
+    // a partial overwrite. Everything else (in particular `attempts`,
+    // `visible_at`, `lease_owner`, `lease_expires_at`) is untouched.
+    const sets: string[] = [];
+    const params: Array<unknown> = [];
+    let nextParam = 1;
+    const push = (col: string, value: unknown): void => {
+      sets.push(`${col} = $${nextParam}`);
+      params.push(value);
+      nextParam += 1;
+    };
+    if ("output" in fields) {
+      push("output", fields.output != null ? JSON.stringify(fields.output) : null);
+    }
+    if ("error" in fields) push("error", fields.error ?? null);
+    if ("error_code" in fields) push("error_code", fields.error_code ?? null);
+    if ("status" in fields) push("status", fields.status);
+    if ("completed_at" in fields) push("completed_at", fields.completed_at ?? null);
+    if ("abort_requested_at" in fields) {
+      push("abort_requested_at", fields.abort_requested_at ?? null);
+    }
+    if (sets.length === 0) return; // nothing to write
+    const idParam = nextParam;
+    nextParam += 1;
+    const queueParam = nextParam;
+    nextParam += 1;
+    const { conditions: prefixConditions, params: prefixParams } =
+      this.buildPrefixWhereClause(nextParam);
+    await this.db.query(
+      `UPDATE ${this.tableName}
+         SET ${sets.join(", ")}
+         WHERE id = $${idParam} AND queue = $${queueParam}${prefixConditions}`,
+      [...params, id, this.queueName, ...prefixParams]
+    );
+  }
+
+  /**
    * Clears all jobs from the queue.
    */
   public async deleteAll(): Promise<void> {

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -477,6 +477,15 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
     );
   }
 
+  /** Force-overwrite status without touching attempts (used to persist DISABLED after lease release). */
+  public async saveStatus(jobId: unknown, status: string): Promise<void> {
+    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(3);
+    await this.db.query(
+      `UPDATE ${this.tableName} SET status = $1 WHERE id = $2 AND queue = $3${prefixConditions}`,
+      [status, jobId, this.queueName, ...prefixParams]
+    );
+  }
+
   /**
    * Retrieves all jobs for a given job run ID.
    * @param job_run_id - The ID of the job run to retrieve

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -407,7 +407,7 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
    * Releases a claimed job back to PENDING without incrementing run_attempts.
    * @param jobId - The id of the claimed job to release.
    */
-  public async release(jobId: unknown): Promise<void> {
+  public async releaseClaim(jobId: unknown): Promise<void> {
     const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(3);
     await this.db.query(
       `

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -425,11 +425,15 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     // Build a dynamic SET clause covering only the fields the caller supplied —
     // a partial overwrite. Everything else (in particular `attempts`,
-    // `visible_at`, `lease_owner`, `lease_expires_at`) is untouched.
+    // `visible_at`, `lease_expires_at`) is untouched.
     const sets: string[] = [];
     const params: Array<unknown> = [];
     let nextParam = 1;
@@ -447,6 +451,15 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
     if ("completed_at" in fields) push("completed_at", fields.completed_at ?? null);
     if ("abort_requested_at" in fields) {
       push("abort_requested_at", fields.abort_requested_at ?? null);
+    }
+    if ("lease_owner" in fields) push("lease_owner", fields.lease_owner ?? null);
+    if ("progress" in fields) push("progress", fields.progress ?? 0);
+    if ("progress_message" in fields) push("progress_message", fields.progress_message ?? "");
+    if ("progress_details" in fields) {
+      push(
+        "progress_details",
+        fields.progress_details != null ? JSON.stringify(fields.progress_details) : null
+      );
     }
     if (sets.length === 0) return; // nothing to write
     const idParam = nextParam;

--- a/providers/postgres/src/job-queue/PostgresQueueStorage.ts
+++ b/providers/postgres/src/job-queue/PostgresQueueStorage.ts
@@ -227,35 +227,76 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
 
   /**
    * Retrieves the next available job that is ready to be processed.
+   * Claims PENDING jobs ready to run, and also reclaims PROCESSING jobs whose
+   * lease has expired (crash recovery). Sets lease_expires_at on the claimed row.
    * @param workerId - Worker ID to associate with the job (required)
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns The next job or undefined if no job is available
    */
-  public async next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
-    // Parameters: $1=status, $2=queue, $3=status, $4=worker_id, $5+=prefix params
-    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(5);
+  public async next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
+    const leaseMs = opts?.leaseMs ?? 30000;
+    // Parameters: $1=PROCESSING, $2=now+leaseMs interval, $3=queue, $4=workerId, $5=PENDING, $6=PROCESSING, $7+=prefix params
+    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(7);
     const result = await this.db.query<
       JobStorageFormat<Input, Output>,
       Array<string | number | JobStatus | null>
     >(
       `
-      UPDATE ${this.tableName} 
-      SET status = $1, last_ran_at = NOW() AT TIME ZONE 'UTC', worker_id = $4
+      UPDATE ${this.tableName}
+      SET status = $1,
+          last_ran_at = NOW() AT TIME ZONE 'UTC',
+          worker_id = $4,
+          lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($2 * INTERVAL '1 millisecond')
       WHERE id = (
-        SELECT id 
-        FROM ${this.tableName} 
-        WHERE queue = $2 
-        AND status = $3
+        SELECT id
+        FROM ${this.tableName}
+        WHERE queue = $3
+        AND (
+          (status = $5 AND run_after <= NOW() AT TIME ZONE 'UTC')
+          OR (status = $6 AND (lease_expires_at IS NULL OR lease_expires_at < NOW() AT TIME ZONE 'UTC'))
+        )
         ${prefixConditions}
-        AND run_after <= NOW() AT TIME ZONE 'UTC'
-        ORDER BY run_after ASC 
-        FOR UPDATE SKIP LOCKED 
+        ORDER BY run_after ASC
+        FOR UPDATE SKIP LOCKED
         LIMIT 1
       )
       RETURNING *`,
-      [JobStatus.PROCESSING, this.queueName, JobStatus.PENDING, workerId, ...prefixParams]
+      [
+        JobStatus.PROCESSING,
+        leaseMs,
+        this.queueName,
+        workerId,
+        JobStatus.PENDING,
+        JobStatus.PROCESSING,
+        ...prefixParams,
+      ]
     );
 
     return result?.rows?.[0] ?? undefined;
+  }
+
+  /**
+   * Extend the lease on a currently PROCESSING job.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(5);
+    const result = await this.db.query(
+      `UPDATE ${this.tableName}
+         SET lease_expires_at = NOW() AT TIME ZONE 'UTC' + ($1 * INTERVAL '1 millisecond')
+         WHERE id = $2 AND queue = $3 AND worker_id = $4 AND status = 'PROCESSING'${prefixConditions}`,
+      [ms, id, this.queueName, workerId, ...prefixParams]
+    );
+    if (!result || result.rowCount === 0) {
+      throw new Error(
+        `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
+      );
+    }
   }
 
   /**
@@ -387,20 +428,34 @@ export class PostgresQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Aborts a job by setting its status to "ABORTING".
-   * This method will signal the corresponding AbortController so that
-   * the job's execute() method (if it supports an AbortSignal parameter)
-   * can clean up and exit.
+   * Aborts a job.
+   * - If PENDING: immediately mark as FAILED with abort_requested_at set.
+   * - If PROCESSING: set abort_requested_at only (leave status as PROCESSING).
+   * - Otherwise: no-op.
    */
   public async abort(jobId: unknown): Promise<void> {
-    const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(3);
-    await this.db.query(
-      `
-      UPDATE ${this.tableName} 
-      SET status = 'ABORTING' 
-      WHERE id = $1 AND queue = $2${prefixConditions}`,
-      [jobId, this.queueName, ...prefixParams]
-    );
+    // Abort PENDING → FAILED immediately
+    {
+      const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(4);
+      await this.db.query(
+        `UPDATE ${this.tableName}
+           SET status = 'FAILED',
+               abort_requested_at = NOW() AT TIME ZONE 'UTC',
+               completed_at = NOW() AT TIME ZONE 'UTC'
+           WHERE id = $1 AND queue = $2 AND status = $3${prefixConditions}`,
+        [jobId, this.queueName, JobStatus.PENDING, ...prefixParams]
+      );
+    }
+    // Abort PROCESSING → set abort_requested_at only
+    {
+      const { conditions: prefixConditions, params: prefixParams } = this.buildPrefixWhereClause(4);
+      await this.db.query(
+        `UPDATE ${this.tableName}
+           SET abort_requested_at = NOW() AT TIME ZONE 'UTC'
+           WHERE id = $1 AND queue = $2 AND status = $3${prefixConditions}`,
+        [jobId, this.queueName, JobStatus.PROCESSING, ...prefixParams]
+      );
+    }
   }
 
   /**

--- a/providers/postgres/src/job-queue/common.ts
+++ b/providers/postgres/src/job-queue/common.ts
@@ -8,6 +8,9 @@
 
 export * from "./PostgresQueueStorage";
 export * from "./PostgresRateLimiterStorage";
+export * from "./PostgresMessageQueue";
+export * from "./PostgresJobStore";
+export * from "./createPostgresQueue";
 
 // Versioned migration sets for the queue + rate-limiter tables, plus the
 // runner that applies them. Re-exported here so callers can compose

--- a/providers/postgres/src/job-queue/createPostgresQueue.ts
+++ b/providers/postgres/src/job-queue/createPostgresQueue.ts
@@ -7,7 +7,7 @@
 import type { QueueStorageOptions } from "@workglow/job-queue";
 import type { Pool } from "@workglow/postgres/storage";
 import { PostgresJobStore } from "./PostgresJobStore";
-import { PostgresMessageQueue, type PendingWrite } from "./PostgresMessageQueue";
+import { PostgresMessageQueue, type PostgresPendingWrite } from "./PostgresMessageQueue";
 import { PostgresQueueStorage } from "./PostgresQueueStorage";
 
 /**
@@ -26,7 +26,7 @@ export function createPostgresQueue<Input, Output>(
   core: PostgresQueueStorage<Input, Output>;
 } {
   const core = new PostgresQueueStorage<Input, Output>(pool, queueName, opts);
-  const pending = new Map<unknown, PendingWrite<Output>>();
+  const pending = new Map<unknown, PostgresPendingWrite<Output>>();
   return {
     messageQueue: new PostgresMessageQueue<Input, Output>(core, pending),
     jobStore: new PostgresJobStore<Input, Output>(core, pending),

--- a/providers/postgres/src/job-queue/createPostgresQueue.ts
+++ b/providers/postgres/src/job-queue/createPostgresQueue.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { QueueStorageOptions } from "@workglow/job-queue";
+import type { Pool } from "@workglow/postgres/storage";
+import { PostgresJobStore } from "./PostgresJobStore";
+import { PostgresMessageQueue, type PendingWrite } from "./PostgresMessageQueue";
+import { PostgresQueueStorage } from "./PostgresQueueStorage";
+
+/**
+ * Factory for the paired Postgres message queue and job store. Both
+ * facades share a single underlying {@link PostgresQueueStorage} so writes
+ * through one are observable through the other.
+ */
+export function createPostgresQueue<Input, Output>(
+  queueName: string,
+  pool: Pool,
+  opts?: QueueStorageOptions
+): {
+  messageQueue: PostgresMessageQueue<Input, Output>;
+  jobStore: PostgresJobStore<Input, Output>;
+  /** @internal — exposed for callers that still need the legacy storage object. */
+  core: PostgresQueueStorage<Input, Output>;
+} {
+  const core = new PostgresQueueStorage<Input, Output>(pool, queueName, opts);
+  const pending = new Map<unknown, PendingWrite<Output>>();
+  return {
+    messageQueue: new PostgresMessageQueue<Input, Output>(core, pending),
+    jobStore: new PostgresJobStore<Input, Output>(core, pending),
+    core,
+  };
+}

--- a/providers/postgres/src/migrations/postgresQueueMigrations.ts
+++ b/providers/postgres/src/migrations/postgresQueueMigrations.ts
@@ -109,10 +109,10 @@ export function postgresQueueMigrations(
             status job_status NOT NULL default 'PENDING',
             input jsonb NOT NULL,
             output jsonb,
-            run_attempts integer default 0,
-            max_retries integer default 20,
-            run_after timestamp with time zone DEFAULT now(),
-            last_ran_at timestamp with time zone,
+            attempts integer default 0,
+            max_attempts integer default 10,
+            visible_at timestamp with time zone DEFAULT now(),
+            last_attempted_at timestamp with time zone,
             created_at timestamp with time zone DEFAULT now(),
             deadline_at timestamp with time zone,
             completed_at timestamp with time zone,
@@ -121,17 +121,17 @@ export function postgresQueueMigrations(
             progress real DEFAULT 0,
             progress_message text DEFAULT '',
             progress_details jsonb,
-            worker_id text
+            lease_owner text
           )
         `);
 
         await db.query(`
           CREATE INDEX IF NOT EXISTS job_fetcher${indexSuffix}_idx
-            ON ${tableName} (${prefixIndexPrefix}id, status, run_after)
+            ON ${tableName} (${prefixIndexPrefix}id, status, visible_at)
         `);
         await db.query(`
           CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx
-            ON ${tableName} (${prefixIndexPrefix}queue, status, run_after)
+            ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at)
         `);
         await db.query(`
           CREATE INDEX IF NOT EXISTS jobs_fingerprint${indexSuffix}_unique_idx
@@ -197,6 +197,32 @@ export function postgresQueueMigrations(
           ALTER TABLE ${tableName}
             ADD COLUMN IF NOT EXISTS abort_requested_at timestamp with time zone,
             ADD COLUMN IF NOT EXISTS lease_expires_at timestamp with time zone
+        `);
+      },
+    },
+    {
+      component,
+      version: 3,
+      description:
+        "Rename columns: run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner",
+      async up(db: Pool) {
+        // Only rename if the old column names still exist (skip on fresh installs)
+        await db.query(`
+          DO $$
+          DECLARE col_exists boolean;
+          BEGIN
+            SELECT EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_name='${tableName}' AND column_name='run_after'
+            ) INTO col_exists;
+            IF col_exists THEN
+              EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN run_after TO visible_at';
+              EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN last_ran_at TO last_attempted_at';
+              EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN run_attempts TO attempts';
+              EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN max_retries TO max_attempts';
+              EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN worker_id TO lease_owner';
+            END IF;
+          END $$
         `);
       },
     },

--- a/providers/postgres/src/migrations/postgresQueueMigrations.ts
+++ b/providers/postgres/src/migrations/postgresQueueMigrations.ts
@@ -213,7 +213,7 @@ export function postgresQueueMigrations(
           BEGIN
             SELECT EXISTS (
               SELECT 1 FROM information_schema.columns
-              WHERE table_name='${tableName}' AND column_name='run_after'
+              WHERE table_name='${tableName}' AND column_name='run_after' AND table_schema = current_schema()
             ) INTO col_exists;
             IF col_exists THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN run_after TO visible_at';

--- a/providers/postgres/src/migrations/postgresQueueMigrations.ts
+++ b/providers/postgres/src/migrations/postgresQueueMigrations.ts
@@ -22,6 +22,10 @@ import type { Pool } from "../storage/_postgres/node-bun";
  * would not — silently producing version-skewed enums and runtime errors on
  * insert. Adding a status requires a NEW migration that runs
  * `ALTER TYPE job_status ADD VALUE IF NOT EXISTS '...'`.
+ *
+ * ABORTING was present in v1 and removed from the application model in PR 2.
+ * It remains in the v1 enum literal so existing databases are not broken;
+ * the application simply no longer writes that value.
  */
 const JOB_STATUS_V1: readonly string[] = [
   "PENDING",
@@ -33,9 +37,10 @@ const JOB_STATUS_V1: readonly string[] = [
 ];
 
 /**
- * Sanity check: if a developer adds a status to {@link JobStatus} without
- * also writing a follow-up migration that ALTER TYPE-adds it, queries that
- * insert the new status will fail at runtime against any DB still on v1.
+ * Sanity check: every current {@link JobStatus} value must be covered by the
+ * v1 enum (or a subsequent ALTER TYPE migration). ABORTING was intentionally
+ * removed from the application model; it is still legal in the DB schema but
+ * we skip it here so the check does not reject a valid removal.
  *
  * Run lazily from {@link postgresQueueMigrations} (NOT at module import) so
  * that consumers re-exporting this module via barrel files don't crash on
@@ -43,13 +48,7 @@ const JOB_STATUS_V1: readonly string[] = [
  */
 function assertJobStatusMatchesV1(): void {
   const current = new Set(Object.values(JobStatus));
-  for (const v of JOB_STATUS_V1) {
-    if (!current.has(v as JobStatus)) {
-      throw new Error(
-        `JobStatus const is missing v1 enum value "${v}"; v1 migration values are frozen.`
-      );
-    }
-  }
+  // Every current status must be present in the v1 enum (or added by a later migration).
   for (const v of current) {
     if (!JOB_STATUS_V1.includes(v)) {
       throw new Error(
@@ -187,6 +186,18 @@ export function postgresQueueMigrations(
           await db.query("ROLLBACK TO SAVEPOINT install_notify_trigger").catch(() => undefined);
           await db.query("RELEASE SAVEPOINT install_notify_trigger").catch(() => undefined);
         }
+      },
+    },
+    {
+      component,
+      version: 2,
+      description: "Add abort_requested_at and lease_expires_at columns",
+      async up(db: Pool) {
+        await db.query(`
+          ALTER TABLE ${tableName}
+            ADD COLUMN IF NOT EXISTS abort_requested_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS lease_expires_at timestamp with time zone
+        `);
       },
     },
   ];

--- a/providers/postgres/src/migrations/postgresQueueMigrations.ts
+++ b/providers/postgres/src/migrations/postgresQueueMigrations.ts
@@ -206,20 +206,24 @@ export function postgresQueueMigrations(
       description:
         "Rename columns: run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner",
       async up(db: Pool) {
-        // Only rename if the old column names still exist (skip on fresh installs)
+        // Rename each column individually so a partial prior run doesn't skip everything.
         await db.query(`
           DO $$
-          DECLARE col_exists boolean;
           BEGIN
-            SELECT EXISTS (
-              SELECT 1 FROM information_schema.columns
-              WHERE table_name='${tableName}' AND column_name='run_after' AND table_schema = current_schema()
-            ) INTO col_exists;
-            IF col_exists THEN
+            IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='${tableName}' AND column_name='run_after' AND table_schema=current_schema()) THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN run_after TO visible_at';
+            END IF;
+            IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='${tableName}' AND column_name='last_ran_at' AND table_schema=current_schema()) THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN last_ran_at TO last_attempted_at';
+            END IF;
+            IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='${tableName}' AND column_name='run_attempts' AND table_schema=current_schema()) THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN run_attempts TO attempts';
+            END IF;
+            IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='${tableName}' AND column_name='max_retries' AND table_schema=current_schema()) THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN max_retries TO max_attempts';
+              EXECUTE 'ALTER TABLE ${tableName} ALTER COLUMN max_attempts SET DEFAULT 10';
+            END IF;
+            IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='${tableName}' AND column_name='worker_id' AND table_schema=current_schema()) THEN
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN worker_id TO lease_owner';
             END IF;
           END $$

--- a/providers/postgres/src/migrations/postgresQueueMigrations.ts
+++ b/providers/postgres/src/migrations/postgresQueueMigrations.ts
@@ -67,6 +67,14 @@ function assertJobStatusMatchesV1(): void {
  * table names get tracked independently in `_storage_migrations`. The v1
  * payload covers schema + indexes + LISTEN/NOTIFY plumbing; the trigger is
  * idempotent (`CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS`).
+ *
+ * v1 is FROZEN byte-for-byte against the pre-PR shape — it MUST keep
+ * creating the `run_after`/`run_attempts`/`max_retries`/`last_ran_at`/
+ * `worker_id` columns and the corresponding `run_after`-keyed indexes.
+ * Renames and index swaps live in v3 (with `IF EXISTS` guards so a fresh
+ * install — which still goes through v1 — can apply v3 without errors).
+ * Mutating v1 would silently produce divergent schemas between fresh and
+ * already-migrated DBs and break older deployments mid-rollout.
  */
 export function postgresQueueMigrations(
   tableName: string,
@@ -109,10 +117,10 @@ export function postgresQueueMigrations(
             status job_status NOT NULL default 'PENDING',
             input jsonb NOT NULL,
             output jsonb,
-            attempts integer default 0,
-            max_attempts integer default 10,
-            visible_at timestamp with time zone DEFAULT now(),
-            last_attempted_at timestamp with time zone,
+            run_attempts integer default 0,
+            max_retries integer default 20,
+            run_after timestamp with time zone DEFAULT now(),
+            last_ran_at timestamp with time zone,
             created_at timestamp with time zone DEFAULT now(),
             deadline_at timestamp with time zone,
             completed_at timestamp with time zone,
@@ -121,17 +129,17 @@ export function postgresQueueMigrations(
             progress real DEFAULT 0,
             progress_message text DEFAULT '',
             progress_details jsonb,
-            lease_owner text
+            worker_id text
           )
         `);
 
         await db.query(`
           CREATE INDEX IF NOT EXISTS job_fetcher${indexSuffix}_idx
-            ON ${tableName} (${prefixIndexPrefix}id, status, visible_at)
+            ON ${tableName} (${prefixIndexPrefix}id, status, run_after)
         `);
         await db.query(`
           CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx
-            ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at)
+            ON ${tableName} (${prefixIndexPrefix}queue, status, run_after)
         `);
         await db.query(`
           CREATE INDEX IF NOT EXISTS jobs_fingerprint${indexSuffix}_unique_idx
@@ -204,9 +212,11 @@ export function postgresQueueMigrations(
       component,
       version: 3,
       description:
-        "Rename columns: run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner",
+        "Rename run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner; drop run_after-keyed indexes and recreate visible_at-keyed",
       async up(db: Pool) {
-        // Rename each column individually so a partial prior run doesn't skip everything.
+        // Each rename is guarded by IF EXISTS — fresh installs (which still
+        // run v1 → v2 → v3) skip every branch and end up with the v1 schema
+        // exactly. Existing installs from before this PR get renamed in place.
         await db.query(`
           DO $$
           BEGIN
@@ -227,6 +237,25 @@ export function postgresQueueMigrations(
               EXECUTE 'ALTER TABLE ${tableName} RENAME COLUMN worker_id TO lease_owner';
             END IF;
           END $$
+        `);
+
+        // Drop the v1 run_after-keyed indexes and recreate them keyed on
+        // visible_at. CREATE INDEX cannot be wrapped in CONCURRENTLY here
+        // because the migration runs inside a transaction. The old indexes
+        // are useless after the rename — PostgreSQL automatically retargets
+        // them onto `visible_at` post-rename, but their NAMES still encode
+        // the old column, which is confusing for operators and slot-binds
+        // against the wrong stats; doing an explicit DROP + CREATE swap
+        // keeps names and schemas consistent.
+        await db.query(`DROP INDEX IF EXISTS job_fetcher${indexSuffix}_idx`);
+        await db.query(`DROP INDEX IF EXISTS job_queue_fetcher${indexSuffix}_idx`);
+        await db.query(`
+          CREATE INDEX IF NOT EXISTS job_fetcher${indexSuffix}_idx
+            ON ${tableName} (${prefixIndexPrefix}id, status, visible_at)
+        `);
+        await db.query(`
+          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx
+            ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at)
         `);
       },
     },

--- a/providers/sqlite/src/job-queue/SqliteJobStore.ts
+++ b/providers/sqlite/src/job-queue/SqliteJobStore.ts
@@ -88,4 +88,8 @@ export class SqliteJobStore<Input, Output> implements IJobStore<Input, Output> {
   async abort(id: MessageId): Promise<void> {
     await this.core.abort(id);
   }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    await this.core.saveStatus(id, status);
+  }
 }

--- a/providers/sqlite/src/job-queue/SqliteJobStore.ts
+++ b/providers/sqlite/src/job-queue/SqliteJobStore.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
-import type { PendingWrite } from "./SqliteMessageQueue";
+import type { SqlitePendingWrite } from "./SqliteMessageQueue";
 import { SqliteQueueStorage } from "./SqliteQueueStorage";
 
 export class SqliteJobStore<Input, Output> implements IJobStore<Input, Output> {
@@ -13,11 +13,11 @@ export class SqliteJobStore<Input, Output> implements IJobStore<Input, Output> {
   public readonly core: SqliteQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, SqlitePendingWrite<Output>>;
 
   constructor(
     core: SqliteQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, SqlitePendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;

--- a/providers/sqlite/src/job-queue/SqliteJobStore.ts
+++ b/providers/sqlite/src/job-queue/SqliteJobStore.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
+import type { PendingWrite } from "./SqliteMessageQueue";
+import { SqliteQueueStorage } from "./SqliteQueueStorage";
+
+export class SqliteJobStore<Input, Output> implements IJobStore<Input, Output> {
+  /** @internal — shared with the paired message queue */
+  public readonly core: SqliteQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: SqliteQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.core.get(id);
+  }
+
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.peek(status, num);
+  }
+
+  size(status?: JobStatus): Promise<number> {
+    return this.core.size(status as any);
+  }
+
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.getByRunId(runId);
+  }
+
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.core.outputForInput(input);
+  }
+
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.core.saveProgress(id, progress, message, details ?? {});
+  }
+
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.core.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.delete(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.core.deleteAll();
+  }
+
+  async abort(id: MessageId): Promise<void> {
+    await this.core.abort(id);
+  }
+}

--- a/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
+++ b/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
@@ -22,7 +22,7 @@ import { SqliteQueueStorage } from "./SqliteQueueStorage";
  * stage output/error until the terminal claim.ack()/fail() persists them in
  * a single complete() call (avoids double-bumping `attempts`).
  */
-export type PendingWrite<Output> = {
+export type SqlitePendingWrite<Output> = {
   output?: Output | null;
   error?: string | null;
   errorCode?: string | null;
@@ -32,7 +32,7 @@ export type PendingWrite<Output> = {
 class SqliteClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
   constructor(
     private readonly core: SqliteQueueStorage<Input, Output>,
-    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    private readonly pending: Map<unknown, SqlitePendingWrite<Output>>,
     public readonly id: MessageId,
     public readonly body: JobStorageFormat<Input, Output>,
     public readonly attempts: number,
@@ -105,11 +105,11 @@ export class SqliteMessageQueue<Input, Output> implements IMessageQueue<
   public readonly core: SqliteQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, SqlitePendingWrite<Output>>;
 
   constructor(
     core: SqliteQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, SqlitePendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;

--- a/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
+++ b/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
@@ -112,6 +112,20 @@ class SqliteClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outpu
   async extendLease(ms: number): Promise<void> {
     await this.core.extendLease(this.id, this.workerId, ms);
   }
+
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.core.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.core.finalize(this.id, {
+      status: JobStatus.DISABLED,
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
 }
 
 export class SqliteMessageQueue<Input, Output> implements IMessageQueue<

--- a/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
+++ b/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
@@ -39,20 +39,22 @@ class SqliteClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outpu
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      output: buf?.output ?? current.output ?? null,
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
+    await this.core.finalize(this.id, {
+      output: output as Output | null,
       error: null,
       error_code: null,
       status: JobStatus.COMPLETED,
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -72,22 +74,38 @@ class SqliteClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outpu
     });
   }
 
-  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent;
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
+    await this.core.finalize(this.id, {
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: JobStatus.FAILED,
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 

--- a/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
+++ b/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IClaim,
+  IMessageQueue,
+  JobStorageFormat,
+  MessageId,
+  QueueChangePayload,
+  QueueStorageScope,
+  QueueSubscribeOptions,
+  SendOptions,
+} from "@workglow/job-queue";
+import { JobStatus } from "@workglow/job-queue";
+import { SqliteQueueStorage } from "./SqliteQueueStorage";
+
+/**
+ * Per-id buffer that lets {@link IJobStore.saveResult}/{@link IJobStore.saveError}
+ * stage output/error until the terminal claim.ack()/fail() persists them in
+ * a single complete() call (avoids double-bumping `attempts`).
+ */
+export type PendingWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class SqliteClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly core: SqliteQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: JobStatus.COMPLETED,
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      status: JobStatus.PENDING,
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: new Date(Date.now() + delay * 1000).toISOString(),
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: JobStatus.FAILED,
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.core.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+export class SqliteMessageQueue<Input, Output> implements IMessageQueue<
+  JobStorageFormat<Input, Output>
+> {
+  public readonly scope: QueueStorageScope = "process";
+
+  /** @internal — shared with the paired job store */
+  public readonly core: SqliteQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: SqliteQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    return this.core.add(applySendOptions(body, opts));
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!job) return [];
+    return [
+      new SqliteClaim<Input, Output>(
+        this.core,
+        this.pending,
+        job.id,
+        job,
+        job.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.core.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.core.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.core.subscribeToChanges(callback, options);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}

--- a/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
+++ b/providers/sqlite/src/job-queue/SqliteMessageQueue.ts
@@ -135,18 +135,23 @@ export class SqliteMessageQueue<Input, Output> implements IMessageQueue<
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!job) return [];
-    return [
-      new SqliteClaim<Input, Output>(
-        this.core,
-        this.pending,
-        job.id,
-        job,
-        job.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!job) break;
+      claims.push(
+        new SqliteClaim<Input, Output>(
+          this.core,
+          this.pending,
+          job.id,
+          job,
+          job.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -263,7 +263,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
    * Releases a claimed job back to PENDING without incrementing run_attempts.
    * @param jobId - The id of the claimed job to release.
    */
-  public async release(jobId: unknown): Promise<void> {
+  public async releaseClaim(jobId: unknown): Promise<void> {
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();
 

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -242,21 +242,39 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
   }
 
   /**
-   * Aborts a job by setting its status to "ABORTING".
-   * This method will signal the corresponding AbortController so that
-   * the job's execute() method (if it supports an AbortSignal parameter)
-   * can clean up and exit.
+   * Aborts a job.
+   * - If PENDING: immediately mark as FAILED with abort_requested_at set.
+   * - If PROCESSING: set abort_requested_at only (leave status as PROCESSING).
+   * - Otherwise: no-op.
    */
   public async abort(jobId: unknown): Promise<void> {
+    const now = new Date().toISOString();
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();
 
-    const AbortQuery = `
+    // Abort PENDING → FAILED immediately
+    const AbortPendingQuery = `
       UPDATE ${this.tableName}
-        SET status = ?  
-        WHERE id = ? AND queue = ?${prefixConditions}`;
-    const stmt = this.db.prepare(AbortQuery);
-    stmt.run(JobStatus.ABORTING, String(jobId), this.queueName, ...prefixParams);
+        SET status = ?, abort_requested_at = ?, completed_at = ?
+        WHERE id = ? AND queue = ? AND status = ?${prefixConditions}`;
+    const stmtPending = this.db.prepare(AbortPendingQuery);
+    stmtPending.run(
+      JobStatus.FAILED,
+      now,
+      now,
+      String(jobId),
+      this.queueName,
+      JobStatus.PENDING,
+      ...prefixParams
+    );
+
+    // Abort PROCESSING → set abort_requested_at only
+    const AbortProcessingQuery = `
+      UPDATE ${this.tableName}
+        SET abort_requested_at = ?
+        WHERE id = ? AND queue = ? AND status = ?${prefixConditions}`;
+    const stmtProcessing = this.db.prepare(AbortProcessingQuery);
+    stmtProcessing.run(now, String(jobId), this.queueName, JobStatus.PROCESSING, ...prefixParams);
   }
 
   /**
@@ -312,18 +330,25 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
   }
 
   /**
-   * Retrieves the next available job that is ready to be processed,
-   * and updates its status to PROCESSING.
+   * Retrieves the next available job that is ready to be processed.
+   * Claims PENDING jobs ready to run, and also reclaims PROCESSING jobs whose
+   * lease has expired (crash recovery). Sets lease_expires_at on the claimed row.
    *
    * @param workerId - Worker ID to associate with the job
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns The next job or undefined if no job is available
    */
-  public async next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
+  public async next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
     const now = new Date().toISOString();
+    const leaseMs = opts?.leaseMs ?? 30000;
+    const leaseExpiry = new Date(Date.now() + leaseMs).toISOString();
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();
 
-    // Then, get the next job to process
+    // Claim either a PENDING job ready to run, or a PROCESSING job with an expired lease
     const stmt = this.db.prepare<
       unknown[],
       JobStorageFormat<Input, Output> & {
@@ -333,15 +358,17 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       }
     >(
       `
-      UPDATE ${this.tableName} 
-      SET status = ?, last_ran_at = ?, worker_id = ?
+      UPDATE ${this.tableName}
+      SET status = ?, last_ran_at = ?, worker_id = ?, lease_expires_at = ?
       WHERE id = (
-        SELECT id 
-        FROM ${this.tableName} 
-        WHERE queue = ? 
-        AND status = ?${prefixConditions}
-        AND run_after <= ? 
-        ORDER BY run_after ASC 
+        SELECT id
+        FROM ${this.tableName}
+        WHERE queue = ?
+        AND (
+          (status = ? AND run_after <= ?)
+          OR (status = ? AND (lease_expires_at IS NULL OR lease_expires_at < ?))
+        )${prefixConditions}
+        ORDER BY run_after ASC
         LIMIT 1
       )
       RETURNING *`
@@ -350,10 +377,13 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       JobStatus.PROCESSING,
       now,
       workerId,
+      leaseExpiry,
       this.queueName,
       JobStatus.PENDING,
-      ...prefixParams,
-      now
+      now,
+      JobStatus.PROCESSING,
+      now,
+      ...prefixParams
     );
     if (!result) return undefined;
 
@@ -363,6 +393,37 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     if (result.progress_details) result.progress_details = JSON.parse(result.progress_details);
 
     return result;
+  }
+
+  /**
+   * Extend the lease on a currently PROCESSING job.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    const leaseExpiry = new Date(Date.now() + ms).toISOString();
+    const prefixConditions = this.buildPrefixWhereClause();
+    const prefixParams = this.getPrefixParamValues();
+
+    const stmt = this.db.prepare<unknown[], { changes: number }>(
+      `UPDATE ${this.tableName}
+         SET lease_expires_at = ?
+         WHERE id = ? AND queue = ? AND worker_id = ? AND status = ?${prefixConditions}`
+    );
+    const info = stmt.run(
+      leaseExpiry,
+      String(id),
+      this.queueName,
+      workerId,
+      JobStatus.PROCESSING,
+      ...prefixParams
+    ) as { changes: number };
+    if (info.changes === 0) {
+      throw new Error(
+        `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
+      );
+    }
   }
 
   /**

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -549,6 +549,10 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     const sets: string[] = [];
@@ -566,6 +570,15 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     if ("completed_at" in fields) push("completed_at", fields.completed_at ?? null);
     if ("abort_requested_at" in fields)
       push("abort_requested_at", fields.abort_requested_at ?? null);
+    if ("lease_owner" in fields) push("lease_owner", fields.lease_owner ?? null);
+    if ("progress" in fields) push("progress", fields.progress ?? 0);
+    if ("progress_message" in fields) push("progress_message", fields.progress_message ?? "");
+    if ("progress_details" in fields) {
+      push(
+        "progress_details",
+        fields.progress_details != null ? JSON.stringify(fields.progress_details) : null
+      );
+    }
     if (sets.length === 0) return;
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -285,13 +285,17 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();
 
+    // releaseClaim returns the row to PENDING without consuming an attempt.
+    // Clear abort_requested_at so an abort that was requested mid-claim does
+    // not survive the release and cancel the next worker that picks it up.
     const ReleaseQuery = `
       UPDATE ${this.tableName}
         SET status = ?,
             lease_owner = NULL,
             progress = 0,
             progress_message = '',
-            progress_details = NULL
+            progress_details = NULL,
+            abort_requested_at = NULL
         WHERE id = ? AND queue = ?${prefixConditions}`;
     const stmt = this.db.prepare(ReleaseQuery);
     stmt.run(JobStatus.PENDING, String(jobId), this.queueName, ...prefixParams);
@@ -367,9 +371,21 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
         progress_details: string | null;
       }
     >(
+      // The `CASE WHEN status = 'PROCESSING'` clause bumps attempts only for
+      // lease-expiry reclaim (a crashed-worker scenario — one used-up attempt
+      // against max_attempts). PENDING claims do not bump here; the worker's
+      // existing validateJobState() FAILs the job in the next-step branch when
+      // attempts >= max_attempts. abort_requested_at is always cleared on
+      // (re)claim so a stale flag from a previous worker can't immediately
+      // abort the new lease.
       `
       UPDATE ${this.tableName}
-      SET status = ?, last_attempted_at = ?, lease_owner = ?, lease_expires_at = ?
+      SET status = ?,
+          last_attempted_at = ?,
+          lease_owner = ?,
+          lease_expires_at = ?,
+          attempts = CASE WHEN status = ? THEN attempts + 1 ELSE attempts END,
+          abort_requested_at = NULL
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
@@ -384,15 +400,16 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       RETURNING *`
     );
     const result = stmt.get(
-      JobStatus.PROCESSING,
-      now,
-      workerId,
-      leaseExpiry,
-      this.queueName,
-      JobStatus.PENDING,
-      now,
-      JobStatus.PROCESSING,
-      now,
+      JobStatus.PROCESSING, // SET status = PROCESSING
+      now, // last_attempted_at
+      workerId, // lease_owner
+      leaseExpiry, // lease_expires_at
+      JobStatus.PROCESSING, // CASE WHEN status = PROCESSING (lease-expiry reclaim bumps attempts)
+      this.queueName, // WHERE queue = ?
+      JobStatus.PENDING, // status = PENDING
+      now, // visible_at <= now
+      JobStatus.PROCESSING, // status = PROCESSING (lease-expiry reclaim)
+      now, // lease_expires_at < now
       ...prefixParams
     );
     if (!result) return undefined;
@@ -482,6 +499,11 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
             WHERE id = ? AND queue = ?${prefixConditions}`;
       params = [job.status, now, job.id as string, this.queueName, ...prefixParams];
     } else {
+      // PENDING-retry / FAILED / COMPLETED — bump attempts and clear
+      // abort_requested_at. The retry branch in particular must clear it
+      // so an abort that was requested DURING the previous attempt does
+      // not immediately cancel the retry. For terminal statuses the
+      // clearing is a harmless cleanup.
       updateQuery = `
           UPDATE ${this.tableName}
             SET
@@ -494,7 +516,8 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
               progress_details = NULL,
               last_attempted_at = ?,
               completed_at = ?,
-              attempts = attempts + 1
+              attempts = attempts + 1,
+              abort_requested_at = NULL
             WHERE id = ? AND queue = ?${prefixConditions}`;
       params = [
         job.output ? JSON.stringify(job.output) : null,

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -535,6 +535,48 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     stmt.run(...params);
   }
 
+  /**
+   * Terminal write that does NOT bump `attempts`. See IQueueStorage.finalize
+   * for the rationale (avoids double-counting on ack/fail because the lease
+   * reclaim path already charged the attempt at next() time).
+   */
+  public async finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
+    const sets: string[] = [];
+    const params: Array<unknown> = [];
+    const push = (col: string, value: unknown): void => {
+      sets.push(`${col} = ?`);
+      params.push(value);
+    };
+    if ("output" in fields) {
+      push("output", fields.output != null ? JSON.stringify(fields.output) : null);
+    }
+    if ("error" in fields) push("error", fields.error ?? null);
+    if ("error_code" in fields) push("error_code", fields.error_code ?? null);
+    if ("status" in fields) push("status", fields.status);
+    if ("completed_at" in fields) push("completed_at", fields.completed_at ?? null);
+    if ("abort_requested_at" in fields)
+      push("abort_requested_at", fields.abort_requested_at ?? null);
+    if (sets.length === 0) return;
+    const prefixConditions = this.buildPrefixWhereClause();
+    const prefixParams = this.getPrefixParamValues();
+    const stmt = this.db.prepare(
+      `UPDATE ${this.tableName}
+         SET ${sets.join(", ")}
+         WHERE id = ? AND queue = ?${prefixConditions}`
+    );
+    stmt.run(...(params as never[]), String(id), this.queueName, ...prefixParams);
+  }
+
   public async deleteAll(): Promise<void> {
     const prefixConditions = this.buildPrefixWhereClause();
     const prefixParams = this.getPrefixParamValues();

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -297,6 +297,16 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     stmt.run(JobStatus.PENDING, String(jobId), this.queueName, ...prefixParams);
   }
 
+  /** Force-overwrite status without touching attempts (used to persist DISABLED after lease release). */
+  public saveStatus(jobId: unknown, status: string): void {
+    const prefixConditions = this.buildPrefixWhereClause();
+    const prefixParams = this.getPrefixParamValues();
+    const stmt = this.db.prepare(
+      `UPDATE ${this.tableName} SET status = ? WHERE id = ? AND queue = ?${prefixConditions}`
+    );
+    stmt.run(status, String(jobId), this.queueName, ...prefixParams);
+  }
+
   /**
    * Retrieves all jobs for a given job run ID.
    * @param job_run_id - The ID of the job run to retrieve

--- a/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
+++ b/providers/sqlite/src/job-queue/SqliteQueueStorage.ts
@@ -126,7 +126,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     job.progress_message = "";
     job.progress_details = null;
     job.created_at = now;
-    job.run_after = now;
+    job.visible_at = now;
 
     const { columns: prefixColumnsInsert, placeholders: prefixPlaceholders } =
       buildPrefixInsertFragments(SqliteDialect, this.prefixes);
@@ -134,15 +134,15 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
 
     const AddQuery = `
       INSERT INTO ${this.tableName}(
-        ${prefixColumnsInsert}queue, 
-        fingerprint, 
-        input, 
-        run_after, 
-        deadline_at, 
-        max_retries, 
-        job_run_id, 
-        progress, 
-        progress_message, 
+        ${prefixColumnsInsert}queue,
+        fingerprint,
+        input,
+        visible_at,
+        deadline_at,
+        max_attempts,
+        job_run_id,
+        progress,
+        progress_message,
         progress_details,
         created_at
       )
@@ -156,9 +156,9 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       job.queue,
       job.fingerprint,
       JSON.stringify(job.input),
-      job.run_after,
+      job.visible_at,
       job.deadline_at ?? null,
-      job.max_retries!,
+      job.max_attempts!,
       job.job_run_id,
       job.progress,
       job.progress_message,
@@ -216,11 +216,11 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     const prefixParams = this.getPrefixParamValues();
 
     const FutureJobQuery = `
-      SELECT * 
+      SELECT *
         FROM ${this.tableName}
         WHERE queue = ?
         AND status = ?${prefixConditions}
-        ORDER BY run_after ASC
+        ORDER BY visible_at ASC
         LIMIT ${num}`;
     const stmt = this.db.prepare<
       unknown[],
@@ -278,7 +278,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
   }
 
   /**
-   * Releases a claimed job back to PENDING without incrementing run_attempts.
+   * Releases a claimed job back to PENDING without incrementing attempts.
    * @param jobId - The id of the claimed job to release.
    */
   public async releaseClaim(jobId: unknown): Promise<void> {
@@ -288,7 +288,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     const ReleaseQuery = `
       UPDATE ${this.tableName}
         SET status = ?,
-            worker_id = NULL,
+            lease_owner = NULL,
             progress = 0,
             progress_message = '',
             progress_details = NULL
@@ -359,16 +359,16 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     >(
       `
       UPDATE ${this.tableName}
-      SET status = ?, last_ran_at = ?, worker_id = ?, lease_expires_at = ?
+      SET status = ?, last_attempted_at = ?, lease_owner = ?, lease_expires_at = ?
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
         WHERE queue = ?
         AND (
-          (status = ? AND run_after <= ?)
+          (status = ? AND visible_at <= ?)
           OR (status = ? AND (lease_expires_at IS NULL OR lease_expires_at < ?))
         )${prefixConditions}
-        ORDER BY run_after ASC
+        ORDER BY visible_at ASC
         LIMIT 1
       )
       RETURNING *`
@@ -398,7 +398,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
   /**
    * Extend the lease on a currently PROCESSING job.
    * @param id - The ID of the job to extend the lease for
-   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param workerId - Worker ID that must match the current lease owner (lease_owner)
    * @param ms - Number of milliseconds to extend the lease by
    */
   public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
@@ -409,7 +409,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
     const stmt = this.db.prepare<unknown[], { changes: number }>(
       `UPDATE ${this.tableName}
          SET lease_expires_at = ?
-         WHERE id = ? AND queue = ? AND worker_id = ? AND status = ?${prefixConditions}`
+         WHERE id = ? AND queue = ? AND lease_owner = ? AND status = ?${prefixConditions}`
     );
     const info = stmt.run(
       leaseExpiry,
@@ -449,7 +449,7 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
    * Marks a job as complete with its output or error.
    * Enhanced error handling:
    * - Increments the retry count.
-   * - For a retryable error, updates run_after with the retry date.
+   * - For a retryable error, updates visible_at with the retry date.
    * - Marks the job as FAILED for permanent or generic errors.
    * - Marks the job as DISABLED for disabled jobs.
    */
@@ -473,18 +473,18 @@ export class SqliteQueueStorage<Input, Output> implements IQueueStorage<Input, O
       params = [job.status, now, job.id as string, this.queueName, ...prefixParams];
     } else {
       updateQuery = `
-          UPDATE ${this.tableName} 
-            SET 
-              output = ?, 
-              error = ?, 
-              error_code = ?, 
-              status = ?, 
-              progress = 100, 
-              progress_message = '', 
-              progress_details = NULL, 
-              last_ran_at = ?,
+          UPDATE ${this.tableName}
+            SET
+              output = ?,
+              error = ?,
+              error_code = ?,
+              status = ?,
+              progress = 100,
+              progress_message = '',
+              progress_details = NULL,
+              last_attempted_at = ?,
               completed_at = ?,
-              run_attempts = run_attempts + 1
+              attempts = attempts + 1
             WHERE id = ? AND queue = ?${prefixConditions}`;
       params = [
         job.output ? JSON.stringify(job.output) : null,

--- a/providers/sqlite/src/job-queue/common.ts
+++ b/providers/sqlite/src/job-queue/common.ts
@@ -7,6 +7,9 @@
 // organize-imports-ignore
 
 export * from "./SqliteQueueStorage";
+export * from "./SqliteMessageQueue";
+export * from "./SqliteJobStore";
+export * from "./createSqliteQueue";
 export * from "./SqliteRateLimiterStorage";
 
 // Versioned migration sets for the queue + rate-limiter tables, plus the

--- a/providers/sqlite/src/job-queue/createSqliteQueue.ts
+++ b/providers/sqlite/src/job-queue/createSqliteQueue.ts
@@ -6,7 +6,7 @@
 
 import type { Sqlite } from "@workglow/sqlite/storage";
 import { SqliteJobStore } from "./SqliteJobStore";
-import { SqliteMessageQueue, type PendingWrite } from "./SqliteMessageQueue";
+import { SqliteMessageQueue, type SqlitePendingWrite } from "./SqliteMessageQueue";
 import { SqliteQueueStorage, type SqliteQueueStorageOptions } from "./SqliteQueueStorage";
 
 /**
@@ -25,7 +25,7 @@ export function createSqliteQueue<Input, Output>(
   core: SqliteQueueStorage<Input, Output>;
 } {
   const core = new SqliteQueueStorage<Input, Output>(db, queueName, opts);
-  const pending = new Map<unknown, PendingWrite<Output>>();
+  const pending = new Map<unknown, SqlitePendingWrite<Output>>();
   return {
     messageQueue: new SqliteMessageQueue<Input, Output>(core, pending),
     jobStore: new SqliteJobStore<Input, Output>(core, pending),

--- a/providers/sqlite/src/job-queue/createSqliteQueue.ts
+++ b/providers/sqlite/src/job-queue/createSqliteQueue.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Sqlite } from "@workglow/sqlite/storage";
+import { SqliteJobStore } from "./SqliteJobStore";
+import { SqliteMessageQueue, type PendingWrite } from "./SqliteMessageQueue";
+import { SqliteQueueStorage, type SqliteQueueStorageOptions } from "./SqliteQueueStorage";
+
+/**
+ * Factory for the paired SQLite message queue and job store. Both facades
+ * share a single underlying {@link SqliteQueueStorage} so writes through one
+ * are observable through the other.
+ */
+export function createSqliteQueue<Input, Output>(
+  queueName: string,
+  db: Sqlite.Database,
+  opts?: SqliteQueueStorageOptions
+): {
+  messageQueue: SqliteMessageQueue<Input, Output>;
+  jobStore: SqliteJobStore<Input, Output>;
+  /** @internal — exposed for callers that still need the legacy storage object. */
+  core: SqliteQueueStorage<Input, Output>;
+} {
+  const core = new SqliteQueueStorage<Input, Output>(db, queueName, opts);
+  const pending = new Map<unknown, PendingWrite<Output>>();
+  return {
+    messageQueue: new SqliteMessageQueue<Input, Output>(core, pending),
+    jobStore: new SqliteJobStore<Input, Output>(core, pending),
+    core,
+  };
+}

--- a/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
+++ b/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
@@ -60,5 +60,16 @@ export function sqliteQueueMigrations(
         `);
       },
     },
+    {
+      component,
+      version: 2,
+      description: "Add abort_requested_at and lease_expires_at columns",
+      up(db: Sqlite.Database) {
+        db.exec(`
+          ALTER TABLE ${tableName} ADD COLUMN abort_requested_at TEXT;
+          ALTER TABLE ${tableName} ADD COLUMN lease_expires_at TEXT;
+        `);
+      },
+    },
   ];
 }

--- a/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
+++ b/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
@@ -39,10 +39,10 @@ export function sqliteQueueMigrations(
             status TEXT NOT NULL default 'PENDING',
             input TEXT NOT NULL,
             output TEXT,
-            run_attempts INTEGER default 0,
-            max_retries INTEGER default 23,
-            run_after TEXT NOT NULL,
-            last_ran_at TEXT,
+            attempts INTEGER default 0,
+            max_attempts INTEGER default 10,
+            visible_at TEXT NOT NULL,
+            last_attempted_at TEXT,
             created_at TEXT NOT NULL,
             completed_at TEXT,
             deadline_at TEXT,
@@ -51,10 +51,10 @@ export function sqliteQueueMigrations(
             progress REAL DEFAULT 0,
             progress_message TEXT DEFAULT '',
             progress_details TEXT NULL,
-            worker_id TEXT
+            lease_owner TEXT
           );
 
-          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, run_after);
+          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at);
           CREATE INDEX IF NOT EXISTS job_queue_fingerprint${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, fingerprint, status);
           CREATE INDEX IF NOT EXISTS job_queue_job_run_id${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, job_run_id);
         `);
@@ -69,6 +69,31 @@ export function sqliteQueueMigrations(
           ALTER TABLE ${tableName} ADD COLUMN abort_requested_at TEXT;
           ALTER TABLE ${tableName} ADD COLUMN lease_expires_at TEXT;
         `);
+      },
+    },
+    {
+      component,
+      version: 3,
+      description:
+        "Rename columns: run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner",
+      up(db: Sqlite.Database) {
+        // Only rename if the old column names still exist (skip on fresh installs)
+        const cols: string[] = db
+          .prepare<[], { name: string }>(`PRAGMA table_info(${tableName})`)
+          .all()
+          .map((r) => r.name);
+        const renames: [string, string][] = [
+          ["run_after", "visible_at"],
+          ["last_ran_at", "last_attempted_at"],
+          ["run_attempts", "attempts"],
+          ["max_retries", "max_attempts"],
+          ["worker_id", "lease_owner"],
+        ];
+        for (const [oldName, newName] of renames) {
+          if (cols.includes(oldName)) {
+            db.exec(`ALTER TABLE ${tableName} RENAME COLUMN ${oldName} TO ${newName};`);
+          }
+        }
       },
     },
   ];

--- a/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
+++ b/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
@@ -14,7 +14,16 @@ import {
   SqliteDialect,
 } from "@workglow/storage";
 
-/** Initial migration set for the SQLite queue table identified by `tableName`. */
+/**
+ * Initial migration set for the SQLite queue table identified by `tableName`.
+ *
+ * v1 is FROZEN byte-for-byte against the pre-PR shape — it creates the
+ * `run_after`/`run_attempts`/`max_retries`/`last_ran_at`/`worker_id`
+ * columns and the `run_after`-keyed index. Renames and the index swap
+ * live in v3, guarded by `PRAGMA table_info` lookups so fresh installs
+ * (which still run v1 → v2 → v3) end up at the same final schema as
+ * already-migrated DBs.
+ */
 export function sqliteQueueMigrations(
   tableName: string,
   prefixes: readonly PrefixColumn[]
@@ -39,10 +48,10 @@ export function sqliteQueueMigrations(
             status TEXT NOT NULL default 'PENDING',
             input TEXT NOT NULL,
             output TEXT,
-            attempts INTEGER default 0,
-            max_attempts INTEGER default 10,
-            visible_at TEXT NOT NULL,
-            last_attempted_at TEXT,
+            run_attempts INTEGER default 0,
+            max_retries INTEGER default 23,
+            run_after TEXT NOT NULL,
+            last_ran_at TEXT,
             created_at TEXT NOT NULL,
             completed_at TEXT,
             deadline_at TEXT,
@@ -51,10 +60,10 @@ export function sqliteQueueMigrations(
             progress REAL DEFAULT 0,
             progress_message TEXT DEFAULT '',
             progress_details TEXT NULL,
-            lease_owner TEXT
+            worker_id TEXT
           );
 
-          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at);
+          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, run_after);
           CREATE INDEX IF NOT EXISTS job_queue_fingerprint${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, fingerprint, status);
           CREATE INDEX IF NOT EXISTS job_queue_job_run_id${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, job_run_id);
         `);
@@ -75,9 +84,11 @@ export function sqliteQueueMigrations(
       component,
       version: 3,
       description:
-        "Rename columns: run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner",
+        "Rename run_after→visible_at, last_ran_at→last_attempted_at, run_attempts→attempts, max_retries→max_attempts, worker_id→lease_owner; drop run_after-keyed index and recreate visible_at-keyed",
       up(db: Sqlite.Database) {
-        // Only rename if the old column names still exist (skip on fresh installs)
+        // PRAGMA table_info guards each rename so fresh installs (which
+        // arrive at v3 having just created the v1 schema in this same
+        // migration run) are no-ops here.
         const cols: string[] = db
           .prepare<[], { name: string }>(`PRAGMA table_info(${tableName})`)
           .all()
@@ -94,6 +105,15 @@ export function sqliteQueueMigrations(
             db.exec(`ALTER TABLE ${tableName} RENAME COLUMN ${oldName} TO ${newName};`);
           }
         }
+
+        // SQLite carries indexes across RENAME COLUMN transparently, but the
+        // index name still encodes the old column intent. Drop the v1
+        // run_after-keyed index and recreate it keyed on visible_at so the
+        // schema is self-describing. `IF EXISTS` covers fresh installs too.
+        db.exec(`
+          DROP INDEX IF EXISTS job_queue_fetcher${indexSuffix}_idx;
+          CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at);
+        `);
       },
     },
   ];

--- a/providers/supabase/src/job-queue/SupabaseJobStore.ts
+++ b/providers/supabase/src/job-queue/SupabaseJobStore.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
+import type { PendingWrite } from "./SupabaseMessageQueue";
+import type { SupabaseQueueStorage } from "./SupabaseQueueStorage";
+
+export class SupabaseJobStore<Input, Output> implements IJobStore<Input, Output> {
+  /** @internal — shared with the paired message queue */
+  public readonly core: SupabaseQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: SupabaseQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+  }
+
+  get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
+    return this.core.get(id);
+  }
+
+  async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.peek(status, num);
+  }
+
+  size(status?: JobStatus): Promise<number> {
+    return this.core.size(status);
+  }
+
+  async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {
+    return this.core.getByRunId(runId);
+  }
+
+  outputForInput(input: Input): Promise<Output | null> {
+    return this.core.outputForInput(input);
+  }
+
+  async saveProgress(
+    id: MessageId,
+    progress: number,
+    message: string,
+    details: Record<string, any> | null
+  ): Promise<void> {
+    await this.core.saveProgress(id, progress, message, details as Record<string, any>);
+  }
+
+  async saveResult(id: MessageId, output: Output): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.output = output ?? null;
+    this.pending.set(id, buf);
+  }
+
+  async saveError(
+    id: MessageId,
+    error: string,
+    errorCode: string | null,
+    abortRequested: boolean
+  ): Promise<void> {
+    const buf = this.pending.get(id) ?? {};
+    buf.error = error;
+    buf.errorCode = errorCode;
+    buf.abortRequested = abortRequested;
+    this.pending.set(id, buf);
+  }
+
+  async deleteByStatusAndAge(status: JobStatus, olderThanMs: number): Promise<void> {
+    await this.core.deleteJobsByStatusAndAge(status, olderThanMs);
+  }
+
+  async delete(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.delete(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    this.pending.clear();
+    await this.core.deleteAll();
+  }
+
+  async abort(id: MessageId): Promise<void> {
+    await this.core.abort(id);
+  }
+}

--- a/providers/supabase/src/job-queue/SupabaseJobStore.ts
+++ b/providers/supabase/src/job-queue/SupabaseJobStore.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IJobStore, JobRecord, JobStatus, MessageId } from "@workglow/job-queue";
-import type { PendingWrite } from "./SupabaseMessageQueue";
+import type { SupabasePendingWrite } from "./SupabaseMessageQueue";
 import type { SupabaseQueueStorage } from "./SupabaseQueueStorage";
 
 export class SupabaseJobStore<Input, Output> implements IJobStore<Input, Output> {
@@ -13,11 +13,11 @@ export class SupabaseJobStore<Input, Output> implements IJobStore<Input, Output>
   public readonly core: SupabaseQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, SupabasePendingWrite<Output>>;
 
   constructor(
     core: SupabaseQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, SupabasePendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;
@@ -28,11 +28,11 @@ export class SupabaseJobStore<Input, Output> implements IJobStore<Input, Output>
   }
 
   async peek(status?: JobStatus, num?: number): Promise<readonly JobRecord<Input, Output>[]> {
-    return this.core.peek(status, num);
+    return this.core.peek(status as any, num);
   }
 
   size(status?: JobStatus): Promise<number> {
-    return this.core.size(status);
+    return this.core.size(status as any);
   }
 
   async getByRunId(runId: string): Promise<readonly JobRecord<Input, Output>[]> {

--- a/providers/supabase/src/job-queue/SupabaseJobStore.ts
+++ b/providers/supabase/src/job-queue/SupabaseJobStore.ts
@@ -88,4 +88,8 @@ export class SupabaseJobStore<Input, Output> implements IJobStore<Input, Output>
   async abort(id: MessageId): Promise<void> {
     await this.core.abort(id);
   }
+
+  async saveStatus(id: MessageId, status: JobStatus): Promise<void> {
+    await this.core.saveStatus(id, status);
+  }
 }

--- a/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
+++ b/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
@@ -111,6 +111,20 @@ class SupabaseClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
   async extendLease(ms: number): Promise<void> {
     await this.core.extendLease(this.id, this.workerId, ms);
   }
+
+  async disable(): Promise<void> {
+    this.pending.delete(this.id);
+    const current = await this.core.get(this.id);
+    const completedAt = current?.completed_at ?? new Date().toISOString();
+    await this.core.finalize(this.id, {
+      status: "DISABLED",
+      completed_at: completedAt,
+      lease_owner: null,
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
 }
 
 export class SupabaseMessageQueue<Input, Output> implements IMessageQueue<

--- a/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
+++ b/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
@@ -21,7 +21,7 @@ import type { SupabaseQueueStorage } from "./SupabaseQueueStorage";
  * stage output/error until the terminal claim.ack()/fail() persists them in
  * a single complete() call (avoids double-bumping `attempts`).
  */
-export type PendingWrite<Output> = {
+export type SupabasePendingWrite<Output> = {
   output?: Output | null;
   error?: string | null;
   errorCode?: string | null;
@@ -31,7 +31,7 @@ export type PendingWrite<Output> = {
 class SupabaseClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
   constructor(
     private readonly core: SupabaseQueueStorage<Input, Output>,
-    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    private readonly pending: Map<unknown, SupabasePendingWrite<Output>>,
     public readonly id: MessageId,
     public readonly body: JobStorageFormat<Input, Output>,
     public readonly attempts: number,
@@ -104,11 +104,11 @@ export class SupabaseMessageQueue<Input, Output> implements IMessageQueue<
   public readonly core: SupabaseQueueStorage<Input, Output>;
 
   /** @internal — shared transient buffer for saveResult/saveError. */
-  private readonly pending: Map<unknown, PendingWrite<Output>>;
+  private readonly pending: Map<unknown, SupabasePendingWrite<Output>>;
 
   constructor(
     core: SupabaseQueueStorage<Input, Output>,
-    pending: Map<unknown, PendingWrite<Output>>
+    pending: Map<unknown, SupabasePendingWrite<Output>>
   ) {
     this.core = core;
     this.pending = pending;

--- a/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
+++ b/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  IClaim,
+  IMessageQueue,
+  JobStorageFormat,
+  MessageId,
+  QueueChangePayload,
+  QueueStorageScope,
+  QueueSubscribeOptions,
+  SendOptions,
+} from "@workglow/job-queue";
+import type { SupabaseQueueStorage } from "./SupabaseQueueStorage";
+
+/**
+ * Per-id buffer that lets {@link IJobStore.saveResult}/{@link IJobStore.saveError}
+ * stage output/error until the terminal claim.ack()/fail() persists them in
+ * a single complete() call (avoids double-bumping `attempts`).
+ */
+export type PendingWrite<Output> = {
+  output?: Output | null;
+  error?: string | null;
+  errorCode?: string | null;
+  abortRequested?: boolean;
+};
+
+class SupabaseClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
+  constructor(
+    private readonly core: SupabaseQueueStorage<Input, Output>,
+    private readonly pending: Map<unknown, PendingWrite<Output>>,
+    public readonly id: MessageId,
+    public readonly body: JobStorageFormat<Input, Output>,
+    public readonly attempts: number,
+    private readonly workerId: string
+  ) {}
+
+  async ack(): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      output: buf?.output ?? current.output ?? null,
+      error: null,
+      error_code: null,
+      status: "COMPLETED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async retry(opts?: { delaySeconds?: number }): Promise<void> {
+    this.pending.delete(this.id);
+    const delay = opts?.delaySeconds ?? 0;
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      status: "PENDING",
+      lease_owner: null,
+      lease_expires_at: null,
+      visible_at: new Date(Date.now() + delay * 1000).toISOString(),
+      progress: 0,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+    const buf = this.pending.get(this.id);
+    this.pending.delete(this.id);
+    const current = (await this.core.get(this.id)) ?? this.body;
+    await this.core.complete({
+      ...current,
+      error: buf?.error ?? current.error ?? null,
+      error_code: buf?.errorCode ?? current.error_code ?? null,
+      abort_requested_at: buf?.abortRequested
+        ? (current.abort_requested_at ?? new Date().toISOString())
+        : (current.abort_requested_at ?? null),
+      status: "FAILED",
+      completed_at: current.completed_at ?? new Date().toISOString(),
+      progress: 100,
+      progress_message: "",
+      progress_details: null,
+    });
+  }
+
+  async extendLease(ms: number): Promise<void> {
+    await this.core.extendLease(this.id, this.workerId, ms);
+  }
+}
+
+export class SupabaseMessageQueue<Input, Output> implements IMessageQueue<
+  JobStorageFormat<Input, Output>
+> {
+  public readonly scope: QueueStorageScope;
+
+  /** @internal — shared with the paired job store */
+  public readonly core: SupabaseQueueStorage<Input, Output>;
+
+  /** @internal — shared transient buffer for saveResult/saveError. */
+  private readonly pending: Map<unknown, PendingWrite<Output>>;
+
+  constructor(
+    core: SupabaseQueueStorage<Input, Output>,
+    pending: Map<unknown, PendingWrite<Output>>
+  ) {
+    this.core = core;
+    this.pending = pending;
+    this.scope = core.scope;
+  }
+
+  async send(body: JobStorageFormat<Input, Output>, opts?: SendOptions): Promise<MessageId> {
+    return this.core.add(applySendOptions(body, opts));
+  }
+
+  async sendBatch(
+    bodies: readonly JobStorageFormat<Input, Output>[],
+    opts?: SendOptions
+  ): Promise<readonly MessageId[]> {
+    const ids: MessageId[] = [];
+    for (const body of bodies) {
+      ids.push(await this.send(body, opts));
+    }
+    return ids;
+  }
+
+  async receive(opts: {
+    workerId: string;
+    leaseMs: number;
+    max?: number;
+  }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
+    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+    if (!job) return [];
+    return [
+      new SupabaseClaim<Input, Output>(
+        this.core,
+        this.pending,
+        job.id,
+        job,
+        job.attempts ?? 0,
+        opts.workerId
+      ),
+    ];
+  }
+
+  async releaseClaim(id: MessageId): Promise<void> {
+    this.pending.delete(id);
+    await this.core.releaseClaim(id);
+  }
+
+  async migrate(): Promise<void> {
+    await this.core.migrate();
+  }
+
+  getMigrations(): ReadonlyArray<unknown> {
+    return this.core.getMigrations();
+  }
+
+  subscribeToChanges(
+    callback: (change: QueueChangePayload<any, any>) => void,
+    options?: QueueSubscribeOptions
+  ): () => void {
+    return this.core.subscribeToChanges(callback, options);
+  }
+}
+
+function applySendOptions<Input, Output>(
+  body: JobStorageFormat<Input, Output>,
+  opts?: SendOptions
+): JobStorageFormat<Input, Output> {
+  if (!opts) return body;
+  const out: JobStorageFormat<Input, Output> = { ...body };
+  if (opts.delaySeconds != null) {
+    out.visible_at = new Date(Date.now() + opts.delaySeconds * 1000).toISOString();
+  }
+  if (opts.timeoutSeconds != null) {
+    out.deadline_at = new Date(Date.now() + opts.timeoutSeconds * 1000).toISOString();
+  }
+  if (opts.fingerprint != null) out.fingerprint = opts.fingerprint;
+  if (opts.jobRunId != null) out.job_run_id = opts.jobRunId;
+  if (opts.maxAttempts != null) out.max_attempts = opts.maxAttempts;
+  return out;
+}

--- a/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
+++ b/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
@@ -38,20 +38,22 @@ class SupabaseClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     private readonly workerId: string
   ) {}
 
-  async ack(): Promise<void> {
+  async ack(result?: unknown): Promise<void> {
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      output: buf?.output ?? current.output ?? null,
+    const output =
+      result !== undefined
+        ? result
+        : buf?.output !== undefined
+          ? buf.output
+          : (current.output ?? null);
+    await this.core.finalize(this.id, {
+      output: output as Output | null,
       error: null,
       error_code: null,
       status: "COMPLETED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 
@@ -71,22 +73,38 @@ class SupabaseClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Out
     });
   }
 
-  async fail(_opts?: { permanent?: boolean }): Promise<void> {
+  async fail(opts?: {
+    error?: string | null;
+    errorCode?: string | null;
+    abortRequested?: boolean;
+    permanent?: boolean;
+  }): Promise<void> {
+    void opts?.permanent;
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.core.get(this.id)) ?? this.body;
-    await this.core.complete({
-      ...current,
-      error: buf?.error ?? current.error ?? null,
-      error_code: buf?.errorCode ?? current.error_code ?? null,
-      abort_requested_at: buf?.abortRequested
+    const error =
+      opts?.error !== undefined
+        ? opts.error
+        : buf?.error !== undefined
+          ? buf.error
+          : (current.error ?? null);
+    const errorCode =
+      opts?.errorCode !== undefined
+        ? opts.errorCode
+        : buf?.errorCode !== undefined
+          ? buf.errorCode
+          : (current.error_code ?? null);
+    const abortRequested =
+      opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
+    await this.core.finalize(this.id, {
+      error,
+      error_code: errorCode,
+      abort_requested_at: abortRequested
         ? (current.abort_requested_at ?? new Date().toISOString())
         : (current.abort_requested_at ?? null),
       status: "FAILED",
       completed_at: current.completed_at ?? new Date().toISOString(),
-      progress: 100,
-      progress_message: "",
-      progress_details: null,
     });
   }
 

--- a/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
+++ b/providers/supabase/src/job-queue/SupabaseMessageQueue.ts
@@ -135,18 +135,23 @@ export class SupabaseMessageQueue<Input, Output> implements IMessageQueue<
     leaseMs: number;
     max?: number;
   }): Promise<readonly IClaim<JobStorageFormat<Input, Output>>[]> {
-    const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
-    if (!job) return [];
-    return [
-      new SupabaseClaim<Input, Output>(
-        this.core,
-        this.pending,
-        job.id,
-        job,
-        job.attempts ?? 0,
-        opts.workerId
-      ),
-    ];
+    const max = Math.max(1, opts.max ?? 1);
+    const claims: IClaim<JobStorageFormat<Input, Output>>[] = [];
+    while (claims.length < max) {
+      const job = await this.core.next(opts.workerId, { leaseMs: opts.leaseMs });
+      if (!job) break;
+      claims.push(
+        new SupabaseClaim<Input, Output>(
+          this.core,
+          this.pending,
+          job.id,
+          job,
+          job.attempts ?? 0,
+          opts.workerId
+        )
+      );
+    }
+    return claims;
   }
 
   async releaseClaim(id: MessageId): Promise<void> {

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -235,10 +235,11 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     ];
     for (const sql of alterSqls) {
       const { error } = await this.client.rpc("exec_sql", { query: sql });
-      // Ignore errors (column may already exist)
-      if (error && error.code !== "42701") {
-        // 42701 = duplicate_column
-        // ignore
+      // 42703 = undefined_column: expected on re-run after a RENAME COLUMN has
+      // already applied (the old column no longer exists). All other errors
+      // (permission denied, wrong table name, etc.) are re-thrown.
+      if (error && error.code !== "42703") {
+        throw new Error(`Failed to rename column: ${error.message}`);
       }
     }
 
@@ -526,7 +527,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
 
     if (jobDetails.status === JobStatus.PENDING) {
       // Check if the next attempt would exceed max attempts
-      if (nextAttempts > maxAttempts) {
+      if (nextAttempts >= maxAttempts) {
         // Update to FAILED status instead of rescheduling
         let failQuery = this.client
           .from(this.tableName)

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -198,10 +198,10 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       status job_status NOT NULL default 'PENDING',
       input jsonb NOT NULL,
       output jsonb,
-      run_attempts integer default 0,
-      max_retries integer default 20,
-      run_after timestamp with time zone DEFAULT now(),
-      last_ran_at timestamp with time zone,
+      attempts integer default 0,
+      max_attempts integer default 10,
+      visible_at timestamp with time zone DEFAULT now(),
+      last_attempted_at timestamp with time zone,
       created_at timestamp with time zone DEFAULT now(),
       deadline_at timestamp with time zone,
       completed_at timestamp with time zone,
@@ -210,7 +210,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       progress real DEFAULT 0,
       progress_message text DEFAULT '',
       progress_details jsonb,
-      worker_id text,
+      lease_owner text,
       abort_requested_at timestamp with time zone,
       lease_expires_at timestamp with time zone
     )`;
@@ -223,10 +223,15 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       }
     }
 
-    // Add new columns to existing tables (idempotent via IF NOT EXISTS workaround)
+    // Add new columns to existing tables and rename old columns (idempotent)
     const alterSqls = [
       `ALTER TABLE ${this.tableName} ADD COLUMN IF NOT EXISTS abort_requested_at timestamp with time zone`,
       `ALTER TABLE ${this.tableName} ADD COLUMN IF NOT EXISTS lease_expires_at timestamp with time zone`,
+      `ALTER TABLE ${this.tableName} RENAME COLUMN run_after TO visible_at`,
+      `ALTER TABLE ${this.tableName} RENAME COLUMN last_ran_at TO last_attempted_at`,
+      `ALTER TABLE ${this.tableName} RENAME COLUMN run_attempts TO attempts`,
+      `ALTER TABLE ${this.tableName} RENAME COLUMN max_retries TO max_attempts`,
+      `ALTER TABLE ${this.tableName} RENAME COLUMN worker_id TO lease_owner`,
     ];
     for (const sql of alterSqls) {
       const { error } = await this.client.rpc("exec_sql", { query: sql });
@@ -239,8 +244,8 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
 
     // Create indexes with prefix columns prepended
     const indexes = [
-      `CREATE INDEX IF NOT EXISTS job_fetcher${indexSuffix}_idx ON ${this.tableName} (${prefixIndexPrefix}id, status, run_after)`,
-      `CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${this.tableName} (${prefixIndexPrefix}queue, status, run_after)`,
+      `CREATE INDEX IF NOT EXISTS job_fetcher${indexSuffix}_idx ON ${this.tableName} (${prefixIndexPrefix}id, status, visible_at)`,
+      `CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${this.tableName} (${prefixIndexPrefix}queue, status, visible_at)`,
       `CREATE INDEX IF NOT EXISTS jobs_fingerprint${indexSuffix}_unique_idx ON ${this.tableName} (${prefixIndexPrefix}queue, fingerprint, status)`,
     ];
 
@@ -270,7 +275,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     job.progress_message = "";
     job.progress_details = null;
     job.created_at = now;
-    job.run_after = now;
+    job.visible_at = now;
 
     const prefixInsertValues = this.getPrefixInsertValues();
 
@@ -281,10 +286,10 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
         queue: job.queue,
         fingerprint: job.fingerprint,
         input: job.input,
-        run_after: job.run_after,
+        visible_at: job.visible_at,
         created_at: job.created_at,
         deadline_at: job.deadline_at,
-        max_retries: job.max_retries,
+        max_attempts: job.max_attempts,
         job_run_id: job.job_run_id,
         progress: job.progress,
         progress_message: job.progress_message,
@@ -344,7 +349,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
 
     query = this.applyPrefixFilters(query);
 
-    const { data, error } = await query.order("run_after", { ascending: true }).limit(num);
+    const { data, error } = await query.order("visible_at", { ascending: true }).limit(num);
 
     if (error) throw error;
     return (data as JobStorageFormat<Input, Output>[]) ?? [];
@@ -372,19 +377,19 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     const sql = `
       UPDATE ${this.tableName}
       SET status = '${JobStatus.PROCESSING}',
-          last_ran_at = NOW() AT TIME ZONE 'UTC',
-          worker_id = '${escapedWorkerId}',
+          last_attempted_at = NOW() AT TIME ZONE 'UTC',
+          lease_owner = '${escapedWorkerId}',
           lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(leaseMs)} * INTERVAL '1 millisecond')
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
         WHERE queue = '${escapedQueueName}'
         AND (
-          (status = '${JobStatus.PENDING}' AND run_after <= NOW() AT TIME ZONE 'UTC')
+          (status = '${JobStatus.PENDING}' AND visible_at <= NOW() AT TIME ZONE 'UTC')
           OR (status = '${JobStatus.PROCESSING}' AND (lease_expires_at IS NULL OR lease_expires_at < NOW() AT TIME ZONE 'UTC'))
         )
         ${prefixConditions}
-        ORDER BY run_after ASC
+        ORDER BY visible_at ASC
         FOR UPDATE SKIP LOCKED
         LIMIT 1
       )
@@ -405,7 +410,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Extend the lease on a currently PROCESSING job.
    * @param id - The ID of the job to extend the lease for
-   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param workerId - Worker ID that must match the current lease owner (lease_owner)
    * @param ms - Number of milliseconds to extend the lease by
    */
   public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
@@ -423,7 +428,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
         SET lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(ms)} * INTERVAL '1 millisecond')
         WHERE id = ${numericId}
           AND queue = '${this.escapeSqlString(this.validateSqlValue(this.queueName, "queueName"))}'
-          AND worker_id = '${escapedWorkerId}'
+          AND lease_owner = '${escapedWorkerId}'
           AND status = '${JobStatus.PROCESSING}'
           ${prefixConditions}
         RETURNING id`;
@@ -479,7 +484,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Marks a job as complete with its output or error.
    * Enhanced error handling:
-   * - For a retryable error, increments run_attempts and updates run_after.
+   * - For a retryable error, increments attempts and updates visible_at.
    * - Marks a job as FAILED immediately for permanent or generic errors.
    */
   public async complete(jobDetails: JobStorageFormat<Input, Output>): Promise<void> {
@@ -495,7 +500,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
           progress_message: "",
           progress_details: null,
           completed_at: now,
-          last_ran_at: now,
+          last_attempted_at: now,
         })
         .eq("id", jobDetails.id)
         .eq("queue", this.queueName);
@@ -508,31 +513,32 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     // Read current attempts to compute next value deterministically
     let getQuery = this.client
       .from(this.tableName)
-      .select("run_attempts, max_retries")
+      .select("attempts, max_attempts")
       .eq("id", jobDetails.id as number)
       .eq("queue", this.queueName);
     getQuery = this.applyPrefixFilters(getQuery);
     const { data: current, error: getError } = await getQuery.single();
     if (getError) throw getError;
-    const currentAttempts = (current?.run_attempts as number | undefined) ?? 0;
-    const maxRetries = (current?.max_retries as number | undefined) ?? jobDetails.max_retries ?? 10;
+    const currentAttempts = (current?.attempts as number | undefined) ?? 0;
+    const maxAttempts =
+      (current?.max_attempts as number | undefined) ?? jobDetails.max_attempts ?? 10;
     const nextAttempts = currentAttempts + 1;
 
     if (jobDetails.status === JobStatus.PENDING) {
-      // Check if the next attempt would exceed max retries
-      if (nextAttempts > maxRetries) {
+      // Check if the next attempt would exceed max attempts
+      if (nextAttempts > maxAttempts) {
         // Update to FAILED status instead of rescheduling
         let failQuery = this.client
           .from(this.tableName)
           .update({
             status: JobStatus.FAILED,
-            error: "Max retries reached",
-            error_code: "MAX_RETRIES_REACHED",
+            error: "Max attempts reached",
+            error_code: "MAX_ATTEMPTS_REACHED",
             progress: 100,
             progress_message: "",
             progress_details: null,
             completed_at: now,
-            last_ran_at: now,
+            last_attempted_at: now,
           })
           .eq("id", jobDetails.id)
           .eq("queue", this.queueName);
@@ -549,12 +555,12 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
           error: jobDetails.error ?? null,
           error_code: jobDetails.error_code ?? null,
           status: jobDetails.status,
-          run_after: jobDetails.run_after!,
+          visible_at: jobDetails.visible_at!,
           progress: 0,
           progress_message: "",
           progress_details: null,
-          run_attempts: nextAttempts,
-          last_ran_at: now,
+          attempts: nextAttempts,
+          last_attempted_at: now,
         })
         .eq("id", jobDetails.id)
         .eq("queue", this.queueName);
@@ -575,9 +581,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
           progress: 100,
           progress_message: "",
           progress_details: null,
-          run_attempts: nextAttempts,
+          attempts: nextAttempts,
           completed_at: now,
-          last_ran_at: now,
+          last_attempted_at: now,
         })
         .eq("id", jobDetails.id)
         .eq("queue", this.queueName);
@@ -595,9 +601,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
         output: jobDetails.output ?? null,
         error: jobDetails.error ?? null,
         error_code: jobDetails.error_code ?? null,
-        run_after: jobDetails.run_after ?? null,
-        run_attempts: nextAttempts,
-        last_ran_at: now,
+        visible_at: jobDetails.visible_at ?? null,
+        attempts: nextAttempts,
+        last_attempted_at: now,
       })
       .eq("id", jobDetails.id)
       .eq("queue", this.queueName);
@@ -614,7 +620,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       .from(this.tableName)
       .update({
         status: JobStatus.PENDING,
-        worker_id: null,
+        lease_owner: null,
         progress: 0,
         progress_message: "",
         progress_details: null,

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -383,7 +383,14 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       SET status = '${JobStatus.PROCESSING}',
           last_attempted_at = NOW() AT TIME ZONE 'UTC',
           lease_owner = '${escapedWorkerId}',
-          lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(leaseMs)} * INTERVAL '1 millisecond')
+          lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(leaseMs)} * INTERVAL '1 millisecond'),
+          -- Lease-expiry reclaim consumes one attempt against max_attempts;
+          -- PENDING claims do not (the worker's validateJobState will FAIL
+          -- the job when attempts >= max_attempts at next-step time).
+          attempts = CASE WHEN status = '${JobStatus.PROCESSING}' THEN attempts + 1 ELSE attempts END,
+          -- Always clear stale abort_requested_at on (re)claim so a flag set
+          -- by an earlier worker doesn't immediately abort the new lease.
+          abort_requested_at = NULL
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
@@ -555,7 +562,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
         return;
       }
 
-      // Reschedule the job
+      // Reschedule the job. Clear abort_requested_at so an abort that was
+      // requested DURING the previous attempt does not immediately cancel
+      // the retry.
       let query = this.client
         .from(this.tableName)
         .update({
@@ -568,6 +577,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
           progress_details: null,
           attempts: nextAttempts,
           last_attempted_at: now,
+          abort_requested_at: null,
         })
         .eq("id", jobDetails.id)
         .eq("queue", this.queueName);
@@ -623,6 +633,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
    * Releases a claimed job without consuming a retry attempt.
    */
   public async releaseClaim(jobId: unknown): Promise<void> {
+    // releaseClaim returns the row to PENDING without consuming an attempt.
+    // Clear abort_requested_at so an abort that was requested mid-claim does
+    // not survive the release and immediately cancel the next claim.
     let query = this.client
       .from(this.tableName)
       .update({
@@ -631,6 +644,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
         progress: 0,
         progress_message: "",
         progress_details: null,
+        abort_requested_at: null,
       })
       .eq("id", jobId)
       .eq("queue", this.queueName);

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -668,6 +668,10 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       status?: JobStatus;
       completed_at?: string | null;
       abort_requested_at?: string | null;
+      lease_owner?: string | null;
+      progress?: number;
+      progress_message?: string;
+      progress_details?: Record<string, any> | null;
     }
   ): Promise<void> {
     // Partial update — Supabase's PostgREST `update()` only writes the
@@ -681,6 +685,10 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     if ("abort_requested_at" in fields) {
       patch.abort_requested_at = fields.abort_requested_at ?? null;
     }
+    if ("lease_owner" in fields) patch.lease_owner = fields.lease_owner ?? null;
+    if ("progress" in fields) patch.progress = fields.progress ?? 0;
+    if ("progress_message" in fields) patch.progress_message = fields.progress_message ?? "";
+    if ("progress_details" in fields) patch.progress_details = fields.progress_details ?? null;
     if (Object.keys(patch).length === 0) return;
     let query = this.client
       .from(this.tableName)

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -655,6 +655,44 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
+   * Terminal write that does NOT bump `attempts`. See IQueueStorage.finalize
+   * for the rationale (avoids double-counting on ack/fail because the lease
+   * reclaim path already charged the attempt at next() time).
+   */
+  public async finalize(
+    id: unknown,
+    fields: {
+      output?: Output | null;
+      error?: string | null;
+      error_code?: string | null;
+      status?: JobStatus;
+      completed_at?: string | null;
+      abort_requested_at?: string | null;
+    }
+  ): Promise<void> {
+    // Partial update — Supabase's PostgREST `update()` only writes the
+    // properties present on the object passed in.
+    const patch: Record<string, unknown> = {};
+    if ("output" in fields) patch.output = fields.output ?? null;
+    if ("error" in fields) patch.error = fields.error ?? null;
+    if ("error_code" in fields) patch.error_code = fields.error_code ?? null;
+    if ("status" in fields) patch.status = fields.status;
+    if ("completed_at" in fields) patch.completed_at = fields.completed_at ?? null;
+    if ("abort_requested_at" in fields) {
+      patch.abort_requested_at = fields.abort_requested_at ?? null;
+    }
+    if (Object.keys(patch).length === 0) return;
+    let query = this.client
+      .from(this.tableName)
+      .update(patch)
+      .eq("id", id as never)
+      .eq("queue", this.queueName);
+    query = this.applyPrefixFilters(query);
+    const { error } = await query;
+    if (error) throw error;
+  }
+
+  /**
    * Clears all jobs from the queue.
    */
   public async deleteAll(): Promise<void> {

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -168,10 +168,14 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
    */
   public async migrate(): Promise<void> {
     // Note: For Supabase, table creation should typically be done through migrations
-    // This setup assumes the table already exists or uses exec_sql RPC function
-    const createTypeSql = `CREATE TYPE job_status AS ENUM (${Object.values(JobStatus)
+    // This setup assumes the table already exists or uses exec_sql RPC function.
+    // ABORTING is included in the enum for backward compatibility with existing data,
+    // but the application no longer writes that value.
+    const enumValues = [...Object.values(JobStatus), "ABORTING"]
+      .filter((v, i, a) => a.indexOf(v) === i)
       .map((v) => `'${v}'`)
-      .join(",")})`;
+      .join(",");
+    const createTypeSql = `CREATE TYPE job_status AS ENUM (${enumValues})`;
 
     const { error: typeError } = await this.client.rpc("exec_sql", { query: createTypeSql });
     // Ignore error if type already exists (code 42710)
@@ -206,7 +210,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       progress real DEFAULT 0,
       progress_message text DEFAULT '',
       progress_details jsonb,
-      worker_id text
+      worker_id text,
+      abort_requested_at timestamp with time zone,
+      lease_expires_at timestamp with time zone
     )`;
 
     const { error: tableError } = await this.client.rpc("exec_sql", { query: createTableSql });
@@ -214,6 +220,20 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       // Ignore error if table already exists (code 42P07)
       if (tableError.code !== "42P07") {
         throw tableError;
+      }
+    }
+
+    // Add new columns to existing tables (idempotent via IF NOT EXISTS workaround)
+    const alterSqls = [
+      `ALTER TABLE ${this.tableName} ADD COLUMN IF NOT EXISTS abort_requested_at timestamp with time zone`,
+      `ALTER TABLE ${this.tableName} ADD COLUMN IF NOT EXISTS lease_expires_at timestamp with time zone`,
+    ];
+    for (const sql of alterSqls) {
+      const { error } = await this.client.rpc("exec_sql", { query: sql });
+      // Ignore errors (column may already exist)
+      if (error && error.code !== "42701") {
+        // 42701 = duplicate_column
+        // ignore
       }
     }
 
@@ -332,28 +352,38 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
 
   /**
    * Retrieves the next available job that is ready to be processed.
-   * Uses atomic UPDATE with subquery SELECT FOR UPDATE SKIP LOCKED to prevent race conditions.
+   * Claims PENDING jobs ready to run, and also reclaims PROCESSING jobs whose
+   * lease has expired (crash recovery). Sets lease_expires_at on the claimed row.
    * @param workerId - Worker ID to associate with the job (required)
+   * @param opts - Optional options including leaseMs (default 30000)
    * @returns The next job or undefined if no job is available
    */
-  public async next(workerId: string): Promise<JobStorageFormat<Input, Output> | undefined> {
+  public async next(
+    workerId: string,
+    opts?: { leaseMs?: number }
+  ): Promise<JobStorageFormat<Input, Output> | undefined> {
+    const leaseMs = opts?.leaseMs ?? 30000;
     const prefixConditions = this.buildPrefixWhereSql();
     const validatedQueueName = this.validateSqlValue(this.queueName, "queueName");
     const validatedWorkerId = this.validateSqlValue(workerId, "workerId");
     const escapedQueueName = this.escapeSqlString(validatedQueueName);
     const escapedWorkerId = this.escapeSqlString(validatedWorkerId);
 
-    // Use the same atomic UPDATE...WHERE id = (SELECT...FOR UPDATE SKIP LOCKED) pattern as PostgresQueueStorage
     const sql = `
       UPDATE ${this.tableName}
-      SET status = '${JobStatus.PROCESSING}', last_ran_at = NOW() AT TIME ZONE 'UTC', worker_id = '${escapedWorkerId}'
+      SET status = '${JobStatus.PROCESSING}',
+          last_ran_at = NOW() AT TIME ZONE 'UTC',
+          worker_id = '${escapedWorkerId}',
+          lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(leaseMs)} * INTERVAL '1 millisecond')
       WHERE id = (
         SELECT id
         FROM ${this.tableName}
         WHERE queue = '${escapedQueueName}'
-        AND status = '${JobStatus.PENDING}'
+        AND (
+          (status = '${JobStatus.PENDING}' AND run_after <= NOW() AT TIME ZONE 'UTC')
+          OR (status = '${JobStatus.PROCESSING}' AND (lease_expires_at IS NULL OR lease_expires_at < NOW() AT TIME ZONE 'UTC'))
+        )
         ${prefixConditions}
-        AND run_after <= NOW() AT TIME ZONE 'UTC'
         ORDER BY run_after ASC
         FOR UPDATE SKIP LOCKED
         LIMIT 1
@@ -370,6 +400,42 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     }
 
     return data[0] as JobStorageFormat<Input, Output>;
+  }
+
+  /**
+   * Extend the lease on a currently PROCESSING job.
+   * @param id - The ID of the job to extend the lease for
+   * @param workerId - Worker ID that must match the current lease owner (worker_id)
+   * @param ms - Number of milliseconds to extend the lease by
+   */
+  public async extendLease(id: unknown, workerId: string, ms: number): Promise<void> {
+    const validatedWorkerId = this.validateSqlValue(workerId, "workerId");
+    const escapedWorkerId = this.escapeSqlString(validatedWorkerId);
+    const numericId = Number(id);
+    if (!Number.isFinite(numericId)) {
+      throw new Error(`Invalid job id: ${id}`);
+    }
+
+    const prefixConditions = this.buildPrefixWhereSql();
+
+    const sql = `
+      UPDATE ${this.tableName}
+        SET lease_expires_at = NOW() AT TIME ZONE 'UTC' + (${Number(ms)} * INTERVAL '1 millisecond')
+        WHERE id = ${numericId}
+          AND queue = '${this.escapeSqlString(this.validateSqlValue(this.queueName, "queueName"))}'
+          AND worker_id = '${escapedWorkerId}'
+          AND status = '${JobStatus.PROCESSING}'
+          ${prefixConditions}`;
+
+    const { data, error } = await this.client.rpc("exec_sql", { query: sql });
+    if (error) throw error;
+
+    // exec_sql returns affected rows; if empty, the lease was lost
+    if (!data || !Array.isArray(data) || data.length === 0) {
+      throw new Error(
+        `extendLease failed: job ${String(id)} is not PROCESSING or lease is not owned by worker ${workerId}`
+      );
+    }
   }
 
   /**
@@ -520,7 +586,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       return;
     }
 
-    // Transitional states: PROCESSING/ABORTING etc - increment attempts like other stores
+    // Transitional states (e.g. PROCESSING) — increment attempts like other stores
     let query = this.client
       .from(this.tableName)
       .update({
@@ -599,22 +665,43 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
   }
 
   /**
-   * Aborts a job by setting its status to "ABORTING".
-   * This method will signal the corresponding AbortController so that
-   * the job's execute() method (if it supports an AbortSignal parameter)
-   * can clean up and exit.
+   * Aborts a job.
+   * - If PENDING: immediately mark as FAILED with abort_requested_at set.
+   * - If PROCESSING: set abort_requested_at only (leave status as PROCESSING).
+   * - Otherwise: no-op.
    */
   public async abort(jobId: unknown): Promise<void> {
-    let query = this.client
-      .from(this.tableName)
-      .update({ status: JobStatus.ABORTING })
-      .eq("id", jobId)
-      .eq("queue", this.queueName);
+    const now = new Date().toISOString();
 
-    query = this.applyPrefixFilters(query);
-    const { error } = await query;
+    // Abort PENDING → FAILED immediately
+    {
+      let query = this.client
+        .from(this.tableName)
+        .update({
+          status: JobStatus.FAILED,
+          abort_requested_at: now,
+          completed_at: now,
+        })
+        .eq("id", jobId)
+        .eq("queue", this.queueName)
+        .eq("status", JobStatus.PENDING);
+      query = this.applyPrefixFilters(query);
+      const { error } = await query;
+      if (error) throw error;
+    }
 
-    if (error) throw error;
+    // Abort PROCESSING → set abort_requested_at only
+    {
+      let query = this.client
+        .from(this.tableName)
+        .update({ abort_requested_at: now })
+        .eq("id", jobId)
+        .eq("queue", this.queueName)
+        .eq("status", JobStatus.PROCESSING);
+      query = this.applyPrefixFilters(query);
+      const { error } = await query;
+      if (error) throw error;
+    }
   }
 
   /**

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -425,7 +425,8 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
           AND queue = '${this.escapeSqlString(this.validateSqlValue(this.queueName, "queueName"))}'
           AND worker_id = '${escapedWorkerId}'
           AND status = '${JobStatus.PROCESSING}'
-          ${prefixConditions}`;
+          ${prefixConditions}
+        RETURNING id`;
 
     const { data, error } = await this.client.rpc("exec_sql", { query: sql });
     if (error) throw error;

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -369,6 +369,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     opts?: { leaseMs?: number }
   ): Promise<JobStorageFormat<Input, Output> | undefined> {
     const leaseMs = opts?.leaseMs ?? 30000;
+    if (!Number.isFinite(leaseMs) || leaseMs < 0) {
+      throw new Error(`Invalid leaseMs: ${leaseMs}`);
+    }
     const prefixConditions = this.buildPrefixWhereSql();
     const validatedQueueName = this.validateSqlValue(this.queueName, "queueName");
     const validatedWorkerId = this.validateSqlValue(workerId, "workerId");
@@ -420,6 +423,9 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
     const numericId = Number(id);
     if (!Number.isFinite(numericId)) {
       throw new Error(`Invalid job id: ${id}`);
+    }
+    if (!Number.isFinite(ms) || ms < 0) {
+      throw new Error(`Invalid lease extension ms: ${ms}`);
     }
 
     const prefixConditions = this.buildPrefixWhereSql();
@@ -710,6 +716,18 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
       const { error } = await query;
       if (error) throw error;
     }
+  }
+
+  /** Force-overwrite status without touching attempts (used to persist DISABLED after lease release). */
+  public async saveStatus(jobId: unknown, status: string): Promise<void> {
+    let query = this.client
+      .from(this.tableName)
+      .update({ status })
+      .eq("id", jobId)
+      .eq("queue", this.queueName);
+    query = this.applyPrefixFilters(query as any) as any;
+    const { error } = await (query as any);
+    if (error) throw error;
   }
 
   /**

--- a/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
+++ b/providers/supabase/src/job-queue/SupabaseQueueStorage.ts
@@ -542,7 +542,7 @@ export class SupabaseQueueStorage<Input, Output> implements IQueueStorage<Input,
   /**
    * Releases a claimed job without consuming a retry attempt.
    */
-  public async release(jobId: unknown): Promise<void> {
+  public async releaseClaim(jobId: unknown): Promise<void> {
     let query = this.client
       .from(this.tableName)
       .update({

--- a/providers/supabase/src/job-queue/common.ts
+++ b/providers/supabase/src/job-queue/common.ts
@@ -8,3 +8,6 @@
 
 export * from "./SupabaseQueueStorage";
 export * from "./SupabaseRateLimiterStorage";
+export * from "./SupabaseMessageQueue";
+export * from "./SupabaseJobStore";
+export * from "./createSupabaseQueue";

--- a/providers/supabase/src/job-queue/createSupabaseQueue.ts
+++ b/providers/supabase/src/job-queue/createSupabaseQueue.ts
@@ -7,7 +7,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { QueueStorageOptions } from "@workglow/job-queue";
 import { SupabaseJobStore } from "./SupabaseJobStore";
-import { SupabaseMessageQueue, type PendingWrite } from "./SupabaseMessageQueue";
+import { SupabaseMessageQueue, type SupabasePendingWrite } from "./SupabaseMessageQueue";
 import { SupabaseQueueStorage } from "./SupabaseQueueStorage";
 
 /**
@@ -26,7 +26,7 @@ export function createSupabaseQueue<Input, Output>(
   core: SupabaseQueueStorage<Input, Output>;
 } {
   const core = new SupabaseQueueStorage<Input, Output>(client, queueName, opts);
-  const pending = new Map<unknown, PendingWrite<Output>>();
+  const pending = new Map<unknown, SupabasePendingWrite<Output>>();
   return {
     messageQueue: new SupabaseMessageQueue<Input, Output>(core, pending),
     jobStore: new SupabaseJobStore<Input, Output>(core, pending),

--- a/providers/supabase/src/job-queue/createSupabaseQueue.ts
+++ b/providers/supabase/src/job-queue/createSupabaseQueue.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { QueueStorageOptions } from "@workglow/job-queue";
+import { SupabaseJobStore } from "./SupabaseJobStore";
+import { SupabaseMessageQueue, type PendingWrite } from "./SupabaseMessageQueue";
+import { SupabaseQueueStorage } from "./SupabaseQueueStorage";
+
+/**
+ * Factory for the paired Supabase message queue and job store. Both
+ * facades share a single underlying {@link SupabaseQueueStorage} so writes
+ * through one are observable through the other.
+ */
+export function createSupabaseQueue<Input, Output>(
+  queueName: string,
+  client: SupabaseClient,
+  opts?: QueueStorageOptions
+): {
+  messageQueue: SupabaseMessageQueue<Input, Output>;
+  jobStore: SupabaseJobStore<Input, Output>;
+  /** @internal — exposed for callers that still need the legacy storage object. */
+  core: SupabaseQueueStorage<Input, Output>;
+} {
+  const core = new SupabaseQueueStorage<Input, Output>(client, queueName, opts);
+  const pending = new Map<unknown, PendingWrite<Output>>();
+  return {
+    messageQueue: new SupabaseMessageQueue<Input, Output>(core, pending),
+    jobStore: new SupabaseJobStore<Input, Output>(core, pending),
+    core,
+  };
+}


### PR DESCRIPTION
## Summary

This PR layers eight Critical/High-severity correctness fixes on top of PR #511's job-queue refactor (which is in the diff for context). Each fix is a separate commit.

- **[main-H1] test(tabular-storage): split subscribeToChanges contract by ordering model** — `subscribeToChangesBlock` is split into `subscribeToChanges.eventDriven` (strict commit order) and `subscribeToChanges.polling` (set equality + count). `usesPolling` is promoted to required when `supportsSubscriptions: true` via a discriminated `TabularStorageContractOpts` union; backend test wirings under `packages/test/src/test/storage-tabular/` are updated to set it explicitly. A meta-test covers the failure modes each block is designed to catch.

- **[main-H2] fix(resource): close InactivityStrategy race via runStart hook** — Adds an optional `onRunStart(scope)` to `IDisposeStrategy` plus `ResourceScope.runStart()`. Both `TaskRunner.handleStart` and `TaskGraphRunner.handleStart` `await scope.runStart()` before user code. `InactivityStrategy.onRunStart` clears all pending timers, closing the race where a timer armed at `runComplete` could fire mid-next-run and dispose a resource the new run was about to use. `InactivityStrategy.onRegister` additionally clears any pending timer for the re-registered key.

- **[H3] fix(migrations): restore postgres/sqlite v1 to frozen state, move renames into v3** — PR #511 had mutated v1 in place to use the new column names, silently diverging fresh installs from pre-PR upgrades. v1 is restored byte-for-byte to the pre-PR shape (run_after / run_attempts / max_retries / last_ran_at / worker_id and run_after-keyed indexes). v2 adds the new abort_requested_at / lease_expires_at columns. v3 carries the renames and the index swap (drops run_after-keyed indexes, recreates them keyed on visible_at), guarded by `IF EXISTS` (postgres) / `PRAGMA table_info` (sqlite) so fresh installs that walk v1 → v2 → v3 land on the same schema as upgraded installs.

- **[C1] fix(indexeddb): add v2 migration for queue_status_visible_at rename** — Same shape as H3 for IndexedDB. v1 restored to the original `queue_status_run_after` index + `run_after` field. v2 drops the old index, cursor-walks every row copying `run_after → visible_at` synchronously (IDB upgrade transactions auto-commit on any await), then creates the new `queue_status_visible_at` index.

- **[Worker H1+H4] fix(job-queue): clear abort_requested_at on retry; bump attempts on lease-expiry reclaim** — Every backend now sets `abort_requested_at = NULL` on (a) `complete()` PENDING-retry branch, (b) `releaseClaim()`, and (c) `next()` lease-expiry reclaim. The `next()` lease-expiry reclaim additionally bumps `attempts` via `CASE WHEN status = 'PROCESSING' THEN attempts + 1 ELSE attempts END` so a crashed-worker lease leak terminates via MAX_ATTEMPTS_REACHED instead of looping forever. PENDING claims do not bump here. Covers Postgres, SQLite, Supabase, IndexedDB, InMemory, and the wrapQueueStorage adapter.

- **[C2 + M4] fix(job-queue): introduce finalize() so ack/fail do not bump attempts** — Adds `finalize(id, fields)` to `IQueueStorage` (partial overwrite of output/error/error_code/status/completed_at/abort_requested_at without touching `attempts`). `WrappedClaim.ack` and `WrappedClaim.fail` now call `finalize` instead of `complete`. The `attempts: (current.attempts ?? 1) - 1` compensation in `WrappedJobStore.saveStatus` is removed. `InMemoryQueueStorage.updateJobStatus` standardized to `saveStatus`. Existing maxAttempts-exhaustion tests updated to the new semantics (attempts now counts only "bumped" transitions — PENDING-retry and lease reclaims — not terminal ack/fail).

- **[H2] feat(job-queue): atomic ack/fail with result/error args** — `IClaim.ack` accepts an optional `result`; `IClaim.fail` accepts `{ error, errorCode, abortRequested, permanent }`. `completeJob` calls `claim.ack(output ?? null)` directly and `failJob` calls `claim.fail({...})` directly, eliminating the two-write window where a crash between `jobStore.saveResult(...)` and `claim.ack()` left a PROCESSING row with the output already written. `IJobStore.saveResult`/`saveError` are marked `@deprecated` and kept as buffered no-op wrappers for one minor release.

- **[H5] fix(job-queue): atomic disableJob via IClaim.disable** — Adds optional `IClaim.disable()` and an extended `finalize()` signature that also writes `lease_owner` / `progress*` fields. `disableJob` now performs a single storage write that sets status=DISABLED, releases the lease, and clears progress — no error/error_code. Replaces the legacy two-write `claim.fail()` then `saveStatus(DISABLED)` path which briefly persisted FAILED and fired a spurious `job_error` to any subscriber observing during the window. A subscribe-driven contract test asserts the final state is DISABLED and (where the backend supports subscriptions) no FAILED transition appears in the event stream.

## Test plan

- [x] `bun run build:types` — clean.
- [x] `bun scripts/test.ts vitest storage` — 47 files, 1223 passed.
- [x] `bun scripts/test.ts vitest queue` — 13 files, 355 passed (incl. new contract tests on every backend).
- [x] `bun scripts/test.ts vitest util` — passes.
- [x] `bun scripts/test.ts vitest resource` — 2 files, 29 passed (incl. new runStart fake-timer tests).
- [x] `bun scripts/test.ts vitest graph` — passes.
- [x] `bun scripts/test.ts vitest task` — passes.
- [x] Combined `bun scripts/test.ts vitest storage queue util resource graph task` — 235 files, 3968 passed, 53 skipped.

## Risk surface

- **`IClaim` public-API additions (optional → required path)** — `ack(result?)`, `fail(opts?)`, and `disable?()` are added. `ack`'s arg and `fail`'s opts are optional with legacy fallbacks through the pending-buffer; external `IClaim` impls compile unchanged. `disable` is optional in the interface; in-tree impls all provide it, and the worker falls back to `jobStore.saveStatus(DISABLED)` when `claim.disable` is absent.
- **`IQueueStorage.finalize` addition** — net-new method on the storage interface. Every in-tree impl provides it (Postgres, SQLite, Supabase, IndexedDB, InMemory, Telemetry, wrapper). External impls implementing `IQueueStorage` will fail to typecheck until they implement `finalize` — this is the intended forcing function for the C2 fix.
- **Postgres v1 schema rewind** — v1 body is restored byte-for-byte to the pre-PR shape. Existing installs that ran the previous PR-511 v1 are NOT broken: the bookkeeping row is keyed `(component, version)` and a v1 run is `CREATE TABLE IF NOT EXISTS` — no-op against an existing table. v3 IF-EXISTS-renames so it's a no-op on fresh installs and a real rename on legacy installs. Same shape for SQLite (PRAGMA-guarded renames).
- **IDB v2 migration touches every install on upgrade** — drops `queue_status_run_after`, cursor-walks the store copying `run_after → visible_at`, recreates `queue_status_visible_at`. Synchronous inside the upgrade tx (no awaits between IDB requests). Existing rows preserve their original `run_after` value as `visible_at` so the queue continues operating across the upgrade.

## Findings origin

Automated review of PR #511 (`claude/standardize-job-queue-1kQBU`) plus PRs #509 (Add pluggable disposal strategies to ResourceScope) and #510 (tabular-storage contract invariant suite), which are already merged to main.

https://claude.ai/code/session_018KX5qLNZBPC5Wp5WFhvSQj

---
_Generated by [Claude Code](https://claude.ai/code/session_018KX5qLNZBPC5Wp5WFhvSQj)_