### PR TITLE
fix(task-graph): cache policy routing follow-ups (#515)

### DIFF
--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -159,6 +159,7 @@ export class TaskGraphRunner {
    * run. Used to fire-and-forget clearRun() after a successful run.
    */
   protected currentRunPrivate?: RunPrivateCacheRepo;
+  protected baseRegistryForRun?: ServiceRegistry;
 
   /**
    * Edge materializer — owns dataflow read/write, transforms, and error-port routing.
@@ -650,6 +651,7 @@ export class TaskGraphRunner {
     if (config?.resourceScope !== undefined) {
       this.resourceScope = config.resourceScope;
     }
+    this.baseRegistryForRun = this.registry;
 
     // Store run identifier for per-task propagation.
     this.runId = config?.runId;
@@ -877,6 +879,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("complete");
   }
@@ -909,6 +915,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("error", error);
   }
@@ -947,6 +957,10 @@ export class TaskGraphRunner {
     }
     ctx?.dispose();
     this.currentCtx = undefined;
+    if (this.baseRegistryForRun !== undefined) {
+      this.registry = this.baseRegistryForRun;
+      this.baseRegistryForRun = undefined;
+    }
 
     this.graph.emit("abort");
   }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -16,12 +16,8 @@ import {
   SpanStatusCode,
   uuid4,
 } from "@workglow/util";
+import { CACHE_REGISTRY, DefaultCacheRegistry, RunPrivateCacheRepo } from "../cache";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
-import {
-  CACHE_REGISTRY,
-  DefaultCacheRegistry,
-  RunPrivateCacheRepo,
-} from "../cache";
 import { ENTITLEMENT_ENFORCER, formatEntitlementDenial } from "../task/EntitlementEnforcer";
 import { ITask } from "../task/ITask";
 import { isTaskStreamable } from "../task/StreamTypes";
@@ -601,6 +597,37 @@ export class TaskGraphRunner {
   }
 
   /**
+   * Conservative two-tier detector that decides whether a graph may route any
+   * task to the `private` cache slot. Used by the `runId`-required guard in
+   * {@link handleStart}.
+   *
+   * 1. Read the static `cachePolicy` off the task's constructor. If `kind` is
+   *    "private", the task is definitely private.
+   * 2. Otherwise, if the task overrides `getCachePolicy` (i.e. its prototype's
+   *    method is not `Task.prototype.getCachePolicy`), conservatively treat it
+   *    as potentially private — the override may decide based on inputs that
+   *    are not available at graph-start time.
+   *
+   * Note: probing `getCachePolicy({} as any)` is unsafe because input-dependent
+   * overrides can throw or return the wrong branch when given empty inputs.
+   */
+  public static graphUsesPrivatePolicy(graph: TaskGraph): boolean {
+    return graph.getTasks().some((t) => {
+      const ctor = t.constructor as typeof Task;
+      if (ctor.cachePolicy?.kind === "private") return true;
+      // Override detection: prototype method differs from Task.prototype's.
+      const proto = ctor.prototype as { getCachePolicy?: unknown };
+      if (
+        typeof proto.getCachePolicy === "function" &&
+        proto.getCachePolicy !== Task.prototype.getCachePolicy
+      ) {
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /**
    * Handles the start of task graph execution
    * @param parentSignal Optional abort signal from parent
    */
@@ -636,6 +663,19 @@ export class TaskGraphRunner {
           getLogger().warn(
             "TaskGraphRunner: private cache is non-durable — restart-survival will not work. " +
               "Configure a durable storage backend for the CacheRegistry 'private' slot."
+          );
+        }
+      }
+
+      // Strict guard: if the graph contains a private-policy task but no runId
+      // was provided, we cannot namespace writes — they would land directly in
+      // the shared private repo and collide across runs. TaskGraphRunner is the
+      // documented owner of runId, so this is a configuration error.
+      if (!this.runId && checkRegistry.private) {
+        if (TaskGraphRunner.graphUsesPrivatePolicy(this.graph)) {
+          throw new TaskConfigurationError(
+            "TaskGraphRunner: graph contains a private-policy task but no runId was provided. " +
+              "Provide `runId` in TaskGraphRunConfig so private cache entries can be namespaced."
           );
         }
       }

--- a/packages/task-graph/src/task-graph/TaskGraphRunner.ts
+++ b/packages/task-graph/src/task-graph/TaskGraphRunner.ts
@@ -597,9 +597,18 @@ export class TaskGraphRunner {
   }
 
   /**
+   * Tracks private cache repos that have already received the durability warning,
+   * keyed by the repo instance. WeakSet so a freshly constructed repo that is no
+   * longer referenced is automatically eligible for re-warning if it shows up
+   * again later. Static because routing is repo-instance scoped, not runner
+   * scoped — a process can have one durable repo and many `TaskGraphRunner`s.
+   */
+  private static __durabilityWarnedRepos = new WeakSet<object>();
+
+  /**
    * Conservative two-tier detector that decides whether a graph may route any
-   * task to the `private` cache slot. Used by the `runId`-required guard in
-   * {@link handleStart}.
+   * task to the `private` cache slot. Used by both the durability warning and
+   * the `runId`-required guard in {@link handleStart}.
    *
    * 1. Read the static `cachePolicy` off the task's constructor. If `kind` is
    *    "private", the task is definitely private.
@@ -645,25 +654,25 @@ export class TaskGraphRunner {
     // Store run identifier for per-task propagation.
     this.runId = config?.runId;
 
-    // Warn once per run when a non-durable private cache slot is registered and
-    // at least one task in the graph routes to the private slot. This catches the
+    // Warn once per non-durable private repo (across runs) when at least one
+    // task in the graph routes to the private slot. This catches the
     // dev-mode-in-production misconfiguration where an in-memory store is wired
-    // for convenience but restart-survival is expected.
+    // for convenience but restart-survival is expected. Rate-limited via a
+    // WeakSet keyed by the repo instance so repeated `runGraph` calls against
+    // the same registry do not flood the log.
     if (this.registry.has(CACHE_REGISTRY)) {
       const checkRegistry = this.registry.get(CACHE_REGISTRY);
       if (checkRegistry.private && !checkRegistry.private.isDurable()) {
-        const usesPrivate = this.graph.getTasks().some((t) => {
-          try {
-            return (t as Task).getCachePolicy({} as any).kind === "private";
-          } catch {
-            return false;
+        if (TaskGraphRunner.graphUsesPrivatePolicy(this.graph)) {
+          const repo = checkRegistry.private as object;
+          if (!TaskGraphRunner.__durabilityWarnedRepos.has(repo)) {
+            TaskGraphRunner.__durabilityWarnedRepos.add(repo);
+            getLogger().warn(
+              "TaskGraphRunner: private cache repo may be used but is non-durable — " +
+                "restart-survival will not work. Ensure the CacheRegistry 'private' " +
+                "slot is backed by a durable storage backend."
+            );
           }
-        });
-        if (usesPrivate) {
-          getLogger().warn(
-            "TaskGraphRunner: private cache is non-durable — restart-survival will not work. " +
-              "Configure a durable storage backend for the CacheRegistry 'private' slot."
-          );
         }
       }
 

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -5,10 +5,10 @@
  */
 
 import type { ServiceRegistry } from "@workglow/util";
-import { type CachePolicy, DEFAULT_CACHE_POLICY } from "../cache/CachePolicy";
 import { deepEqual, EventEmitter, getLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
+import { type CachePolicy, DEFAULT_CACHE_POLICY } from "../cache/CachePolicy";
 import { DATAFLOW_ALL_PORTS } from "../task-graph/Dataflow";
 import { TaskGraph } from "../task-graph/TaskGraph";
 import type { IExecuteContext, IExecutePreviewContext, IRunConfig, ITask } from "./ITask";
@@ -388,8 +388,7 @@ export class Task<
   public getCachePolicy(_inputs: Input): CachePolicy {
     const ctor = this.constructor as typeof Task;
     const hasLegacyOverride =
-      Object.prototype.hasOwnProperty.call(ctor, "cacheable") &&
-      (ctor as any).cacheable === false;
+      Object.prototype.hasOwnProperty.call(ctor, "cacheable") && (ctor as any).cacheable === false;
     const hasPolicyOverride = Object.prototype.hasOwnProperty.call(ctor, "cachePolicy");
 
     if (hasLegacyOverride && !hasPolicyOverride) {
@@ -542,6 +541,24 @@ export class Task<
 
     // Store runtime configuration
     this.runConfig = runConfig;
+
+    // Reject input schemas that declare a `__cv` port: this name is reserved by
+    // CacheCoordinator.buildKey for the cache version sentinel. Allowing a task
+    // to declare it would silently shadow cache versioning and cause cache
+    // collisions across versions. `inputSchema()` can legally return a boolean
+    // (see addInput/setInput handling); skip the check in that case.
+    const inputSchema = (this.constructor as typeof Task).inputSchema();
+    if (
+      inputSchema &&
+      typeof inputSchema !== "boolean" &&
+      inputSchema.properties &&
+      Object.prototype.hasOwnProperty.call(inputSchema.properties, "__cv")
+    ) {
+      throw new TaskConfigurationError(
+        `Task "${(this.constructor as typeof Task).type}": input port name '__cv' is reserved ` +
+          `for cache versioning. Rename the port to avoid collision with the cache key sentinel.`
+      );
+    }
   }
 
   // ========================================================================

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -233,8 +233,9 @@ export class TaskRunner<
             TaskRunner.__privateWithoutRunIdWarned.add(taskType);
             getLogger().warn(
               `TaskRunner: task "${taskType}" has a private cache policy but no runId was ` +
-                `provided. Private cache writes are skipped for this run — run via TaskGraphRunner ` +
-                `or pass a runId in IRunConfig to enable run-namespaced private caching.`
+                `provided. Private cache writes are skipped for this run — use TaskGraphRunner ` +
+                `with runId for run-namespaced private caching, or provide an already namespaced ` +
+                `private cache repo in CACHE_REGISTRY.`
             );
           }
           policy = { kind: "none" };

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -12,12 +12,8 @@ import {
   ServiceRegistry,
   SpanStatusCode,
 } from "@workglow/util";
+import { CACHE_REGISTRY, DefaultCacheRegistry, type CacheRegistry } from "../cache";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
-import {
-  CACHE_REGISTRY,
-  DefaultCacheRegistry,
-  type CacheRegistry,
-} from "../cache";
 import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";
 import { CacheCoordinator } from "./CacheCoordinator";
@@ -133,6 +129,13 @@ export class TaskRunner<
   protected runId?: string;
 
   /**
+   * Tracks task types that have already received the "private policy without
+   * runId" downgrade warning, so the warning fires only once per task type
+   * across the process lifetime. Mirrors {@link Task.__cacheableDeprecationWarned}.
+   */
+  private static __privateWithoutRunIdWarned = new Set<string>();
+
+  /**
    * Constructor for TaskRunner
    * @param task The task to run
    */
@@ -216,7 +219,27 @@ export class TaskRunner<
           }
         }
 
-        const policy = this.task.getCachePolicy(inputs);
+        let policy = this.task.getCachePolicy(inputs);
+
+        // Standalone TaskRunner cannot namespace private cache writes without a
+        // runId — TaskGraphRunner owns the wrap. If a standalone caller routes
+        // to the private slot with no runId, downgrade to `kind: "none"` so the
+        // task does not write directly into the shared private repo (which
+        // would collide across callers). Warn once per task type so the
+        // configuration mistake surfaces without flooding the log.
+        if (policy.kind === "private" && !this.runId && this.cacheRegistry?.private !== undefined) {
+          const taskType = this.task.type;
+          if (!TaskRunner.__privateWithoutRunIdWarned.has(taskType)) {
+            TaskRunner.__privateWithoutRunIdWarned.add(taskType);
+            getLogger().warn(
+              `TaskRunner: task "${taskType}" has a private cache policy but no runId was ` +
+                `provided. Private cache writes are skipped for this run — run via TaskGraphRunner ` +
+                `or pass a runId in IRunConfig to enable run-namespaced private caching.`
+            );
+          }
+          policy = { kind: "none" };
+        }
+
         const keyInputs = await this.cacheCoordinator.buildKeyForPolicy(
           inputs,
           this.cacheRegistry,

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -12,7 +12,8 @@ import {
   ServiceRegistry,
   SpanStatusCode,
 } from "@workglow/util";
-import { CACHE_REGISTRY, DefaultCacheRegistry, type CacheRegistry } from "../cache";
+import { CACHE_REGISTRY, DefaultCacheRegistry } from "../cache";
+import type { CacheRegistry } from "../cache";
 import { TASK_OUTPUT_REPOSITORY, TaskOutputRepository } from "../storage/TaskOutputRepository";
 import type { Taskish } from "../task-graph/Conversions";
 import { ensureTask } from "../task-graph/Conversions";

--- a/packages/test/src/test/task-graph-cache/PrivateRequiresRunId.test.ts
+++ b/packages/test/src/test/task-graph-cache/PrivateRequiresRunId.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  Task,
+  TaskConfigurationError,
+  TaskGraph,
+  type CachePolicy,
+} from "@workglow/task-graph";
+import { Container, ResourceScope, ServiceRegistry, getLogger, setLogger } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
+
+class PrivatePolicyTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "PrivateRunIdTask";
+  public static override cachePolicy: CachePolicy = { kind: "private" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: `done:${input.q}` };
+  }
+}
+
+class DeterministicTask extends Task<{ q: string }, { r: string }> {
+  public static override type = "DeterministicRunIdTask";
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+      required: ["q"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        r: { type: "string" },
+      },
+      required: ["r"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public override async execute(input: { q: string }): Promise<{ r: string }> {
+    return { r: `det:${input.q}` };
+  }
+}
+
+async function freshPrivateRepo(): Promise<InMemoryTaskOutputRepository> {
+  const r = new InMemoryTaskOutputRepository();
+  await (r as any).setupDatabase?.();
+  return r;
+}
+
+function freshServices(privateRepo: InMemoryTaskOutputRepository): ServiceRegistry {
+  const services = new ServiceRegistry(new Container());
+  services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: privateRepo }));
+  return services;
+}
+
+describe("private cache policy requires a runId", () => {
+  let originalLogger: ReturnType<typeof getLogger>;
+  let warnings: string[];
+
+  beforeEach(() => {
+    originalLogger = getLogger();
+    warnings = [];
+    setLogger({
+      debug: () => {},
+      info: () => {},
+      warn: (msg: unknown) => warnings.push(String(msg)),
+      error: () => {},
+    } as any);
+  });
+
+  afterEach(() => {
+    setLogger(originalLogger);
+  });
+
+  it("TaskRunner standalone: private-policy task with no runId logs warn-once and does not write to shared private repo", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    // Two distinct tasks of the same type, run with no runId — only the first
+    // call should emit the warning (warn-once-per-task-type).
+    const t1 = new PrivatePolicyTask({ defaults: { q: "hello" } } as any);
+    const t2 = new PrivatePolicyTask({ defaults: { q: "world" } } as any);
+
+    await t1.run({}, { registry: services });
+    await t2.run({}, { registry: services });
+
+    // The private repo must be untouched — without a runId the task should
+    // skip caching entirely rather than colliding in the shared namespace.
+    const stored = await backing.getOutput(PrivatePolicyTask.type, { q: "hello", __cv: "1" });
+    expect(stored).toBeUndefined();
+
+    const matches = warnings.filter(
+      (w) => w.includes("private cache policy") && w.includes(PrivatePolicyTask.type)
+    );
+    expect(matches.length).toBe(1);
+  });
+
+  it("TaskGraphRunner: graph with private-policy task and no runId throws TaskConfigurationError", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    const g = new TaskGraph();
+    g.addTask(new PrivatePolicyTask({ defaults: { q: "hello" } } as any));
+
+    await expect(
+      g.run({}, { registry: services, resourceScope: new ResourceScope() })
+    ).rejects.toBeInstanceOf(TaskConfigurationError);
+  });
+
+  it("TaskGraphRunner: graph with no private-policy task and no runId runs normally", async () => {
+    const backing = await freshPrivateRepo();
+    const services = freshServices(backing);
+
+    const g = new TaskGraph();
+    g.addTask(new DeterministicTask({ defaults: { q: "hello" } } as any));
+
+    // Should not throw despite missing runId, because no task routes to private.
+    await expect(
+      g.run({}, { registry: services, resourceScope: new ResourceScope() })
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/test/src/test/task-graph-cache/TaskCacheVersion.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskCacheVersion.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Task } from "@workglow/task-graph";
+import { Task, TaskConfigurationError } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 
 describe("Task.getCacheVersion", () => {
@@ -32,5 +33,43 @@ describe("Task.getCacheVersion", () => {
 
   it("defaults to '1' when no subclass overrides", () => {
     expect(new Task().getCacheVersion()).toBe("1");
+  });
+});
+
+describe("__cv reserved input port name", () => {
+  it("rejects construction of a Task whose inputSchema declares __cv", () => {
+    class BadTask extends Task {
+      public static override type = "BadCvTask";
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            __cv: { type: "string" },
+            other: { type: "string" },
+          },
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+    }
+
+    expect(() => new BadTask()).toThrow(TaskConfigurationError);
+    expect(() => new BadTask()).toThrow(/__cv/);
+  });
+
+  it("permits construction when __cv is absent", () => {
+    class OkTask extends Task {
+      public static override type = "OkCvTask";
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+          },
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+    }
+
+    expect(() => new OkTask()).not.toThrow();
   });
 });

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
@@ -189,6 +189,21 @@ describe("TaskGraphRunner durability warning", () => {
     expect(matches.length).toBe(2);
   });
 
+  it("restores registry between runs to avoid nested RunPrivateCacheRepo wrappers", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new PrivTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "wrap-a", registry: services, resourceScope: new ResourceScope() });
+    await g.run({}, { runId: "wrap-b", resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("RunPrivateCacheRepo.clearRun failed"))).toBe(false);
+  });
+
   it("warns when task declares static cachePolicy:'private' even if getCachePolicy returns 'deterministic' for empty inputs", async () => {
     class TrickyTask extends Task<{ q: string }, { r: string }> {
       public static override type = "TrickyPrivateForEmpty";

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
@@ -9,9 +9,9 @@ import {
   DefaultCacheRegistry,
   Task,
   TaskGraph,
-  type CachePolicy,
 } from "@workglow/task-graph";
 import { Container, ResourceScope, ServiceRegistry, getLogger, setLogger } from "@workglow/util";
+import type { CachePolicy } from "@workglow/task-graph";
 import type { DataPortSchema } from "@workglow/util/schema";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";

--- a/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
+++ b/packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
-  Task,
-  TaskGraph,
   CACHE_REGISTRY,
   DefaultCacheRegistry,
+  Task,
+  TaskGraph,
   type CachePolicy,
 } from "@workglow/task-graph";
 import { Container, ResourceScope, ServiceRegistry, getLogger, setLogger } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { InMemoryTaskOutputRepository } from "../../binding/InMemoryTaskOutputRepository";
 
 class PrivTask extends Task<{ q: string }, { r: string }> {
@@ -142,5 +142,156 @@ describe("TaskGraphRunner durability warning", () => {
     await g.run({}, { runId: "warn-3", registry: services, resourceScope: new ResourceScope() });
 
     expect(messages.some((m) => m.includes("non-durable"))).toBe(false);
+  });
+
+  it("emits durability warning only once per private repo across multiple runGraph calls", async () => {
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    // Three runs against the same non-durable private repo. The warning must
+    // fire on the first run only — subsequent runs hit the WeakSet rate-limit.
+    for (let i = 0; i < 3; i++) {
+      const g = new TaskGraph();
+      g.addTask(new PrivTask({ defaults: { q: `hello-${i}` } } as any));
+      await g.run(
+        {},
+        { runId: `rate-${i}`, registry: services, resourceScope: new ResourceScope() }
+      );
+    }
+
+    const matches = messages.filter((m) => m.includes("non-durable"));
+    expect(matches.length).toBe(1);
+  });
+
+  it("emits a fresh warning for a different repo instance", async () => {
+    // First repo — should warn once.
+    const backingA = new InMemoryTaskOutputRepository();
+    await (backingA as any).setupDatabase?.();
+    const servicesA = new ServiceRegistry(new Container());
+    servicesA.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backingA }));
+    const gA = new TaskGraph();
+    gA.addTask(new PrivTask({ defaults: { q: "a" } } as any));
+    await gA.run({}, { runId: "ra", registry: servicesA, resourceScope: new ResourceScope() });
+
+    // Second, separate repo instance — must warn again (WeakSet keys on repo).
+    const backingB = new InMemoryTaskOutputRepository();
+    await (backingB as any).setupDatabase?.();
+    const servicesB = new ServiceRegistry(new Container());
+    servicesB.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backingB }));
+    const gB = new TaskGraph();
+    gB.addTask(new PrivTask({ defaults: { q: "b" } } as any));
+    await gB.run({}, { runId: "rb", registry: servicesB, resourceScope: new ResourceScope() });
+
+    const matches = messages.filter((m) => m.includes("non-durable"));
+    expect(matches.length).toBe(2);
+  });
+
+  it("warns when task declares static cachePolicy:'private' even if getCachePolicy returns 'deterministic' for empty inputs", async () => {
+    class TrickyTask extends Task<{ q: string }, { r: string }> {
+      public static override type = "TrickyPrivateForEmpty";
+      public static override cachePolicy: CachePolicy = { kind: "private" };
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+          },
+          required: ["q"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            r: { type: "string" },
+          },
+          required: ["r"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      // Override that lies about empty inputs — old probe would have missed
+      // this. New static-first detector catches it via static cachePolicy.
+      public override getCachePolicy(inputs: { q: string }): CachePolicy {
+        if (!inputs || !inputs.q) return { kind: "deterministic" };
+        return { kind: "private" };
+      }
+
+      public override async execute(input: { q: string }): Promise<{ r: string }> {
+        return { r: input.q };
+      }
+    }
+
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new TrickyTask({ defaults: { q: "hello" } } as any));
+
+    await g.run({}, { runId: "tricky-1", registry: services, resourceScope: new ResourceScope() });
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(true);
+  });
+
+  it("warns for input-dependent private tasks via override detection", async () => {
+    // No static cachePolicy — only the override decides. Detector must still
+    // conservatively flag it because the override exists.
+    class OverrideOnlyTask extends Task<{ priv: boolean; q: string }, { r: string }> {
+      public static override type = "OverrideOnlyPrivate";
+
+      public static override inputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            priv: { type: "boolean" },
+            q: { type: "string" },
+          },
+          required: ["priv", "q"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public static override outputSchema(): DataPortSchema {
+        return {
+          type: "object",
+          properties: {
+            r: { type: "string" },
+          },
+          required: ["r"],
+          additionalProperties: false,
+        } as const satisfies DataPortSchema;
+      }
+
+      public override getCachePolicy(inputs: { priv: boolean; q: string }): CachePolicy {
+        return inputs.priv ? { kind: "private" } : { kind: "deterministic" };
+      }
+
+      public override async execute(input: { priv: boolean; q: string }): Promise<{ r: string }> {
+        return { r: input.q };
+      }
+    }
+
+    const backing = new InMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+    const services = new ServiceRegistry(new Container());
+    services.registerInstance(CACHE_REGISTRY, new DefaultCacheRegistry({ private: backing }));
+
+    const g = new TaskGraph();
+    g.addTask(new OverrideOnlyTask({ defaults: { priv: true, q: "hello" } } as any));
+
+    await g.run(
+      {},
+      { runId: "override-1", registry: services, resourceScope: new ResourceScope() }
+    );
+
+    expect(messages.some((m) => m.includes("non-durable"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Stacked follow-up to PR #515. Addresses one CRITICAL and three HIGH issues found in review of the cache policy routing work. Targets `claude/refactor-task-runner-execution-9I4tB` (NOT `main`).

### C1 — guard private policy against missing `runId`

Without a `runId`, the `RunPrivateCacheRepo` wrap in `TaskGraphRunner.handleStart` is skipped and `private`-policy tasks write directly to the shared private repo, colliding across runs. Hybrid fix:

- `TaskGraphRunner.handleStart` (`packages/task-graph/src/task-graph/TaskGraphRunner.ts:687`): throws `TaskConfigurationError` when the graph contains a private-policy task but no `runId` is provided. The graph runner is the documented owner of `runId`, so this is a configuration error.
- `TaskRunner.handleStart` (`packages/task-graph/src/task/TaskRunner.ts:226` — at the policy-resolution site): warn-once-per-task-type and locally downgrade to `kind: "none"`. Standalone callers may not know about `runId`; degrading gracefully is more useful than throwing.

A new static helper `TaskGraphRunner.graphUsesPrivatePolicy(graph)` centralizes the detection (reused by H4 below).

### H1 — reject `__cv` input port collision

`CacheCoordinator.buildKey` injects a reserved `__cv` sentinel into normalized inputs before fingerprinting. A task that declares an input port named `__cv` would silently shadow cache versioning. `Task.constructor` (`packages/task-graph/src/task/Task.ts:546`) now reads the static `inputSchema()` once and throws `TaskConfigurationError` if its properties include `__cv`. Boolean schemas are skipped (they cannot declare ports).

### H3 — rate-limit durability warning

Repeated `runGraph` calls against the same non-durable private repo would log the durability warning every call. Now tracked via a static `WeakSet<object>` keyed by the repo instance (`TaskGraphRunner.ts:610`). Different repo instance is still warned; throwaway repos become eligible again after GC.

### H4 — robust durability detection

The previous durability check probed each task with `getCachePolicy({} as any)`, which is unsafe for input-dependent overrides (can throw, can return the wrong branch on empty inputs). Switched to `TaskGraphRunner.graphUsesPrivatePolicy()`: read static `cachePolicy` first, fall back to override detection (`proto.getCachePolicy !== Task.prototype.getCachePolicy`). Warning message updated to "may be used but is non-durable".

### H2 — PR #515 description update (for `@sroussey`)

H2 is documentation-only. Updates needed on PR #515's body (cannot be applied here because PR #515 is owned by `@sroussey`):

- Replace "fires non-blocking cleanup" / "fire-and-forget" language with: "awaits `RunPrivateCacheRepo.clearRun()` (`TaskGraphRunner.ts:270`) so a same-runId restart cannot race against deletions — see commit `fd3724b2`."
- Document the C1 hybrid choice: TaskGraphRunner throws on missing `runId` with a private-policy task; standalone TaskRunner warns once per task type and degrades the policy to `{ kind: "none" }`.

## Files

- `packages/task-graph/src/task-graph/TaskGraphRunner.ts` — C1 guard, H4 detector, H3 rate-limit.
- `packages/task-graph/src/task/TaskRunner.ts` — C1 standalone warn-and-degrade.
- `packages/task-graph/src/task/Task.ts` — H1 `__cv` rejection.
- `packages/test/src/test/task-graph-cache/PrivateRequiresRunId.test.ts` — new C1 tests.
- `packages/test/src/test/task-graph-cache/TaskCacheVersion.test.ts` — appended H1 tests.
- `packages/test/src/test/task-graph-cache/TaskGraphRunnerDurabilityWarning.test.ts` — appended H3/H4 tests.

## Test plan

- [x] `npx vitest run packages/test/src/test/task-graph-cache/` — 14 files / 47 tests pass.
- [x] `bun scripts/test.ts vitest graph unit` — 63 files / 669 tests pass.
- [x] Static helper `graphUsesPrivatePolicy` reused by both the C1 guard and the H4 warning.
- [ ] (deferred) Lint not run — `bun run lint` is broken on the base branch with 169 parsing errors (pre-existing, unrelated to this PR).

## Notes

- Stacked on PR #515 (`claude/refactor-task-runner-execution-9I4tB`); merge that first.
- Commits are unsigned because the environment's signing service is returning `400 missing source` for every signing request. The base PR #515 work has been signed; only this fixup branch is unsigned due to the outage.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PqntVCfKgKmJ5396w7BPC)_