### PR TITLE
fix: FetchUrl permanent codes + SQLite v4 + error-code registry

### DIFF
--- a/packages/job-queue/README.md
+++ b/packages/job-queue/README.md
@@ -414,12 +414,23 @@ Contract:
   if a second registration overwrites the first).
 - **Reconstructors MUST NOT throw.** Return a fallback `PermanentJobError`
   with `code` set when you receive an unknown future code sharing your prefix —
-  this keeps older clients forward-compatible with newer workers.
-- Built-in codes (`PermanentJobError`, `RetryableJobError`, `AbortSignalJobError`,
-  `JobDisabledError`) are handled by the client directly and do not need to be
-  registered.
-- Use `clearErrorCodeReconstructors()` / `unregisterErrorCodeReconstructor()`
-  in tests to keep the global table clean between cases.
+  this keeps older clients forward-compatible with newer workers. If a
+  reconstructor does throw, the client logs a warning and falls through to a
+  generic `JobError` with `code` set to the persisted code.
+- **Built-in codes take precedence over registered reconstructors.**
+  `PermanentJobError`, `RetryableJobError`, `AbortSignalJobError`, and
+  `JobDisabledError` are handled by the client directly — a registered prefix
+  that happens to match (e.g. `"P"` against `PermanentJobError`) will *not*
+  intercept them. Do not register reconstructors for these names.
+- **Reconstructors MUST set `code` to the passed `errorCode`.** The client
+  defensively overrides any mismatch (and warns) so downstream branching on
+  `err.code` is reliable.
+- For test hygiene, prefer `snapshotErrorCodeReconstructors()` +
+  `restoreErrorCodeReconstructors(snapshot)` in `beforeEach`/`afterEach` so
+  registrations made by neighboring test files (via ESM import side-effects)
+  are not destroyed for the rest of the worker. `clearErrorCodeReconstructors()`
+  and `unregisterErrorCodeReconstructor()` remain available but permanently
+  clear the table for the current worker.
 
 ### Event Listeners
 

--- a/packages/job-queue/README.md
+++ b/packages/job-queue/README.md
@@ -385,6 +385,42 @@ class ApiCallJob extends Job<{ endpoint: string }, { data: unknown }> {
 }
 ```
 
+#### Custom error-code reconstruction
+
+When a worker persists a domain-specific `error_code` (e.g. `FETCH_PRIVATE_DENIED`,
+`LLM_CONTEXT_LENGTH_EXCEEDED`) and a client `waitFor()`s the job, the client
+needs to rebuild a typed `JobError` (retryable vs permanent) from the persisted
+code alone — the worker process may not exist anymore.
+
+`JobQueueClient` consults the **error-code reconstructor registry** for this.
+Packages register a reconstructor for their code prefix as a module side-effect:
+
+```typescript
+import { registerErrorCodeReconstructor, PermanentJobError, RetryableJobError } from "@workglow/job-queue";
+
+function buildMyError(errorCode: string, message: string) {
+  if (errorCode === "MY_RATE_LIMITED") return new RetryableJobError(message);
+  const err = new PermanentJobError(message);
+  err.code = errorCode;
+  return err;
+}
+
+registerErrorCodeReconstructor("MY_", buildMyError);
+```
+
+Contract:
+
+- **Prefix-matched, first-registered-wins** on conflicts (a warning is logged
+  if a second registration overwrites the first).
+- **Reconstructors MUST NOT throw.** Return a fallback `PermanentJobError`
+  with `code` set when you receive an unknown future code sharing your prefix —
+  this keeps older clients forward-compatible with newer workers.
+- Built-in codes (`PermanentJobError`, `RetryableJobError`, `AbortSignalJobError`,
+  `JobDisabledError`) are handled by the client directly and do not need to be
+  registered.
+- Use `clearErrorCodeReconstructors()` / `unregisterErrorCodeReconstructor()`
+  in tests to keep the global table clean between cases.
+
 ### Event Listeners
 
 ```typescript

--- a/packages/job-queue/src/common.ts
+++ b/packages/job-queue/src/common.ts
@@ -10,6 +10,7 @@ export type { DeadLetter } from "./job/DeadLetter";
 export * from "./job/Job";
 export * from "./job/JobError";
 export * from "./job/JobErrorDiagnostics";
+export * from "./job/JobErrorRegistry";
 export * from "./job/JobQueueClient";
 export * from "./job/JobQueueEventListeners";
 export * from "./job/JobQueueServer";

--- a/packages/job-queue/src/job/JobErrorRegistry.ts
+++ b/packages/job-queue/src/job/JobErrorRegistry.ts
@@ -95,10 +95,35 @@ export function unregisterErrorCodeReconstructor(prefix: string): boolean {
 }
 
 /**
- * Clear all registered reconstructors. Intended for test hygiene — call in
- * `afterEach` so one test's registrations cannot leak into another.
- * Production code should not call this.
+ * Clear all registered reconstructors. TEST-ONLY: this permanently wipes the
+ * global table for the current worker, including registrations made by
+ * sibling test files via ESM module-load side effects (those can't re-run
+ * because ESM caches modules). For tests that share a worker with code that
+ * relies on side-effect registrations, prefer
+ * {@link snapshotErrorCodeReconstructors} +
+ * {@link restoreErrorCodeReconstructors}. Production code should not call this.
  */
 export function clearErrorCodeReconstructors(): void {
   reconstructors.length = 0;
+}
+
+/**
+ * Snapshot the current registry as a defensive copy. Pair with
+ * {@link restoreErrorCodeReconstructors} in `beforeEach`/`afterEach` so test
+ * mutations don't bleed across files in the same Vitest worker.
+ */
+export function snapshotErrorCodeReconstructors(): RegistryEntry[] {
+  return reconstructors.map((e) => ({ prefix: e.prefix, reconstructor: e.reconstructor }));
+}
+
+/**
+ * Replace the registry contents with the given snapshot (in order). Intended
+ * to be used with the value returned from {@link snapshotErrorCodeReconstructors}.
+ * Mutating the snapshot after passing it in does not affect the registry.
+ */
+export function restoreErrorCodeReconstructors(snapshot: readonly RegistryEntry[]): void {
+  reconstructors.length = 0;
+  for (const entry of snapshot) {
+    reconstructors.push({ prefix: entry.prefix, reconstructor: entry.reconstructor });
+  }
 }

--- a/packages/job-queue/src/job/JobErrorRegistry.ts
+++ b/packages/job-queue/src/job/JobErrorRegistry.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { JobError } from "./JobError";
+
+/**
+ * Reconstructs a domain-specific {@link JobError} from a persisted error code
+ * and message. Implementations should return a fully-typed `JobError` subclass
+ * (e.g. `PermanentJobError`, `RetryableJobError`) with `code` set to
+ * `errorCode` so callers can branch on it.
+ *
+ * The returned error MUST set `code` to `errorCode`. The reconstructor MUST
+ * NOT throw — return a fallback `PermanentJobError` for unknown future codes
+ * sharing the same prefix.
+ */
+export type ErrorCodeReconstructor = (errorCode: string, message: string) => JobError;
+
+interface RegistryEntry {
+  readonly prefix: string;
+  readonly reconstructor: ErrorCodeReconstructor;
+}
+
+/**
+ * Prefix → reconstructor table. Registered first wins on prefix conflicts
+ * (a warning is emitted to make accidental shadowing visible). Idempotent
+ * re-registration of the *same* function is a no-op.
+ *
+ * @internal Module-private; access via the exported `*ErrorCodeReconstructor*`
+ * functions.
+ */
+const reconstructors: RegistryEntry[] = [];
+
+/**
+ * Register a reconstructor for a given error-code prefix. Tasks/providers
+ * call this from their side-effect entry point so the {@link
+ * JobQueueClient.buildErrorFromCode} round-trip preserves the original
+ * `JobError` subclass (retryable vs permanent) across process boundaries.
+ *
+ * The same fn re-registered against the same prefix is a silent no-op.
+ * A *different* fn registered against an already-claimed prefix logs a
+ * warning and overwrites (last-writer-wins) so tests can override defaults
+ * without leaking state — pair with {@link clearErrorCodeReconstructors}.
+ */
+export function registerErrorCodeReconstructor(
+  prefix: string,
+  reconstructor: ErrorCodeReconstructor
+): void {
+  if (!prefix) {
+    throw new Error("registerErrorCodeReconstructor: prefix must be non-empty");
+  }
+  const existingIdx = reconstructors.findIndex((e) => e.prefix === prefix);
+  if (existingIdx !== -1) {
+    if (reconstructors[existingIdx]!.reconstructor === reconstructor) {
+      return; // idempotent — same fn, same prefix
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `registerErrorCodeReconstructor: overwriting existing reconstructor for prefix "${prefix}"`
+    );
+    reconstructors[existingIdx] = { prefix, reconstructor };
+    return;
+  }
+  reconstructors.push({ prefix, reconstructor });
+}
+
+/**
+ * Look up a reconstructor for a given error code. Matches by `startsWith` —
+ * first registered prefix that matches wins. Returns `undefined` when no
+ * registered prefix matches.
+ */
+export function lookupErrorCodeReconstructor(
+  errorCode: string
+): ErrorCodeReconstructor | undefined {
+  for (const entry of reconstructors) {
+    if (errorCode.startsWith(entry.prefix)) {
+      return entry.reconstructor;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Remove a single reconstructor by prefix. Returns `true` when an entry was
+ * removed. Primarily for tests that register a reconstructor for assertion
+ * and need to leave the global table clean.
+ */
+export function unregisterErrorCodeReconstructor(prefix: string): boolean {
+  const idx = reconstructors.findIndex((e) => e.prefix === prefix);
+  if (idx === -1) return false;
+  reconstructors.splice(idx, 1);
+  return true;
+}
+
+/**
+ * Clear all registered reconstructors. Intended for test hygiene — call in
+ * `afterEach` so one test's registrations cannot leak into another.
+ * Production code should not call this.
+ */
+export function clearErrorCodeReconstructors(): void {
+  reconstructors.length = 0;
+}

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EventEmitter } from "@workglow/util";
+import { EventEmitter, getLogger } from "@workglow/util";
 import type { IJobStore } from "../queue-storage/IJobStore";
 import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type {
@@ -616,18 +616,12 @@ export class JobQueueClient<Input, Output> {
   }
 
   protected buildErrorFromCode(message: string, errorCode?: string): JobError {
-    // Domain-specific codes (e.g. FETCH_*, LLM_*, FILE_*) reconstruct via the
-    // {@link JobErrorRegistry}. Packages register their reconstructors on
-    // import so JobQueueClient stays decoupled from concrete error
-    // taxonomies. See `JobErrorRegistry.ts` for the contract.
-    if (errorCode) {
-      const reconstructor = lookupErrorCodeReconstructor(errorCode);
-      if (reconstructor) {
-        const err = reconstructor(errorCode, message);
-        applyPersistedDiagnosticsToStack(err, message);
-        return err;
-      }
-    }
+    // Built-in codes take precedence over the {@link JobErrorRegistry} so a
+    // registered prefix can never accidentally intercept core types
+    // (e.g. a `"P"` prefix shadowing `PermanentJobError`). Only after the
+    // built-in switch fails do we consult the registry for domain-specific
+    // codes (e.g. FETCH_*, LLM_*, FILE_*). See `JobErrorRegistry.ts` for
+    // the contract.
     if (errorCode === "PermanentJobError") {
       const err = new PermanentJobError(message);
       applyPersistedDiagnosticsToStack(err, message);
@@ -647,6 +641,37 @@ export class JobQueueClient<Input, Output> {
       const err = new JobDisabledError(message);
       applyPersistedDiagnosticsToStack(err, message);
       return err;
+    }
+    if (errorCode) {
+      const reconstructor = lookupErrorCodeReconstructor(errorCode);
+      if (reconstructor) {
+        try {
+          const err = reconstructor(errorCode, message);
+          // Reconstructors MUST set `code` per the registry contract, but
+          // defend against forgetful implementations so downstream branching
+          // on `err.code` still works. Mismatches are likely bugs in the
+          // reconstructor — warn so they're visible.
+          if (err.code !== errorCode) {
+            if (err.code) {
+              getLogger().warn("error-code reconstructor returned mismatched code; overriding", {
+                errorCode,
+                reconstructorCode: err.code,
+              });
+            }
+            err.code = errorCode;
+          }
+          applyPersistedDiagnosticsToStack(err, message);
+          return err;
+        } catch (reconstructorError) {
+          // A throwing reconstructor must not break job-result delivery —
+          // fall through to the generic `JobError` path with `code`
+          // preserved so callers can still branch on the persisted code.
+          getLogger().warn("error-code reconstructor threw", {
+            errorCode,
+            error: reconstructorError,
+          });
+        }
+      }
     }
     const err = new JobError(message);
     if (errorCode) {

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -24,6 +24,7 @@ import {
   RetryableJobError,
 } from "./JobError";
 import { applyPersistedDiagnosticsToStack } from "./JobErrorDiagnostics";
+import { lookupErrorCodeReconstructor } from "./JobErrorRegistry";
 import {
   JobProgressListener,
   JobQueueEventListener,
@@ -615,16 +616,17 @@ export class JobQueueClient<Input, Output> {
   }
 
   protected buildErrorFromCode(message: string, errorCode?: string): JobError {
-    // FetchUrlTask codes — keep retryable set in sync with @workglow/tasks FetchUrlErrorCode
-    if (errorCode?.startsWith("FETCH_")) {
-      const retryable =
-        errorCode === "FETCH_HTTP_RATE_LIMITED" ||
-        errorCode === "FETCH_HTTP_SERVER_ERROR" ||
-        errorCode === "FETCH_NETWORK_ERROR";
-      const err = retryable ? new RetryableJobError(message) : new PermanentJobError(message);
-      err.code = errorCode;
-      applyPersistedDiagnosticsToStack(err, message);
-      return err;
+    // Domain-specific codes (e.g. FETCH_*, LLM_*, FILE_*) reconstruct via the
+    // {@link JobErrorRegistry}. Packages register their reconstructors on
+    // import so JobQueueClient stays decoupled from concrete error
+    // taxonomies. See `JobErrorRegistry.ts` for the contract.
+    if (errorCode) {
+      const reconstructor = lookupErrorCodeReconstructor(errorCode);
+      if (reconstructor) {
+        const err = reconstructor(errorCode, message);
+        applyPersistedDiagnosticsToStack(err, message);
+        return err;
+      }
     }
     if (errorCode === "PermanentJobError") {
       const err = new PermanentJobError(message);

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -9,6 +9,13 @@
 
 import "./task/adaptive";
 
+// Register the FETCH_* error-code reconstructor as a module side-effect so
+// JobQueueClient can rebuild typed FetchUrl errors from persisted codes
+// without statically importing @workglow/tasks (cross-package coupling).
+import { registerErrorCodeReconstructor } from "@workglow/job-queue";
+import { buildFetchUrlError } from "./task/FetchUrlJobError";
+registerErrorCodeReconstructor("FETCH_", buildFetchUrlError);
+
 export * from "./task/adaptive";
 export * from "./task/ArrayTask";
 export * from "./task/DateFormatTask";

--- a/packages/tasks/src/task/FetchUrlJobError.ts
+++ b/packages/tasks/src/task/FetchUrlJobError.ts
@@ -117,6 +117,29 @@ export function fetchUrlJobErrorFromPersisted(
   return attachFetchUrlFields(new PermanentJobError(message), errorCode, undefined);
 }
 
+/**
+ * Adapter for {@link registerErrorCodeReconstructor}. Reconstructs a
+ * `FetchUrlJobError`-shaped error from a persisted `FETCH_*` code.
+ *
+ * Unknown future codes that still start with `FETCH_` fall back to a generic
+ * `PermanentJobError` so a forward-compat worker can persist a new code and
+ * an older client can still surface a typed error (with a warning logged so
+ * the version skew is visible).
+ */
+export function buildFetchUrlError(errorCode: string, message: string): JobError {
+  const reconstructed = fetchUrlJobErrorFromPersisted(message, errorCode);
+  if (reconstructed) {
+    return reconstructed;
+  }
+  // eslint-disable-next-line no-console
+  console.warn(
+    `buildFetchUrlError: unknown FETCH_* error code "${errorCode}" — falling back to PermanentJobError`
+  );
+  const fallback = new PermanentJobError(message);
+  fallback.code = errorCode;
+  return fallback;
+}
+
 export function httpStatusToFetchUrlErrorCode(status: number): FetchUrlErrorCodeValue {
   if (status === 429) {
     return FetchUrlErrorCode.HTTP_RATE_LIMITED;

--- a/packages/tasks/src/task/FetchUrlTask.ts
+++ b/packages/tasks/src/task/FetchUrlTask.ts
@@ -144,7 +144,7 @@ async function fetchWithProgress(
   try {
     response = await safeFetch(url, options);
   } catch (err) {
-    if (err instanceof Error && err.name === "AbortSignalJobError") {
+    if (isFetchUrlJobError(err) || err instanceof AbortSignalJobError) {
       throw err;
     }
     throw wrapFetchUrlNetworkError(url, err);
@@ -256,7 +256,7 @@ export class FetchUrlJob<
         async (progress: number) => await context.updateProgress(progress)
       );
     } catch (err) {
-      if (err instanceof AbortSignalJobError) {
+      if (isFetchUrlJobError(err) || err instanceof AbortSignalJobError) {
         throw err;
       }
       throw wrapFetchUrlNetworkError(input.url!, err);

--- a/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
+++ b/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
@@ -16,7 +16,9 @@ import {
   lookupErrorCodeReconstructor,
   PermanentJobError,
   registerErrorCodeReconstructor,
+  restoreErrorCodeReconstructors,
   RetryableJobError,
+  snapshotErrorCodeReconstructors,
   unregisterErrorCodeReconstructor,
   type IJobExecuteContext,
 } from "@workglow/job-queue";
@@ -46,13 +48,19 @@ class BarError extends RetryableJobError {
 // ---------------------------------------------------------------------------
 
 describe("JobErrorRegistry", () => {
-  // Capture and restore the registry around each test so we never leak global
-  // state between tests in this file or to neighboring test files.
+  // Snapshot the registry before each test and restore after, so registrations
+  // made by neighboring test files (e.g. `FetchTask.test.ts` registering
+  // FETCH_* via ESM import side-effects) survive this file's mutations. A
+  // plain `clear()` would permanently wipe those for the rest of the worker,
+  // because ESM module caches mean the registration code only runs once.
+  let registrySnapshot: ReturnType<typeof snapshotErrorCodeReconstructors>;
   beforeEach(() => {
+    registrySnapshot = snapshotErrorCodeReconstructors();
+    // Start each test from a clean slate so prefix assertions are unambiguous.
     clearErrorCodeReconstructors();
   });
   afterEach(() => {
-    clearErrorCodeReconstructors();
+    restoreErrorCodeReconstructors(registrySnapshot);
   });
 
   test("client reconstructs registered prefix as the registered error class", () => {

--- a/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
+++ b/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AbortSignalJobError,
+  clearErrorCodeReconstructors,
+  InMemoryQueueStorage,
+  Job,
+  JobDisabledError,
+  JobError,
+  JobQueueClient,
+  JobQueueServer,
+  lookupErrorCodeReconstructor,
+  PermanentJobError,
+  registerErrorCodeReconstructor,
+  RetryableJobError,
+  unregisterErrorCodeReconstructor,
+  type IJobExecuteContext,
+} from "@workglow/job-queue";
+import { sleep } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers — expose the protected reconstruction path so we can assert the
+// JobQueueClient round-trip without standing up a full queue.
+// ---------------------------------------------------------------------------
+
+class TestableClient<I, O> extends JobQueueClient<I, O> {
+  // Surface the protected method for tests; no behavior change.
+  public buildErrorFromCodePublic(message: string, errorCode?: string): JobError {
+    return this.buildErrorFromCode(message, errorCode);
+  }
+}
+
+class FooError extends PermanentJobError {
+  public static override type = "FooError";
+}
+
+class BarError extends RetryableJobError {
+  public static override type = "BarError";
+}
+
+// ---------------------------------------------------------------------------
+
+describe("JobErrorRegistry", () => {
+  // Capture and restore the registry around each test so we never leak global
+  // state between tests in this file or to neighboring test files.
+  beforeEach(() => {
+    clearErrorCodeReconstructors();
+  });
+  afterEach(() => {
+    clearErrorCodeReconstructors();
+  });
+
+  test("client reconstructs registered prefix as the registered error class", () => {
+    registerErrorCodeReconstructor("FOO_", (errorCode, message) => {
+      const err = new FooError(message);
+      err.code = errorCode;
+      return err;
+    });
+
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+    const err = client.buildErrorFromCodePublic("boom", "FOO_BAR");
+    expect(err).toBeInstanceOf(FooError);
+    expect(err).toBeInstanceOf(PermanentJobError);
+    expect(err.code).toBe("FOO_BAR");
+    expect(err.message).toBe("boom");
+  });
+
+  test("unregistered code prefix falls back to generic JobError", () => {
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+    const err = client.buildErrorFromCodePublic("oops", "UNKNOWN_PREFIX_FOO");
+    // Should be a plain JobError, not any of the built-in subclasses.
+    expect(err).toBeInstanceOf(JobError);
+    expect(err).not.toBeInstanceOf(PermanentJobError);
+    expect(err).not.toBeInstanceOf(RetryableJobError);
+    expect(err.code).toBe("UNKNOWN_PREFIX_FOO");
+  });
+
+  test("built-in codes still work after the registry rewrite", () => {
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+    expect(client.buildErrorFromCodePublic("p", "PermanentJobError")).toBeInstanceOf(
+      PermanentJobError
+    );
+    expect(client.buildErrorFromCodePublic("r", "RetryableJobError")).toBeInstanceOf(
+      RetryableJobError
+    );
+    expect(client.buildErrorFromCodePublic("a", "AbortSignalJobError")).toBeInstanceOf(
+      AbortSignalJobError
+    );
+    expect(client.buildErrorFromCodePublic("d", "JobDisabledError")).toBeInstanceOf(
+      JobDisabledError
+    );
+  });
+
+  test("registering different fn against same prefix warns and overwrites", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerErrorCodeReconstructor("X_", (_c, m) => new FooError(m));
+      registerErrorCodeReconstructor("X_", (_c, m) => new BarError(m));
+      expect(warn).toHaveBeenCalledOnce();
+
+      const client = new TestableClient<unknown, unknown>({
+        storage: new InMemoryQueueStorage("q"),
+        queueName: "q",
+      });
+      // Last writer wins — should reconstruct as BarError now.
+      expect(client.buildErrorFromCodePublic("m", "X_CODE")).toBeInstanceOf(BarError);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("registering identical fn against same prefix is idempotent (no warning)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fn = (_c: string, m: string) => new FooError(m);
+      registerErrorCodeReconstructor("Y_", fn);
+      registerErrorCodeReconstructor("Y_", fn);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("unregisterErrorCodeReconstructor removes a single entry", () => {
+    registerErrorCodeReconstructor("Z_", (_c, m) => new FooError(m));
+    expect(lookupErrorCodeReconstructor("Z_FOO")).toBeDefined();
+    expect(unregisterErrorCodeReconstructor("Z_")).toBe(true);
+    expect(lookupErrorCodeReconstructor("Z_FOO")).toBeUndefined();
+    // Second remove is a no-op.
+    expect(unregisterErrorCodeReconstructor("Z_")).toBe(false);
+  });
+
+  test("clearErrorCodeReconstructors restores defaults (no registered entries)", () => {
+    registerErrorCodeReconstructor("FOO_", (_c, m) => new FooError(m));
+    registerErrorCodeReconstructor("BAR_", (_c, m) => new BarError(m));
+    clearErrorCodeReconstructors();
+    expect(lookupErrorCodeReconstructor("FOO_X")).toBeUndefined();
+    expect(lookupErrorCodeReconstructor("BAR_X")).toBeUndefined();
+  });
+
+  test("first-registered-prefix wins when multiple prefixes both match", () => {
+    // Register the more general prefix first; a later, more specific prefix
+    // should not preempt it — first-registered wins per the documented v1
+    // semantics.
+    registerErrorCodeReconstructor("ABC_", (_c, m) => new FooError(m));
+    registerErrorCodeReconstructor("ABC_DEF_", (_c, m) => new BarError(m));
+
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+    expect(client.buildErrorFromCodePublic("m", "ABC_DEF_GHI")).toBeInstanceOf(FooError);
+  });
+
+  test("end-to-end: queued job rejection propagates the reconstructed error class", async () => {
+    const queueName = "registry-roundtrip-q";
+    registerErrorCodeReconstructor("CUSTOM_", (errorCode, message) => {
+      const err = new FooError(message);
+      err.code = errorCode;
+      return err;
+    });
+
+    class ThrowsCustomJob extends Job<{ thing: string }, { ok: boolean }> {
+      override async execute(
+        _input: { thing: string },
+        _ctx: IJobExecuteContext
+      ): Promise<{ ok: boolean }> {
+        const err = new PermanentJobError("worker-side failure");
+        err.code = "CUSTOM_RUNTIME";
+        throw err;
+      }
+    }
+
+    const storage = new InMemoryQueueStorage<{ thing: string }, { ok: boolean }>(queueName);
+    await storage.migrate();
+    const server = new JobQueueServer<{ thing: string }, { ok: boolean }>(ThrowsCustomJob, {
+      storage,
+      queueName,
+      pollIntervalMs: 1,
+    });
+    const client = new JobQueueClient<{ thing: string }, { ok: boolean }>({
+      storage,
+      queueName,
+    });
+    client.attach(server);
+
+    const handle = await client.send({ thing: "x" }, { maxAttempts: 1 });
+    await server.start();
+    const err = await handle.waitFor().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FooError);
+    expect((err as JobError).code).toBe("CUSTOM_RUNTIME");
+    await server.stop();
+    await sleep(0);
+    await storage.deleteAll();
+  });
+});

--- a/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
+++ b/packages/test/src/test/job-queue/JobErrorRegistry.test.ts
@@ -166,6 +166,69 @@ describe("JobErrorRegistry", () => {
     expect(client.buildErrorFromCodePublic("m", "ABC_DEF_GHI")).toBeInstanceOf(FooError);
   });
 
+  test("registered 'P' prefix does not intercept PermanentJobError built-in", () => {
+    // A short prefix that would naively `startsWith`-match the built-in
+    // `PermanentJobError` code. The client must dispatch built-ins first so
+    // the registered reconstructor is never consulted for them.
+    let reconstructorCalls = 0;
+    registerErrorCodeReconstructor("P", (errorCode, message) => {
+      reconstructorCalls += 1;
+      const err = new FooError(message);
+      err.code = errorCode;
+      return err;
+    });
+
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+
+    const err = client.buildErrorFromCodePublic("boom", "PermanentJobError");
+    expect(err).toBeInstanceOf(PermanentJobError);
+    expect(err).not.toBeInstanceOf(FooError);
+    expect(reconstructorCalls).toBe(0);
+  });
+
+  test("reconstructor that throws falls through to JobError with code preserved", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      registerErrorCodeReconstructor("BOOM_", () => {
+        throw new Error("reconstructor exploded");
+      });
+
+      const client = new TestableClient<unknown, unknown>({
+        storage: new InMemoryQueueStorage("q"),
+        queueName: "q",
+      });
+
+      const err = client.buildErrorFromCodePublic("boom-msg", "BOOM_OOPS");
+      // Generic JobError (not any subclass) with code preserved.
+      expect(err).toBeInstanceOf(JobError);
+      expect(err).not.toBeInstanceOf(PermanentJobError);
+      expect(err).not.toBeInstanceOf(RetryableJobError);
+      expect(err.code).toBe("BOOM_OOPS");
+      expect(err.message).toBe("boom-msg");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("reconstructor that returns error without code has code injected", () => {
+    registerErrorCodeReconstructor("NOCODE_", (_errorCode, message) => {
+      // Buggy implementation — forgets to set err.code.
+      return new FooError(message);
+    });
+
+    const client = new TestableClient<unknown, unknown>({
+      storage: new InMemoryQueueStorage("q"),
+      queueName: "q",
+    });
+
+    const err = client.buildErrorFromCodePublic("oops", "NOCODE_BAD");
+    expect(err).toBeInstanceOf(FooError);
+    expect(err.code).toBe("NOCODE_BAD");
+  });
+
   test("end-to-end: queued job rejection propagates the reconstructed error class", async () => {
     const queueName = "registry-roundtrip-q";
     registerErrorCodeReconstructor("CUSTOM_", (errorCode, message) => {

--- a/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
@@ -205,14 +205,262 @@ describe("sqlite queue migrations: canonical v3 schema", () => {
       await new SqliteMigrationRunner(sqlite).run(sqliteQueueMigrations("jobs", []));
 
       const row = sqlite
-        .prepare<[string], { readonly sql: string | null }>(
-          "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?"
-        )
+        .prepare<
+          [string],
+          { readonly sql: string | null }
+        >("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
         .get("jobs");
       expect(row?.sql).toBeDefined();
 
       const normalizeSql = (sql: string): string => sql.replace(/\s+/g, " ").trim();
-      expect(normalizeSql(row!.sql!)).toBe(normalizeSql(buildSqliteQueuePostV3TableSql("jobs", "")));
+      expect(normalizeSql(row!.sql!)).toBe(
+        normalizeSql(buildSqliteQueuePostV3TableSql("jobs", ""))
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+/**
+ * H1: v4 migration converges already-applied pre-fix v3 DBs.
+ *
+ * Pre-fix v3 only IF-EXISTS-renamed columns; it did not rebuild the table to
+ * change `max_attempts DEFAULT 23 → 10`. DBs that ran the pre-fix v3 have a
+ * v3 bookkeeping row in `_storage_migrations` and would never re-run v3, so
+ * the default stays at 23 indefinitely — Postgres parity (default 10) never
+ * applies. v4 idempotently re-runs the same rebuild helper so converged DBs
+ * (fresh installs that hit the in-place v3 rebuild) get a no-op while
+ * pre-fix v3 DBs get repaired.
+ */
+describe("sqlite queue migrations: v4 max_attempts convergence", () => {
+  const MIGRATIONS_LEDGER = "_storage_migrations";
+
+  /** Hand-build a pre-fix-v3 DB: run v1 + v2, perform the v3 renames, mark
+   * v3 applied in the ledger — but DO NOT rebuild the table to DEFAULT 10.
+   * This is the on-disk shape a deployment that ran the pre-fix migration
+   * would have. */
+  function fabricatePreFixV3Db(
+    db: import("@workglow/sqlite/storage").Sqlite.Database,
+    tableName: string
+  ): void {
+    const all = sqliteQueueMigrations(tableName, []);
+    // Run v1's CREATE TABLE statement directly (which lands DEFAULT 23 on
+    // `max_retries`).
+    all[0]!.up(db, () => {});
+    // Run v2's ALTER TABLE ADD COLUMNs.
+    all[1]!.up(db, () => {});
+
+    // Replicate v3's IF-EXISTS column renames *without* the post-rebuild.
+    db.exec(`ALTER TABLE ${tableName} RENAME COLUMN run_after TO visible_at;`);
+    db.exec(`ALTER TABLE ${tableName} RENAME COLUMN last_ran_at TO last_attempted_at;`);
+    db.exec(`ALTER TABLE ${tableName} RENAME COLUMN run_attempts TO attempts;`);
+    db.exec(`ALTER TABLE ${tableName} RENAME COLUMN max_retries TO max_attempts;`);
+    db.exec(`ALTER TABLE ${tableName} RENAME COLUMN worker_id TO lease_owner;`);
+
+    // Mark v1, v2, v3 as applied in the migrations ledger so the runner
+    // skips them and only runs v4. We also need the ledger table to exist.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS ${MIGRATIONS_LEDGER} (
+        component TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        description TEXT,
+        applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (component, version)
+      );
+      INSERT INTO ${MIGRATIONS_LEDGER}(component, version, description) VALUES
+        ('queue:sqlite:${tableName}', 1, 'v1'),
+        ('queue:sqlite:${tableName}', 2, 'v2'),
+        ('queue:sqlite:${tableName}', 3, 'pre-fix v3 (no rebuild)');
+    `);
+  }
+
+  const getMaxAttemptsDefault = (
+    db: import("@workglow/sqlite/storage").Sqlite.Database,
+    tbl: string
+  ): string | null =>
+    db
+      .prepare<[], { name: string; dflt_value: string | null }>(`PRAGMA table_info(${tbl})`)
+      .all()
+      .find((r) => r.name === "max_attempts")?.dflt_value ?? null;
+
+  it("DB stuck at max_attempts DEFAULT 23 (simulated pre-fix v3) is repaired by v4", async () => {
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      fabricatePreFixV3Db(sqlite, "jobs");
+
+      // Sanity precondition: this synthetic DB really *is* stuck at 23.
+      expect(Number(getMaxAttemptsDefault(sqlite, "jobs"))).toBe(23);
+
+      // Run the full migration list — only v4 should fire.
+      const applied = await new SqliteMigrationRunner(sqlite).run(
+        sqliteQueueMigrations("jobs", [])
+      );
+      expect(applied.map((m) => m.version)).toEqual([4]);
+
+      // Post-condition: default is now 10 (matches Postgres parity).
+      expect(Number(getMaxAttemptsDefault(sqlite, "jobs"))).toBe(10);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("v4 is no-op on a fixed-v3 DB (fresh install)", async () => {
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      // Fresh install runs the full chain; v3's in-place rebuild already
+      // converged the default to 10, so v4 should detect that and skip.
+      const firstRun = await new SqliteMigrationRunner(sqlite).run(
+        sqliteQueueMigrations("jobs", [])
+      );
+      expect(firstRun.map((m) => m.version)).toEqual([1, 2, 3, 4]);
+      expect(Number(getMaxAttemptsDefault(sqlite, "jobs"))).toBe(10);
+
+      // Capture the table SQL to assert v4 left it untouched on re-run.
+      const beforeSql = sqlite
+        .prepare<
+          [string],
+          { readonly sql: string | null }
+        >("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("jobs")?.sql;
+
+      // Second `run()` should apply nothing — ledger already has v1..v4.
+      const secondRun = await new SqliteMigrationRunner(sqlite).run(
+        sqliteQueueMigrations("jobs", [])
+      );
+      expect(secondRun).toEqual([]);
+
+      const afterSql = sqlite
+        .prepare<
+          [string],
+          { readonly sql: string | null }
+        >("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("jobs")?.sql;
+      expect(afterSql).toBe(beforeSql);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("data is preserved across v4 rebuild", async () => {
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      fabricatePreFixV3Db(sqlite, "jobs");
+
+      // Insert representative rows into the pre-fix v3 table.
+      sqlite.exec(`
+        INSERT INTO jobs (
+          fingerprint, queue, job_run_id, status, input, output, attempts,
+          max_attempts, visible_at, last_attempted_at, created_at,
+          completed_at, deadline_at, error, error_code, progress,
+          progress_message, progress_details, lease_owner,
+          abort_requested_at, lease_expires_at
+        ) VALUES
+        ('fp1', 'q', 'run-1', 'PENDING', '{"x":1}', NULL, 0,
+          23, '2025-01-01T00:00:00Z', NULL, '2025-01-01T00:00:00Z',
+          NULL, NULL, NULL, NULL, 0,
+          '', NULL, NULL,
+          NULL, NULL),
+        ('fp2', 'q', 'run-2', 'COMPLETED', '{"x":2}', '{"y":2}', 1,
+          5, '2025-01-02T00:00:00Z', '2025-01-02T00:00:01Z',
+          '2025-01-02T00:00:00Z', '2025-01-02T00:00:02Z', NULL, NULL,
+          NULL, 100, 'done', NULL, NULL, NULL, NULL);
+      `);
+
+      await new SqliteMigrationRunner(sqlite).run(sqliteQueueMigrations("jobs", []));
+
+      const rows = sqlite
+        .prepare<
+          [],
+          { fingerprint: string; status: string; max_attempts: number }
+        >("SELECT fingerprint, status, max_attempts FROM jobs ORDER BY fingerprint")
+        .all();
+      expect(rows).toEqual([
+        { fingerprint: "fp1", status: "PENDING", max_attempts: 23 },
+        { fingerprint: "fp2", status: "COMPLETED", max_attempts: 5 },
+      ]);
+
+      // The column DEFAULT is what changed — existing row values are
+      // preserved as-is. New inserts without an explicit max_attempts now
+      // get 10.
+      sqlite.exec(`
+        INSERT INTO jobs (fingerprint, queue, job_run_id, status, input,
+          visible_at, created_at)
+        VALUES ('fp3', 'q', 'run-3', 'PENDING', '{"x":3}',
+          '2025-01-03T00:00:00Z', '2025-01-03T00:00:00Z');
+      `);
+      const newRow = sqlite
+        .prepare<
+          [],
+          { max_attempts: number }
+        >("SELECT max_attempts FROM jobs WHERE fingerprint = 'fp3'")
+        .get();
+      expect(newRow?.max_attempts).toBe(10);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("v4 preserves user-defined triggers on the queue table", async () => {
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      fabricatePreFixV3Db(sqlite, "jobs");
+
+      // User-defined trigger + audit table referencing the queue table.
+      sqlite.exec(`
+        CREATE TABLE audit (job_fp TEXT, status TEXT);
+        CREATE TRIGGER jobs_audit_trg AFTER UPDATE OF status ON jobs
+        BEGIN
+          INSERT INTO audit (job_fp, status) VALUES (NEW.fingerprint, NEW.status);
+        END;
+      `);
+
+      // Seed and assert the trigger is alive before v4 rebuilds the table.
+      sqlite.exec(`
+        INSERT INTO jobs (fingerprint, queue, job_run_id, status, input,
+          visible_at, created_at)
+        VALUES ('fp1', 'q', 'r', 'PENDING', '{}',
+          '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z');
+      `);
+
+      await new SqliteMigrationRunner(sqlite).run(sqliteQueueMigrations("jobs", []));
+
+      // The trigger should still be present after v4's drop+rename.
+      const triggers = sqlite
+        .prepare<
+          [],
+          { name: string }
+        >("SELECT name FROM sqlite_schema WHERE type = 'trigger' AND tbl_name = 'jobs'")
+        .all();
+      expect(triggers.map((t) => t.name)).toContain("jobs_audit_trg");
+
+      // And it must still fire — write to status and check the audit row.
+      sqlite.exec("UPDATE jobs SET status = 'COMPLETED' WHERE fingerprint = 'fp1';");
+      const audit = sqlite
+        .prepare<[], { job_fp: string; status: string }>("SELECT job_fp, status FROM audit")
+        .all();
+      expect(audit).toContainEqual({ job_fp: "fp1", status: "COMPLETED" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("v4 restores foreign_keys pragma to prior value", async () => {
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      // Caller opted into FK enforcement before running migrations.
+      sqlite.exec("PRAGMA foreign_keys = ON;");
+      fabricatePreFixV3Db(sqlite, "jobs");
+
+      await new SqliteMigrationRunner(sqlite).run(sqliteQueueMigrations("jobs", []));
+
+      const fk = sqlite.prepare<[], { foreign_keys: number }>("PRAGMA foreign_keys").get();
+      expect(fk?.foreign_keys).toBe(1);
     } finally {
       sqlite.close();
     }

--- a/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
+++ b/packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts
@@ -404,7 +404,7 @@ describe("sqlite queue migrations: v4 max_attempts convergence", () => {
     }
   });
 
-  it("v4 preserves user-defined triggers on the queue table", async () => {
+  it("v4 preserves user-defined triggers on the queue table (and the trigger still fires)", async () => {
     await Sqlite.init();
     const sqlite = new Sqlite.Database(":memory:");
     try {
@@ -444,6 +444,54 @@ describe("sqlite queue migrations: v4 max_attempts convergence", () => {
         .prepare<[], { job_fp: string; status: string }>("SELECT job_fp, status FROM audit")
         .all();
       expect(audit).toContainEqual({ job_fp: "fp1", status: "COMPLETED" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("v4 does NOT capture user-defined views over the queue table (documented limitation)", async () => {
+    // Pins the documented behavior so anyone tempted to add view preservation
+    // also updates the README/migration description: in `sqlite_schema` a
+    // view's `tbl_name` is the VIEW's own name, not the referenced table —
+    // so our `tbl_name = ?` snapshot cannot locate views that reference the
+    // queue table, and we deliberately don't parse view SQL to fix it.
+    //
+    // We do not exercise the "view present during rebuild" path here because
+    // SQLite's drop+rename in the rebuild leaves a dependent view in an
+    // invalid state (its referenced table briefly does not exist), which
+    // breaks the whole txn. Operators with views on the queue table must
+    // drop and re-create those views around the migration; we assert below
+    // only what's relevant to the comment claim — that the snapshot query
+    // returns zero rows for views, not triggers.
+    await Sqlite.init();
+    const sqlite = new Sqlite.Database(":memory:");
+    try {
+      fabricatePreFixV3Db(sqlite, "jobs");
+      sqlite.exec("CREATE VIEW jobs_pending AS SELECT * FROM jobs WHERE status = 'PENDING';");
+
+      // The snapshot query that the rebuild helper uses must not match the
+      // view, by design (views have `tbl_name = <view-name>`, not `jobs`).
+      const matchedByRebuildQuery = sqlite
+        .prepare<
+          [string],
+          { type: string; name: string }
+        >("SELECT type, name FROM sqlite_schema WHERE type = 'trigger' AND tbl_name = ? AND name NOT LIKE 'sqlite_%'")
+        .all("jobs");
+      expect(matchedByRebuildQuery.find((r) => r.name === "jobs_pending")).toBeUndefined();
+
+      // Drop the dependent view so the rebuild can run cleanly (mirrors the
+      // operator workflow the README/migration description documents).
+      sqlite.exec("DROP VIEW jobs_pending;");
+      await new SqliteMigrationRunner(sqlite).run(sqliteQueueMigrations("jobs", []));
+
+      // After migration, the view is not re-created (operator must do so).
+      const views = sqlite
+        .prepare<
+          [],
+          { name: string }
+        >("SELECT name FROM sqlite_schema WHERE type = 'view' AND name = 'jobs_pending'")
+        .all();
+      expect(views).toEqual([]);
     } finally {
       sqlite.close();
     }

--- a/packages/test/src/test/task/FetchTask.test.ts
+++ b/packages/test/src/test/task/FetchTask.test.ts
@@ -7,6 +7,7 @@
 import {
   InMemoryQueueStorage,
   InMemoryRateLimiterStorage,
+  JobError,
   JobQueueClient,
   JobQueueServer,
   PermanentJobError,
@@ -19,6 +20,7 @@ import {
   setTaskQueueRegistry,
 } from "@workglow/task-graph";
 import {
+  createFetchUrlJobError,
   fetchUrl,
   FetchUrlErrorCode,
   FetchUrlJob,
@@ -713,6 +715,101 @@ describe("FetchUrlTask", () => {
       task.setInput({ response_type: "json" });
 
       expect(schemaChangeEmitted).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // C1 regression: SafeFetch throws permanent FETCH_* errors (SSRF deny, DNS
+  // failure, invalid URL, etc). The outer catches in fetchWithProgress /
+  // FetchUrlJob.execute previously rewrote *every* non-Abort throw into a
+  // NETWORK_ERROR (retryable) — burning the full retry budget on a permanent
+  // SSRF deny. Each case below asserts the original code/class is preserved.
+  //
+  // SECURITY: a permanent SSRF deny that gets re-classified as retryable is
+  // a privilege-escalation amplifier — the queue worker keeps the
+  // (potentially attacker-controlled) URL alive for 10 attempts. Treat any
+  // regression here as a security issue.
+  // -------------------------------------------------------------------------
+  describe("FetchUrlTask permanent error pass-through", () => {
+    const permanentCases: ReadonlyArray<{
+      readonly label: string;
+      readonly code: (typeof FetchUrlErrorCode)[keyof typeof FetchUrlErrorCode];
+    }> = [
+      { label: "PRIVATE_DENIED", code: FetchUrlErrorCode.PRIVATE_DENIED },
+      { label: "SCOPE_DENIED", code: FetchUrlErrorCode.SCOPE_DENIED },
+      { label: "INVALID_URL", code: FetchUrlErrorCode.INVALID_URL },
+      { label: "DNS_FAILED", code: FetchUrlErrorCode.DNS_FAILED },
+      { label: "REDIRECT_MISSING_LOCATION", code: FetchUrlErrorCode.REDIRECT_MISSING_LOCATION },
+      { label: "TOO_MANY_REDIRECTS", code: FetchUrlErrorCode.TOO_MANY_REDIRECTS },
+      { label: "NO_RESPONSE_BODY", code: FetchUrlErrorCode.NO_RESPONSE_BODY },
+      { label: "CONFIGURATION", code: FetchUrlErrorCode.CONFIGURATION },
+    ];
+
+    for (const { label, code } of permanentCases) {
+      test(`${label} thrown by safeFetch is preserved (not rewrapped as NETWORK_ERROR)`, async () => {
+        mockFetch.mockImplementation(() =>
+          Promise.reject(createFetchUrlJobError(code, `${label} from mock`, { url: "x" }))
+        );
+
+        const fetchPromise = fetchUrl({
+          url: "https://api.example.com/will-deny",
+        });
+        const error = await fetchPromise.catch((e: unknown) => e);
+        // JobTaskFailedError wraps at the task layer; assert on `.jobError`.
+        const jobErr = (error as { jobError?: unknown }).jobError ?? error;
+        expect(isFetchUrlJobError(jobErr)).toBe(true);
+        expect((jobErr as { code?: string }).code).toBe(code);
+        expect(jobErr).toBeInstanceOf(PermanentJobError);
+        // Critical: not rewrapped as NETWORK_ERROR (retryable).
+        expect((jobErr as { code?: string }).code).not.toBe(FetchUrlErrorCode.NETWORK_ERROR);
+      });
+    }
+
+    test("genuine TypeError still wraps to NETWORK_ERROR (positive control)", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.reject(new TypeError("connect ECONNREFUSED 127.0.0.1:443"))
+      );
+      const error = await fetchUrl({ url: "https://api.example.com/down" }).catch(
+        (e: unknown) => e
+      );
+      const jobErr = (error as { jobError?: unknown }).jobError ?? error;
+      expect(isFetchUrlJobError(jobErr)).toBe(true);
+      expect((jobErr as { code?: string }).code).toBe(FetchUrlErrorCode.NETWORK_ERROR);
+      expect(jobErr).toBeInstanceOf(RetryableJobError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // H2 regression: confirm @workglow/tasks registers its FETCH_*
+  // reconstructor on import so JobQueueClient round-trips persisted codes
+  // back to the correct retryable/permanent JobError subclass.
+  // -------------------------------------------------------------------------
+  describe("FETCH_* codes reconstructed by JobQueueClient", () => {
+    class TestableClient<I, O> extends JobQueueClient<I, O> {
+      public buildErrorFromCodePublic(message: string, errorCode?: string): JobError {
+        return this.buildErrorFromCode(message, errorCode);
+      }
+    }
+
+    test("FETCH_HTTP_RATE_LIMITED reconstructed by client is RetryableJobError", () => {
+      const client = new TestableClient<unknown, unknown>({
+        storage: new InMemoryQueueStorage("q"),
+        queueName: "q",
+      });
+      const err = client.buildErrorFromCodePublic("rate limited", "FETCH_HTTP_RATE_LIMITED");
+      expect(err).toBeInstanceOf(RetryableJobError);
+      expect(err.code).toBe("FETCH_HTTP_RATE_LIMITED");
+    });
+
+    test("FETCH_PRIVATE_DENIED reconstructed by client is PermanentJobError", () => {
+      const client = new TestableClient<unknown, unknown>({
+        storage: new InMemoryQueueStorage("q"),
+        queueName: "q",
+      });
+      const err = client.buildErrorFromCodePublic("private denied", "FETCH_PRIVATE_DENIED");
+      expect(err).toBeInstanceOf(PermanentJobError);
+      expect(err).not.toBeInstanceOf(RetryableJobError);
+      expect(err.code).toBe("FETCH_PRIVATE_DENIED");
     });
   });
 });

--- a/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
+++ b/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
@@ -94,21 +94,29 @@ function rebuildSqliteQueueTableForV4Default(
   db.exec("PRAGMA foreign_keys = OFF;");
 
   try {
-    // Snapshot user-defined triggers + views attached to this table; SQLite
-    // drops these when we drop the original table, so we replay them after
-    // the rename so a deployment's user-defined automation survives the
-    // rebuild. Indexes are recreated explicitly below via CREATE INDEX so
-    // we skip them here on purpose.
+    // Snapshot user-defined triggers attached to this table; SQLite drops
+    // them when we drop the original table, so we replay them after the
+    // rename so a deployment's user-defined automation survives the rebuild.
+    // Indexes are recreated explicitly below via CREATE INDEX so we skip
+    // them here on purpose.
+    //
+    // VIEWS are intentionally NOT preserved here: in `sqlite_schema` a view's
+    // `tbl_name` column is the VIEW's own name, not the table the view
+    // references, so a `tbl_name = ?` filter cannot locate views that
+    // reference the queue table. Parsing the view's `sql` to find dependent
+    // tables is fragile (whitespace, quoting, aliases, subselects, CTEs) and
+    // there are no in-tree consumers that rely on it. Operators with views
+    // over the queue table must re-create them after this migration runs.
     type SchemaObj = {
       readonly type: string;
       readonly name: string;
       readonly sql: string | null;
     };
-    const userObjects: SchemaObj[] = db
+    const userTriggers: SchemaObj[] = db
       .prepare<
         [string],
         SchemaObj
-      >("SELECT type, name, sql FROM sqlite_schema " + "WHERE type IN ('trigger','view') AND tbl_name = ? " + "AND name NOT LIKE 'sqlite_%'")
+      >("SELECT type, name, sql FROM sqlite_schema " + "WHERE type = 'trigger' AND tbl_name = ? " + "AND name NOT LIKE 'sqlite_%'")
       .all(tableName);
 
     const newTable = `${tableName}__new_v4`;
@@ -123,9 +131,9 @@ function rebuildSqliteQueueTableForV4Default(
       CREATE INDEX IF NOT EXISTS job_queue_job_run_id${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, job_run_id);
     `);
 
-    for (const obj of userObjects) {
-      if (obj.sql) {
-        db.exec(`${obj.sql};`);
+    for (const trg of userTriggers) {
+      if (trg.sql) {
+        db.exec(`${trg.sql};`);
       }
     }
 
@@ -296,7 +304,7 @@ export function sqliteQueueMigrations(
       // fresh installs (and on DBs whose v3 already converged inside v3's
       // block above) the includes(...) guard turns this into a no-op.
       description:
-        "Converge SQLite queue max_attempts DEFAULT 23 → 10 on pre-fix v3 DBs (idempotent rebuild)",
+        "Converge SQLite queue max_attempts DEFAULT 23 → 10 on pre-fix v3 DBs (idempotent rebuild). User-defined triggers on the queue table are preserved; user-defined views referencing the queue table are NOT preserved and must be DROPped before this migration runs and re-created afterwards by the operator (SQLite's drop+rename leaves a dependent view invalid mid-rebuild and fails the txn).",
       up(db: Sqlite.Database) {
         type TableSqlRow = { readonly sql: string | null };
         const tableSqlRow = db

--- a/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
+++ b/providers/sqlite/src/migrations/sqliteQueueMigrations.ts
@@ -58,6 +58,94 @@ export function buildSqliteQueuePostV3TableSql(
 }
 
 /**
+ * Rebuilds `tableName` from the canonical post-v3 CREATE TABLE so the
+ * `max_attempts INTEGER DEFAULT 10` lands on disk. Idempotent: callers guard
+ * with `tableSql.includes("max_attempts INTEGER DEFAULT 10")` (the only
+ * already-converged shape) and skip if already correct.
+ *
+ * H3 safety wrap:
+ *   - Capture the prior `PRAGMA foreign_keys` value so we restore it after.
+ *   - Issue `PRAGMA foreign_keys = OFF;` for documentation purposes — this is
+ *     a NO-OP inside an active transaction (sqlite ignores it), and the
+ *     {@link SqliteMigrationRunner} wraps every `up()` in BEGIN/COMMIT. We
+ *     therefore additionally run `PRAGMA foreign_key_check` post-rebuild to
+ *     fail the migration if our copy left dangling references. The
+ *     SQLite-documented 12-step procedure requires foreign_keys=OFF *outside*
+ *     the txn, but our queue table has no inbound FKs in the canonical
+ *     schema, so the failure mode is "user-defined FK to the queue table is
+ *     left dangling" — captured by the post-check.
+ *   - Snapshot triggers/views that reference `tableName` (sqlite drops them
+ *     transparently when the table is dropped) and replay them after the
+ *     rename so user-defined automation is preserved across the rebuild.
+ */
+function rebuildSqliteQueueTableForV4Default(
+  db: Sqlite.Database,
+  tableName: string,
+  prefixColumnsSql: string,
+  postV3ColumnList: string,
+  prefixIndexPrefix: string,
+  indexSuffix: string
+): void {
+  const fkPrev = db.prepare<[], { readonly foreign_keys: number }>("PRAGMA foreign_keys").get();
+
+  // Documented no-op inside a txn — kept so a future caller that runs this
+  // helper outside the migration runner's BEGIN/COMMIT gets the right
+  // semantics. The post-check below is the real safety net.
+  db.exec("PRAGMA foreign_keys = OFF;");
+
+  try {
+    // Snapshot user-defined triggers + views attached to this table; SQLite
+    // drops these when we drop the original table, so we replay them after
+    // the rename so a deployment's user-defined automation survives the
+    // rebuild. Indexes are recreated explicitly below via CREATE INDEX so
+    // we skip them here on purpose.
+    type SchemaObj = {
+      readonly type: string;
+      readonly name: string;
+      readonly sql: string | null;
+    };
+    const userObjects: SchemaObj[] = db
+      .prepare<
+        [string],
+        SchemaObj
+      >("SELECT type, name, sql FROM sqlite_schema " + "WHERE type IN ('trigger','view') AND tbl_name = ? " + "AND name NOT LIKE 'sqlite_%'")
+      .all(tableName);
+
+    const newTable = `${tableName}__new_v4`;
+    db.exec(`
+      ${buildSqliteQueuePostV3TableSql(newTable, prefixColumnsSql)};
+      INSERT INTO ${newTable} (${postV3ColumnList}) SELECT ${postV3ColumnList} FROM ${tableName};
+      DROP TABLE ${tableName};
+      ALTER TABLE ${newTable} RENAME TO ${tableName};
+
+      CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at);
+      CREATE INDEX IF NOT EXISTS job_queue_fingerprint${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, fingerprint, status);
+      CREATE INDEX IF NOT EXISTS job_queue_job_run_id${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, job_run_id);
+    `);
+
+    for (const obj of userObjects) {
+      if (obj.sql) {
+        db.exec(`${obj.sql};`);
+      }
+    }
+
+    // FK precheck: surface any user-defined FOREIGN KEY → queue-table
+    // reference that our drop+rename left dangling. This catches the case
+    // the PRAGMA-inside-txn limitation cannot prevent — fail loudly so the
+    // migration rolls back rather than silently corrupting data.
+    const violations = db
+      .prepare<[], { readonly table: string; readonly rowid: number }>("PRAGMA foreign_key_check")
+      .all();
+    if (violations.length > 0) {
+      throw new Error(`sqlite queue v4 rebuild left FK violations: ${JSON.stringify(violations)}`);
+    }
+  } finally {
+    // Restore the caller's foreign_keys setting either way.
+    db.exec(`PRAGMA foreign_keys = ${fkPrev?.foreign_keys ? "ON" : "OFF"};`);
+  }
+}
+
+/**
  * Initial migration set for the SQLite queue table identified by `tableName`.
  *
  * v1 is FROZEN byte-for-byte against the pre-PR shape — it creates the
@@ -134,7 +222,9 @@ export function sqliteQueueMigrations(
         // arrive at v3 having just created the v1 schema in this same
         // migration run) are no-ops here.
         type ColInfo = { readonly name: string };
-        const colInfos: ColInfo[] = db.prepare<[], ColInfo>(`PRAGMA table_info(${tableName})`).all();
+        const colInfos: ColInfo[] = db
+          .prepare<[], ColInfo>(`PRAGMA table_info(${tableName})`)
+          .all();
         const cols: string[] = colInfos.map((r) => r.name);
         const renames: [string, string][] = [
           ["run_after", "visible_at"],
@@ -167,9 +257,10 @@ export function sqliteQueueMigrations(
         // the correct default using SQLite's documented 12-step procedure
         // (https://www.sqlite.org/lang_altertable.html#otheralter).
         const tableSqlRow = db
-          .prepare<[string], { readonly sql: string | null }>(
-            "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?"
-          )
+          .prepare<
+            [string],
+            { readonly sql: string | null }
+          >("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
           .get(tableName);
         if (tableSqlRow?.sql && !tableSqlRow.sql.includes("max_attempts INTEGER DEFAULT 10")) {
           // Rebuild from the canonical post-v3 CREATE TABLE statement instead
@@ -177,18 +268,53 @@ export function sqliteQueueMigrations(
           // metadata such as explicit NULL/COLLATE/CHECK clauses, so deriving
           // DDL from it would silently erase future schema details during this
           // rebuild step.
-          const newTable = `${tableName}__new_v3`;
-          db.exec(`
-            ${buildSqliteQueuePostV3TableSql(`${tableName}__new_v3`, prefixColumnsSql)};
-            INSERT INTO ${newTable} (${postV3ColumnList}) SELECT ${postV3ColumnList} FROM ${tableName};
-            DROP TABLE ${tableName};
-            ALTER TABLE ${newTable} RENAME TO ${tableName};
-
-            CREATE INDEX IF NOT EXISTS job_queue_fetcher${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, status, visible_at);
-            CREATE INDEX IF NOT EXISTS job_queue_fingerprint${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, fingerprint, status);
-            CREATE INDEX IF NOT EXISTS job_queue_job_run_id${indexSuffix}_idx ON ${tableName} (${prefixIndexPrefix}queue, job_run_id);
-          `);
+          //
+          // Fresh installs land here on first migrate (the v1 CREATE TABLE
+          // ran in the same migration call, so its `max_retries DEFAULT 23`
+          // is still present until renamed). v4 below is a no-op for these
+          // because this rebuild already converged them.
+          rebuildSqliteQueueTableForV4Default(
+            db,
+            tableName,
+            prefixColumnsSql,
+            postV3ColumnList,
+            prefixIndexPrefix,
+            indexSuffix
+          );
         }
+      },
+    },
+    {
+      component,
+      version: 4,
+      // Convergence migration for already-applied v3 DBs that landed on
+      // `max_attempts INTEGER DEFAULT 23` before the in-place v3 fix
+      // shipped. These DBs have the v3 bookkeeping row in
+      // `_storage_migrations` and would never re-run v3, so the default
+      // would stay at 23 indefinitely — Postgres parity (default 10) would
+      // never apply. v4 idempotently re-runs the same rebuild helper. On
+      // fresh installs (and on DBs whose v3 already converged inside v3's
+      // block above) the includes(...) guard turns this into a no-op.
+      description:
+        "Converge SQLite queue max_attempts DEFAULT 23 → 10 on pre-fix v3 DBs (idempotent rebuild)",
+      up(db: Sqlite.Database) {
+        type TableSqlRow = { readonly sql: string | null };
+        const tableSqlRow = db
+          .prepare<
+            [string],
+            TableSqlRow
+          >("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?")
+          .get(tableName);
+        if (!tableSqlRow?.sql) return;
+        if (tableSqlRow.sql.includes("max_attempts INTEGER DEFAULT 10")) return;
+        rebuildSqliteQueueTableForV4Default(
+          db,
+          tableName,
+          prefixColumnsSql,
+          postV3ColumnList,
+          prefixIndexPrefix,
+          indexSuffix
+        );
       },
     },
   ];


### PR DESCRIPTION
## Summary

Bundles one **CRITICAL** and three **HIGH** fixes spanning `@workglow/tasks`, `@workglow/job-queue`, and the SQLite provider.

### C1 — Guard FetchUrl outer catches against permanent codes [SECURITY]

`packages/tasks/src/task/FetchUrlTask.ts:144-150` and `:258-263`

**Security regression.** The outer catches in `fetchWithProgress` and `FetchUrlJob.execute` were unconditionally rewrapping every non-Abort error via `wrapFetchUrlNetworkError`. `safeFetch` throws **permanent** `FetchUrlJobError`s with codes `PRIVATE_DENIED`, `SCOPE_DENIED`, `INVALID_URL`, `DNS_FAILED`, `REDIRECT_MISSING_LOCATION`, `TOO_MANY_REDIRECTS`, `NO_RESPONSE_BODY`, `CONFIGURATION` — these were getting rewrapped to retryable `NETWORK_ERROR`. **An SSRF deny would burn the full retry budget instead of failing fast**, amplifying any compromised-URL exposure and pinging the denied target up to 10 times per submission. The response-parse catch at `:312-315` already had the correct guard; this PR mirrors it on both outer catches.

Fix: replace `if (err instanceof Error && err.name === "AbortSignalJobError") throw` with `if (isFetchUrlJobError(err) || err instanceof AbortSignalJobError) throw` (the `instanceof` form matches the parse catch; the import was already present). Tests cover each permanent code plus a positive control that real `TypeError("ECONNREFUSED")` still wraps to retryable `NETWORK_ERROR`.

### H2 — Error-code reconstructor registry

`packages/job-queue/src/job/JobErrorRegistry.ts` (new), `JobQueueClient.ts:617-628`, `packages/tasks/src/common.ts`, `packages/tasks/src/task/FetchUrlJobError.ts`, `packages/job-queue/README.md`

`JobQueueClient.buildErrorFromCode` had a hardcoded `FETCH_*` block that knew which fetch codes were retryable, coupling `@workglow/job-queue` to `@workglow/tasks` and preventing downstream packages (LLM, file IO, etc.) from extending the typed-error round-trip the same way. Replaced with a module-level prefix→reconstructor registry. `@workglow/tasks` registers `buildFetchUrlError` for the `FETCH_` prefix as a `common.ts` import side-effect. Built-in codes (`PermanentJobError`, `RetryableJobError`, `AbortSignalJobError`, `JobDisabledError`) stay in the existing switch — registry is purely additive.

Contract documented in `packages/job-queue/README.md`: prefix-matched, first-registered-wins, idempotent on identical fn, warn-and-overwrite on conflict. `buildFetchUrlError` falls back to `PermanentJobError` (with `console.warn`) for unknown future `FETCH_*` codes so older clients stay forward-compatible with newer workers.

### H1 — v4 SQLite migration to converge max_attempts default

`providers/sqlite/src/migrations/sqliteQueueMigrations.ts`

The v3 in-place rebuild that converged `max_attempts DEFAULT 23 → 10` ran *inside* v3's `up()`. Deployments that already applied the **pre-fix** v3 have v3 marked applied in `_storage_migrations` and will never re-run it — their DBs stay at `DEFAULT 23` indefinitely while Postgres lands at `DEFAULT 10`. Callers omitting `maxAttempts` get divergent retry behavior across backends.

Fix: factor the rebuild into a shared helper, append v4 that idempotently re-runs the same logic. Both v3 and v4 guard with `tableSql.includes("max_attempts INTEGER DEFAULT 10")` so fresh installs land at 10 inside v3 and v4 no-ops; pre-fix-v3 DBs are repaired by v4.

### H3 — SQLite v4 rebuild safety (FK precheck, trigger awareness)

Same `sqliteQueueMigrations.ts` helper.

The rebuild now (1) snapshots user-defined triggers/views referencing the queue table before the DROP and replays them after the RENAME so deployments that attach automation to the queue survive the rebuild, (2) captures and restores the caller's `PRAGMA foreign_keys` value, and (3) runs `PRAGMA foreign_key_check` after the rebuild so any dangling FK references throw and roll back. See "Open questions" below re: PRAGMA-inside-txn limitation.

## Test plan

Validated locally with `bun scripts/test.ts bun unit task queue` and `bun scripts/test.ts bun integration storage queue`.

- [x] All existing tests pass (1263 unit task+queue, 1212 integration storage+queue)
- [x] `bun test packages/test/src/test/task/FetchTask.test.ts` — 36 pass, 0 fail (9 C1 pass-through tests, 1 positive control, 2 H2 regression tests)
- [x] `bun test packages/test/src/test/job-queue/JobErrorRegistry.test.ts` — 9 pass, 0 fail
- [x] `bun test packages/test/src/test/storage-migrations/queueMigrationsParity.integration.test.ts` — 9 pass, 0 fail (5 new H1/H3 tests)
- [x] `bun run build:types` — clean
- [x] `bun run format` — clean

## Open questions for reviewer

1. **PRAGMA foreign_keys inside a txn.** `SqliteMigrationRunner` wraps every `up()` in `BEGIN/COMMIT`. `PRAGMA foreign_keys = OFF` is a documented no-op inside an active transaction, so the SQLite docs' canonical 12-step procedure cannot be followed literally here. The queue table has no inbound FKs in the canonical schema, but user-defined FKs *to* it would not be silenced by our pragma. We fail the migration via `foreign_key_check` post-validation instead. Is that acceptable, or should the runner expose a `withForeignKeysOff()` escape hatch that suspends the txn for this case?

2. **Migration ledger access.** The test fabricates a pre-fix-v3 DB by hand-inserting rows into `_storage_migrations`. This couples tests to the runner's table-name constant — an exported `MIGRATIONS_TABLE` is already imported from `@workglow/storage`, but tests inline the string for clarity. Worth standardizing?

3. **Prefix-match semantics.** Registry v1 is **first-registered-wins** on prefix conflicts. Longest-prefix-wins would let a `FETCH_HTTP_` reconstructor preempt a more general `FETCH_` one — happy to switch if the design intent is hierarchical taxonomies. Currently the conflict is documented and a warning is logged on overwrite.

4. **Registration ergonomics.** Side-effect registration in `packages/tasks/src/common.ts` is consistent with the existing `import "./task/adaptive"` pattern but is invisible to tree-shakers — if a task user only imports a single task they still pull the FETCH_ reconstructor. Acceptable given the tiny code size?

5. **Signing.** Commits in this PR are unsigned because the `code-sign` environment-runner returned HTTP 400 `"missing source"` for every signing attempt (see request IDs `req_011CbDXEr2gNMd5usCxmPgEq`, `req_011CbDXJCXnsSzcy2ctLatoF` in the diagnostics). This appears to be an infrastructure issue with the signing server rather than something fixable from the worktree.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PqntVCfKgKmJ5396w7BPC)_