### PR TITLE
Implement cache policy routing and run-private cache support

### DIFF
--- a/examples/web/src/App.tsx
+++ b/examples/web/src/App.tsx
@@ -7,6 +7,8 @@
 import { registerAiTasks } from "@workglow/ai";
 import { registerHuggingFaceTransformers } from "@workglow/huggingface-transformers/ai";
 import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
   getTaskQueueRegistry,
   JsonTaskItem,
   registerBaseTasks,
@@ -15,6 +17,7 @@ import {
 } from "@workglow/task-graph";
 import { JsonTask, registerCommonTasks } from "@workglow/tasks";
 import { registerTensorFlowMediaPipe } from "@workglow/tf-mediapipe/ai";
+import { Container, ServiceRegistry } from "@workglow/util";
 import { ReactFlowProvider } from "@xyflow/react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "./Resize";
@@ -59,13 +62,11 @@ await queueRegistry.clearQueues();
 await queueRegistry.startQueues();
 const taskOutputCache = new IndexedDbTaskOutputRepository();
 const taskGraphRepo = new IndexedDbTaskGraphRepository();
-
-// const cacheServices = globalServiceRegistry;
-// cacheServices.registerInstance(
-//   CACHE_REGISTRY,
-//   new DefaultCacheRegistry({ deterministic: taskOutputCache })
-// );
-
+const cacheServices = new ServiceRegistry(new Container());
+cacheServices.registerInstance(
+  CACHE_REGISTRY,
+  new DefaultCacheRegistry({ deterministic: taskOutputCache })
+);
 const resetGraph = () => {
   const workflow = (window as any)["workflow"] as Workflow;
   // Demo flow: embed a sentence + classify its sentiment.
@@ -122,7 +123,7 @@ const resetGraph = () => {
   taskGraphRepo.saveTaskGraph("default", workflow.graph);
 };
 
-(window as any)["workflow"] = new Workflow(taskOutputCache);
+(window as any)["workflow"] = new Workflow();
 let graph: TaskGraph | undefined;
 try {
   graph = await taskGraphRepo.getTaskGraph("default");
@@ -153,7 +154,7 @@ const setupWorkflow = async () => {
   workflow.run = async () => {
     console.log("Running task graph...");
     try {
-      const result = await run();
+      const result = await run({}, { registry: cacheServices });
       console.log("Task graph complete.", workflow);
       return result;
     } catch (error: any) {
@@ -186,21 +187,13 @@ export const App = () => {
   const [jsonData, setJsonData] = useState<string>(initialJson);
   const [cacheEnabled, setCacheEnabled] = useState<boolean>(true);
 
-  const handleCacheToggle = useCallback(
-    (enabled: boolean) => {
-      setCacheEnabled(enabled);
-      const cache = enabled ? taskOutputCache : undefined;
-      // Update the graph property and the workflow's internal cache field.
-      workflow.graph.outputCache = cache;
-      (workflow as any)._outputCache = cache;
-      // Reset the graph runner so the next run constructs a fresh TaskGraphRunner
-      // with the correct outputCache. Without this, the runner's stale reference
-      // persists because TaskGraphRunner.handleStart only updates when the config
-      // value is !== undefined, so passing undefined never clears it.
-      (workflow.graph as any)._runner = undefined;
-    },
-    [workflow]
-  );
+  const handleCacheToggle = useCallback((enabled: boolean) => {
+    setCacheEnabled(enabled);
+    cacheServices.registerInstance(
+      CACHE_REGISTRY,
+      new DefaultCacheRegistry({ deterministic: enabled ? taskOutputCache : undefined })
+    );
+  }, []);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -210,9 +203,6 @@ export const App = () => {
       ) {
         workflow = (window as any)["workflow"] as Workflow;
         setWorkflow(workflow);
-        const cache = cacheEnabled ? taskOutputCache : undefined;
-        workflow.graph.outputCache = cache;
-        (workflow as any)._outputCache = cache;
         setupWorkflow();
       }
     }, 10);

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { resolveHumanConnector } from "@workglow/util";
@@ -181,7 +181,7 @@ export class AiChatTask extends StreamingAiTask<AiChatTaskInput, AiChatTaskOutpu
   public static override title = "AI Chat";
   public static override description =
     "Multi-turn chat with a language model, using a human connector to collect user input between turns.";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return {

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -6,7 +6,7 @@
 
 import type { ChunkSearchResult, KnowledgeBase } from "@workglow/knowledge-base";
 import { getKnowledgeBase, slugifyHeading } from "@workglow/knowledge-base";
-import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
 import { resolveHumanConnector } from "@workglow/util";
@@ -283,7 +283,7 @@ export class AiChatWithKbTask extends StreamingAiTask<
   public static override title = "AI Chat (Knowledge Base)";
   public static override description =
     "Multi-turn chat grounded in one or more knowledge bases. Retrieves on every user turn, injects numbered context, and emits structured per-chunk citation references.";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return {

--- a/packages/ai/src/task/ChunkVectorUpsertTask.ts
+++ b/packages/ai/src/task/ChunkVectorUpsertTask.ts
@@ -6,7 +6,7 @@
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
 import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import {
   DataPortSchema,
@@ -87,7 +87,7 @@ export class ChunkVectorUpsertTask extends Task<
   public static override title = "Add to Vector Store";
   public static override description =
     "Store chunks + their embeddings in a knowledge base (1:1 aligned)";
-  public static override cacheable = false; // Has side effects
+  public static override cachePolicy: CachePolicy = { kind: "none" }; // Has side effects
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/DocumentUpsertTask.ts
+++ b/packages/ai/src/task/DocumentUpsertTask.ts
@@ -11,7 +11,7 @@ import {
   KnowledgeBase,
   TypeKnowledgeBase,
 } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -95,7 +95,7 @@ export class DocumentUpsertTask extends Task<
   public static override category = "Document";
   public static override title = "Add Document";
   public static override description = "Persist a parsed document tree to a knowledge base";
-  public static override cacheable = false; // Has side effects
+  public static override cachePolicy: CachePolicy = { kind: "none" }; // Has side effects
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/HierarchyJoinTask.ts
+++ b/packages/ai/src/task/HierarchyJoinTask.ts
@@ -7,7 +7,7 @@
 import { ChunkRecordArraySchema, TypeKnowledgeBase } from "@workglow/knowledge-base";
 
 import type { ChunkRecord, KnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -110,7 +110,7 @@ export class HierarchyJoinTask extends Task<
   public static override category = "RAG";
   public static override title = "Hierarchy Join";
   public static override description = "Enrich retrieval metadata with document hierarchy context";
-  public static override cacheable = false; // Has external dependency
+  public static override cachePolicy: CachePolicy = { kind: "none" }; // Has external dependency
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbAddDocumentTask.ts
+++ b/packages/ai/src/task/KbAddDocumentTask.ts
@@ -6,7 +6,7 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { Document, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -64,7 +64,7 @@ export class KbAddDocumentTask extends Task<
   public static override title = "KB Add Document";
   public static override description =
     "Ingest a document into a knowledge base: chunk, embed, and store via the KB's installed strategy.";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbDeleteTask.ts
+++ b/packages/ai/src/task/KbDeleteTask.ts
@@ -6,7 +6,7 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -56,7 +56,7 @@ export class KbDeleteTask extends Task<KbDeleteTaskInput, KbDeleteTaskOutput, Kb
   public static override category = "RAG";
   public static override title = "KB Delete Document";
   public static override description = "Delete a document and its chunks from a knowledge base.";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbReindexTask.ts
+++ b/packages/ai/src/task/KbReindexTask.ts
@@ -6,7 +6,7 @@
 
 import type { KnowledgeBase } from "@workglow/knowledge-base";
 import { TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -56,7 +56,7 @@ export class KbReindexTask extends Task<
   public static override description =
     "Re-chunk and re-embed every document in a knowledge base using its configured models.";
   public static readonly requires: readonly Capability[] = [] as const satisfies Capability[];
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/KbToDocumentsTask.ts
+++ b/packages/ai/src/task/KbToDocumentsTask.ts
@@ -5,7 +5,7 @@
  */
 
 import { DocumentNode, KnowledgeBase, TypeKnowledgeBase } from "@workglow/knowledge-base";
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -77,7 +77,7 @@ export class KbToDocumentsTask extends Task<
   public static override title = "Knowledge Base to Documents";
   public static override description =
     "List documents from a knowledge base, optionally filtering to only those that need embedding";
-  public static override cacheable = false; // Depends on external state
+  public static override cachePolicy: CachePolicy = { kind: "none" }; // Depends on external state
 
   public static override inputSchema(): DataPortSchema {
     return inputSchema as DataPortSchema;

--- a/packages/ai/src/task/ModelDownloadRemoveTask.ts
+++ b/packages/ai/src/task/ModelDownloadRemoveTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -80,7 +80,7 @@ export class ModelDownloadRemoveTask extends AiTask<
   public static override outputSchema(): DataPortSchema {
     return ModelDownloadRemoveOutputSchema satisfies DataPortSchema;
   }
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 }
 
 /**

--- a/packages/ai/src/task/ModelDownloadTask.ts
+++ b/packages/ai/src/task/ModelDownloadTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -79,7 +79,7 @@ export class ModelDownloadTask extends AiTask<
   public static override outputSchema(): DataPortSchema {
     return ModelDownloadOutputSchema satisfies DataPortSchema;
   }
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public files: { file: string; progress: number }[] = [];
 

--- a/packages/ai/src/task/ModelInfoTask.ts
+++ b/packages/ai/src/task/ModelInfoTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, Workflow } from "@workglow/task-graph";
 
-import type { IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { accumulatingEmit } from "../capability/accumulatingEmit";
 import type { Capability } from "../capability/Capabilities";
@@ -88,7 +88,7 @@ export class ModelInfoTask extends AiTask<
   /** Capabilities required of the model; gated in {@link AiTask.execute}. */
   public static override readonly requires = ["model.info"] as const satisfies Capability[];
   public static override category = "AI Model";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override title = "Model Info";
   public static override description =
     "Returns runtime information about a model including locality, cache status, and file sizes";

--- a/packages/ai/src/task/ModelSearchTask.ts
+++ b/packages/ai/src/task/ModelSearchTask.ts
@@ -6,7 +6,7 @@
 
 import { CreateWorkflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 
-import type { IRunConfig, TaskConfig } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskConfig } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { accumulatingEmit } from "../capability/accumulatingEmit";
 import type { Capability } from "../capability/Capabilities";
@@ -128,7 +128,7 @@ export class ModelSearchTask extends Task<
   public static override category = "AI Model";
   public static override title = "Model Search";
   public static override description = "Search for models using provider-specific search functions";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override hasDynamicSchemas = true;
 
   public static override inputSchema(): DataPortSchema {

--- a/packages/ai/src/task/base/AiImageOutputTask.ts
+++ b/packages/ai/src/task/base/AiImageOutputTask.ts
@@ -24,6 +24,7 @@
  */
 
 import type {
+  CachePolicy,
   IExecuteContext,
   IExecutePreviewContext,
   StreamEvent,
@@ -58,13 +59,13 @@ export class AiImageOutputTask<
   protected _latestPartial: ImageValue | undefined = undefined;
 
   // --------------------------------------------------------------------
-  // Cacheable: seed-aware
+  // Cache policy: seed-aware
   // --------------------------------------------------------------------
 
-  public override get cacheable(): boolean {
-    const seed = (this.runInputData as { seed?: number } | undefined)?.seed;
-    if (seed === undefined || seed === null) return false;
-    return super.cacheable;
+  public override getCachePolicy(inputs: Input): CachePolicy {
+    const seed = (inputs as { seed?: number | null } | undefined)?.seed;
+    if (seed === undefined || seed === null) return { kind: "private" };
+    return { kind: "deterministic" };
   }
 
   // --------------------------------------------------------------------

--- a/packages/browser-control/src/task/tasks/BrowserAttributeTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserAttributeTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -61,7 +62,7 @@ export class BrowserAttributeTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Attribute";
   public static override description = "Retrieves the value of an attribute from a browser element";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserBackTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserBackTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -48,7 +49,7 @@ export class BrowserBackTask extends Task<BrowserBackTaskInput, BrowserBackTaskO
   public static override title = "Browser Back";
   public static override description =
     "Navigates back in the browser history and returns the current URL";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserClickTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserClickTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -83,7 +84,7 @@ export class BrowserClickTask extends Task<
   public static override title = "Browser Click";
   public static override description =
     "Clicks an element in the browser by ref or by ARIA role and name";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserClickTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserCloseTabTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserCloseTabTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -63,7 +64,7 @@ export class BrowserCloseTabTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Close Tab";
   public static override description = "Closes a browser tab by tab ID";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserCloseTabTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserCloseTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserCloseTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -39,7 +40,7 @@ export class BrowserCloseTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Close";
   public static override description = "Disconnects and closes an existing browser session";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserEvaluateTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserEvaluateTask.ts
@@ -14,6 +14,7 @@ import {
 } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
+import type { CachePolicy } from "@workglow/task-graph";
 
 const inputSchema = {
   type: "object",
@@ -63,7 +64,7 @@ export class BrowserEvaluateTask extends Task<
   public static override title = "Browser Evaluate";
   public static override description =
     "Evaluates a JavaScript expression in the browser page context";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserExtractHtmlTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserExtractHtmlTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -75,7 +76,7 @@ export class BrowserExtractHtmlTask extends Task<
   public static override title = "Browser Extract HTML";
   public static override description =
     "Extracts HTML content from a specific element by ref or CSS selector";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserExtractHtmlTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserExtractTextTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserExtractTextTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -70,7 +71,7 @@ export class BrowserExtractTextTask extends Task<
   public static override title = "Browser Extract Text";
   public static override description =
     "Extracts text content from a specific element or the full page";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserExtractTextTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserFillTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserFillTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -79,7 +80,7 @@ export class BrowserFillTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Fill";
   public static override description = "Fills a text input in the browser by ref or by label";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserFillTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserForwardTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserForwardTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -52,7 +53,7 @@ export class BrowserForwardTask extends Task<
   public static override title = "Browser Forward";
   public static override description =
     "Navigates forward in the browser history and returns the current URL";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserHoverTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserHoverTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -61,7 +62,7 @@ export class BrowserHoverTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Hover";
   public static override description = "Hovers over an element in the browser identified by ref";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserLoginTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserLoginTask.ts
@@ -15,6 +15,7 @@ import {
 } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
+import type { CachePolicy } from "@workglow/task-graph";
 
 const browserLoginTaskConfigSchema = {
   type: "object",
@@ -86,7 +87,7 @@ export class BrowserLoginTask extends Task<
   public static override title = "Browser Login";
   public static override description =
     "Logs into a website using manual, credential, or AI-driven login strategies";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override hasDynamicEntitlements = true;
 

--- a/packages/browser-control/src/task/tasks/BrowserNavigateTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserNavigateTask.ts
@@ -14,6 +14,7 @@ import {
 } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
+import type { CachePolicy } from "@workglow/task-graph";
 
 const browserNavigateTaskConfigSchema = {
   type: "object",
@@ -89,7 +90,7 @@ export class BrowserNavigateTask extends Task<
   public static override title = "Browser Navigate";
   public static override description =
     "Navigates the browser to a URL and returns the page title and URL";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserNavigateTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserNewTabTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserNewTabTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -66,7 +67,7 @@ export class BrowserNewTabTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser New Tab";
   public static override description = "Opens a new browser tab and returns its tab ID";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserNewTabTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserPressKeyTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserPressKeyTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -73,7 +74,7 @@ export class BrowserPressKeyTask extends Task<
   public static override title = "Browser Press Key";
   public static override description =
     "Presses a keyboard key in the browser, optionally with modifiers";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserPressKeyTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserQuerySelectorTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserQuerySelectorTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -58,7 +59,7 @@ export class BrowserQuerySelectorTask extends Task<
   public static override title = "Browser Query Selector";
   public static override description =
     "Queries all elements matching a CSS selector and returns their refs";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserReloadTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserReloadTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -46,7 +47,7 @@ export class BrowserReloadTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Reload";
   public static override description = "Reloads the current page in the browser";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserScreenshotTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserScreenshotTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -78,7 +79,7 @@ export class BrowserScreenshotTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Screenshot";
   public static override description = "Takes a screenshot of the current browser page";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserScreenshotTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserScrollTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserScrollTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -78,7 +79,7 @@ export class BrowserScrollTask extends Task<
   public static override title = "Browser Scroll";
   public static override description =
     "Scrolls the page or a specific element by the given pixel deltas";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserScrollTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserSelectTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserSelectTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -61,7 +62,7 @@ export class BrowserSelectTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Select";
   public static override description = "Selects an option in a select element identified by ref";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserSessionTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserSessionTask.ts
@@ -16,6 +16,7 @@ import {
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
 import { getBrowserDeps } from "../BrowserTaskDeps";
+import type { CachePolicy } from "@workglow/task-graph";
 
 const browserSessionTaskConfigSchema = {
   type: "object",
@@ -85,7 +86,7 @@ export class BrowserSessionTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Session";
   public static override description = "Creates a new browser session and returns its session ID";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override hasDynamicEntitlements = true;
 

--- a/packages/browser-control/src/task/tasks/BrowserSnapshotTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserSnapshotTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -53,7 +54,7 @@ export class BrowserSnapshotTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Snapshot";
   public static override description = "Returns the accessibility tree of the current browser page";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return TaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserSwitchTabTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserSwitchTabTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -61,7 +62,7 @@ export class BrowserSwitchTabTask extends Task<
   static override readonly category = "Browser";
   public static override title = "Browser Switch Tab";
   public static override description = "Switches the active browser tab to the specified tab ID";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserSwitchTabTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserTypeTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserTypeTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -62,7 +63,7 @@ export class BrowserTypeTask extends Task<
   public static override title = "Browser Type";
   public static override description =
     "Types text into the currently focused element in the browser";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserTypeTaskConfigSchema;

--- a/packages/browser-control/src/task/tasks/BrowserUploadTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserUploadTask.ts
@@ -14,6 +14,7 @@ import {
 } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
+import type { CachePolicy } from "@workglow/task-graph";
 
 const browserUploadTaskConfigSchema = {
   type: "object",
@@ -77,7 +78,7 @@ export class BrowserUploadTask extends Task<
   public static override title = "Browser Upload";
   public static override description =
     "Uploads one or more files to a file input element in the browser";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override entitlements(): TaskEntitlements {
     return {

--- a/packages/browser-control/src/task/tasks/BrowserWaitTask.ts
+++ b/packages/browser-control/src/task/tasks/BrowserWaitTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskConfig, TaskConfigSchema } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 import { BrowserSessionRegistry } from "../BrowserSessionRegistry";
@@ -79,7 +80,7 @@ export class BrowserWaitTask extends Task<
   public static override title = "Browser Wait";
   public static override description =
     "Waits for a navigation, selector, or network idle state in the browser";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return browserWaitTaskConfigSchema;

--- a/packages/mcp/src/tasks/McpListTask.ts
+++ b/packages/mcp/src/tasks/McpListTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import {
   getMcpServerConfig,
   getMcpServerTransport,
@@ -194,7 +195,7 @@ export class McpListTask extends Task<McpListTaskInput, McpListTaskOutput, TaskC
   public static override title = "MCP List";
   public static override description =
     "Lists tools, resources, or prompts available on an MCP server";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override hasDynamicSchemas: boolean = true;
   public static override hasDynamicEntitlements: boolean = true;
 

--- a/packages/mcp/src/tasks/McpPromptGetTask.ts
+++ b/packages/mcp/src/tasks/McpPromptGetTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import type { McpServerConfig } from "@workglow/mcp/util";
 import {
   getMcpServerConfig,
@@ -175,7 +176,7 @@ export class McpPromptGetTask extends Task<
   public static override category = "MCP";
   public static override title = "MCP Get Prompt";
   public static override description = "Gets a prompt from an MCP server";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override customizable = true;
   public static override hasDynamicSchemas = true;
   public static override hasDynamicEntitlements: boolean = true;

--- a/packages/mcp/src/tasks/McpResourceReadTask.ts
+++ b/packages/mcp/src/tasks/McpResourceReadTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import {
   getMcpServerConfig,
   getMcpServerTransport,
@@ -83,7 +84,7 @@ export class McpResourceReadTask extends Task<
   public static override category = "MCP";
   public static override title = "MCP Read Resource";
   public static override description = "Reads a resource from an MCP server";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override customizable = true;
   public static override hasDynamicEntitlements: boolean = true;
 

--- a/packages/mcp/src/tasks/McpSearchTask.ts
+++ b/packages/mcp/src/tasks/McpSearchTask.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskEntitlements } from "@workglow/task-graph";
+import type { CachePolicy, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Entitlements,
@@ -258,7 +258,7 @@ export class McpSearchTask extends Task<McpSearchTaskInput, McpSearchTaskOutput,
   public static override title = "MCP Search";
   public static override description =
     "Search the MCP server registry for servers matching a query";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override entitlements(): TaskEntitlements {
     return {

--- a/packages/mcp/src/tasks/McpToolCallTask.ts
+++ b/packages/mcp/src/tasks/McpToolCallTask.ts
@@ -11,7 +11,7 @@ import {
   getMcpTaskDeps,
   TypeMcpServer,
 } from "@workglow/mcp/util";
-import type { TaskEntitlements } from "@workglow/task-graph";
+import type { CachePolicy, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Entitlements,
@@ -171,7 +171,7 @@ export class McpToolCallTask extends Task<
   public static override category = "MCP";
   public static override title = "MCP Call Tool";
   public static override description = "Calls a tool on an MCP server and returns the result";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override customizable = true;
   public static override hasDynamicSchemas = true;
   public static override hasDynamicEntitlements: boolean = true;

--- a/packages/task-graph/CHANGELOG.md
+++ b/packages/task-graph/CHANGELOG.md
@@ -1,5 +1,38 @@
 # @workglow/task-graph
 
+## [Unreleased]
+
+### Added
+
+- `CachePolicy` discriminated union (`deterministic` / `private` / `none`) declared via static `Task.cachePolicy` or instance `getCachePolicy(inputs)` override for input-dependent policies.
+- `Task.version` static + `getCacheVersion()` for explicit cache invalidation. Bumping the version invalidates cached outputs.
+- `CacheRegistry` service registered under `CACHE_REGISTRY` token with two optional slots (`deterministic`, `private`). Missing slot = no-op caching.
+- `RunPrivateCacheRepo` namespacing wrapper keyed by `runId`. `TaskGraphRunner` builds this automatically when `runId` is supplied in run config.
+- `CacheJanitor.sweepStaleRunPrivate(olderThanMs)` for app-scheduled cleanup of crashed-run cache rows.
+- New abstract methods on `TaskOutputRepository`: `isDurable()`, `deleteByTaskTypePrefix()`, `clearOlderThanWithTaskTypePrefix()`, `sizeByTaskTypePrefix()`. `TaskOutputTabularRepository` provides default implementations via row iteration.
+
+### Changed
+
+- `TaskRunner` resolves the per-task cache via `CACHE_REGISTRY` in the `ServiceRegistry` and routes by `getCachePolicy(inputs)`. Legacy `config.outputCache: TaskOutputRepository` still works as a back-compat shim mapped to the `deterministic` slot.
+- `TaskGraphRunner` threads `runId` through `IExecuteContext`. Throws `TaskConfigurationError` if a graph contains a `private`-policy task but no `runId` is provided. Awaits `clearRun()` on successful completion; failed/aborted runs leave entries for restart or TTL sweep.
+- Cache key now includes the task's `cacheVersion` via a reserved `__cv` sentinel injected into normalized inputs. Tasks may not declare an input port named `__cv` (rejected at construction).
+- `AiImageOutputTask` now routes to `private` when no `seed` is supplied (was: uncached) and `deterministic` when seeded.
+- Telemetry span attribute renamed from `workglow.task.cacheable` (boolean) to `workglow.task.cache_policy` (string) and is now set after policy resolution, so input-dependent policies report the correct value.
+
+### Deprecated
+
+- `static cacheable: boolean` on Task subclasses. Use `static cachePolicy: CachePolicy = { kind: "none" | "deterministic" | "private" }` instead. The boolean shim emits a one-shot warning per task type and will be removed in a future release.
+- `ITaskStaticProperties.cacheable` interface field marked `@deprecated`. The interface now declares the optional `cachePolicy` field as the canonical replacement.
+
+### Migration
+
+- Replace `static cacheable = false` with `static cachePolicy: CachePolicy = { kind: "none" }`.
+- Replace any `outputCache: someRepo` run-config use with registering a `CacheRegistry` instance in `ServiceRegistry`:
+  ```ts
+  services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ deterministic: repo }));
+  ```
+- Provide a `runId` in `IRunConfig` when running graphs with `private`-policy tasks (caller-supplied; typically a UUID matching a DB row).
+
 ## 0.2.37
 
 ### Features

--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -182,7 +182,7 @@ You can define schemas using plain JSON Schema, TypeBox, or Zod. Here are exampl
 #### Using Plain JSON Schema
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util";
 
 const MyInputSchema = {
@@ -232,7 +232,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -268,7 +268,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
 TypeBox schemas are JSON Schema compatible and can be used directly:
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { Type } from "@sinclair/typebox";
 import { DataPortSchema, FromSchema } from "@workglow/util";
 
@@ -291,7 +291,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -343,7 +343,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
 Zod 4 has built-in JSON Schema support using the `.toJSONSchema()` method:
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { z } from "zod";
 import { DataPortSchema } from "@workglow/util";
 
@@ -371,7 +371,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -711,26 +711,174 @@ const result = await workflow.run();
 
 ## Storage and Caching
 
-### Task Output Caching
+### Cache Policy
 
-Output caching lets repeat executions with identical inputs return instantly without redoing work.
+Every task declares how its outputs may be cached through a `CachePolicy`:
+
+```typescript
+type CachePolicy =
+  | { kind: "deterministic" }  // same inputs → same outputs; safe to share across runs
+  | { kind: "private" }        // non-deterministic but worth caching; scoped to one run
+  | { kind: "none" };          // do not cache (side-effecting tasks)
+```
+
+The default is `{ kind: "deterministic" }`. Side-effecting tasks (writes to external systems, sends messages) declare `{ kind: "none" }`. Non-deterministic tasks worth caching for the lifetime of a single run (image generation without a seed, model calls without a temperature lock) declare `{ kind: "private" }` — their outputs are namespaced by `runId` and visible only to that run and its restarts.
+
+For tasks whose policy depends on inputs (a seed turns "private" into "deterministic"), override `getCachePolicy(inputs)`:
+
+```typescript
+class AiImageOutputTask extends Task<ImageInput, ImageOutput> {
+  static readonly type = "AiImageOutputTask";
+  // Static default used when the instance method is not overridden.
+  static readonly cachePolicy: CachePolicy = { kind: "private" };
+
+  override getCachePolicy(inputs: ImageInput): CachePolicy {
+    return inputs.seed !== undefined
+      ? { kind: "deterministic" }
+      : { kind: "private" };
+  }
+}
+```
+
+### CacheRegistry: two slots
+
+The runner picks a repository per task by reading `CACHE_REGISTRY` from the `ServiceRegistry`. The registry has exactly two slots:
+
+```typescript
+interface CacheRegistry {
+  deterministic?: TaskOutputRepository;
+  private?: TaskOutputRepository;
+}
+```
+
+Both slots are optional. A missing slot is a silent no-op — the task still runs, it just runs uncached. Apps wire the slots they care about:
+
+```typescript
+import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  TaskOutputPrimaryKeyNames,
+  TaskOutputSchema,
+  TaskOutputTabularRepository,
+} from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
+
+await Sqlite.init();
+
+const deterministic = new TaskOutputTabularRepository({
+  tabularRepository: new SqliteTabularStorage(
+    "./cache.sqlite",
+    "task_outputs_deterministic",
+    TaskOutputSchema,
+    TaskOutputPrimaryKeyNames,
+    ["createdAt"]
+  ),
+});
+
+const privateBacking = new TaskOutputTabularRepository({
+  tabularRepository: new SqliteTabularStorage(
+    "./cache.sqlite",
+    "task_outputs_private",
+    TaskOutputSchema,
+    TaskOutputPrimaryKeyNames,
+    ["createdAt"]
+  ),
+});
+
+const registry = new ServiceRegistry();
+registry.registerInstance(
+  CACHE_REGISTRY,
+  new DefaultCacheRegistry({ deterministic, private: privateBacking })
+);
+
+// TaskGraph.run takes (input, config) — runId/registry are run config, not input.
+await graph.run({}, { registry, runId: "run-" + crypto.randomUUID() });
+```
+
+The runner constructs a per-run `RunPrivateCacheRepo` wrapper over the `private` slot, namespaced by `runId`. The wrapper exists only for the duration of the run; the rows it writes survive in the backing store until either explicit cleanup (on successful completion) or the TTL janitor sweeps them (after a crashed run is abandoned).
+
+### Run identity and durable execution
+
+A run is identified by an opaque `runId` string supplied by the caller of `.run()` in the run config (the second argument; the first argument is graph input):
+
+```typescript
+await graph.run({}, { runId, registry });
+```
+
+- **First start** of a user-triggered run: generate a fresh `runId` (UUID is typical) and persist it alongside the rest of the run metadata.
+- **Restart** after a crash: re-dispatch with the **same** `runId`. The new process constructs a fresh in-memory scheduler but the durable `private` repo still holds the outputs of every task that completed before the crash. Cache hits skip that work; the run finishes from where it effectively left off.
+- **Concurrent runs** of the same workflow get different `runId`s, so they never see each other's private-tier outputs.
+
+The runner does not generate `runId` for you. That is the caller's job — only the caller knows whether this `.run()` call is a fresh start or a restart.
+
+If the registered `private` slot is present and the graph contains any task whose policy may resolve to `kind: "private"` (statically or via `getCachePolicy(inputs)`), the runner rejects the run synchronously when `runId` is missing. Graphs without a private slot (or without any private-policy task) don't need a `runId`.
+
+#### Cleanup
+
+- On `succeeded`, the runner awaits `privateRepo.clearRun()` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt. The wrapper already knows its `runId`, so the method takes no arguments.
+- On crash (no terminal status reached), nothing happens at the cache layer — the entries stay on disk so the restart can find them.
+- For abandoned runs (crashed and never restarted), schedule the `CacheJanitor`:
+
+```typescript
+import { CacheJanitor } from "@workglow/task-graph";
+
+const janitor = new CacheJanitor({ privateBacking });
+// Sweep run-private rows older than 24 hours.
+await janitor.sweepStaleRunPrivate(24 * 60 * 60 * 1000);
+```
+
+The janitor only touches rows with the `__run:` prefix that `RunPrivateCacheRepo` writes; deterministic-tier rows are never affected.
+
+#### Durability warning
+
+At run start the runner checks whether the registered `private` repo reports `isDurable() === true`. If a graph contains a `private`-policy task but the repo is backed by, say, in-memory storage, a one-time warning is logged: restart survival cannot work against a non-durable backend. For production, point the `private` slot at SQLite, Postgres, or another durable store.
+
+### Cache key and `cacheVersion`
+
+The cache key is:
+
+```
+sha256(taskType + getCacheVersion() + fingerprint(inputs))
+```
+
+`fingerprint(inputs)` normalizes inputs using the existing `PortCodec` so that ports with `format` annotations hash by their stable wire representation.
+
+`Task.version` (a static number, default `1`) feeds `getCacheVersion()`, which walks the prototype chain and combines each ancestor's version. Bump `version` when the task's semantics change (new prompt template, new defaults, fixed-bug-in-implementation) to force misses for all prior keys:
+
+```typescript
+class SummarizeTask extends Task<...> {
+  static readonly type = "SummarizeTask";
+  static readonly version = 3; // bump → all old cache entries become stale
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
+  // ...
+}
+```
+
+Override `getCacheVersion()` only if you need a different versioning story (e.g., include the runtime model hash).
+
+### End-to-end example
 
 ```typescript
 import {
   Task,
   TaskGraph,
   Workflow,
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
   TaskOutputPrimaryKeyNames,
   TaskOutputSchema,
   TaskOutputTabularRepository,
+  type CachePolicy,
 } from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
 import { InMemoryTabularStorage } from "@workglow/storage";
 import { DataPortSchema } from "@workglow/util";
 
-// A cacheable task that simulates expensive work
+// A task with deterministic cache policy that simulates expensive work
 class ExpensiveTask extends Task<{ n: number }, { result: number }> {
   static readonly type = "ExpensiveTask";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return {
@@ -761,56 +909,37 @@ class ExpensiveTask extends Task<{ n: number }, { result: number }> {
   }
 }
 
-// Create an output cache
-const outputCache = new TaskOutputTabularRepository({
+// Build a CacheRegistry with a deterministic slot. (Private slot omitted here —
+// ExpensiveTask is deterministic, so it never needs the private tier.)
+const deterministic = new TaskOutputTabularRepository({
   tabularRepository: new InMemoryTabularStorage(TaskOutputSchema, TaskOutputPrimaryKeyNames, [
     "createdAt",
   ]),
 });
 
-// Example 1: TaskGraph caching (second run is near-instant)
-const graph = new TaskGraph({ outputCache });
+const registry = new ServiceRegistry();
+registry.registerInstance(
+  CACHE_REGISTRY,
+  new DefaultCacheRegistry({ deterministic })
+);
+
+const graph = new TaskGraph();
 graph.addTask(new ExpensiveTask({ n: 42 }, { id: "exp" }));
 
+// TaskGraph.run takes (input, config). registry/runId live in config.
 let t = Date.now();
-await graph.run();
+await graph.run({}, { registry, runId: "run-1" });
 const firstRunMs = Date.now() - t;
 
 t = Date.now();
-await graph.run(); // identical inputs -> served from cache
+await graph.run({}, { registry, runId: "run-2" }); // different run, same inputs → cache hit
 const secondRunMs = Date.now() - t;
 
 console.log({ firstRunMs, secondRunMs });
 // e.g. { firstRunMs: ~500, secondRunMs: ~1-5 }
-
-// Example 2: Direct Task caching across instances
-const missTask = new ExpensiveTask({ n: 43 }, { outputCache });
-t = Date.now();
-await missTask.run(); // cache miss -> compute and store
-const missMs = Date.now() - t;
-
-const hitTask = new ExpensiveTask({ n: 43 }, { outputCache });
-t = Date.now();
-await hitTask.run(); // cache hit -> instant
-const hitMs = Date.now() - t;
-
-console.log({ missMs, hitMs });
-// e.g. { missMs: ~500, hitMs: ~1-5 }
-
-// Example 3: Workflow with the same cache
-const workflow = new Workflow(outputCache);
-workflow.addTask(new ExpensiveTask({ n: 10 }));
-
-t = Date.now();
-await workflow.run(); // compute
-const wfFirstMs = Date.now() - t;
-
-t = Date.now();
-await workflow.run(); // cached
-const wfSecondMs = Date.now() - t;
-
-console.log({ wfFirstMs, wfSecondMs });
 ```
+
+The deterministic slot is shared across runs — that is the whole point. The private slot is per-run on read and per-run on cleanup, but the underlying storage handle is long-lived (one connection, many runs). Set up the registry once at app startup; bind it to every `.run()` call.
 
 ### Task Graph Persistence
 
@@ -859,9 +988,8 @@ import {
   FsFolderTabularStorage,
   InMemoryTabularStorage,
   IndexedDbTabularStorage,
-  SqliteTabularStorage,
 } from "@workglow/storage";
-import { Sqlite } from "@workglow/storage/sqlite";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
 
 // In-memory (e.g. tests)
 const memoryOutput = new TaskOutputTabularRepository({

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -8,6 +8,7 @@ This document explains the internal execution model of the task graph system. It
 - [Task Lifecycle](#task-lifecycle)
 - [Normal Execution (run)](#normal-execution-run)
 - [Preview Execution (runPreview)](#preview-execution-runpreview)
+- [Cache, Run Identity, and Durable Execution](#cache-run-identity-and-durable-execution)
 - [Dataflow and Input Propagation](#dataflow-and-input-propagation)
 - [GraphAsTask (Subgraphs)](#graphastask-subgraphs)
 - [Key Invariants](#key-invariants)
@@ -78,9 +79,10 @@ TaskRunner.run(overrides)
 2. setInput(overrides)           # Merge overrides into runInputData
 3. resolveSchemaInputs()         # Resolve model/repository strings to instances
 4. validateInput()               # Validate against input schema
-5. Check cache                   # If cacheable: cache hit returns verbatim, no preview overlay
+5. Check cache                   # Per task's CachePolicy + CacheRegistry slot;
+                                 # cache hit returns verbatim, no preview overlay
 6. executeTask()                 # Call task.execute(input, context) only
-7. Store in cache                # If cacheable, cache the result
+7. Store in cache                # If policy ≠ "none" and slot present, persist the result
 8. handleComplete()              # Set status = COMPLETED
     ↓
 Return runOutputData (locked)
@@ -213,6 +215,93 @@ Return-value semantics:
 - `undefined` — leaves `runOutputData` unchanged.
 
 If a preview needs the prior output, it can read `this.runOutputData` directly.
+
+---
+
+## Cache, Run Identity, and Durable Execution
+
+### Cache policy
+
+Every task declares a `CachePolicy` — a property of the task type, not of the deployment:
+
+| Kind            | Meaning                                                                                  | Cache slot used     |
+| --------------- | ---------------------------------------------------------------------------------------- | ------------------- |
+| `deterministic` | Same inputs → same outputs. Safe to share across runs (and, in apps, across projects).   | `deterministic`     |
+| `private`       | Non-deterministic but worth caching for the lifetime of one run (e.g., seedless images). | `private` (per-run) |
+| `none`          | Do not cache. Side-effecting tasks (writes to external systems, sends, mutations).       | _none_              |
+
+The default is `{ kind: "deterministic" }`. Policy can be made input-dependent by overriding `getCachePolicy(inputs)` — e.g., an image task that returns `deterministic` when a seed is provided and `private` when it isn't.
+
+### CacheRegistry
+
+A two-slot service registered under `CACHE_REGISTRY`:
+
+```ts
+interface CacheRegistry {
+  deterministic?: TaskOutputRepository;
+  private?: TaskOutputRepository;
+}
+```
+
+`TaskGraphRunner` resolves the registry from the per-run `ServiceRegistry` and dispatches each task's read/write to the slot named by its policy. Both slots are independently optional. A missing slot is a silent no-op: the task runs uncached, no error.
+
+For the `private` slot, the runner constructs a per-run `RunPrivateCacheRepo` wrapper that prefixes every key with `__run:${runId}::`. Two runs with different `runId`s never see each other's rows; the same `runId` (a restart) does.
+
+### Run identity (`runId`)
+
+`runId` is an opaque string passed in `TaskGraphRunConfig`. `TaskGraph.run` takes `(input, config)` — `runId` lives in the config (second argument), not the input:
+
+```ts
+graph.run({}, { runId, registry, ... });
+```
+
+The caller owns generation. The contract:
+
+- A user-triggered run gets a fresh `runId` (UUID typical).
+- A restart after a crash uses the **same** `runId` — that is how durable resume works.
+- Concurrent runs of the same workflow get **different** `runId`s.
+
+`handleStart` rejects the run synchronously only when **all** of the following hold: a `CACHE_REGISTRY` is registered, its `private` slot is populated, and the graph contains at least one task whose policy may resolve to `kind: "private"` (a static `cachePolicy` of that kind, or a `getCachePolicy(inputs)` override that can return it). Graphs without a private slot — or without any private-policy task — can omit `runId`.
+
+### Cache key
+
+```
+key = sha256(taskType + getCacheVersion() + fingerprint(inputs))
+```
+
+`fingerprint(inputs)` reuses the `PortCodec` normalization in `CacheCoordinator` — ports with `format` annotations hash by their canonical wire representation. Scope namespacing (the `runId` prefix for the private tier) is handled by the repo wrapper, not the key function.
+
+`getCacheVersion()` walks the prototype chain and combines each ancestor's static `version` (default `1`). Bump `version` on a task when its semantics change — every prior cached entry becomes a miss.
+
+### Lifecycle of cache rows
+
+| Tier            | Written        | Read                                  | Deleted                                                                                                                                |
+| --------------- | -------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `deterministic` | On task success | On task start                         | Never automatically. App owns invalidation (typically via `version` bumps).                                                            |
+| `private`       | On task success | On task start, filtered to current `runId` | **(a)** `privateRepo.clearRun()` on `succeeded` (the wrapper already knows its `runId`). **(b)** TTL sweep via `CacheJanitor.sweepStaleRunPrivate(olderThanMs)` for abandoned runs. |
+
+Failed tasks are never cached — only `Ok` results reach `saveOutput`. `saveOutput` is upsert by primary key (last writer wins) — the underlying `TaskOutputTabularRepository` calls `put()` on its tabular storage, so a same-key write replaces the existing row.
+
+### Durable execution model
+
+A run is an atomic unit on a single worker. When the worker crashes:
+
+1. Builder (or whatever scheduler dispatched the run) detects the crash via heartbeat / timeout.
+2. The same job is re-dispatched **with the same `runId`** to a (possibly different) worker.
+3. The new process constructs a fresh in-memory scheduler, but the durable `private` repo still holds every task output that completed before the crash.
+4. The runner re-traverses the DAG from scratch; cache hits skip completed work, cache misses execute.
+
+The runner emits a one-time startup warning if any task in the graph declares `kind: "private"` and the registered `private` repo reports `isDurable() === false`. The detection is a repo capability flag, not a registration check — in-memory backings, ephemeral wrappers, and test doubles all surface as non-durable.
+
+#### What durable execution does **not** cover
+
+- **Mid-graph checkpointing of in-flight scheduler state.** Crashed runs re-execute from scratch; the cache absorbs completed work. There is no resumption of a single in-flight task.
+- **Streaming partial outputs.** A task that crashed mid-stream re-executes from scratch on restart; only fully completed tasks become cache hits.
+- **Splitting one run across multiple workers.** A run is atomic on one worker.
+
+### Re-dispatch correctness invariant
+
+Re-execution must produce the same DAG traversal given the same inputs and cache state. Task ordering, parallelism limits, and scheduling decisions in `RunScheduler` must not depend on wall-clock time, machine identity, or worker-local random state. Today's scheduler satisfies this; the model treats it as a maintained invariant.
 
 ---
 

--- a/packages/task-graph/src/cache/CacheJanitor.ts
+++ b/packages/task-graph/src/cache/CacheJanitor.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+
+export interface CacheJanitorOptions {
+  privateBacking: TaskOutputRepository;
+}
+
+/**
+ * Periodic cleanup helper for run-private cache entries left behind by runs
+ * that crashed and were never restarted.
+ *
+ * Run-private rows are namespaced by `RunPrivateCacheRepo` with the taskType
+ * prefix `__run:`. This janitor sweeps those rows when they are older than
+ * `olderThanMs`. Entries lacking the prefix (deterministic cache, shared tier)
+ * are not touched.
+ *
+ * Apps schedule the sweep themselves (cron, periodic worker, on startup) —
+ * libs does not run it automatically.
+ */
+export class CacheJanitor {
+  private readonly privateBacking: TaskOutputRepository;
+
+  constructor({ privateBacking }: CacheJanitorOptions) {
+    this.privateBacking = privateBacking;
+  }
+
+  async sweepStaleRunPrivate(olderThanMs: number): Promise<void> {
+    await this.privateBacking.clearOlderThanWithTaskTypePrefix("__run:", olderThanMs);
+  }
+}

--- a/packages/task-graph/src/cache/CachePolicy.ts
+++ b/packages/task-graph/src/cache/CachePolicy.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type CachePolicy =
+  | { kind: "deterministic" }
+  | { kind: "private" }
+  | { kind: "none" };
+
+export const DEFAULT_CACHE_POLICY: CachePolicy = { kind: "deterministic" };
+
+export function isPolicyCached(policy: CachePolicy): boolean {
+  return policy.kind !== "none";
+}
+
+export function isPolicyPrivate(policy: CachePolicy): boolean {
+  return policy.kind === "private";
+}

--- a/packages/task-graph/src/cache/CacheRegistry.ts
+++ b/packages/task-graph/src/cache/CacheRegistry.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createServiceToken } from "@workglow/util";
+import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
+
+/**
+ * Two-slot registry of task output repositories selected by `CachePolicy.kind`.
+ *
+ * - `deterministic` — shared cache for tasks whose outputs are determined entirely
+ *   by their inputs. Same inputs → same outputs, safe to share across runs and
+ *   (in app deployments like builder) across projects.
+ * - `private` — per-run cache for tasks producing non-deterministic outputs worth
+ *   keeping (e.g., image generation without a seed). Namespaced by `runId` so
+ *   two runs of the same workflow do not see each other's data.
+ *
+ * Both slots are optional. When a slot is unset, caching for matching tasks is
+ * a silent no-op — the task still runs correctly, just uncached.
+ */
+export interface CacheRegistry {
+  deterministic?: TaskOutputRepository;
+  private?: TaskOutputRepository;
+}
+
+export const CACHE_REGISTRY = createServiceToken<CacheRegistry>(
+  "taskgraph.cacheRegistry"
+);
+
+export class DefaultCacheRegistry implements CacheRegistry {
+  public deterministic?: TaskOutputRepository;
+  public private?: TaskOutputRepository;
+
+  constructor(init: Partial<CacheRegistry> = {}) {
+    this.deterministic = init.deterministic;
+    this.private = init.private;
+  }
+}

--- a/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
+++ b/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskInput, TaskOutput } from "../task/TaskTypes";
+import { TaskOutputRepository } from "../storage/TaskOutputRepository";
+
+export interface RunPrivateCacheRepoOptions {
+  backing: TaskOutputRepository;
+  runId: string;
+}
+
+/**
+ * Wraps a TaskOutputRepository so that all entries are namespaced by `runId`.
+ *
+ * Namespacing happens at the `taskType` axis: rows are stored as
+ * `__run:${runId}::${taskType}` in the backing store. The input fingerprint is
+ * unchanged, so deterministic-style keying still works.
+ *
+ * - Two wrappers with the same `runId` (e.g., a restart after a crash) see each
+ *   other's writes via the backing store — that's the restart-survival contract.
+ * - Two wrappers with different `runId`s see only their own entries.
+ */
+export class RunPrivateCacheRepo extends TaskOutputRepository {
+  private readonly backing: TaskOutputRepository;
+  private readonly runId: string;
+
+  constructor({ backing, runId }: RunPrivateCacheRepoOptions) {
+    super({ outputCompression: backing.outputCompression });
+    this.backing = backing;
+    this.runId = runId;
+  }
+
+  private ns(taskType: string): string {
+    return `__run:${this.runId}::${taskType}`;
+  }
+
+  public async saveOutput(
+    taskType: string,
+    inputs: TaskInput,
+    output: TaskOutput,
+    createdAt?: Date
+  ): Promise<void> {
+    await this.backing.saveOutput(this.ns(taskType), inputs, output, createdAt);
+  }
+
+  public async getOutput(taskType: string, inputs: TaskInput): Promise<TaskOutput | undefined> {
+    return this.backing.getOutput(this.ns(taskType), inputs);
+  }
+
+  /**
+   * Override of `TaskOutputRepository.clear()` that only deletes entries
+   * namespaced under THIS wrapper's `runId`. Entries from other runs are not
+   * touched. Use the backing repository directly if you need a global clear.
+   */
+  public async clear(): Promise<void> {
+    await this.clearRun();
+  }
+
+  /**
+   * Delete every entry written through this wrapper's `runId`. Called by the
+   * graph runner after a successful run, and by the janitor for stale runs.
+   * Requires the backing repository to implement `deleteByTaskTypePrefix`.
+   */
+  public async clearRun(): Promise<void> {
+    await this.backing.deleteByTaskTypePrefix(`__run:${this.runId}::`);
+  }
+
+  /**
+   * Returns the count of entries namespaced under THIS wrapper's `runId`.
+   * Consistent with `saveOutput`/`getOutput`/`clear()` being run-scoped.
+   */
+  public async size(): Promise<number> {
+    return this.backing.sizeByTaskTypePrefix(`__run:${this.runId}::`);
+  }
+
+  /**
+   * Override of `TaskOutputRepository.clearOlderThan()` scoped to THIS
+   * wrapper's `runId`. Without the scope override, the wrapper would
+   * accidentally prune the entire backing store (including deterministic
+   * cache entries and other runs' private rows).
+   */
+  public async clearOlderThan(olderThanInMs: number): Promise<void> {
+    await this.backing.clearOlderThanWithTaskTypePrefix(
+      `__run:${this.runId}::`,
+      olderThanInMs
+    );
+  }
+
+  public isDurable(): boolean {
+    return this.backing.isDurable();
+  }
+}

--- a/packages/task-graph/src/cache/index.ts
+++ b/packages/task-graph/src/cache/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./CacheJanitor";
+export * from "./CachePolicy";
+export * from "./CacheRegistry";
+export * from "./RunPrivateCacheRepo";

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -38,6 +38,7 @@ export * from "./task-graph/TransformTypes";
 export * from "./task-graph/transforms";
 export * from "./task-graph/autoConnect";
 
+export * from "./cache";
 export * from "./task/CacheCoordinator";
 export * from "./task/StreamProcessor";
 export * from "./task/TaskRunContext";

--- a/packages/task-graph/src/storage/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputRepository.ts
@@ -94,10 +94,13 @@ export abstract class TaskOutputRepository {
   }
 
   /**
-   * Saves a task output to the repository
-   * @param taskType The type of task to save the output for
-   * @param inputs The input parameters for the task
-   * @param output The task output to save
+   * Persist a task output keyed by `(taskType, fingerprint(inputs))`.
+   *
+   * Backing implementations upsert by primary key (last-writer-wins). For
+   * deterministic cache entries (`CachePolicy.kind === "deterministic"`) this
+   * is benign because all writers produce equal values. Run-private writes
+   * are single-writer-per-runId in practice (one worker per run), so the
+   * upsert behavior is also fine there.
    */
   abstract saveOutput(
     taskType: string,
@@ -131,4 +134,53 @@ export abstract class TaskOutputRepository {
    * @param olderThanInMs The time in milliseconds to clear task outputs older than
    */
   abstract clearOlderThan(olderThanInMs: number): Promise<void>;
+
+  /**
+   * Whether entries written to this repository will survive a process crash / restart.
+   *
+   * Used by the task runner to warn when `kind: "private"` tasks are configured with a
+   * non-durable backing store (e.g., in-memory) — restart-survival, which is the whole
+   * point of the private cache tier, will not actually work in that case.
+   */
+  abstract isDurable(): boolean;
+
+  /**
+   * Delete every entry whose `taskType` starts with `prefix`. Used by
+   * `RunPrivateCacheRepo.clearRun()` to delete entries for a specific `runId`.
+   *
+   * Default implementation throws — backing repositories that support run-private
+   * caching MUST override this.
+   */
+  async deleteByTaskTypePrefix(_prefix: string): Promise<void> {
+    throw new Error(
+      `${this.constructor.name}: deleteByTaskTypePrefix is not supported by this repository.`
+    );
+  }
+
+  /**
+   * Delete entries whose `taskType` starts with `prefix` and were created more
+   * than `olderThanMs` ago. Used by `CacheJanitor.sweepStaleRunPrivate()`.
+   *
+   * Default implementation throws — backing repositories that support periodic
+   * janitor sweeps of run-private rows MUST override this.
+   */
+  async clearOlderThanWithTaskTypePrefix(_prefix: string, _olderThanMs: number): Promise<void> {
+    throw new Error(
+      `${this.constructor.name}: clearOlderThanWithTaskTypePrefix is not supported by this repository.`
+    );
+  }
+
+  /**
+   * Count entries whose `taskType` starts with `prefix`. Used by
+   * `RunPrivateCacheRepo.size()` so the wrapper's count reflects only its own
+   * namespaced view rather than the entire backing store.
+   *
+   * Default implementation throws — backing repositories that support run-private
+   * caching MUST override this.
+   */
+  async sizeByTaskTypePrefix(_prefix: string): Promise<number> {
+    throw new Error(
+      `${this.constructor.name}: sizeByTaskTypePrefix is not supported by this repository.`
+    );
+  }
 }

--- a/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputTabularRepository.ts
@@ -59,6 +59,11 @@ export class TaskOutputTabularRepository extends TaskOutputRepository {
     this.outputCompression = outputCompression;
   }
 
+  public isDurable(): boolean {
+    const backing = this.tabularRepository as unknown as { isDurable?: () => boolean };
+    return backing.isDurable?.() ?? true;
+  }
+
   /**
    * Sets up the database for the repository.
    * Must be called before using any other methods.
@@ -172,5 +177,58 @@ export class TaskOutputTabularRepository extends TaskOutputRepository {
     const date = new Date(Date.now() - olderThanInMs).toISOString();
     await this.tabularRepository.deleteSearch({ createdAt: { value: date, operator: "<" } });
     this.emit("output_pruned");
+  }
+
+  /**
+   * Deletes all entries whose `taskType` starts with the given prefix.
+   * Used by {@link RunPrivateCacheRepo.clearRun} to remove all entries for a specific runId.
+   *
+   * @param prefix - The prefix to match against `taskType` (e.g. `__run:my-run::`)
+   */
+  override async deleteByTaskTypePrefix(prefix: string): Promise<void> {
+    for await (const row of this.tabularRepository.records()) {
+      if (typeof row.taskType === "string" && row.taskType.startsWith(prefix)) {
+        await this.tabularRepository.delete({ key: row.key, taskType: row.taskType });
+      }
+    }
+  }
+
+  /**
+   * Deletes entries whose `taskType` starts with the given prefix AND whose
+   * `createdAt` is older than `olderThanInMs` milliseconds ago.
+   *
+   * Used by {@link CacheJanitor} to prune stale run-private entries left behind
+   * by runs that crashed and were never restarted.
+   *
+   * @param prefix - The taskType prefix to match (e.g. `__run:`)
+   * @param olderThanInMs - Age threshold in milliseconds; rows older than this are deleted
+   */
+  override async clearOlderThanWithTaskTypePrefix(prefix: string, olderThanInMs: number): Promise<void> {
+    const cutoff = Date.now() - olderThanInMs;
+    for await (const row of this.tabularRepository.records()) {
+      if (typeof row.taskType === "string" && row.taskType.startsWith(prefix)) {
+        const ts = typeof row.createdAt === "string" ? new Date(row.createdAt).getTime() : NaN;
+        if (!isNaN(ts) && ts < cutoff) {
+          await this.tabularRepository.delete({ key: row.key, taskType: row.taskType });
+        }
+      }
+    }
+  }
+
+  /**
+   * Counts entries whose `taskType` starts with the given prefix.
+   * Used by {@link RunPrivateCacheRepo.size} so the wrapper's count reflects
+   * only its own namespaced view.
+   *
+   * @param prefix - The taskType prefix to match (e.g. `__run:my-run::`)
+   */
+  override async sizeByTaskTypePrefix(prefix: string): Promise<number> {
+    let count = 0;
+    for await (const row of this.tabularRepository.records()) {
+      if (typeof row.taskType === "string" && row.taskType.startsWith(prefix)) {
+        count++;
+      }
+    }
+    return count;
   }
 }

--- a/packages/task-graph/src/task-graph/Conversions.ts
+++ b/packages/task-graph/src/task-graph/Conversions.ts
@@ -8,6 +8,7 @@ import type { DataPortSchema } from "@workglow/util/schema";
 import { GraphAsTask } from "../task/GraphAsTask";
 import type { IExecuteContext, ITask } from "../task/ITask";
 import { Task } from "../task/Task";
+import type { CachePolicy } from "../cache/CachePolicy";
 import type { DataPorts } from "../task/TaskTypes";
 import { DATAFLOW_ALL_PORTS } from "./Dataflow";
 import type { ITaskGraph } from "./ITaskGraph";
@@ -118,7 +119,7 @@ function convertPipeFunctionToTask<I extends DataPorts, O extends DataPorts>(
         additionalProperties: true,
       } as const satisfies DataPortSchema;
     };
-    public static override cacheable = false;
+    public static override cachePolicy: CachePolicy = { kind: "none" };
     public override async execute(input: I, context: IExecuteContext) {
       return fn(input, context);
     }

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -39,6 +39,14 @@ export interface StreamingRunOptions {
     message?: string,
     ...args: any[]
   ) => Promise<void>;
+  /** Stable identifier for the current graph run; threaded into each task's IRunConfig. */
+  readonly runId?: string;
+  /**
+   * True when the caller explicitly disabled caching (outputCache: false). When
+   * set, `false` is passed to task.runner.run() so TaskRunner clears any stale
+   * cacheRegistry rather than falling through to CACHE_REGISTRY resolution.
+   */
+  readonly legacyCacheExplicitlyDisabled?: boolean;
 }
 
 /**
@@ -177,11 +185,14 @@ export class StreamPump {
 
     try {
       const results = await task.runner.run(input, {
-        outputCache: options.outputCache ?? false,
+        // Pass false when explicitly disabled so TaskRunner clears stale state;
+        // otherwise pass the legacy repo (or undefined to use CACHE_REGISTRY).
+        outputCache: options.legacyCacheExplicitlyDisabled ? false : options.outputCache,
         shouldAccumulate,
         updateProgress: options.updateProgress,
         registry: options.registry,
         resourceScope: options.resourceScope,
+        runId: options.runId,
       });
 
       await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);

--- a/packages/task-graph/src/task-graph/TaskGraph.ts
+++ b/packages/task-graph/src/task-graph/TaskGraph.ts
@@ -84,6 +84,14 @@ export interface TaskGraphRunConfig {
 
   /** Same semantics as on {@link IRunConfig}. */
   disposeStrategy?: IDisposeStrategy;
+
+  /**
+   * Stable identifier for this logical run. When provided, the graph runner
+   * wraps the `private` cache slot in a {@link RunPrivateCacheRepo} keyed by
+   * this value, so that a restarted run (same `runId`) can resume from cached
+   * private outputs rather than re-executing every task.
+   */
+  runId?: string;
 }
 
 export interface TaskGraphRunPreviewConfig extends Omit<
@@ -162,6 +170,7 @@ export class TaskGraph implements ITaskGraph {
       maxTasks: config?.maxTasks,
       resourceScope: config?.resourceScope,
       disposeStrategy: config?.disposeStrategy,
+      runId: config?.runId,
     });
   }
 

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -16,6 +16,7 @@ import {
   SpanStatusCode,
   uuid4,
 } from "@workglow/util";
+import { CACHE_REGISTRY, DefaultCacheRegistry, RunPrivateCacheRepo } from "../cache";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
@@ -114,6 +115,15 @@ export class TaskGraphRunner {
    * Output cache repository
    */
   protected outputCache?: TaskOutputRepository;
+
+  /**
+   * True when the caller explicitly passed `outputCache: false` in the run
+   * config, meaning all caching (including CACHE_REGISTRY-based routing) should
+   * be suppressed. Distinct from `this.outputCache === undefined`, which just
+   * means no legacy repo was configured (CACHE_REGISTRY may still apply).
+   */
+  protected legacyCacheExplicitlyDisabled: boolean = false;
+
   /**
    * Whether leaf tasks (no outgoing edges) should accumulate their streaming
    * output. True by default so workflow return values are complete.
@@ -135,6 +145,21 @@ export class TaskGraphRunner {
    * and disable() methods (which take no arguments) have something to act on.
    */
   protected currentCtx?: RunContext;
+
+  /**
+   * Stable identifier for the current graph run. Threaded from
+   * {@link TaskGraphRunConfig.runId} through handleStart so that each
+   * per-task run call carries the same identifier.
+   */
+  protected runId?: string;
+
+  /**
+   * Run-private cache wrapper for the current run. Set by handleStart when a
+   * runId and private cache slot are both present; cleared at the end of each
+   * run. Used to fire-and-forget clearRun() after a successful run.
+   */
+  protected currentRunPrivate?: RunPrivateCacheRepo;
+  protected baseRegistryForRun?: ServiceRegistry;
 
   /**
    * Edge materializer — owns dataflow read/write, transforms, and error-port routing.
@@ -232,6 +257,18 @@ export class TaskGraphRunner {
       }
 
       await this.handleComplete();
+
+      // Await cleanup of run-private cache entries so that a same-runId restart
+      // immediately after this call cannot race against deletions.
+      const runPrivateToClean = this.currentRunPrivate;
+      this.currentRunPrivate = undefined;
+      if (runPrivateToClean) {
+        try {
+          await runPrivateToClean.clearRun();
+        } catch (e) {
+          getLogger().warn("RunPrivateCacheRepo.clearRun failed", { error: e });
+        }
+      }
 
       return this.filterLeafResults(results);
     } finally {
@@ -511,13 +548,17 @@ export class TaskGraphRunner {
         accumulateLeafOutputs: this.accumulateLeafOutputs,
         updateProgress: (t, p, m, ...a) =>
           this.runScheduler.handleProgress(this.currentCtx!, t, p, m, ...a),
+        runId: this.runId,
+        legacyCacheExplicitlyDisabled: this.legacyCacheExplicitlyDisabled,
       });
     }
 
     const results = await task.runner.run(input, {
-      // Pass `false` when no cache so TaskRunner.handleStart explicitly clears
-      // its own cached reference (undefined would leave the old value intact).
-      outputCache: this.outputCache ?? false,
+      // When caching was explicitly disabled (outputCache: false in run config),
+      // pass `false` so TaskRunner clears any stale cacheRegistry. Otherwise pass
+      // `this.outputCache` (which may be undefined, letting TaskRunner use
+      // CACHE_REGISTRY from the per-run ServiceRegistry).
+      outputCache: this.legacyCacheExplicitlyDisabled ? false : this.outputCache,
       updateProgress: async (
         task: ITask,
         progress: number | undefined,
@@ -527,6 +568,7 @@ export class TaskGraphRunner {
         await this.runScheduler.handleProgress(this.currentCtx!, task, progress, message, ...args),
       registry: this.registry,
       resourceScope: this.resourceScope,
+      runId: this.runId,
     });
 
     await this.edgeMaterializer.pushOutputFromNodeToEdges(task, results);
@@ -556,6 +598,46 @@ export class TaskGraphRunner {
   }
 
   /**
+   * Tracks private cache repos that have already received the durability warning,
+   * keyed by the repo instance. WeakSet so a freshly constructed repo that is no
+   * longer referenced is automatically eligible for re-warning if it shows up
+   * again later. Static because routing is repo-instance scoped, not runner
+   * scoped — a process can have one durable repo and many `TaskGraphRunner`s.
+   */
+  private static __durabilityWarnedRepos = new WeakSet<object>();
+
+  /**
+   * Conservative two-tier detector that decides whether a graph may route any
+   * task to the `private` cache slot. Used by both the durability warning and
+   * the `runId`-required guard in {@link handleStart}.
+   *
+   * 1. Read the static `cachePolicy` off the task's constructor. If `kind` is
+   *    "private", the task is definitely private.
+   * 2. Otherwise, if the task overrides `getCachePolicy` (i.e. its prototype's
+   *    method is not `Task.prototype.getCachePolicy`), conservatively treat it
+   *    as potentially private — the override may decide based on inputs that
+   *    are not available at graph-start time.
+   *
+   * Note: probing `getCachePolicy({} as any)` is unsafe because input-dependent
+   * overrides can throw or return the wrong branch when given empty inputs.
+   */
+  public static graphUsesPrivatePolicy(graph: TaskGraph): boolean {
+    return graph.getTasks().some((t) => {
+      const ctor = t.constructor as typeof Task;
+      if (ctor.cachePolicy?.kind === "private") return true;
+      // Override detection: prototype method differs from Task.prototype's.
+      const proto = ctor.prototype as { getCachePolicy?: unknown };
+      if (
+        typeof proto.getCachePolicy === "function" &&
+        proto.getCachePolicy !== Task.prototype.getCachePolicy
+      ) {
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /**
    * Handles the start of task graph execution
    * @param parentSignal Optional abort signal from parent
    */
@@ -569,6 +651,77 @@ export class TaskGraphRunner {
     if (config?.resourceScope !== undefined) {
       this.resourceScope = config.resourceScope;
     }
+    this.baseRegistryForRun = this.registry;
+
+    // Store run identifier for per-task propagation.
+    this.runId = config?.runId;
+
+    // Warn once per non-durable private repo (across runs) when at least one
+    // task in the graph routes to the private slot. This catches the
+    // dev-mode-in-production misconfiguration where an in-memory store is wired
+    // for convenience but restart-survival is expected. Rate-limited via a
+    // WeakSet keyed by the repo instance so repeated `runGraph` calls against
+    // the same registry do not flood the log.
+    if (this.registry.has(CACHE_REGISTRY)) {
+      const checkRegistry = this.registry.get(CACHE_REGISTRY);
+      if (checkRegistry.private && !checkRegistry.private.isDurable()) {
+        if (TaskGraphRunner.graphUsesPrivatePolicy(this.graph)) {
+          const repo = checkRegistry.private as object;
+          if (!TaskGraphRunner.__durabilityWarnedRepos.has(repo)) {
+            TaskGraphRunner.__durabilityWarnedRepos.add(repo);
+            getLogger().warn(
+              "TaskGraphRunner: private cache repo may be used but is non-durable — " +
+                "restart-survival will not work. Ensure the CacheRegistry 'private' " +
+                "slot is backed by a durable storage backend."
+            );
+          }
+        }
+      }
+
+      // Strict guard: if the graph contains a private-policy task but no runId
+      // was provided, we cannot namespace writes — they would land directly in
+      // the shared private repo and collide across runs. TaskGraphRunner is the
+      // documented owner of runId, so this is a configuration error.
+      if (!this.runId && checkRegistry.private) {
+        if (TaskGraphRunner.graphUsesPrivatePolicy(this.graph)) {
+          throw new TaskConfigurationError(
+            "TaskGraphRunner: graph contains a private-policy task but no runId was provided. " +
+              "Provide `runId` in TaskGraphRunConfig so private cache entries can be namespaced."
+          );
+        }
+      }
+    }
+
+    // If there is a private cache slot and a runId, wrap the private slot in a
+    // RunPrivateCacheRepo so all tasks in this run see a namespaced view of the
+    // backing store. Build a child ServiceRegistry that overrides CACHE_REGISTRY
+    // for this run only; the parent registry is unchanged.
+    if (this.runId && this.registry.has(CACHE_REGISTRY)) {
+      const baseRegistry = this.registry.get(CACHE_REGISTRY);
+      if (baseRegistry.private) {
+        const wrappedPrivate = new RunPrivateCacheRepo({
+          backing: baseRegistry.private,
+          runId: this.runId,
+        });
+        // Retain a reference so runGraph can fire-and-forget clearRun() after success.
+        this.currentRunPrivate = wrappedPrivate;
+        const wrappedRegistry = new DefaultCacheRegistry({
+          deterministic: baseRegistry.deterministic,
+          private: wrappedPrivate,
+        });
+        const childContainer = this.registry.container.createChildContainer();
+        const runtimeServices = new ServiceRegistry(childContainer);
+        // Copy all registrations from parent into child, then override CACHE_REGISTRY.
+        runtimeServices.registerInstance(CACHE_REGISTRY, wrappedRegistry);
+        this.registry = runtimeServices;
+
+        // Register a disposal marker in the resource scope so the run boundary is
+        // documented and callers can attach connection-bearing disposers on the same key.
+        this.resourceScope?.register(`cache:private:${this.runId}`, async () => {
+          // intentionally empty — RunPrivateCacheRepo has no resources of its own
+        });
+      }
+    }
 
     this.accumulateLeafOutputs = config?.accumulateLeafOutputs !== false;
 
@@ -576,13 +729,21 @@ export class TaskGraphRunner {
       if (typeof config.outputCache === "boolean") {
         if (config.outputCache === true) {
           this.outputCache = this.registry.get(TASK_OUTPUT_REPOSITORY);
+          this.legacyCacheExplicitlyDisabled = false;
         } else {
+          // outputCache: false — suppress all caching, including CACHE_REGISTRY.
           this.outputCache = undefined;
+          this.legacyCacheExplicitlyDisabled = true;
         }
       } else {
         this.outputCache = config.outputCache;
+        this.legacyCacheExplicitlyDisabled = false;
       }
       this.graph.outputCache = this.outputCache;
+    } else {
+      // No explicit outputCache in this run's config — preserve existing legacy
+      // repo (if any) but do not disable CACHE_REGISTRY routing.
+      this.legacyCacheExplicitlyDisabled = false;
     }
 
     // Prevent reentrancy
@@ -718,6 +879,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("complete");
   }
@@ -738,6 +903,8 @@ export class TaskGraphRunner {
         }
       })
     );
+    // Do NOT clear run-private entries on failure — left for restart / janitor TTL sweep.
+    this.currentRunPrivate = undefined;
     const ctx = this.currentCtx;
     this.running = false;
 
@@ -748,6 +915,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("error", error);
   }
@@ -775,6 +946,8 @@ export class TaskGraphRunner {
         }
       })
     );
+    // Do NOT clear run-private entries on abort — left for restart / janitor TTL sweep.
+    this.currentRunPrivate = undefined;
     const ctx = this.currentCtx;
 
     if (ctx?.telemetrySpan) {
@@ -784,6 +957,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("abort");
   }

--- a/packages/task-graph/src/task/CacheCoordinator.ts
+++ b/packages/task-graph/src/task/CacheCoordinator.ts
@@ -5,6 +5,8 @@
  */
 
 import { getPortCodec } from "@workglow/util";
+import type { CacheRegistry } from "../cache/CacheRegistry";
+import { type CachePolicy, isPolicyCached, isPolicyPrivate } from "../cache/CachePolicy";
 import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { ITask } from "./ITask";
 import type { StreamEvent } from "./StreamTypes";
@@ -35,14 +37,21 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
    * resulting object is a stable, serialization-equivalent representation
    * suitable for use as a cache key. Properties without a format annotation are
    * passed through unchanged. No-op when no cache is configured.
+   *
+   * The reserved sentinel field `__cv` (cache version) is injected into the
+   * normalized object before fingerprinting so that bumping a task's `static
+   * version` automatically invalidates its cached outputs. Tasks must never
+   * declare an input port named `__cv`.
    */
   async buildKey(inputs: Input, outputCache: TaskOutputRepository | undefined): Promise<Input> {
     if (!outputCache) return inputs;
     const inputSchema = (this.task.constructor as typeof Task).inputSchema();
-    return (await CacheCoordinator.normalizeInputsForCacheKey(
+    const normalized = await CacheCoordinator.normalizeInputsForCacheKey(
       inputs as Record<string, unknown>,
       inputSchema as unknown as SchemaProperties
-    )) as Input;
+    );
+    (normalized as Record<string, unknown>).__cv = this.task.getCacheVersion();
+    return normalized as Input;
   }
 
   /**
@@ -99,6 +108,51 @@ export class CacheCoordinator<Input extends TaskInput, Output extends TaskOutput
       outputSchema as unknown as SchemaProperties
     );
     await outputCache.saveOutput(this.task.type, keyInputs, wireOutputs as Output);
+  }
+
+  // ========================================================================
+  // Policy-aware routing methods
+  // ========================================================================
+
+  /**
+   * Resolve the repository slot to use given a registry and policy. Returns
+   * `undefined` if the registry is missing, the policy is `kind: "none"`, or
+   * the relevant slot is unregistered. All callers treat `undefined` as "skip
+   * caching" — no errors, no warnings.
+   */
+  private repoFor(
+    registry: CacheRegistry | undefined,
+    policy: CachePolicy
+  ): TaskOutputRepository | undefined {
+    if (!registry || !isPolicyCached(policy)) return undefined;
+    return isPolicyPrivate(policy) ? registry.private : registry.deterministic;
+  }
+
+  public async buildKeyForPolicy(
+    inputs: Input,
+    registry: CacheRegistry | undefined,
+    policy: CachePolicy
+  ): Promise<Input> {
+    return this.buildKey(inputs, this.repoFor(registry, policy));
+  }
+
+  public async lookupByPolicy(
+    keyInputs: Input,
+    registry: CacheRegistry | undefined,
+    policy: CachePolicy,
+    isStreamable: boolean,
+    ctx: TaskRunContext
+  ): Promise<Output | undefined> {
+    return this.lookup(keyInputs, this.repoFor(registry, policy), isStreamable, ctx);
+  }
+
+  public async saveByPolicy(
+    keyInputs: Input,
+    output: Output,
+    registry: CacheRegistry | undefined,
+    policy: CachePolicy
+  ): Promise<void> {
+    return this.save(keyInputs, output, this.repoFor(registry, policy));
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -27,6 +27,7 @@ import type {
 } from "./TaskEvents";
 import type { JsonTaskItem, TaskGraphItemJson, TaskGraphJsonOptions } from "./TaskJSON";
 import { TaskRunner } from "./TaskRunner";
+import type { CachePolicy } from "../cache/CachePolicy";
 import type { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes";
 
 /**
@@ -34,6 +35,11 @@ import type { TaskConfig, TaskInput, TaskOutput, TaskStatus } from "./TaskTypes"
  */
 export interface IExecuteContext {
   signal: AbortSignal;
+  /**
+   * Stable identifier for the current graph run. Set when the caller passes
+   * `runId` in the run config; `undefined` for ad-hoc task runs.
+   */
+  runId?: string;
   /**
    * Update the task's progress.
    * @param progress - 0..100 for measured progress, or `undefined` for
@@ -124,6 +130,13 @@ export interface IRunConfig {
   registry?: ServiceRegistry;
 
   /**
+   * Stable identifier for the current graph run, threaded through from
+   * {@link TaskGraphRunConfig.runId}. Exposed on {@link IExecuteContext} so
+   * tasks can correlate their work to the enclosing run.
+   */
+  runId?: string;
+
+  /**
    * Parent abort signal to link to this task's abort controller.
    * When the parent signal is aborted, this task will also be aborted.
    * Set automatically by context.own() to propagate cancellation from parent to child tasks.
@@ -166,7 +179,13 @@ export interface ITaskStaticProperties {
   readonly category?: string;
   readonly title?: string;
   readonly description?: string;
-  readonly cacheable: boolean;
+  /**
+   * @deprecated Use `cachePolicy: CachePolicy` instead. The `cacheable` static
+   * is preserved as a back-compat shim and will be removed in a future release.
+   */
+  readonly cacheable?: boolean;
+  /** Canonical declaration of this task's cache policy. */
+  readonly cachePolicy?: CachePolicy;
   readonly hasDynamicSchemas: boolean;
   readonly hasDynamicEntitlements: boolean;
   readonly passthroughInputsToOutputs?: boolean;
@@ -244,6 +263,8 @@ export interface ITaskIO<Input extends TaskInput> {
   addInput(overrides: Partial<Input> | undefined): boolean;
   validateInput(input: Input): Promise<boolean>;
   get cacheable(): boolean;
+  getCacheVersion(): string;
+  getCachePolicy(inputs: Input): CachePolicy;
   narrowInput(input: Partial<Input>, registry: ServiceRegistry): Promise<Partial<Input>>;
   entitlements(): TaskEntitlements;
 }

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -5,9 +5,10 @@
  */
 
 import type { ServiceRegistry } from "@workglow/util";
-import { deepEqual, EventEmitter, uuid4 } from "@workglow/util";
+import { deepEqual, EventEmitter, getLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
+import { type CachePolicy, DEFAULT_CACHE_POLICY } from "../cache/CachePolicy";
 import { DATAFLOW_ALL_PORTS } from "../task-graph/Dataflow";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import type { IExecuteContext, IExecutePreviewContext, IRunConfig, ITask } from "./ITask";
@@ -74,6 +75,23 @@ export class Task<
   public static cacheable: boolean = true;
 
   /**
+   * Version number for this task class, used to bust the output cache when the task's
+   * implementation changes. Increment when a change would produce different outputs for
+   * the same inputs. Combined with ancestor versions via getCacheVersion().
+   * Subclasses should override this when their execute() logic changes in a
+   * backwards-incompatible way (different output for same input).
+   */
+  public static version: number = 1;
+
+  /**
+   * Default cache policy for this task class. Used by `getCachePolicy()` when the
+   * task does not override the method. Subclasses with side effects should set
+   * `{ kind: "none" }`; tasks producing non-deterministic-but-expensive outputs
+   * (e.g., image generation without a seed) should set `{ kind: "private" }`.
+   */
+  public static cachePolicy: CachePolicy = { kind: "deterministic" };
+
+  /**
    * Whether this task has dynamic input/output schemas that can change at runtime.
    * Tasks with dynamic schemas should override instance methods for inputSchema() and/or outputSchema()
    * and emit 'schemaChange' events when their schemas change.
@@ -113,6 +131,12 @@ export class Task<
    * and emit 'entitlementChange' events when their entitlements change.
    */
   public static hasDynamicEntitlements: boolean = false;
+
+  /**
+   * Tracks task types that have already received the legacy `cacheable = false` deprecation
+   * warning, so the warning fires only once per task type across the process lifetime.
+   */
+  private static __cacheableDeprecationWarned = new Set<string>();
 
   /**
    * Entitlements required by this task class.
@@ -312,12 +336,74 @@ export class Task<
     return this.config?.description ?? (this.constructor as typeof Task).description;
   }
 
+  /**
+   * Whether this task instance is currently cacheable. Reads `runConfig.cacheable`
+   * and `config.cacheable` first (per-instance overrides for back-compat), then
+   * derives from `getCachePolicy(runInputData)`.
+   *
+   * Note: for tasks that override `getCachePolicy(inputs)` with input-dependent
+   * logic (e.g., `AiImageOutputTask` returns `private` when seed is absent), the
+   * value of `task.cacheable` can change as `runInputData` changes. Prefer calling
+   * `getCachePolicy(inputs)` directly when you have explicit inputs.
+   */
   public get cacheable(): boolean {
-    return (
-      this.runConfig?.cacheable ??
-      this.config?.cacheable ??
-      (this.constructor as typeof Task).cacheable
-    );
+    if (this.runConfig?.cacheable !== undefined) return this.runConfig.cacheable;
+    if (this.config?.cacheable !== undefined) return this.config.cacheable;
+    return this.getCachePolicy((this.runInputData ?? {}) as unknown as Input).kind !== "none";
+  }
+
+  /**
+   * Returns a dot-separated string of version numbers collected from each class in the
+   * prototype chain (leaf first) that declares its own `version` static property.
+   * Every class that owns a `version` contributes one segment, including the base Task
+   * class. Returns "1" when called directly on a Task instance with no subclassing
+   * (Task.version === 1 is the sole contributor).
+   *
+   * Use this as the cache-key version component: when any ancestor's version changes,
+   * the combined string changes and the cached output is invalidated.
+   */
+  public getCacheVersion(): string {
+    const versions: number[] = [];
+    let ctor: unknown = this.constructor;
+    while (ctor && ctor !== Function.prototype) {
+      if (
+        Object.prototype.hasOwnProperty.call(ctor, "version") &&
+        typeof (ctor as { version?: unknown }).version === "number"
+      ) {
+        versions.push((ctor as { version: number }).version);
+      }
+      ctor = Object.getPrototypeOf(ctor as object);
+    }
+    if (versions.length === 0) versions.push(1);
+    return versions.join(".");
+  }
+
+  /**
+   * Returns the effective cache policy for this task given its inputs. Default
+   * implementation honors the legacy `cacheable=false` static (maps to
+   * `{ kind: "none" }`) for back-compat with a one-time deprecation warning,
+   * otherwise returns the class's static `cachePolicy`. Override for dynamic
+   * decisions (e.g., AiImageOutputTask returns `private` when seed is absent).
+   */
+  public getCachePolicy(_inputs: Input): CachePolicy {
+    const ctor = this.constructor as typeof Task;
+    const hasLegacyOverride =
+      Object.prototype.hasOwnProperty.call(ctor, "cacheable") && (ctor as any).cacheable === false;
+    const hasPolicyOverride = Object.prototype.hasOwnProperty.call(ctor, "cachePolicy");
+
+    if (hasLegacyOverride && !hasPolicyOverride) {
+      if (!Task.__cacheableDeprecationWarned.has(ctor.type)) {
+        Task.__cacheableDeprecationWarned.add(ctor.type);
+        getLogger().warn(
+          `Task "${ctor.type}": static \`cacheable = false\` is deprecated. ` +
+            `Use \`static cachePolicy: CachePolicy = { kind: "none" }\` instead.`
+        );
+      }
+      return { kind: "none" };
+    }
+    if (this.runConfig?.cacheable === false || this.config?.cacheable === false)
+      return { kind: "none" }; // per-instance shim, no warning
+    return ctor.cachePolicy ?? DEFAULT_CACHE_POLICY;
   }
 
   // ========================================================================
@@ -455,6 +541,24 @@ export class Task<
 
     // Store runtime configuration
     this.runConfig = runConfig;
+
+    // Reject input schemas that declare a `__cv` port: this name is reserved by
+    // CacheCoordinator.buildKey for the cache version sentinel. Allowing a task
+    // to declare it would silently shadow cache versioning and cause cache
+    // collisions across versions. `inputSchema()` can legally return a boolean
+    // (see addInput/setInput handling); skip the check in that case.
+    const inputSchema = (this.constructor as typeof Task).inputSchema();
+    if (
+      inputSchema &&
+      typeof inputSchema !== "boolean" &&
+      inputSchema.properties &&
+      Object.prototype.hasOwnProperty.call(inputSchema.properties, "__cv")
+    ) {
+      throw new TaskConfigurationError(
+        `Task "${(this.constructor as typeof Task).type}": input port name '__cv' is reserved ` +
+          `for cache versioning. Rename the port to avoid collision with the cache key sentinel.`
+      );
+    }
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -12,6 +12,8 @@ import {
   ServiceRegistry,
   SpanStatusCode,
 } from "@workglow/util";
+import { CACHE_REGISTRY, DefaultCacheRegistry, RunPrivateCacheRepo } from "../cache";
+import type { CacheRegistry } from "../cache";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";
@@ -71,8 +73,18 @@ export class TaskRunner<
 
   /**
    * The output cache for the task
+   * @deprecated Use `cacheRegistry` instead. Kept for back-compat with callers
+   * that pass `outputCache: repo` through IRunConfig.
    */
   protected outputCache?: TaskOutputRepository;
+
+  /**
+   * Per-run cache registry resolved in handleStart. Replaces the legacy
+   * single-repo `outputCache` field as the primary cache routing mechanism.
+   * Set from CACHE_REGISTRY in the ServiceRegistry, or synthesised from the
+   * legacy `config.outputCache` repo shim.
+   */
+  protected cacheRegistry?: CacheRegistry;
 
   /**
    * Cache coordinator for the task (key normalization, lookup, save).
@@ -109,6 +121,20 @@ export class TaskRunner<
    * upstream streaming edges. Keyed by input port name.
    */
   public inputStreams?: Map<string, ReadableStream<StreamEvent>>;
+
+  /**
+   * Stable identifier for the current graph run. Set from IRunConfig.runId by
+   * handleStart; threaded into IExecuteContext so tasks can correlate their
+   * work to the enclosing run.
+   */
+  protected runId?: string;
+
+  /**
+   * Tracks task types that have already received the "private policy without
+   * runId" downgrade warning, so the warning fires only once per task type
+   * across the process lifetime. Mirrors {@link Task.__cacheableDeprecationWarned}.
+   */
+  private static __privateWithoutRunIdWarned = new Set<string>();
 
   /**
    * Constructor for TaskRunner
@@ -194,10 +220,44 @@ export class TaskRunner<
           }
         }
 
-        const keyInputs = await this.cacheCoordinator.buildKey(inputs, this.outputCache);
-        let outputs = await this.cacheCoordinator.lookup(
+        let policy = this.task.getCachePolicy(inputs);
+
+        // Standalone TaskRunner cannot namespace private cache writes without a
+        // runId — TaskGraphRunner owns the wrap. If a standalone caller routes
+        // to the private slot with no runId, downgrade to `kind: "none"` so the
+        // task does not write directly into the shared private repo (which
+        // would collide across callers). Warn once per task type so the
+        // configuration mistake surfaces without flooding the log.
+        if (
+          policy.kind === "private" &&
+          !this.runId &&
+          this.cacheRegistry?.private !== undefined &&
+          !(this.cacheRegistry.private instanceof RunPrivateCacheRepo)
+        ) {
+          const taskType = this.task.type;
+          if (!TaskRunner.__privateWithoutRunIdWarned.has(taskType)) {
+            TaskRunner.__privateWithoutRunIdWarned.add(taskType);
+            getLogger().warn(
+              `TaskRunner: task "${taskType}" has a private cache policy but no runId was ` +
+                `provided. Private cache writes are skipped for this run — use TaskGraphRunner ` +
+                `with runId for run-namespaced private caching, or provide an already namespaced ` +
+                `private cache repo in CACHE_REGISTRY.`
+            );
+          }
+          policy = { kind: "none" };
+        }
+
+        this.currentCtx?.telemetrySpan?.setAttributes({ "workglow.task.cache_policy": policy.kind });
+
+        const keyInputs = await this.cacheCoordinator.buildKeyForPolicy(
+          inputs,
+          this.cacheRegistry,
+          policy
+        );
+        let outputs = await this.cacheCoordinator.lookupByPolicy(
           keyInputs,
-          this.outputCache,
+          this.cacheRegistry,
+          policy,
           isStreamable,
           ctx
         );
@@ -213,7 +273,12 @@ export class TaskRunner<
               })
             : await this.executeTask(inputs, ctx);
 
-          await this.cacheCoordinator.save(keyInputs, outputs as Output, this.outputCache);
+          await this.cacheCoordinator.saveByPolicy(
+            keyInputs,
+            outputs as Output,
+            this.cacheRegistry,
+            policy
+          );
           this.task.runOutputData = outputs ?? ({} as Output);
         }
 
@@ -483,6 +548,7 @@ export class TaskRunner<
       own: this.own,
       registry: this.registry,
       resourceScope: this.resourceScope,
+      runId: this.runId,
     });
     return result;
   }
@@ -551,14 +617,40 @@ export class TaskRunner<
       this.handleAbort();
     });
 
-    const cache = config.outputCache ?? this.task.runConfig?.outputCache;
-    if (cache === true) {
-      let instance = globalServiceRegistry.get(TASK_OUTPUT_REPOSITORY);
-      this.outputCache = instance;
-    } else if (cache === false) {
+    // Apply registry override first so that cache resolution below uses the
+    // correct per-run ServiceRegistry rather than the stale instance field.
+    if (config.registry) {
+      this.registry = config.registry;
+    }
+
+    // Propagate run identifier for use in IExecuteContext.
+    this.runId = config.runId;
+
+    // Cache resolution: prefer CacheRegistry (via ServiceRegistry); honour legacy
+    // config.outputCache as a back-compat shim that maps to the deterministic slot.
+    const legacy = config.outputCache ?? this.task.runConfig?.outputCache;
+    if (legacy === false) {
+      this.cacheRegistry = undefined;
       this.outputCache = undefined;
-    } else if (cache instanceof TaskOutputRepository) {
-      this.outputCache = cache;
+    } else if (legacy instanceof TaskOutputRepository) {
+      // Legacy repo passed directly → treat as the deterministic slot.
+      this.cacheRegistry = new DefaultCacheRegistry({ deterministic: legacy });
+      this.outputCache = legacy;
+    } else if (legacy === true) {
+      // Legacy boolean true → pull from TASK_OUTPUT_REPOSITORY in the global registry.
+      const instance = globalServiceRegistry.has(TASK_OUTPUT_REPOSITORY)
+        ? globalServiceRegistry.get(TASK_OUTPUT_REPOSITORY)
+        : undefined;
+      this.outputCache = instance;
+      this.cacheRegistry = instance
+        ? new DefaultCacheRegistry({ deterministic: instance })
+        : undefined;
+    } else {
+      // No legacy override → look up CACHE_REGISTRY from the per-run ServiceRegistry.
+      this.outputCache = undefined;
+      this.cacheRegistry = this.registry.has(CACHE_REGISTRY)
+        ? this.registry.get(CACHE_REGISTRY)
+        : undefined;
     }
 
     // shouldAccumulate defaults to true (backward-compatible for standalone runs)
@@ -566,10 +658,6 @@ export class TaskRunner<
 
     if (config.updateProgress) {
       this.updateProgress = config.updateProgress;
-    }
-
-    if (config.registry) {
-      this.registry = config.registry;
     }
 
     if (config.resourceScope) {
@@ -604,7 +692,6 @@ export class TaskRunner<
         attributes: {
           "workglow.task.type": this.task.type,
           "workglow.task.id": String(this.task.config.id),
-          "workglow.task.cacheable": this.task.cacheable,
           "workglow.task.title": this.task.title || undefined,
         },
       });

--- a/packages/tasks/src/task/DebugLogTask.ts
+++ b/packages/tasks/src/task/DebugLogTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { CreateWorkflow, Task, TaskConfig, TaskConfigSchema, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
@@ -86,7 +87,7 @@ export class DebugLogTask<
   public static override title = "Debug Log";
   public static override description =
     "Logs messages to the console with configurable log levels for debugging task graphs";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override passthroughInputsToOutputs = true;
   public static override customizable = true;
   public static override isPassthrough = true;

--- a/packages/tasks/src/task/DelayTask.ts
+++ b/packages/tasks/src/task/DelayTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   IExecuteContext,
@@ -58,7 +59,7 @@ export class DelayTask<
   public static override title = "Delay";
   public static override description =
     "Delays execution for a specified duration with progress tracking";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override passthroughInputsToOutputs = true;
   public static override customizable = true;
 

--- a/packages/tasks/src/task/HumanApprovalTask.ts
+++ b/packages/tasks/src/task/HumanApprovalTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import type { IExecuteContext } from "@workglow/task-graph";
 import {
   CreateWorkflow,
@@ -146,7 +147,7 @@ export class HumanApprovalTask extends Task<
   public static override title = "Human Approval";
   public static override description =
     "Pauses execution to request approval from a human (approve/deny) via MCP elicitation";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override configSchema(): DataPortSchema {
     return humanApprovalConfigSchema;

--- a/packages/tasks/src/task/HumanInputTask.ts
+++ b/packages/tasks/src/task/HumanInputTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import type { IExecuteContext } from "@workglow/task-graph";
 import {
   CreateWorkflow,
@@ -168,7 +169,7 @@ export class HumanInputTask extends Task<
   public static override title = "Human Input";
   public static override description =
     "Sends an interaction (notification, display, or input request) to a human";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override hasDynamicSchemas = true;
 
   public static override configSchema(): DataPortSchema {

--- a/packages/tasks/src/task/InputTask.ts
+++ b/packages/tasks/src/task/InputTask.ts
@@ -4,7 +4,7 @@
  * All Rights Reserved
  */
 
-import type { IExecuteContext, StreamEvent, StreamFinish } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent, StreamFinish } from "@workglow/task-graph";
 import { CreateWorkflow, Task, TaskConfig, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 
@@ -22,7 +22,7 @@ export class InputTask extends Task<InputTaskInput, InputTaskOutput, InputTaskCo
   static override title = "Input";
   static override description = "Starts the workflow";
   static override hasDynamicSchemas = true;
-  static override cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
   static override isPassthrough = true;
 
   public static override inputSchema(): DataPortSchema {

--- a/packages/tasks/src/task/OutputTask.ts
+++ b/packages/tasks/src/task/OutputTask.ts
@@ -4,7 +4,7 @@
  * All Rights Reserved
  */
 
-import type { IExecuteContext, StreamEvent, StreamFinish } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent, StreamFinish } from "@workglow/task-graph";
 import { CreateWorkflow, Task, TaskConfig, Workflow } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 
@@ -23,7 +23,7 @@ export class OutputTask extends Task<OutputTaskInput, OutputTaskOutput, OutputTa
   static override title = "Output";
   static override description = "Ends the workflow";
   static override hasDynamicSchemas = true;
-  static override cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
   static override isGraphOutput = true;
   static override isPassthrough = true;
 

--- a/packages/tasks/src/task/SplitTask.ts
+++ b/packages/tasks/src/task/SplitTask.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import { CreateWorkflow, IExecuteContext, Task, TaskConfig, Workflow } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
 
@@ -68,7 +69,7 @@ export class SplitTask<
   public static override title = "Split";
   public static override description =
     "Splits an array into individual outputs, creating one output per element";
-  static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema() {
     return inputSchema;

--- a/packages/test/src/binding/InMemoryTaskOutputRepository.ts
+++ b/packages/test/src/binding/InMemoryTaskOutputRepository.ts
@@ -28,4 +28,8 @@ export class InMemoryTaskOutputRepository extends TaskOutputTabularRepository {
       ]),
     });
   }
+
+  public override isDurable(): boolean {
+    return false;
+  }
 }

--- a/packages/test/src/test/ai/AiChatTask.test.ts
+++ b/packages/test/src/test/ai/AiChatTask.test.ts
@@ -24,7 +24,7 @@ describe("AiChatTask — schema and registration", () => {
   it("has required static properties", () => {
     expect(AiChatTask.type).toBe("AiChatTask");
     expect(AiChatTask.category).toBe("AI Chat");
-    expect(AiChatTask.cacheable).toBe(false);
+    expect(AiChatTask.cachePolicy).toEqual({ kind: "none" });
   });
 
   it("declares input schema with required model and prompt", () => {

--- a/packages/test/src/test/ai/AiChatWithKbTask.test.ts
+++ b/packages/test/src/test/ai/AiChatWithKbTask.test.ts
@@ -27,7 +27,7 @@ describe("AiChatWithKbTask — schema and registration", () => {
   it("has required static properties", () => {
     expect(AiChatWithKbTask.type).toBe("AiChatWithKbTask");
     expect(AiChatWithKbTask.category).toBe("AI Chat");
-    expect(AiChatWithKbTask.cacheable).toBe(false);
+    expect(AiChatWithKbTask.cachePolicy).toEqual({ kind: "none" });
   });
 
   it("input schema requires model, prompt, knowledgeBaseIds", () => {

--- a/packages/test/src/test/ai/AiImageOutputTask.test.ts
+++ b/packages/test/src/test/ai/AiImageOutputTask.test.ts
@@ -41,17 +41,17 @@ function fakeImageValue(width = 8, height = 8, previewScale = 1): ImageValue {
 }
 
 describe("AiImageOutputTask", () => {
-  describe("seed-aware cacheable", () => {
-    it("is not cacheable when seed is undefined", () => {
+  describe("seed-aware cache policy", () => {
+    it("returns private cache policy when seed is undefined", () => {
       const task = new TestImageTask({});
-      task.runInputData = { prompt: "x", model: "m" };
-      expect(task.cacheable).toBe(false);
+      const policy = task.getCachePolicy({ prompt: "x", model: "m" });
+      expect(policy).toEqual({ kind: "private" });
     });
 
-    it("is cacheable when seed is set", () => {
+    it("returns deterministic cache policy when seed is set", () => {
       const task = new TestImageTask({});
-      task.runInputData = { prompt: "x", model: "m", seed: 42 };
-      expect(task.cacheable).toBe(true);
+      const policy = task.getCachePolicy({ prompt: "x", model: "m", seed: 42 });
+      expect(policy).toEqual({ kind: "deterministic" });
     });
   });
 

--- a/packages/test/src/test/ai/AiImageOutputTaskCachePolicy.test.ts
+++ b/packages/test/src/test/ai/AiImageOutputTaskCachePolicy.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { AiImageOutputTask } from "@workglow/ai";
+import type { ModelConfig } from "@workglow/ai";
+
+// Minimal concrete subclass — AiImageOutputTask needs inputSchema/outputSchema
+// to be fully constructable, same pattern as AiImageOutputTask.test.ts.
+class TestImageTask extends AiImageOutputTask<{
+  prompt: string;
+  model: ModelConfig | string;
+  seed?: number | undefined;
+}> {
+  public static override type = "TestImageTask_CachePolicy";
+  public static override category = "Test";
+  public static override inputSchema() {
+    return {
+      type: "object",
+      properties: {
+        prompt: { type: "string" },
+        model: { type: "string", format: "model:TestImageTask_CachePolicy" },
+        seed: { type: "number" },
+      },
+      required: ["prompt", "model"],
+      additionalProperties: false,
+    } as any;
+  }
+}
+
+describe("AiImageOutputTask cache policy", () => {
+  it("with seed → deterministic", () => {
+    const t = new TestImageTask({});
+    const policy = t.getCachePolicy({ prompt: "p", model: "m", seed: 42 });
+    expect(policy).toEqual({ kind: "deterministic" });
+  });
+
+  it("without seed → private (cached per-run only)", () => {
+    const t = new TestImageTask({});
+    const policy = t.getCachePolicy({ prompt: "p", model: "m" });
+    expect(policy).toEqual({ kind: "private" });
+  });
+
+  it("with seed=null → private", () => {
+    const t = new TestImageTask({});
+    // Cast to any to pass null — tests the runtime branch even though the type
+    // declares seed as number | undefined.
+    const policy = t.getCachePolicy({ prompt: "p", model: "m", seed: null as any });
+    expect(policy).toEqual({ kind: "private" });
+  });
+});

--- a/packages/test/src/test/mcp/mcp.test.ts
+++ b/packages/test/src/test/mcp/mcp.test.ts
@@ -169,7 +169,7 @@ describe("MCP", () => {
     test("has correct static properties", () => {
       expect(McpToolCallTask.type).toBe("McpToolCallTask");
       expect(McpToolCallTask.category).toBe("MCP");
-      expect(McpToolCallTask.cacheable).toBe(false);
+      expect(McpToolCallTask.cachePolicy.kind).toBe("none");
     });
   });
 
@@ -196,7 +196,7 @@ describe("MCP", () => {
     test("has correct static properties", () => {
       expect(McpResourceReadTask.type).toBe("McpResourceReadTask");
       expect(McpResourceReadTask.category).toBe("MCP");
-      expect(McpResourceReadTask.cacheable).toBe(false);
+      expect(McpResourceReadTask.cachePolicy.kind).toBe("none");
     });
   });
 
@@ -232,7 +232,7 @@ describe("MCP", () => {
     test("has correct static properties", () => {
       expect(McpPromptGetTask.type).toBe("McpPromptGetTask");
       expect(McpPromptGetTask.category).toBe("MCP");
-      expect(McpPromptGetTask.cacheable).toBe(false);
+      expect(McpPromptGetTask.cachePolicy.kind).toBe("none");
     });
   });
 
@@ -281,7 +281,7 @@ describe("MCP", () => {
     test("has correct static properties", () => {
       expect(McpListTask.type).toBe("McpListTask");
       expect(McpListTask.category).toBe("MCP");
-      expect(McpListTask.cacheable).toBe(false);
+      expect(McpListTask.cachePolicy.kind).toBe("none");
       expect(McpListTask.hasDynamicSchemas).toBe(true);
     });
 

--- a/packages/test/src/test/task-graph-cache/AbstractRepoCapabilities.test.ts
+++ b/packages/test/src/test/task-graph-cache/AbstractRepoCapabilities.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskOutputRepository } from "@workglow/task-graph";
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Minimal concrete subclass that implements only the truly-abstract methods.
+ * Leaves the three default-throwing prefix-aware methods as their base defaults.
+ */
+class MinimalRepo extends TaskOutputRepository {
+  constructor() {
+    super({ outputCompression: false });
+  }
+
+  saveOutput = vi.fn().mockResolvedValue(undefined);
+  getOutput = vi.fn().mockResolvedValue(undefined);
+  clear = vi.fn().mockResolvedValue(undefined);
+  size = vi.fn().mockResolvedValue(0);
+  clearOlderThan = vi.fn().mockResolvedValue(undefined);
+  isDurable() {
+    return false;
+  }
+}
+
+describe("TaskOutputRepository default-throwing prefix-aware methods", () => {
+  it("deleteByTaskTypePrefix throws by default", async () => {
+    const r = new MinimalRepo();
+    await expect(r.deleteByTaskTypePrefix("some-prefix::")).rejects.toThrow(/not supported/);
+  });
+
+  it("clearOlderThanWithTaskTypePrefix throws by default", async () => {
+    const r = new MinimalRepo();
+    await expect(r.clearOlderThanWithTaskTypePrefix("some-prefix::", 86400_000)).rejects.toThrow(
+      /not supported/
+    );
+  });
+
+  it("sizeByTaskTypePrefix throws by default", async () => {
+    const r = new MinimalRepo();
+    await expect(r.sizeByTaskTypePrefix("some-prefix::")).rejects.toThrow(/not supported/);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CacheCoordinatorKey.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheCoordinatorKey.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { Task, CacheCoordinator } from "@workglow/task-graph";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+describe("CacheCoordinator key with version", () => {
+  it("bumping task.version invalidates cache hits", async () => {
+    class V1 extends Task {
+      public static override type = "V";
+      public static override version = 1;
+    }
+    class V2 extends Task {
+      public static override type = "V";
+      public static override version = 2;
+    }
+
+    const repo = new InMemoryTaskOutputRepository();
+    await (repo as any).setupDatabase?.();
+
+    const v1 = new V1();
+    const v2 = new V2();
+    const coordV1 = new CacheCoordinator(v1);
+    const coordV2 = new CacheCoordinator(v2);
+
+    const input = { q: "hello" };
+    const key1 = await coordV1.buildKey(input as any, repo);
+    await coordV1.save(key1, { r: "v1-result" } as any, repo);
+
+    expect(await coordV1.lookup(key1, repo, false, {} as any)).toEqual({ r: "v1-result" });
+
+    const key2 = await coordV2.buildKey(input as any, repo);
+    expect(await coordV2.lookup(key2, repo, false, {} as any)).toBeUndefined();
+  });
+
+  it("identical version + inputs still hit cache", async () => {
+    class Stable extends Task {
+      public static override type = "Stable";
+      public static override version = 7;
+    }
+    const repo = new InMemoryTaskOutputRepository();
+    await (repo as any).setupDatabase?.();
+    const c = new CacheCoordinator(new Stable());
+
+    const key = await c.buildKey({ q: "x" } as any, repo);
+    await c.save(key, { r: "hit" } as any, repo);
+    expect(await c.lookup(key, repo, false, {} as any)).toEqual({ r: "hit" });
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CacheCoordinatorPolicy.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheCoordinatorPolicy.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Task,
+  CacheCoordinator,
+  DefaultCacheRegistry,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class T extends Task {
+  public static override type = "PolicyT";
+}
+
+async function freshRepo() {
+  const r = new InMemoryTaskOutputRepository();
+  await (r as any).setupDatabase?.();
+  return r;
+}
+
+describe("CacheCoordinator policy routing", () => {
+  it("kind: deterministic writes to deterministic slot only", async () => {
+    const det = await freshRepo();
+    const priv = await freshRepo();
+    const reg = new DefaultCacheRegistry({ deterministic: det, private: priv });
+    const c = new CacheCoordinator(new T());
+
+    const policy: CachePolicy = { kind: "deterministic" };
+    const k = await c.buildKeyForPolicy({ q: 1 } as any, reg, policy);
+    await c.saveByPolicy(k, { r: 1 } as any, reg, policy);
+
+    expect(await det.size()).toBe(1);
+    expect(await priv.size()).toBe(0);
+  });
+
+  it("kind: private writes to private slot only", async () => {
+    const det = await freshRepo();
+    const priv = await freshRepo();
+    const reg = new DefaultCacheRegistry({ deterministic: det, private: priv });
+    const c = new CacheCoordinator(new T());
+
+    const policy: CachePolicy = { kind: "private" };
+    const k = await c.buildKeyForPolicy({ q: 1 } as any, reg, policy);
+    await c.saveByPolicy(k, { r: 1 } as any, reg, policy);
+
+    expect(await det.size()).toBe(0);
+    expect(await priv.size()).toBe(1);
+  });
+
+  it("kind: none is a no-op", async () => {
+    const det = await freshRepo();
+    const priv = await freshRepo();
+    const reg = new DefaultCacheRegistry({ deterministic: det, private: priv });
+    const c = new CacheCoordinator(new T());
+
+    const policy: CachePolicy = { kind: "none" };
+    const k = await c.buildKeyForPolicy({ q: 1 } as any, reg, policy);
+    await c.saveByPolicy(k, { r: 1 } as any, reg, policy);
+    expect(await det.size()).toBe(0);
+    expect(await priv.size()).toBe(0);
+  });
+
+  it("missing slot is silent no-op (does not throw)", async () => {
+    const reg = new DefaultCacheRegistry({}); // both slots undefined
+    const c = new CacheCoordinator(new T());
+    const policy: CachePolicy = { kind: "deterministic" };
+
+    const k = await c.buildKeyForPolicy({ q: 1 } as any, reg, policy);
+    await expect(c.saveByPolicy(k, { r: 1 } as any, reg, policy)).resolves.toBeUndefined();
+    expect(await c.lookupByPolicy(k, reg, policy, false, {} as any)).toBeUndefined();
+  });
+
+  it("undefined registry is silent no-op", async () => {
+    const c = new CacheCoordinator(new T());
+    const policy: CachePolicy = { kind: "deterministic" };
+    const k = await c.buildKeyForPolicy({ q: 1 } as any, undefined, policy);
+    await expect(c.saveByPolicy(k, { r: 1 } as any, undefined, policy)).resolves.toBeUndefined();
+    expect(await c.lookupByPolicy(k, undefined, policy, false, {} as any)).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { CacheJanitor } from "@workglow/task-graph";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+describe("CacheJanitor", () => {
+  it("sweepStaleRunPrivate prunes only entries older than the cutoff", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const now = Date.now();
+    await backing.saveOutput("__run:rA::T", { x: 1 }, { ok: 1 }, new Date(now - 8 * 24 * 3600_000));
+    await backing.saveOutput("__run:rB::T", { x: 1 }, { ok: 2 }, new Date(now - 1 * 24 * 3600_000));
+    expect(await backing.size()).toBe(2);
+
+    const janitor = new CacheJanitor({ privateBacking: backing });
+    await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
+
+    expect(await backing.size()).toBe(1);
+    expect(await backing.getOutput("__run:rB::T", { x: 1 })).toEqual({ ok: 2 });
+  });
+
+  it("does not touch entries lacking the __run: prefix", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const now = Date.now();
+    // Shared (deterministic) entry with no run prefix — old but should not be swept.
+    await backing.saveOutput("SharedTaskType", { x: 1 }, { ok: "shared" }, new Date(now - 30 * 24 * 3600_000));
+    // Run-private entry — old, should be swept.
+    await backing.saveOutput("__run:rX::T", { x: 1 }, { ok: "private" }, new Date(now - 30 * 24 * 3600_000));
+
+    const janitor = new CacheJanitor({ privateBacking: backing });
+    await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
+
+    expect(await backing.getOutput("SharedTaskType", { x: 1 })).toEqual({ ok: "shared" });
+    expect(await backing.getOutput("__run:rX::T", { x: 1 })).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CachePolicy.test.ts
+++ b/packages/test/src/test/task-graph-cache/CachePolicy.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Task, type CachePolicy, isPolicyCached, isPolicyPrivate } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+
+describe("CachePolicy", () => {
+  it("Task default policy is deterministic", () => {
+    const policy = new Task().getCachePolicy({} as any);
+    expect(policy).toEqual({ kind: "deterministic" });
+  });
+
+  it("static cachePolicy override flows through getCachePolicy", () => {
+    class Side extends Task {
+      public static override type = "Side";
+      public static override cachePolicy: CachePolicy = { kind: "none" };
+    }
+    expect(new Side().getCachePolicy({} as any)).toEqual({ kind: "none" });
+  });
+
+  it("subclass getCachePolicy override wins over static", () => {
+    class Dyn extends Task {
+      public static override type = "Dyn";
+      public override getCachePolicy(inputs: any): CachePolicy {
+        return inputs.priv ? { kind: "private" } : { kind: "deterministic" };
+      }
+    }
+    expect(new Dyn().getCachePolicy({ priv: true } as any)).toEqual({ kind: "private" });
+    expect(new Dyn().getCachePolicy({ priv: false } as any)).toEqual({ kind: "deterministic" });
+  });
+
+  it("legacy cacheable=false maps to { kind: 'none' }", () => {
+    class Legacy extends Task {
+      public static override type = "Legacy";
+      public static override cacheable = false;
+    }
+    expect(new Legacy().getCachePolicy({} as any)).toEqual({ kind: "none" });
+  });
+
+  it("policy helpers", () => {
+    expect(isPolicyCached({ kind: "none" })).toBe(false);
+    expect(isPolicyCached({ kind: "deterministic" })).toBe(true);
+    expect(isPolicyCached({ kind: "private" })).toBe(true);
+    expect(isPolicyPrivate({ kind: "private" })).toBe(true);
+    expect(isPolicyPrivate({ kind: "deterministic" })).toBe(false);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CacheRegistry.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheRegistry.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CACHE_REGISTRY,
+  type CacheRegistry,
+  DefaultCacheRegistry,
+} from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+describe("CacheRegistry", () => {
+  it("starts with both slots undefined", () => {
+    const reg = new DefaultCacheRegistry();
+    expect(reg.deterministic).toBeUndefined();
+    expect(reg.private).toBeUndefined();
+  });
+
+  it("can be bound under the CACHE_REGISTRY service token", () => {
+    const services = new ServiceRegistry();
+    const reg: CacheRegistry = new DefaultCacheRegistry();
+    reg.deterministic = new InMemoryTaskOutputRepository();
+    services.registerInstance(CACHE_REGISTRY, reg);
+
+    const got = services.get(CACHE_REGISTRY);
+    expect(got).toBe(reg);
+    expect(got.deterministic).toBeDefined();
+    expect(got.private).toBeUndefined();
+  });
+
+  it("constructor seeds slots from init object", () => {
+    const det = new InMemoryTaskOutputRepository();
+    const priv = new InMemoryTaskOutputRepository();
+    const reg = new DefaultCacheRegistry({ deterministic: det, private: priv });
+    expect(reg.deterministic).toBe(det);
+    expect(reg.private).toBe(priv);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/CacheableDeprecation.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheableDeprecation.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { Task } from "@workglow/task-graph";
+import { getLogger, setLogger } from "@workglow/util";
+
+describe("legacy static cacheable deprecation", () => {
+  let originalLogger: ReturnType<typeof getLogger>;
+  let warnings: string[];
+
+  beforeEach(() => {
+    originalLogger = getLogger();
+    warnings = [];
+    setLogger({
+      debug: () => {},
+      info: () => {},
+      warn: (msg: unknown) => warnings.push(String(msg)),
+      error: () => {},
+    } as any);
+  });
+
+  afterEach(() => {
+    setLogger(originalLogger);
+  });
+
+  it("warns exactly once per task type when static cacheable=false is used without cachePolicy", () => {
+    class OldA extends Task {
+      public static override type = "OldCacheableA";
+      public static override cacheable = false;
+    }
+    new OldA().getCachePolicy({} as any);
+    new OldA().getCachePolicy({} as any);
+    new OldA().getCachePolicy({} as any);
+
+    const matches = warnings.filter(
+      (w) => w.includes("cacheable") && w.includes("deprecated") && w.includes("OldCacheableA")
+    );
+    expect(matches.length).toBe(1);
+  });
+
+  it("does NOT warn when cachePolicy is set explicitly", () => {
+    class New extends Task {
+      public static override type = "NewPolicy";
+      public static override cachePolicy = { kind: "none" } as const;
+    }
+    new New().getCachePolicy({} as any);
+    const matches = warnings.filter((w) => w.includes("deprecated"));
+    expect(matches.length).toBe(0);
+  });
+
+  it("returns { kind: 'none' } via the legacy shim", () => {
+    class Old extends Task {
+      public static override type = "OldNonePolicy";
+      public static override cacheable = false;
+    }
+    expect(new Old().getCachePolicy({} as any)).toEqual({ kind: "none" });
+  });
+});

--- a/packages/test/src/test/task-graph-cache/PrivateRequiresRunId.test.ts
+++ b/packages/test/src/test/task-graph-cache/PrivateRequiresRunId.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  RunPrivateCacheRepo,
+  Task,
+  TaskConfigurationError,
+  TaskGraph,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { Container, ResourceScope, ServiceRegistry, getLogger, setLogger } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class PrivatePolicyTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "PrivateRunIdTask";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: `done:${input.q}` };
+  }
+}
+
+class DeterministicTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "DeterministicRunIdTask";
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: `det:${input.q}` };
+  }
+}
+
+async function freshPrivateRepo(): Promise<InMemoryTaskOutputRepository> {
+  const r = new InMemoryTaskOutputRepository();
+  await (r as any).setupDatabase?.();
+  return r;
+}
+
+function freshServices(privateRepo: InMemoryTaskOutputRepository): ServiceRegistry {
+  const services = new ServiceRegistry(new Container());
+  services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: privateRepo }));
+  return services;
+}
+
+describe("private cache policy requires a runId", () => {
+  let originalLogger: ReturnType<typeof getLogger>;
+  let warnings: string[];
+
+  beforeEach(() => {
+    originalLogger = getLogger();
+    warnings = [];
+    setLogger({
+      debug: () => {},
+      info: () => {},
+      warn: (msg: unknown) => warnings.push(String(msg)),
+      error: () => {},
+    } as any);
+  });
+
+  afterEach(() => {
+    setLogger(originalLogger);
+  });
+
+  it("TaskRunner standalone: private-policy task with no runId logs warn-once and does not write to shared private repo", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    // Two distinct tasks of the same type, run with no runId — only the first
+    // call should emit the warning (warn-once-per-task-type).
+    const t1 = new PrivatePolicyTask({ defaults: { q: "hello" } } as any);
+    const t2 = new PrivatePolicyTask({ defaults: { q: "world" } } as any);
+
+    await t1.run({}, { registry: services });
+    await t2.run({}, { registry: services });
+
+    // The private repo must be untouched — without a runId the task should
+    // skip caching entirely rather than colliding in the shared namespace.
+    const stored = await backing.getOutput(PrivatePolicyTask.type, { q: "hello", __cv: "1" });
+    expect(stored).toBeUndefined();
+
+    const matches = warnings.filter(
+      (w) => w.includes("private cache policy") && w.includes(PrivatePolicyTask.type)
+    );
+    expect(matches.length).toBe(1);
+  });
+
+  it("TaskGraphRunner: graph with private-policy task and no runId throws TaskConfigurationError", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    const g = new TaskGraph();
+    g.addTask(new PrivatePolicyTask({ defaults: { q: "hello" } } as any));
+
+    await expect(
+      g.run({}, { registry: services, resourceScope: new ResourceScope() })
+    ).rejects.toBeInstanceOf(TaskConfigurationError);
+  });
+
+  it("TaskGraphRunner: graph with no private-policy task and no runId runs normally", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    const g = new TaskGraph();
+    g.addTask(new DeterministicTask({ defaults: { q: "hello" } } as any));
+
+    // Should not throw despite missing runId, because no task routes to private.
+    await expect(
+      g.run({}, { registry: services, resourceScope: new ResourceScope() })
+    ).resolves.toBeDefined();
+  });
+
+  it("TaskRunner standalone: pre-namespaced RunPrivateCacheRepo bypass — no warning, entry is written", async () => {
+    const rawBacking = await freshPrivateRepo();
+    const runId = "bypass-test-run-001";
+    const preNamespaced = new RunPrivateCacheRepo({ backing: rawBacking, runId });
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(
+      CACHE_REGISTRY,
+      new DefaultCacheRegistry({ private: preNamespaced })
+    );
+
+    // Run with no runId in config — bypass should engage because private slot
+    // IS already a RunPrivateCacheRepo, so no downgrade + no warning.
+    const task = new PrivatePolicyTask({ defaults: { q: "bypass-test" } } as any);
+    await task.run({}, { registry: services });
+
+    // No warning should have been emitted.
+    const matchingWarnings = warnings.filter(
+      (w) => w.includes("private cache policy") || w.includes("runId")
+    );
+    expect(matchingWarnings.length).toBe(0);
+
+    // The cache entry SHOULD be written under the __run:<runId>:: prefix in the raw backing store.
+    const prefixedType = `__run:${runId}::${PrivatePolicyTask.type}`;
+    const stored = await rawBacking.getOutput(prefixedType, { q: "bypass-test", __cv: "1" });
+    expect(stored).toEqual({ r: "done:bypass-test" });
+  });
+});

--- a/packages/test/src/test/task-graph-cache/RepoDurability.test.ts
+++ b/packages/test/src/test/task-graph-cache/RepoDurability.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+describe("Repository durability", () => {
+  it("in-memory repository is not durable", () => {
+    expect(new InMemoryTaskOutputRepository().isDurable()).toBe(false);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/RunPrivateCacheRepo.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateCacheRepo.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { RunPrivateCacheRepo } from "@workglow/task-graph";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+describe("RunPrivateCacheRepo", () => {
+  let backing: InMemoryTaskOutputRepository;
+
+  beforeEach(async () => {
+    backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+  });
+
+  it("namespaces saves and reads by runId", async () => {
+    const repoA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    const repoB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+
+    await repoA.saveOutput("T", { x: 1 }, { ok: "A" });
+    await repoB.saveOutput("T", { x: 1 }, { ok: "B" });
+
+    expect(await repoA.getOutput("T", { x: 1 })).toEqual({ ok: "A" });
+    expect(await repoB.getOutput("T", { x: 1 })).toEqual({ ok: "B" });
+  });
+
+  it("a fresh wrapper for the same runId still sees prior writes (restart survival)", async () => {
+    const first = new RunPrivateCacheRepo({ backing, runId: "run-X" });
+    await first.saveOutput("T", { x: 1 }, { ok: 1 });
+
+    const second = new RunPrivateCacheRepo({ backing, runId: "run-X" });
+    expect(await second.getOutput("T", { x: 1 })).toEqual({ ok: 1 });
+  });
+
+  it("clearRun deletes only its own runId entries", async () => {
+    const repoA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+    const repoB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+    await repoA.saveOutput("T", { x: 1 }, { ok: "A" });
+    await repoB.saveOutput("T", { x: 1 }, { ok: "B" });
+
+    await repoA.clearRun();
+
+    expect(await repoA.getOutput("T", { x: 1 })).toBeUndefined();
+    expect(await repoB.getOutput("T", { x: 1 })).toEqual({ ok: "B" });
+  });
+
+  it("delegates isDurable() to backing", () => {
+    expect(new RunPrivateCacheRepo({ backing, runId: "r" }).isDurable()).toBe(false);
+  });
+
+  it("size() returns only entries for this runId", async () => {
+    const repoA = new RunPrivateCacheRepo({ backing, runId: "size-run-A" });
+    const repoB = new RunPrivateCacheRepo({ backing, runId: "size-run-B" });
+
+    await repoA.saveOutput("T", { x: 1 }, { v: "A1" });
+    await repoA.saveOutput("T", { x: 2 }, { v: "A2" });
+    await repoB.saveOutput("T", { x: 1 }, { v: "B1" });
+    await repoB.saveOutput("T", { x: 2 }, { v: "B2" });
+
+    expect(await repoA.size()).toBe(2);
+    expect(await repoB.size()).toBe(2);
+  });
+
+  it("clearOlderThan() only prunes entries in this runId's namespace", async () => {
+    const repoA = new RunPrivateCacheRepo({ backing, runId: "prune-run-A" });
+    const repoB = new RunPrivateCacheRepo({ backing, runId: "prune-run-B" });
+
+    const oldDate = new Date(Date.now() - 10 * 24 * 3600_000); // 10 days ago
+    const freshDate = new Date(); // now
+
+    // repoA: one old, one fresh
+    await repoA.saveOutput("T", { x: "old" }, { v: "A-old" }, oldDate);
+    await repoA.saveOutput("T", { x: "new" }, { v: "A-new" }, freshDate);
+
+    // repoB: one old
+    await repoB.saveOutput("T", { x: "old" }, { v: "B-old" }, oldDate);
+
+    // Also save a deterministic (non-prefixed) entry directly in the backing store
+    // with an old timestamp — clearOlderThan on repoA must NOT touch it.
+    await backing.saveOutput("DeterministicTask", { x: "det" }, { v: "det-old" }, oldDate);
+
+    // Prune entries in repoA older than 7 days.
+    await repoA.clearOlderThan(7 * 24 * 3600_000);
+
+    // repoA's old entry should be gone.
+    expect(await repoA.getOutput("T", { x: "old" })).toBeUndefined();
+    // repoA's fresh entry should survive.
+    expect(await repoA.getOutput("T", { x: "new" })).toEqual({ v: "A-new" });
+    // repoB's old entry should survive (different runId namespace).
+    expect(await repoB.getOutput("T", { x: "old" })).toEqual({ v: "B-old" });
+    // The deterministic (non-prefixed) entry should survive.
+    expect(await backing.getOutput("DeterministicTask", { x: "det" })).toEqual({ v: "det-old" });
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskCacheVersion.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskCacheVersion.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Task, TaskConfigurationError } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+describe("Task.getCacheVersion", () => {
+  it("returns the static version of the leaf class as a string", () => {
+    class TaskA extends Task {
+      public static override type = "TaskA";
+      public static override version = 3;
+    }
+    const t = new TaskA();
+    expect(t.getCacheVersion()).toBe("3.1"); // 1 is the base Task.version default
+  });
+
+  it("includes ancestor versions when subclasses set version", () => {
+    class Base extends Task {
+      public static override type = "Base";
+      public static override version = 2;
+    }
+    class Child extends Base {
+      public static override type = "Child";
+      public static override version = 5;
+    }
+    const v = new Child().getCacheVersion();
+    expect(v).toBe("5.2.1"); // 1 is the base Task.version default
+  });
+
+  it("defaults to '1' when no subclass overrides", () => {
+    expect(new Task().getCacheVersion()).toBe("1");
+  });
+});
+
+describe("__cv reserved input port name", () => {
+  it("rejects construction of a Task whose inputSchema declares __cv", () => {
+    class BadTask extends Task {
+      public static override type = "BadCvTask";
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            __cv: { type: "string" },
+            other: { type: "string" },
+          },
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+    }
+
+    expect(() => new BadTask()).toThrow(TaskConfigurationError);
+    expect(() => new BadTask()).toThrow(/__cv/);
+  });
+
+  it("permits construction when __cv is absent", () => {
+    class OkTask extends Task {
+      public static override type = "OkCvTask";
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+          },
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+    }
+
+    expect(() => new OkTask()).not.toThrow();
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerCleanup.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerCleanup.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Task,
+  TaskGraph,
+  Dataflow,
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { Container, ResourceScope, ServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class PrivTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "PrivTask_Cleanup";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: input.q };
+  }
+}
+
+class FailingTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "FailingTask_Cleanup";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(): Promise<{ r: string }> {
+    throw new Error("boom");
+  }
+}
+
+function freshServices(privateRepo: InMemoryTaskOutputRepository): ServiceRegistry {
+  const services = new ServiceRegistry(new Container());
+  services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: privateRepo }));
+  return services;
+}
+
+describe("TaskGraphRunner cleanup on success", () => {
+  it("private cache entries for the runId are cleared after a successful run", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = freshServices(backing);
+
+    const graph = new TaskGraph();
+    graph.addTask(new PrivTask({ defaults: { q: "hello" } } as any));
+
+    await graph.run(
+      {},
+      {
+        runId: "rid-1",
+        registry: services,
+        resourceScope: new ResourceScope(),
+      }
+    );
+
+    expect(await backing.size()).toBe(0);
+  });
+
+  it("entries survive a failed run (left for restart/TTL)", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = freshServices(backing);
+
+    // Wire PrivTask → FailingTask so the scheduler guarantees PrivTask completes
+    // (and writes to the private cache) before FailingTask runs and fails.
+    const graph = new TaskGraph();
+    const a = new PrivTask({ defaults: { q: "hello" } } as any);
+    const b = new FailingTask({ defaults: { q: "ignored" } } as any);
+    graph.addTask(a);
+    graph.addTask(b);
+    // PrivTask outputs { r } → FailingTask expects { q }. Wire r→q so PrivTask
+    // is a declared dependency of FailingTask.
+    graph.addDataflow(new Dataflow(a.id, "r", b.id, "q"));
+
+    try {
+      await graph.run(
+        {},
+        {
+          runId: "rid-fail",
+          registry: services,
+          resourceScope: new ResourceScope(),
+        }
+      );
+    } catch {
+      // Swallow the error — we only care about cache state, not the thrown value.
+    }
+    // Some implementations swallow task errors and surface them via a final status;
+    // either way, the cleanup contract is: do NOT clear on non-success.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await backing.size()).toBeGreaterThan(0);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
@@ -1,0 +1,312 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  Task,
+  TaskGraph,
+} from "@workglow/task-graph";
+import { Container, ResourceScope, ServiceRegistry, getLogger, setLogger } from "@workglow/util";
+import type { CachePolicy } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class PrivTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "DurabilityWarnTask";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: input.q };
+  }
+}
+
+describe("TaskGraphRunner durability warning", () => {
+  let originalLogger: ReturnType<typeof getLogger>;
+  let messages: string[];
+
+  beforeEach(() => {
+    originalLogger = getLogger();
+    messages = [];
+    setLogger({
+      debug: () => {},
+      info: () => {},
+      warn: (msg: unknown) => messages.push(String(msg)),
+      error: () => {},
+    } as any);
+  });
+
+  afterEach(() => {
+    setLogger(originalLogger);
+  });
+
+  it("warns when a private-policy task is wired to a non-durable repo", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new PrivTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "warn-1", registry: services, resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("private cache") && m.includes("non-durable"))).toBe(
+      true
+    );
+  });
+
+  it("does NOT warn when private repo is durable", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    (backing as any).isDurable = () => true;
+    await (backing as any).setupDatabase?.();
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new PrivTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "warn-2", registry: services, resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(false);
+  });
+
+  it("does NOT warn when no task uses private policy", async () => {
+    class DetTask extends Task<{ q: string }, { r: string }> {
+      public static override type = "DetTaskNoWarn";
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+          },
+          required: ["q"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            r: { type: "string" },
+          },
+          required: ["r"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public override async execute(input: { q: string }): Promise<{ r: string }> {
+        return { r: input.q };
+      }
+    }
+
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new DetTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "warn-3", registry: services, resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(false);
+  });
+
+  it("emits durability warning only once per private repo across multiple runGraph calls", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    // Three runs against the same non-durable private repo. The warning must
+    // fire on the first run only — subsequent runs hit the WeakSet rate-limit.
+    for (let i = 0; i < 3; i++) {
+      const g = new TaskGraph();
+      g.addTask(new PrivTask({ defaults: { q: `hello-${i}` } } as any));
+      await g.run(
+        {},
+        { runId: `rate-${i}`, registry: services, resourceScope: new ResourceScope() }
+      );
+    }
+
+    const matches = messages.filter((m) => m.includes("non-durable"));
+    expect(matches.length).toBe(1);
+  });
+
+  it("emits a fresh warning for a different repo instance", async () => {
+    // First repo — should warn once.
+    const backingA = new InMemoryTaskOutputRepository();
+    await (backingA as any).setupDatabase?.();
+    const servicesA = new ServiceRegistry(new Container());
+    servicesA.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backingA }));
+    const gA = new TaskGraph();
+    gA.addTask(new PrivTask({ defaults: { q: "a" } } as any));
+    await gA.run({}, { runId: "ra", registry: servicesA, resourceScope: new ResourceScope() });
+
+    // Second, separate repo instance — must warn again (WeakSet keys on repo).
+    const backingB = new InMemoryTaskOutputRepository();
+    await (backingB as any).setupDatabase?.();
+    const servicesB = new ServiceRegistry(new Container());
+    servicesB.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backingB }));
+    const gB = new TaskGraph();
+    gB.addTask(new PrivTask({ defaults: { q: "b" } } as any));
+    await gB.run({}, { runId: "rb", registry: servicesB, resourceScope: new ResourceScope() });
+
+    const matches = messages.filter((m) => m.includes("non-durable"));
+    expect(matches.length).toBe(2);
+  });
+
+  it("restores registry between runs to avoid nested RunPrivateCacheRepo wrappers", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new PrivTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "wrap-a", registry: services, resourceScope: new ResourceScope() });
+    await g.run({}, { runId: "wrap-b", resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("RunPrivateCacheRepo.clearRun failed"))).toBe(false);
+  });
+
+  it("warns when task declares static cachePolicy:'private' even if getCachePolicy returns 'deterministic' for empty inputs", async () => {
+    class TrickyTask extends Task<{ q: string }, { r: string }> {
+      public static override type = "TrickyPrivateForEmpty";
+      public static override cachePolicy: CachePolicy = { kind: "private" };
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+          },
+          required: ["q"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            r: { type: "string" },
+          },
+          required: ["r"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      // Override that lies about empty inputs — old probe would have missed
+      // this. New static-first detector catches it via static cachePolicy.
+      public override getCachePolicy(inputs: { q: string }): CachePolicy {
+        if (!inputs || !inputs.q) return { kind: "deterministic" };
+        return { kind: "private" };
+      }
+
+      public override async execute(input: { q: string }): Promise<{ r: string }> {
+        return { r: input.q };
+      }
+    }
+
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new TrickyTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "tricky-1", registry: services, resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(true);
+  });
+
+  it("warns for input-dependent private tasks via override detection", async () => {
+    // No static cachePolicy — only the override decides. Detector must still
+    // conservatively flag it because the override exists.
+    class OverrideOnlyTask extends Task<{ priv: boolean; q: string }, { r: string }> {
+      public static override type = "OverrideOnlyPrivate";
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            priv: { type: "boolean" },
+            q: { type: "string" },
+          },
+          required: ["priv", "q"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            r: { type: "string" },
+          },
+          required: ["r"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public override getCachePolicy(inputs: { priv: boolean; q: string }): CachePolicy {
+        return inputs.priv ? { kind: "private" } : { kind: "deterministic" };
+      }
+
+      public override async execute(input: { priv: boolean; q: string }): Promise<{ r: string }> {
+        return { r: input.q };
+      }
+    }
+
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new OverrideOnlyTask({ defaults: { priv: true, q: "hello" } } as any));
+
+    await g.run(
+      {},
+      { runId: "override-1", registry: services, resourceScope: new ResourceScope() }
+    );
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(true);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerPrivate.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerPrivate.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Task,
+  TaskGraph,
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  RunPrivateCacheRepo,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { Container, ServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class FlakyTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "FlakyTask";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    (FlakyTask as any).runs.push({ q: input.q });
+    return { r: `done:${input.q}` };
+  }
+}
+
+// Attach the static `runs` array properly
+(FlakyTask as any).runs = [];
+
+function freshServices(privateRepo: InMemoryTaskOutputRepository): ServiceRegistry {
+  const services = new ServiceRegistry(new Container());
+  services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: privateRepo }));
+  return services;
+}
+
+async function freshRepo(): Promise<InMemoryTaskOutputRepository> {
+  const r = new InMemoryTaskOutputRepository();
+  await (r as any).setupDatabase?.();
+  return r;
+}
+
+describe("TaskGraphRunner with run-private cache", () => {
+  it("restart with the same runId reuses run-private entries left by a failed run", async () => {
+    // Restart-survival scenario: a FAILED (or aborted) run leaves private cache
+    // entries in place (Task 10 only clears on SUCCESS). A subsequent run with the
+    // same runId should reuse those entries rather than re-executing the task.
+    (FlakyTask as any).runs = [];
+    const backing = await freshRepo();
+    const runId = "shared-run";
+
+    // Simulate the state left by a previous partial/failed run: write FlakyTask's
+    // output directly into the private-namespaced backing store, exactly as the
+    // RunPrivateCacheRepo would have done during a real (partial) run.
+    // The cache key includes `__cv` (cache version = "1" for FlakyTask which
+    // inherits Task.version = 1 and declares no override).
+    const wrappedForSeeding = new RunPrivateCacheRepo({ backing, runId });
+    await wrappedForSeeding.saveOutput(FlakyTask.type, { q: "hello", __cv: "1" }, { r: "done:hello" });
+
+    const services = freshServices(backing);
+
+    // Now run graph2 with the same runId — it should hit the pre-seeded cache entry
+    // and NOT invoke FlakyTask.execute() again.
+    const graph2 = new TaskGraph();
+    graph2.addTask(new FlakyTask({ defaults: { q: "hello" } } as any));
+
+    await graph2.run({}, { runId, registry: services });
+
+    // FlakyTask should have been skipped (cache hit) — runs array stays empty.
+    expect((FlakyTask as any).runs.length).toBe(0);
+  });
+
+  it("two runs with different runIds do not share private entries", async () => {
+    (FlakyTask as any).runs = [];
+    const backing = await freshRepo();
+    const services = freshServices(backing);
+
+    const graph1 = new TaskGraph();
+    graph1.addTask(new FlakyTask({ defaults: { q: "hello" } } as any));
+
+    const graph2 = new TaskGraph();
+    graph2.addTask(new FlakyTask({ defaults: { q: "hello" } } as any));
+
+    await graph1.run({}, { runId: "run-1", registry: services });
+    await graph2.run({}, { runId: "run-2", registry: services });
+
+    expect((FlakyTask as any).runs.length).toBe(2);
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskRunnerRouting.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskRunnerRouting.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  Task,
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { Container, ServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class CountingTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "CountingTask";
+  public static count = 0;
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    CountingTask.count++;
+    return { r: `out:${input.q}` };
+  }
+}
+
+/**
+ * Create an isolated ServiceRegistry backed by a fresh Container so that
+ * registrations from one test do not bleed into the next (ServiceRegistry's
+ * default constructor uses the global Container).
+ */
+function freshRegistry(): ServiceRegistry {
+  return new ServiceRegistry(new Container());
+}
+
+async function freshRepo() {
+  const r = new InMemoryTaskOutputRepository();
+  await (r as any).setupDatabase?.();
+  return r;
+}
+
+describe("TaskRunner cache routing via CacheRegistry", () => {
+  it("second run with same inputs hits deterministic cache", async () => {
+    CountingTask.count = 0;
+    const services = freshRegistry();
+    const det = await freshRepo();
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ deterministic: det }));
+
+    const task = new CountingTask();
+    // Pass the ServiceRegistry via IRunConfig.registry so handleStart picks up CACHE_REGISTRY.
+    await task.run({ q: "x" }, { registry: services });
+    await task.run({ q: "x" }, { registry: services });
+    expect(CountingTask.count).toBe(1);
+  });
+
+  it("no CacheRegistry registered → runs uncached, no error", async () => {
+    CountingTask.count = 0;
+    const services = freshRegistry();
+    // No CACHE_REGISTRY registered — task should still run fine, executing twice.
+    const task = new CountingTask();
+    await task.run({ q: "x" }, { registry: services });
+    await task.run({ q: "x" }, { registry: services });
+    expect(CountingTask.count).toBe(2);
+  });
+
+  it("task with cachePolicy kind:none never writes", async () => {
+    class NoCache extends CountingTask {
+      public static override type = "NoCacheTask";
+      public static override cachePolicy: CachePolicy = { kind: "none" };
+      public static override count = 0;
+    }
+    NoCache.count = 0;
+
+    const services = freshRegistry();
+    const det = await freshRepo();
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ deterministic: det }));
+
+    const task = new NoCache();
+    await task.run({ q: "x" }, { registry: services });
+    expect(await det.size()).toBe(0);
+  });
+});

--- a/packages/test/src/test/task-graph-output-cache/StreamingCache.test.ts
+++ b/packages/test/src/test/task-graph-output-cache/StreamingCache.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
 import { IExecuteContext, Task, TaskStatus } from "@workglow/task-graph";
 import { setLogger } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
@@ -109,7 +109,7 @@ class CacheReplaceStreamTask extends Task<CacheTestInput, CacheTestOutput> {
  */
 class NoCacheAppendStreamTask extends Task<CacheTestInput, CacheTestOutput> {
   public static override type = "NoCacheAppendStreamTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -175,8 +175,8 @@ describe("Streaming Cache Integration", () => {
       expect(result.text).toBe("cached result");
       expect(task.runOutputData.text).toBe("cached result");
 
-      // Verify the result was cached
-      const cached = await cache.getOutput("CacheAppendStreamTask", { prompt: "hello" });
+      // Verify the result was cached; __cv is the cacheVersion sentinel injected by buildKey
+      const cached = await cache.getOutput("CacheAppendStreamTask", { prompt: "hello", __cv: "1" });
       expect(cached).toBeDefined();
       expect((cached as any).text).toBe("cached result");
     });
@@ -276,7 +276,8 @@ describe("Streaming Cache Integration", () => {
       expect(replaceStreamCallCount).toBe(1);
       expect(result.text).toBe("complete result");
 
-      const cached = await cache.getOutput("CacheReplaceStreamTask", { prompt: "hello" });
+      // __cv is the cacheVersion sentinel injected by buildKey
+      const cached = await cache.getOutput("CacheReplaceStreamTask", { prompt: "hello", __cv: "1" });
       expect(cached).toBeDefined();
       expect((cached as any).text).toBe("complete result");
     });
@@ -351,9 +352,9 @@ describe("Streaming Cache Integration", () => {
       // Both should have been executed
       expect(appendStreamCallCount).toBe(2);
 
-      // Both should be cached
-      const cached1 = await cache.getOutput("CacheAppendStreamTask", { prompt: "hello" });
-      const cached2 = await cache.getOutput("CacheAppendStreamTask", { prompt: "world" });
+      // Both should be cached; __cv is the cacheVersion sentinel injected by buildKey
+      const cached1 = await cache.getOutput("CacheAppendStreamTask", { prompt: "hello", __cv: "1" });
+      const cached2 = await cache.getOutput("CacheAppendStreamTask", { prompt: "world", __cv: "1" });
       expect(cached1).toBeDefined();
       expect(cached2).toBeDefined();
     });

--- a/packages/test/src/test/task-graph-output-cache/genericTaskOutputRepositoryTests.ts
+++ b/packages/test/src/test/task-graph-output-cache/genericTaskOutputRepositoryTests.ts
@@ -108,4 +108,10 @@ export function runGenericTaskOutputRepositoryTests(
       expect(clearListener).toHaveBeenCalled();
     });
   });
+
+  describe("durability capability", () => {
+    it("reports isDurable() as a boolean", () => {
+      expect(typeof repository.isDurable()).toBe("boolean");
+    });
+  });
 }

--- a/packages/test/src/test/task-graph/CacheSerialization.test.ts
+++ b/packages/test/src/test/task-graph/CacheSerialization.test.ts
@@ -28,6 +28,10 @@ class SpyRepo extends TaskOutputRepository {
     return this.map.size;
   }
   async clearOlderThan(_ms: number): Promise<void> {}
+
+  isDurable(): boolean {
+    return false;
+  }
 }
 
 describe("TaskRunner cache port serialization", () => {
@@ -84,8 +88,8 @@ describe("TaskRunner cache port serialization", () => {
     }
 
     const repo = new SpyRepo();
-    // Seed cache with wire-format data directly
-    await repo.saveOutput("MyTask2", {}, { thing: { wire: { live: 99 } } });
+    // Seed cache with wire-format data directly; __cv is the cacheVersion sentinel injected by buildKey
+    await repo.saveOutput("MyTask2", { __cv: "1" }, { thing: { wire: { live: 99 } } });
 
     const t = new MyTask2();
     const result = await t.run({}, { outputCache: repo });

--- a/packages/test/src/test/task-graph/Dataflow.transforms.test.ts
+++ b/packages/test/src/test/task-graph/Dataflow.transforms.test.ts
@@ -10,6 +10,7 @@ import {
   TaskGraph,
   TaskStatus,
   registerBuiltInTransforms,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { globalServiceRegistry } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -102,7 +103,7 @@ describe("Dataflow.semanticallyCompatible with transforms", () => {
       static override readonly category = "Test";
       static override readonly title = "Src";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -128,7 +129,7 @@ describe("Dataflow.semanticallyCompatible with transforms", () => {
       static override readonly category = "Test";
       static override readonly title = "Tgt";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -170,7 +171,7 @@ describe("Dataflow.semanticallyCompatible with transforms", () => {
       static override readonly category = "Test";
       static override readonly title = "SrcX";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -190,7 +191,7 @@ describe("Dataflow.semanticallyCompatible with transforms", () => {
       static override readonly category = "Test";
       static override readonly title = "TgtX";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",

--- a/packages/test/src/test/task-graph/ProgressEvents.test.ts
+++ b/packages/test/src/test/task-graph/ProgressEvents.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { Task, TaskAbortedError, TaskStatus } from "@workglow/task-graph";
 import { sleep } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -14,7 +14,7 @@ type Out = { text: string };
 
 class CompletingTask extends Task<{}, Out> {
   public static override type = "ProgressEvents_Completing";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -36,7 +36,7 @@ class CompletingTask extends Task<{}, Out> {
 
 class FailingTask extends Task<{}, Out> {
   public static override type = "ProgressEvents_Failing";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -58,7 +58,7 @@ class FailingTask extends Task<{}, Out> {
 
 class HangingTask extends Task<{}, Out> {
   public static override type = "ProgressEvents_Hanging";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -131,7 +131,7 @@ describe("Progress events: terminal-100 tick", () => {
 
 class PhaseStreamTask extends Task<{}, { text: string }> {
   public static override type = "ProgressEvents_PhaseStream";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -208,7 +208,7 @@ describe("Progress events: streaming", () => {
   it("phase events do not flip status to STREAMING", async () => {
     class PhaseOnlyTask extends Task<{}, { text: string }> {
       public static override type = "ProgressEvents_PhaseOnly";
-      public static override cacheable = false;
+      public static override cachePolicy: CachePolicy = { kind: "none" };
       public static override inputSchema(): DataPortSchema {
         return {
           type: "object",

--- a/packages/test/src/test/task-graph/StreamingAccumulation.test.ts
+++ b/packages/test/src/test/task-graph/StreamingAccumulation.test.ts
@@ -24,7 +24,7 @@
  *  - Cache: auto-enables accumulation
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
 import {
   Dataflow,
   IExecuteContext,
@@ -54,7 +54,7 @@ type SimpleOutput = { text: string };
  */
 class AppendTask extends Task<SimpleInput, SimpleOutput> {
   public static override type = "AccumTest_AppendTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -94,7 +94,7 @@ class AppendTask extends Task<SimpleInput, SimpleOutput> {
  */
 class ReplaceWithTextDeltasTask extends Task<SimpleInput, SimpleOutput> {
   public static override type = "AccumTest_ReplaceWithTextDeltasTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -134,7 +134,7 @@ class ReplaceWithTextDeltasTask extends Task<SimpleInput, SimpleOutput> {
  */
 class StreamPassThroughTask extends Task<SimpleInput, SimpleOutput> {
   public static override type = "AccumTest_StreamPassThroughTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -170,7 +170,7 @@ class StreamPassThroughTask extends Task<SimpleInput, SimpleOutput> {
  */
 class SinkTask extends Task<SimpleInput, SimpleOutput> {
   public static override type = "AccumTest_SinkTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -307,7 +307,7 @@ describe("Source-task streaming accumulation", () => {
       // Task that produces both a text-delta field and other fields in finish
       class MixedFinishTask extends Task<SimpleInput, { text: string; lang: string }> {
         public static override type = "AccumTest_MixedFinishTask";
-        public static override cacheable = false;
+        public static override cachePolicy: CachePolicy = { kind: "none" };
 
         public static override inputSchema(): DataPortSchema {
           return {
@@ -520,8 +520,11 @@ describe("Source-task streaming accumulation", () => {
       const emittedFinishEvent = emittedFinish[0] as StreamFinish<{ text: string }>;
       expect(emittedFinishEvent.data.text).toBe("cached value");
 
-      // Cached output should contain the accumulated text
-      const cached = await cache.getOutput("AccumTest_CacheableAppendTask", { prompt: "test" });
+      // Cached output should contain the accumulated text; __cv is the cacheVersion sentinel
+      const cached = await cache.getOutput("AccumTest_CacheableAppendTask", {
+        prompt: "test",
+        __cv: "1",
+      });
       expect(cached).toBeDefined();
       expect(cached!.text).toBe("cached value");
     });

--- a/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
+++ b/packages/test/src/test/task-graph/StreamingBackpressure.test.ts
@@ -20,7 +20,7 @@
  *     downstream tasks from starting.
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
 import {
   Dataflow,
   IExecuteContext,
@@ -50,7 +50,7 @@ type TextOutput = { text: string };
  */
 class HighRateProducer extends Task<PromptInput, TextOutput> {
   public static override type = "StreamingBackpressure_HighRateProducer";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public totalEvents: number;
   public yieldCount = 0;
@@ -110,7 +110,7 @@ function expectedAccumulatedText(totalEvents: number): string {
  */
 class MaterialisedConsumer extends Task<{ text: string }, TextOutput> {
   public static override type = "StreamingBackpressure_MaterialisedConsumer";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -138,7 +138,7 @@ class MaterialisedConsumer extends Task<{ text: string }, TextOutput> {
  */
 class ErroringProducer extends Task<PromptInput, TextOutput> {
   public static override type = "StreamingBackpressure_ErroringProducer";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public preErrorEvents: number;
   public readonly errorMessage = "producer failed mid-stream";

--- a/packages/test/src/test/task-graph/TaskGraphRunner.previewSource.test.ts
+++ b/packages/test/src/test/task-graph/TaskGraphRunner.previewSource.test.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 Steven Roussey <sroussey@gmail.com>
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Task, TaskGraph, TaskRegistry } from "@workglow/task-graph";
+import { Task, TaskGraph, TaskRegistry, type CachePolicy } from "@workglow/task-graph";
 import {
   imageValueFromBuffer,
   registerPreviewResizeFn,
@@ -17,7 +17,7 @@ class TestImageSource extends Task<Record<string, unknown>, { image: ImageValue 
   public static override readonly category = "Test" as const;
   public static override readonly title = "TestImageSource";
   public static override readonly description = "";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema() {
     return { type: "object" as const, properties: {} } as any;
   }

--- a/packages/test/src/test/task-graph/TaskGraphRunner.transforms.test.ts
+++ b/packages/test/src/test/task-graph/TaskGraphRunner.transforms.test.ts
@@ -11,6 +11,7 @@ import {
   TaskGraphRunner,
   TaskStatus,
   registerBuiltInTransforms,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -26,7 +27,7 @@ describe("TaskGraphRunner applies transforms on edges", () => {
       static override readonly category = "Test";
       static override readonly title = "Src";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -53,7 +54,7 @@ describe("TaskGraphRunner applies transforms on edges", () => {
       static override readonly category = "Test";
       static override readonly title = "Tgt";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",

--- a/packages/test/src/test/task-graph/TaskGraphStreamEvents.test.ts
+++ b/packages/test/src/test/task-graph/TaskGraphStreamEvents.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent, TaskIdType } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent, TaskIdType } from "@workglow/task-graph";
 import { Dataflow, IExecuteContext, Task, TaskGraph, TaskGraphRunner } from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
@@ -20,7 +20,7 @@ type TextOutput = { text: string };
 
 class StreamSourceTask extends Task<TextInput, TextOutput> {
   public static override type = "StreamSourceTask_Events";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -55,7 +55,7 @@ class StreamSourceTask extends Task<TextInput, TextOutput> {
 
 class NonStreamTask extends Task<{ text: string }, TextOutput> {
   public static override type = "NonStreamTask_Events";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {

--- a/packages/test/src/test/task-graph/TaskGraphStreaming.test.ts
+++ b/packages/test/src/test/task-graph/TaskGraphStreaming.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
 import {
   Dataflow,
   getOutputStreamMode,
@@ -32,7 +32,7 @@ type TextOutput = { text: string };
  */
 class StreamSourceTask extends Task<TextInput, TextOutput> {
   public static override type = "StreamSourceTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -81,7 +81,7 @@ class StreamSourceTask extends Task<TextInput, TextOutput> {
  */
 class StreamConsumerTask extends Task<TextInput, TextOutput> {
   public static override type = "StreamConsumerTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -125,7 +125,7 @@ class StreamConsumerTask extends Task<TextInput, TextOutput> {
  */
 class NonStreamConsumerTask extends Task<TextInput, TextOutput> {
   public static override type = "NonStreamConsumerTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -159,7 +159,7 @@ class NonStreamConsumerTask extends Task<TextInput, TextOutput> {
  */
 class AppendEmptyFinishSource extends Task<TextInput, TextOutput> {
   public static override type = "AppendEmptyFinishSource";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -204,7 +204,7 @@ class AppendEmptyFinishSource extends Task<TextInput, TextOutput> {
  */
 class ReplaceSourceTask extends Task<TextInput, TextOutput> {
   public static override type = "ReplaceSourceTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -714,7 +714,7 @@ describe("TaskGraph Streaming", () => {
    */
   class RapidStreamTask extends Task<TextInput, TextOutput> {
     public static override type = "RapidStreamTask";
-    public static override cacheable = false;
+    public static override cachePolicy: CachePolicy = { kind: "none" };
 
     public static override inputSchema(): DataPortSchema {
       return {
@@ -757,7 +757,7 @@ describe("TaskGraph Streaming", () => {
    */
   class AlwaysFailTask extends Task<TextInput, TextOutput> {
     public static override type = "AlwaysFailTask";
-    public static override cacheable = false;
+    public static override cachePolicy: CachePolicy = { kind: "none" };
 
     public static override inputSchema(): DataPortSchema {
       return {

--- a/packages/test/src/test/task-graph/TimeoutAndErrorRouting.test.ts
+++ b/packages/test/src/test/task-graph/TimeoutAndErrorRouting.test.ts
@@ -17,6 +17,7 @@ import {
   TaskStatus,
   TaskTimeoutError,
   Workflow,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
@@ -33,7 +34,7 @@ import { getTestingLogger } from "../../binding/TestingLogger";
  */
 class SlowTask extends Task<{ input: number }, { output: number }> {
   static override readonly type = "SlowTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -77,7 +78,7 @@ class SlowTask extends Task<{ input: number }, { output: number }> {
  */
 class AlwaysFailTask extends Task<{ input: number }, { output: number }> {
   static override readonly type = "AlwaysFailTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -110,7 +111,7 @@ class AlwaysFailTask extends Task<{ input: number }, { output: number }> {
  */
 class ErrorRecoveryTask extends Task<Record<string, unknown>, { output: number }> {
   static override readonly type = "ErrorRecoveryTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -140,7 +141,7 @@ class ErrorRecoveryTask extends Task<Record<string, unknown>, { output: number }
  */
 class FailingRecoveryTask extends Task<Record<string, unknown>, { output: number }> {
   static override readonly type = "FailingRecoveryTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -170,7 +171,7 @@ class FailingRecoveryTask extends Task<Record<string, unknown>, { output: number
  */
 class DoubleTask extends Task<{ input: number }, { output: number }> {
   static override readonly type = "DoubleTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -202,7 +203,7 @@ class DoubleTask extends Task<{ input: number }, { output: number }> {
  */
 class InspectingRecoveryTask extends Task<Record<string, unknown>, { output: number }> {
   static override readonly type = "InspectingRecoveryTask";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
   public lastInput: Record<string, unknown> = {};
 
   static override inputSchema(): DataPortSchema {

--- a/packages/test/src/test/task-graph/Transforms.integration.test.ts
+++ b/packages/test/src/test/task-graph/Transforms.integration.test.ts
@@ -15,6 +15,7 @@ import {
   createGraphFromGraphJSON,
   registerBaseTasks,
   registerBuiltInTransforms,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { InputTask, OutputTask, registerCommonTasks } from "@workglow/tasks";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -73,7 +74,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "Src";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -94,7 +95,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "Tgt";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -139,7 +140,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "StreamSrc";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -170,7 +171,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "NonStreamTgt";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -210,7 +211,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "SrcRTF";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -231,7 +232,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "TgtRTF";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -269,7 +270,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "RTJSrc";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return { type: "object", properties: {} } as const satisfies DataPortSchema;
       }
@@ -290,7 +291,7 @@ describe("Transforms end-to-end", () => {
       static override readonly category = "Test";
       static override readonly title = "RTJTgt";
       static override readonly description = "";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",

--- a/packages/test/src/test/task-graph/Workflow.test.ts
+++ b/packages/test/src/test/task-graph/Workflow.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import {
   computeGraphInputSchema,
   CreateWorkflow,
@@ -1200,7 +1201,7 @@ type StreamRelayOutput = { text: string };
 
 class StreamRelayTask extends Task<StreamRelayInput, StreamRelayOutput> {
   public static override type = "StreamRelayTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {

--- a/packages/test/src/test/task-graph/WorkflowStreaming.test.ts
+++ b/packages/test/src/test/task-graph/WorkflowStreaming.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent, TaskIdType } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent, TaskIdType } from "@workglow/task-graph";
 import { Dataflow, IExecuteContext, Task, Workflow } from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
@@ -20,7 +20,7 @@ type TextOutput = { text: string };
 
 class WFStreamSource extends Task<TextInput, TextOutput> {
   public static override type = "WFStreamSource";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -55,7 +55,7 @@ class WFStreamSource extends Task<TextInput, TextOutput> {
 
 class WFNonStreamSink extends Task<{ text: string }, TextOutput> {
   public static override type = "WFNonStreamSink";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -176,7 +176,7 @@ describe("Workflow Streaming Events", () => {
 
     class FailingStreamTask extends Task<TextInput, TextOutput> {
       public static override type = "FailingStreamTask";
-      public static override cacheable = false;
+      public static override cachePolicy: CachePolicy = { kind: "none" };
 
       public static override inputSchema(): DataPortSchema {
         return {

--- a/packages/test/src/test/task-graph/runner-internals.test.ts
+++ b/packages/test/src/test/task-graph/runner-internals.test.ts
@@ -15,6 +15,7 @@ import {
   TaskGraphRunner,
   TaskRegistry,
   TaskStatus,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -26,7 +27,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 class RunnerInternalsSourceTask extends Task<{ value: string }, { value: string }> {
   public static override readonly type = "RunnerInternals_Source";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override readonly title = "Source";
   public static override readonly description = "Source";
   public static override inputSchema(): DataPortSchema {
@@ -49,7 +50,7 @@ class RunnerInternalsSourceTask extends Task<{ value: string }, { value: string 
 class RunnerInternalsSinkTask extends Task<{ value: string }, { result: string }> {
   public static override readonly type = "RunnerInternals_Sink";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override readonly title = "Sink";
   public static override readonly description = "Sink";
   public static override inputSchema(): DataPortSchema {

--- a/packages/test/src/test/task-graph/taskrunner-internals.test.ts
+++ b/packages/test/src/test/task-graph/taskrunner-internals.test.ts
@@ -11,6 +11,7 @@ import {
   Task,
   TaskRegistry,
   TaskRunContext,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { globalServiceRegistry } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -56,7 +57,7 @@ type AccumOutput = { text: string };
 class AccumStreamingTask extends Task<AccumInput, AccumOutput> {
   public static override readonly type = "TestAccumStreaming";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override readonly title = "Accum";
   public static override readonly description = "Accum";
   public static override inputSchema(): DataPortSchema {
@@ -87,7 +88,7 @@ type ReplaceOutput = { result: string };
 class ReplaceStreamingTask extends Task<ReplaceInput, ReplaceOutput> {
   public static override readonly type = "TestReplaceStreaming";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override readonly title = "Replace";
   public static override readonly description = "Replace";
   public static override inputSchema(): DataPortSchema {
@@ -189,7 +190,7 @@ class CacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
 class NonCacheableStreamingTask extends Task<CacheableInput, CacheableOutput> {
   public static override readonly type = "TestNonCacheableStreaming";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override readonly title = "NonCacheable";
   public static override readonly description = "NonCacheable";
   public static override inputSchema(): DataPortSchema {

--- a/packages/test/src/test/task-graph/workflow-internals.test.ts
+++ b/packages/test/src/test/task-graph/workflow-internals.test.ts
@@ -14,6 +14,7 @@ import {
   WorkflowBuilder,
   WorkflowEventBridge,
   runLoopAutoConnect,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { EventEmitter } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
@@ -26,7 +27,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 class WfInternalsSourceTask extends Task<{ value: string }, { value: string }> {
   public static override readonly type = "WfInternals_Source";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -47,7 +48,7 @@ class WfInternalsSourceTask extends Task<{ value: string }, { value: string }> {
 class WfInternalsSinkTask extends Task<{ value: string }, { result: string }> {
   public static override readonly type = "WfInternals_Sink";
   public static override readonly category = "Test";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
   public static override inputSchema(): DataPortSchema {
     return {
       type: "object",

--- a/packages/test/src/test/task/DebugLogTask.test.ts
+++ b/packages/test/src/test/task/DebugLogTask.test.ts
@@ -23,7 +23,7 @@ describe("DebugLogTask", () => {
   it("should have correct static properties", () => {
     expect(DebugLogTask.type).toBe("DebugLogTask");
     expect(DebugLogTask.category).toBe("Utility");
-    expect(DebugLogTask.cacheable).toBe(false);
+    expect(DebugLogTask.cachePolicy.kind).toBe("none");
     expect(DebugLogTask.passthroughInputsToOutputs).toBe(true);
   });
 

--- a/packages/test/src/test/task/FallbackTask.test.ts
+++ b/packages/test/src/test/task/FallbackTask.test.ts
@@ -14,6 +14,7 @@ import {
   TaskInput,
   TaskStatus,
   Workflow,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { setLogger, sleep } from "@workglow/util";
 import { DataPortSchema } from "@workglow/util/schema";
@@ -101,7 +102,7 @@ class ConditionalFailTask extends Task<{ value: number }, { result: number }> {
 
 class SlowSucceedingTask extends Task<{ value: number }, { result: number }> {
   public static override type = "FallbackTest_SlowSucceedingTask";
-  public static override readonly cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -357,7 +358,7 @@ describe("FallbackTask", () => {
       // we should see blended values between each pair of attempt markers.
       class MidProgressTask extends Task<{ value: number }, { result: number }> {
         public static override type = "FallbackTest_DataMidProgressTask";
-        public static override readonly cacheable = false;
+        public static override cachePolicy: CachePolicy = { kind: "none" };
 
         public static override inputSchema(): DataPortSchema {
           return {

--- a/packages/test/src/test/task/GraphAsTask.test.ts
+++ b/packages/test/src/test/task/GraphAsTask.test.ts
@@ -12,6 +12,7 @@ import {
   Task,
   TaskGraph,
   Workflow,
+  type CachePolicy,
 } from "@workglow/task-graph";
 import { InputTask, OutputTask } from "@workglow/tasks";
 import { Container, ServiceRegistry, setLogger, sleep } from "@workglow/util";
@@ -633,7 +634,7 @@ describe("GraphAsTask Dynamic Schema", () => {
       // graph, so the activity row was stuck on the stale "Map 22/22" message.
       class MidProgressTask extends Task<{ value: number }, { result: number }> {
         public static override type = "GraphAsTaskTest_MidProgressTask";
-        public static override readonly cacheable = false;
+        public static override cachePolicy: CachePolicy = { kind: "none" };
 
         public static override inputSchema(): DataPortSchema {
           return {
@@ -715,7 +716,7 @@ describe("GraphAsTask Dynamic Schema", () => {
     it("outer graph_progress does not stick on 'Map N/N' while a slow GraphAsTask runs", async () => {
       class EmbedStepTask extends Task<{ value: number }, { embedded: number }> {
         public static override type = "GraphAsTaskTest_EmbedStepTask";
-        public static override readonly cacheable = false;
+        public static override cachePolicy: CachePolicy = { kind: "none" };
 
         public static override inputSchema(): DataPortSchema {
           return {
@@ -748,7 +749,7 @@ describe("GraphAsTask Dynamic Schema", () => {
 
       class MultiplyTask extends Task<{ item: number }, { item: number }> {
         public static override type = "GraphAsTaskTest_MultiplyTask";
-        public static override readonly cacheable = false;
+        public static override cachePolicy: CachePolicy = { kind: "none" };
 
         public static override inputSchema(): DataPortSchema {
           return {

--- a/packages/test/src/test/task/ImageCacheRoundTrip.test.ts
+++ b/packages/test/src/test/task/ImageCacheRoundTrip.test.ts
@@ -34,6 +34,10 @@ class MapRepo extends TaskOutputRepository {
   }
 
   async clearOlderThan(_olderThanInMs: number): Promise<void> {}
+
+  isDurable(): boolean {
+    return false;
+  }
 }
 
 function makeImageValue(bytes: number[]): ImageValue {

--- a/packages/test/src/test/task/ImageFilterTask.test.ts
+++ b/packages/test/src/test/task/ImageFilterTask.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type IExecuteContext, type IExecutePreviewContext } from "@workglow/task-graph";
+import { type IExecuteContext, type IExecutePreviewContext, type CachePolicy } from "@workglow/task-graph";
 import { ImageFilterTask, type ImageFilterInput, type ImageFilterOutput } from "@workglow/tasks";
 import {
   CpuImage,
@@ -69,7 +69,7 @@ interface BumpInput extends ImageFilterInput, Record<string, unknown> {
 class BumpTask extends ImageFilterTask<BumpParams, BumpInput> {
   static override readonly type = "BumpTask";
   static override readonly category = "Image";
-  static override readonly cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
   static override inputSchema(): DataPortSchema {
     return {
       type: "object",
@@ -125,7 +125,7 @@ describe("ImageFilterTask", () => {
     class Capture extends ImageFilterTask<BumpParams, BumpInput> {
       static override readonly type = "CaptureTask";
       static override readonly category = "Image";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -172,7 +172,7 @@ describe("ImageFilterTask scalePreviewParams hook", () => {
     class ScaleAwareTask extends ImageFilterTask<{ radius: number }, ScaleInput> {
       static override readonly type = "ScaleAwareTask";
       static override readonly category = "Image";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",
@@ -216,7 +216,7 @@ describe("ImageFilterTask scalePreviewParams hook", () => {
     class ScaleTask extends ImageFilterTask<{ radius: number }, ScaleInput> {
       static override readonly type = "ScalePassthroughTask";
       static override readonly category = "Image";
-      static override readonly cacheable = false;
+      static override cachePolicy: CachePolicy = { kind: "none" };
       static override inputSchema(): DataPortSchema {
         return {
           type: "object",

--- a/packages/test/src/test/task/InputOutputTask.test.ts
+++ b/packages/test/src/test/task/InputOutputTask.test.ts
@@ -18,7 +18,7 @@ describe("InputTask", () => {
     expect(InputTask.type).toBe("InputTask");
     expect(InputTask.category).toBe("Flow Control");
     expect(InputTask.hasDynamicSchemas).toBe(true);
-    expect(InputTask.cacheable).toBe(false);
+    expect(InputTask.cachePolicy.kind).toBe("none");
     // Must be marked passthrough so it is excluded from graph-level progress averaging.
     expect(InputTask.isPassthrough).toBe(true);
   });
@@ -52,7 +52,7 @@ describe("OutputTask", () => {
     expect(OutputTask.type).toBe("OutputTask");
     expect(OutputTask.category).toBe("Flow Control");
     expect(OutputTask.hasDynamicSchemas).toBe(true);
-    expect(OutputTask.cacheable).toBe(false);
+    expect(OutputTask.cachePolicy.kind).toBe("none");
     // Must be marked passthrough so it is excluded from graph-level progress averaging.
     expect(OutputTask.isPassthrough).toBe(true);
   });

--- a/packages/test/src/test/task/TaskRunnerStreaming.test.ts
+++ b/packages/test/src/test/task/TaskRunnerStreaming.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StreamEvent } from "@workglow/task-graph";
+import type { CachePolicy, StreamEvent } from "@workglow/task-graph";
 import {
   IExecuteContext,
   IRunConfig,
@@ -113,7 +113,7 @@ class TestStreamingReplaceTask extends Task<StreamTestInput, StreamTestOutput> {
  */
 class TestStreamingErrorTask extends Task<StreamTestInput, StreamTestOutput> {
   public static override type = "TestStreamingErrorTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -152,7 +152,7 @@ class TestStreamingErrorTask extends Task<StreamTestInput, StreamTestOutput> {
  */
 class TestStreamingAbortableTask extends Task<StreamTestInput, StreamTestOutput> {
   public static override type = "TestStreamingAbortableTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -199,7 +199,7 @@ type CodeTestOutput = { code: string };
 
 class TestStreamingCodeAppendTask extends Task<CodeTestInput, CodeTestOutput> {
   public static override type = "TestStreamingCodeAppendTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -255,7 +255,7 @@ type ToolCallOutput = { toolCalls: ToolCallItem[] };
  */
 class TestStreamingToolCallTask extends Task<ToolCallInput, ToolCallOutput> {
   public static override type = "TestStreamingToolCallTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -314,7 +314,7 @@ type StructuredOutput = { result: Record<string, unknown> };
 
 class TestStreamingStructuredTask extends Task<StructuredInput, StructuredOutput> {
   public static override type = "TestStreamingStructuredTask";
-  public static override cacheable = false;
+  public static override cachePolicy: CachePolicy = { kind: "none" };
 
   public static override inputSchema(): DataPortSchema {
     return {
@@ -435,7 +435,7 @@ describe("TaskRunner Streaming", () => {
       expect(result.text).toBe("Hello world");
 
       // Verify it was actually cached
-      const cached = await cache.getOutput("TestStreamingAppendTask", { prompt: "test" });
+      const cached = await cache.getOutput("TestStreamingAppendTask", { prompt: "test", __cv: "1" });
       expect(cached).toBeDefined();
       expect((cached as any)?.text).toBe("Hello world");
     });
@@ -559,7 +559,7 @@ describe("TaskRunner Streaming", () => {
 
       await task.run({ prompt: "test" });
 
-      const cached = await cache.getOutput("TestStreamingReplaceTask", { prompt: "test" });
+      const cached = await cache.getOutput("TestStreamingReplaceTask", { prompt: "test", __cv: "1" });
       expect(cached).toBeDefined();
       expect((cached as any)?.text).toBe("Bonjour le monde");
     });

--- a/packages/test/src/test/task/TestTasks.ts
+++ b/packages/test/src/test/task/TestTasks.ts
@@ -10,6 +10,7 @@
  * of different task behaviors like error handling and progress reporting.
  */
 
+import type { CachePolicy } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   GraphAsTask,
@@ -1825,7 +1826,7 @@ export class GraphAsTask_InputTask extends Task<Record<string, unknown>, Record<
   static override type = "GraphAsTask_InputTask";
   static override category = "Test";
   static override hasDynamicSchemas = true;
-  static override cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -1858,7 +1859,7 @@ export class GraphAsTask_InputTask extends Task<Record<string, unknown>, Record<
 export class GraphAsTask_ComputeTask extends Task<{ a: number; b: number }, { result: number }> {
   static override type = "GraphAsTask_ComputeTask";
   static override category = "Test";
-  static override cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {
@@ -2100,7 +2101,7 @@ export class GraphAsTask_TaskC extends Task {
 export class GraphAsTask_OutputTask extends Task<Record<string, unknown>, Record<string, unknown>> {
   static override type = "GraphAsTask_OutputTask";
   static override category = "Test";
-  static override cacheable = false;
+  static override cachePolicy: CachePolicy = { kind: "none" };
 
   static override inputSchema(): DataPortSchema {
     return {

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -58,6 +58,7 @@ function shouldLimitParallelismForHeavyIntegration(files: string[]): boolean {
 const SECTION_DIRS: Record<Section, string[]> = {
   graph: [
     join(TEST_BASE, "task-graph"),
+    join(TEST_BASE, "task-graph-cache"),
     join(TEST_BASE, "task-graph-job-queue"),
     join(TEST_BASE, "task-graph-output-cache"),
     join(TEST_BASE, "task-graph-storage"),


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive caching system for task-graph that supports multiple cache policies (deterministic, private, none) and run-scoped cache isolation. Tasks can now declare their cacheability semantics, and the graph runner routes cache operations to appropriate backends via a `CacheRegistry`. Run-private caches are automatically cleaned up after successful runs and support restart-survival for failed runs.

## Key Changes

### New Cache Infrastructure
- **`CachePolicy`** type system: `{ kind: "deterministic" | "private" | "none" }` with helper functions `isPolicyCached()` and `isPolicyPrivate()`
- **`CacheRegistry`** interface and `DefaultCacheRegistry` implementation: two-slot registry for deterministic and private cache backends
- **`RunPrivateCacheRepo`**: wraps a `TaskOutputRepository` to namespace entries by `runId`, enabling per-run isolation while supporting restart-survival
- **`CacheJanitor`**: utility for sweeping stale run-private entries older than a configurable threshold

### Task-Level Cache Control
- **`Task.cachePolicy`** static property: replaces the deprecated `cacheable` boolean with explicit policy declaration
- **`Task.version`** static property: version number for cache invalidation when task implementation changes
- **`Task.getCachePolicy(inputs)`**: instance method allowing dynamic policy selection based on inputs (e.g., image generation with/without seed)
- **Deprecation warning**: `cacheable = false` now warns once per task type, directing users to `cachePolicy: { kind: "none" }`

### TaskRunner & TaskGraphRunner Integration
- **`TaskRunner`**: resolves `CACHE_REGISTRY` from `ServiceRegistry` in `handleStart()`, routes cache operations via `CacheCoordinator.buildKeyForPolicy()` and `saveByPolicy()`
- **`TaskGraphRunner`**:
  - Accepts `runId` in `TaskGraphRunConfig`
  - Creates `RunPrivateCacheRepo` wrapper when both `runId` and private cache slot are present
  - Awaits `RunPrivateCacheRepo.clearRun()` (`TaskGraphRunner.ts:270`) so a same-runId restart cannot race against deletions — see commit `fd3724b2`
  - Threads `runId` through `StreamPump` into each task's `IRunConfig`
- **`CacheCoordinator`**: injects `__cv` (cache version) sentinel into normalized inputs before fingerprinting, ensuring version bumps invalidate cached outputs

### Missing-runId Policy (added in follow-up PR #517)
The `private` cache policy cannot be safely applied without a `runId` — writes would land in the shared private repo and collide across runs. The follow-up adopts a hybrid:
- **`TaskGraphRunner`**: throws `TaskConfigurationError` if the graph contains a private-policy task but no `runId` is provided. The graph runner is the documented owner of `runId`.
- **Standalone `TaskRunner`**: warns once per task type and locally degrades the policy to `{ kind: "none" }`. Callers using `TaskRunner` directly may not know about `runId`; degrading gracefully is more useful than throwing.

### Durability Warnings
- **`TaskOutputRepository.isDurable()`**: new method (default `true`) for backends to declare durability
- **`TaskGraphRunner`**: warns once per non-durable private repo (rate-limited via WeakSet, see PR #517) if a task with `kind: "private"` policy is routed to a non-durable repository (e.g., in-memory), since private cache entries would be lost on restart

### Test Coverage
- **`CachePolicy.test.ts`**: policy type and helper functions
- **`CacheRegistry.test.ts`**: registry slot management
- **`CacheCoordinatorKey.test.ts`**: version injection and cache invalidation
- **`CacheCoordinatorPolicy.test.ts`**: policy-based routing to deterministic vs. private slots
- **`RunPrivateCacheRepo.test.ts`**: namespacing and restart-survival
- **`TaskGraphRunnerPrivate.test.ts`**: run-private cache reuse across restarts
- **`TaskGraphRunnerCleanup.test.ts`**: cleanup on success, survival on failure
- **`TaskGraphRunnerDurabilityWarning.test.ts`**: durability warnings for non-durable private repos
- **`TaskRunnerRouting.test.ts`**: cache routing via `CacheRegistry`
- **`CacheableDeprecation.test.ts`**: deprecation warning for legacy `cacheable = false`
- **`CacheJanitor.test.ts`**: stale entry sweeping
- **`TaskCacheVersion.test.ts`**: version string composition from class hierarchy
- **`AiImageOutputTaskCachePolicy.test.ts`**: dynamic policy for image tasks (deterministic with seed, private without)

### Backward Compatibility
- Legacy `outputCache` parameter in `IRun

https://claude.ai/code/session_016ciJC1fH5gmmz8G3Jno1hX