### PR TITLE
Replace cacheable boolean with CachePolicy type system

### DIFF
--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -182,7 +182,7 @@ You can define schemas using plain JSON Schema, TypeBox, or Zod. Here are exampl
 #### Using Plain JSON Schema
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { DataPortSchema, FromSchema } from "@workglow/util";
 
 const MyInputSchema = {
@@ -268,7 +268,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
 TypeBox schemas are JSON Schema compatible and can be used directly:
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { Type } from "@sinclair/typebox";
 import { DataPortSchema, FromSchema } from "@workglow/util";
 
@@ -343,7 +343,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
 Zod 4 has built-in JSON Schema support using the `.toJSONSchema()` method:
 
 ```typescript
-import { Task, IExecuteContext } from "@workglow/task-graph";
+import { Task, IExecuteContext, type CachePolicy } from "@workglow/task-graph";
 import { z } from "zod";
 import { DataPortSchema } from "@workglow/util";
 
@@ -762,7 +762,9 @@ import {
   TaskOutputTabularRepository,
 } from "@workglow/task-graph";
 import { ServiceRegistry } from "@workglow/util";
-import { InMemoryTabularStorage, SqliteTabularStorage } from "@workglow/storage";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
+
+await Sqlite.init();
 
 const deterministic = new TaskOutputTabularRepository({
   tabularRepository: new SqliteTabularStorage(
@@ -785,22 +787,23 @@ const privateBacking = new TaskOutputTabularRepository({
 });
 
 const registry = new ServiceRegistry();
-registry.set(CACHE_REGISTRY, new DefaultCacheRegistry({
-  deterministic,
-  private: privateBacking,
-}));
+registry.registerInstance(
+  CACHE_REGISTRY,
+  new DefaultCacheRegistry({ deterministic, private: privateBacking })
+);
 
-await graph.run({ registry, runId: "run-" + crypto.randomUUID() });
+// TaskGraph.run takes (input, config) — runId/registry are run config, not input.
+await graph.run({}, { registry, runId: "run-" + crypto.randomUUID() });
 ```
 
 The runner constructs a per-run `RunPrivateCacheRepo` wrapper over the `private` slot, namespaced by `runId`. The wrapper exists only for the duration of the run; the rows it writes survive in the backing store until either explicit cleanup (on successful completion) or the TTL janitor sweeps them (after a crashed run is abandoned).
 
 ### Run identity and durable execution
 
-A run is identified by an opaque `runId` string supplied by the caller of `.run()`:
+A run is identified by an opaque `runId` string supplied by the caller of `.run()` in the run config (the second argument; the first argument is graph input):
 
 ```typescript
-await graph.run({ runId, registry });
+await graph.run({}, { runId, registry });
 ```
 
 - **First start** of a user-triggered run: generate a fresh `runId` (UUID is typical) and persist it alongside the rest of the run metadata.
@@ -809,9 +812,11 @@ await graph.run({ runId, registry });
 
 The runner does not generate `runId` for you. That is the caller's job — only the caller knows whether this `.run()` call is a fresh start or a restart.
 
+If the registered `private` slot is present and the graph contains any task whose policy may resolve to `kind: "private"` (statically or via `getCachePolicy(inputs)`), the runner rejects the run synchronously when `runId` is missing. Graphs without a private slot (or without any private-policy task) don't need a `runId`.
+
 #### Cleanup
 
-- On `succeeded`, the runner awaits `privateRepo.clearRun(runId)` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt.
+- On `succeeded`, the runner awaits `privateRepo.clearRun()` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt. The wrapper already knows its `runId`, so the method takes no arguments.
 - On crash (no terminal status reached), nothing happens at the cache layer — the entries stay on disk so the restart can find them.
 - For abandoned runs (crashed and never restarted), schedule the `CacheJanitor`:
 
@@ -913,17 +918,21 @@ const deterministic = new TaskOutputTabularRepository({
 });
 
 const registry = new ServiceRegistry();
-registry.set(CACHE_REGISTRY, new DefaultCacheRegistry({ deterministic }));
+registry.registerInstance(
+  CACHE_REGISTRY,
+  new DefaultCacheRegistry({ deterministic })
+);
 
 const graph = new TaskGraph();
 graph.addTask(new ExpensiveTask({ n: 42 }, { id: "exp" }));
 
+// TaskGraph.run takes (input, config). registry/runId live in config.
 let t = Date.now();
-await graph.run({ registry, runId: "run-1" });
+await graph.run({}, { registry, runId: "run-1" });
 const firstRunMs = Date.now() - t;
 
 t = Date.now();
-await graph.run({ registry, runId: "run-2" }); // different run, same inputs → cache hit
+await graph.run({}, { registry, runId: "run-2" }); // different run, same inputs → cache hit
 const secondRunMs = Date.now() - t;
 
 console.log({ firstRunMs, secondRunMs });
@@ -979,9 +988,8 @@ import {
   FsFolderTabularStorage,
   InMemoryTabularStorage,
   IndexedDbTabularStorage,
-  SqliteTabularStorage,
 } from "@workglow/storage";
-import { Sqlite } from "@workglow/storage/sqlite";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
 
 // In-memory (e.g. tests)
 const memoryOutput = new TaskOutputTabularRepository({

--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -232,7 +232,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -291,7 +291,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -371,7 +371,7 @@ class TextProcessorTask extends Task<MyInput, MyOutput> {
   static readonly title = "Text Processor";
   static readonly description = "Processes text";
   static readonly category = "Text Processing";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return MyInputSchema;
@@ -711,26 +711,169 @@ const result = await workflow.run();
 
 ## Storage and Caching
 
-### Task Output Caching
+### Cache Policy
 
-Output caching lets repeat executions with identical inputs return instantly without redoing work.
+Every task declares how its outputs may be cached through a `CachePolicy`:
+
+```typescript
+type CachePolicy =
+  | { kind: "deterministic" }  // same inputs → same outputs; safe to share across runs
+  | { kind: "private" }        // non-deterministic but worth caching; scoped to one run
+  | { kind: "none" };          // do not cache (side-effecting tasks)
+```
+
+The default is `{ kind: "deterministic" }`. Side-effecting tasks (writes to external systems, sends messages) declare `{ kind: "none" }`. Non-deterministic tasks worth caching for the lifetime of a single run (image generation without a seed, model calls without a temperature lock) declare `{ kind: "private" }` — their outputs are namespaced by `runId` and visible only to that run and its restarts.
+
+For tasks whose policy depends on inputs (a seed turns "private" into "deterministic"), override `getCachePolicy(inputs)`:
+
+```typescript
+class AiImageOutputTask extends Task<ImageInput, ImageOutput> {
+  static readonly type = "AiImageOutputTask";
+  // Static default used when the instance method is not overridden.
+  static readonly cachePolicy: CachePolicy = { kind: "private" };
+
+  override getCachePolicy(inputs: ImageInput): CachePolicy {
+    return inputs.seed !== undefined
+      ? { kind: "deterministic" }
+      : { kind: "private" };
+  }
+}
+```
+
+### CacheRegistry: two slots
+
+The runner picks a repository per task by reading `CACHE_REGISTRY` from the `ServiceRegistry`. The registry has exactly two slots:
+
+```typescript
+interface CacheRegistry {
+  deterministic?: TaskOutputRepository;
+  private?: TaskOutputRepository;
+}
+```
+
+Both slots are optional. A missing slot is a silent no-op — the task still runs, it just runs uncached. Apps wire the slots they care about:
+
+```typescript
+import {
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
+  TaskOutputPrimaryKeyNames,
+  TaskOutputSchema,
+  TaskOutputTabularRepository,
+} from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+import { InMemoryTabularStorage, SqliteTabularStorage } from "@workglow/storage";
+
+const deterministic = new TaskOutputTabularRepository({
+  tabularRepository: new SqliteTabularStorage(
+    "./cache.sqlite",
+    "task_outputs_deterministic",
+    TaskOutputSchema,
+    TaskOutputPrimaryKeyNames,
+    ["createdAt"]
+  ),
+});
+
+const privateBacking = new TaskOutputTabularRepository({
+  tabularRepository: new SqliteTabularStorage(
+    "./cache.sqlite",
+    "task_outputs_private",
+    TaskOutputSchema,
+    TaskOutputPrimaryKeyNames,
+    ["createdAt"]
+  ),
+});
+
+const registry = new ServiceRegistry();
+registry.set(CACHE_REGISTRY, new DefaultCacheRegistry({
+  deterministic,
+  private: privateBacking,
+}));
+
+await graph.run({ registry, runId: "run-" + crypto.randomUUID() });
+```
+
+The runner constructs a per-run `RunPrivateCacheRepo` wrapper over the `private` slot, namespaced by `runId`. The wrapper exists only for the duration of the run; the rows it writes survive in the backing store until either explicit cleanup (on successful completion) or the TTL janitor sweeps them (after a crashed run is abandoned).
+
+### Run identity and durable execution
+
+A run is identified by an opaque `runId` string supplied by the caller of `.run()`:
+
+```typescript
+await graph.run({ runId, registry });
+```
+
+- **First start** of a user-triggered run: generate a fresh `runId` (UUID is typical) and persist it alongside the rest of the run metadata.
+- **Restart** after a crash: re-dispatch with the **same** `runId`. The new process constructs a fresh in-memory scheduler but the durable `private` repo still holds the outputs of every task that completed before the crash. Cache hits skip that work; the run finishes from where it effectively left off.
+- **Concurrent runs** of the same workflow get different `runId`s, so they never see each other's private-tier outputs.
+
+The runner does not generate `runId` for you. That is the caller's job — only the caller knows whether this `.run()` call is a fresh start or a restart.
+
+#### Cleanup
+
+- On `succeeded`, the runner awaits `privateRepo.clearRun(runId)` before resolving so that a restart with the same `runId` cannot accidentally hit stale entries from the previous attempt.
+- On crash (no terminal status reached), nothing happens at the cache layer — the entries stay on disk so the restart can find them.
+- For abandoned runs (crashed and never restarted), schedule the `CacheJanitor`:
+
+```typescript
+import { CacheJanitor } from "@workglow/task-graph";
+
+const janitor = new CacheJanitor({ privateBacking });
+// Sweep run-private rows older than 24 hours.
+await janitor.sweepStaleRunPrivate(24 * 60 * 60 * 1000);
+```
+
+The janitor only touches rows with the `__run:` prefix that `RunPrivateCacheRepo` writes; deterministic-tier rows are never affected.
+
+#### Durability warning
+
+At run start the runner checks whether the registered `private` repo reports `isDurable() === true`. If a graph contains a `private`-policy task but the repo is backed by, say, in-memory storage, a one-time warning is logged: restart survival cannot work against a non-durable backend. For production, point the `private` slot at SQLite, Postgres, or another durable store.
+
+### Cache key and `cacheVersion`
+
+The cache key is:
+
+```
+sha256(taskType + getCacheVersion() + fingerprint(inputs))
+```
+
+`fingerprint(inputs)` normalizes inputs using the existing `PortCodec` so that ports with `format` annotations hash by their stable wire representation.
+
+`Task.version` (a static number, default `1`) feeds `getCacheVersion()`, which walks the prototype chain and combines each ancestor's version. Bump `version` when the task's semantics change (new prompt template, new defaults, fixed-bug-in-implementation) to force misses for all prior keys:
+
+```typescript
+class SummarizeTask extends Task<...> {
+  static readonly type = "SummarizeTask";
+  static readonly version = 3; // bump → all old cache entries become stale
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
+  // ...
+}
+```
+
+Override `getCacheVersion()` only if you need a different versioning story (e.g., include the runtime model hash).
+
+### End-to-end example
 
 ```typescript
 import {
   Task,
   TaskGraph,
   Workflow,
+  CACHE_REGISTRY,
+  DefaultCacheRegistry,
   TaskOutputPrimaryKeyNames,
   TaskOutputSchema,
   TaskOutputTabularRepository,
+  type CachePolicy,
 } from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
 import { InMemoryTabularStorage } from "@workglow/storage";
 import { DataPortSchema } from "@workglow/util";
 
-// A cacheable task that simulates expensive work
+// A task with deterministic cache policy that simulates expensive work
 class ExpensiveTask extends Task<{ n: number }, { result: number }> {
   static readonly type = "ExpensiveTask";
-  static readonly cacheable = true;
+  static readonly cachePolicy: CachePolicy = { kind: "deterministic" };
 
   static inputSchema() {
     return {
@@ -761,56 +904,33 @@ class ExpensiveTask extends Task<{ n: number }, { result: number }> {
   }
 }
 
-// Create an output cache
-const outputCache = new TaskOutputTabularRepository({
+// Build a CacheRegistry with a deterministic slot. (Private slot omitted here —
+// ExpensiveTask is deterministic, so it never needs the private tier.)
+const deterministic = new TaskOutputTabularRepository({
   tabularRepository: new InMemoryTabularStorage(TaskOutputSchema, TaskOutputPrimaryKeyNames, [
     "createdAt",
   ]),
 });
 
-// Example 1: TaskGraph caching (second run is near-instant)
-const graph = new TaskGraph({ outputCache });
+const registry = new ServiceRegistry();
+registry.set(CACHE_REGISTRY, new DefaultCacheRegistry({ deterministic }));
+
+const graph = new TaskGraph();
 graph.addTask(new ExpensiveTask({ n: 42 }, { id: "exp" }));
 
 let t = Date.now();
-await graph.run();
+await graph.run({ registry, runId: "run-1" });
 const firstRunMs = Date.now() - t;
 
 t = Date.now();
-await graph.run(); // identical inputs -> served from cache
+await graph.run({ registry, runId: "run-2" }); // different run, same inputs → cache hit
 const secondRunMs = Date.now() - t;
 
 console.log({ firstRunMs, secondRunMs });
 // e.g. { firstRunMs: ~500, secondRunMs: ~1-5 }
-
-// Example 2: Direct Task caching across instances
-const missTask = new ExpensiveTask({ n: 43 }, { outputCache });
-t = Date.now();
-await missTask.run(); // cache miss -> compute and store
-const missMs = Date.now() - t;
-
-const hitTask = new ExpensiveTask({ n: 43 }, { outputCache });
-t = Date.now();
-await hitTask.run(); // cache hit -> instant
-const hitMs = Date.now() - t;
-
-console.log({ missMs, hitMs });
-// e.g. { missMs: ~500, hitMs: ~1-5 }
-
-// Example 3: Workflow with the same cache
-const workflow = new Workflow(outputCache);
-workflow.addTask(new ExpensiveTask({ n: 10 }));
-
-t = Date.now();
-await workflow.run(); // compute
-const wfFirstMs = Date.now() - t;
-
-t = Date.now();
-await workflow.run(); // cached
-const wfSecondMs = Date.now() - t;
-
-console.log({ wfFirstMs, wfSecondMs });
 ```
+
+The deterministic slot is shared across runs — that is the whole point. The private slot is per-run on read and per-run on cleanup, but the underlying storage handle is long-lived (one connection, many runs). Set up the registry once at app startup; bind it to every `.run()` call.
 
 ### Task Graph Persistence
 

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -8,6 +8,7 @@ This document explains the internal execution model of the task graph system. It
 - [Task Lifecycle](#task-lifecycle)
 - [Normal Execution (run)](#normal-execution-run)
 - [Preview Execution (runPreview)](#preview-execution-runpreview)
+- [Cache, Run Identity, and Durable Execution](#cache-run-identity-and-durable-execution)
 - [Dataflow and Input Propagation](#dataflow-and-input-propagation)
 - [GraphAsTask (Subgraphs)](#graphastask-subgraphs)
 - [Key Invariants](#key-invariants)
@@ -78,9 +79,10 @@ TaskRunner.run(overrides)
 2. setInput(overrides)           # Merge overrides into runInputData
 3. resolveSchemaInputs()         # Resolve model/repository strings to instances
 4. validateInput()               # Validate against input schema
-5. Check cache                   # If cacheable: cache hit returns verbatim, no preview overlay
+5. Check cache                   # Per task's CachePolicy + CacheRegistry slot;
+                                 # cache hit returns verbatim, no preview overlay
 6. executeTask()                 # Call task.execute(input, context) only
-7. Store in cache                # If cacheable, cache the result
+7. Store in cache                # If policy ≠ "none" and slot present, persist the result
 8. handleComplete()              # Set status = COMPLETED
     ↓
 Return runOutputData (locked)
@@ -213,6 +215,93 @@ Return-value semantics:
 - `undefined` — leaves `runOutputData` unchanged.
 
 If a preview needs the prior output, it can read `this.runOutputData` directly.
+
+---
+
+## Cache, Run Identity, and Durable Execution
+
+### Cache policy
+
+Every task declares a `CachePolicy` — a property of the task type, not of the deployment:
+
+| Kind            | Meaning                                                                                  | Cache slot used     |
+| --------------- | ---------------------------------------------------------------------------------------- | ------------------- |
+| `deterministic` | Same inputs → same outputs. Safe to share across runs (and, in apps, across projects).   | `deterministic`     |
+| `private`       | Non-deterministic but worth caching for the lifetime of one run (e.g., seedless images). | `private` (per-run) |
+| `none`          | Do not cache. Side-effecting tasks (writes to external systems, sends, mutations).       | _none_              |
+
+The default is `{ kind: "deterministic" }`. Policy can be made input-dependent by overriding `getCachePolicy(inputs)` — e.g., an image task that returns `deterministic` when a seed is provided and `private` when it isn't.
+
+### CacheRegistry
+
+A two-slot service registered under `CACHE_REGISTRY`:
+
+```ts
+interface CacheRegistry {
+  deterministic?: TaskOutputRepository;
+  private?: TaskOutputRepository;
+}
+```
+
+`TaskGraphRunner` resolves the registry from the per-run `ServiceRegistry` and dispatches each task's read/write to the slot named by its policy. Both slots are independently optional. A missing slot is a silent no-op: the task runs uncached, no error.
+
+For the `private` slot, the runner constructs a per-run `RunPrivateCacheRepo` wrapper that prefixes every key with `__run:${runId}::`. Two runs with different `runId`s never see each other's rows; the same `runId` (a restart) does.
+
+### Run identity (`runId`)
+
+`runId` is an opaque string passed in `TaskGraphRunConfig`:
+
+```ts
+graph.run({ runId, registry, ... });
+```
+
+The caller owns generation. The contract:
+
+- A user-triggered run gets a fresh `runId` (UUID typical).
+- A restart after a crash uses the **same** `runId` — that is how durable resume works.
+- Concurrent runs of the same workflow get **different** `runId`s.
+
+If the graph contains any `private`-policy task and `runId` is missing, `handleStart` rejects the run synchronously.
+
+### Cache key
+
+```
+key = sha256(taskType + getCacheVersion() + fingerprint(inputs))
+```
+
+`fingerprint(inputs)` reuses the `PortCodec` normalization in `CacheCoordinator` — ports with `format` annotations hash by their canonical wire representation. Scope namespacing (the `runId` prefix for the private tier) is handled by the repo wrapper, not the key function.
+
+`getCacheVersion()` walks the prototype chain and combines each ancestor's static `version` (default `1`). Bump `version` on a task when its semantics change — every prior cached entry becomes a miss.
+
+### Lifecycle of cache rows
+
+| Tier            | Written        | Read                                  | Deleted                                                                                                                                |
+| --------------- | -------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `deterministic` | On task success | On task start                         | Never automatically. App owns invalidation (typically via `version` bumps).                                                            |
+| `private`       | On task success | On task start, filtered to current `runId` | **(a)** `privateRepo.clearRun(runId)` on `succeeded`. **(b)** TTL sweep via `CacheJanitor.sweepStaleRunPrivate(olderThanMs)` for abandoned runs. |
+
+Failed tasks are never cached — only `Ok` results reach `saveOutput`. Both slots are insert-if-absent: a same-key write while the original row exists is dropped silently.
+
+### Durable execution model
+
+A run is an atomic unit on a single worker. When the worker crashes:
+
+1. Builder (or whatever scheduler dispatched the run) detects the crash via heartbeat / timeout.
+2. The same job is re-dispatched **with the same `runId`** to a (possibly different) worker.
+3. The new process constructs a fresh in-memory scheduler, but the durable `private` repo still holds every task output that completed before the crash.
+4. The runner re-traverses the DAG from scratch; cache hits skip completed work, cache misses execute.
+
+The runner emits a one-time startup warning if any task in the graph declares `kind: "private"` and the registered `private` repo reports `isDurable() === false`. The detection is a repo capability flag, not a registration check — in-memory backings, ephemeral wrappers, and test doubles all surface as non-durable.
+
+#### What durable execution does **not** cover
+
+- **Mid-graph checkpointing of in-flight scheduler state.** Crashed runs re-execute from scratch; the cache absorbs completed work. There is no resumption of a single in-flight task.
+- **Streaming partial outputs.** A task that crashed mid-stream re-executes from scratch on restart; only fully completed tasks become cache hits.
+- **Splitting one run across multiple workers.** A run is atomic on one worker.
+
+### Re-dispatch correctness invariant
+
+Re-execution must produce the same DAG traversal given the same inputs and cache state. Task ordering, parallelism limits, and scheduling decisions in `RunScheduler` must not depend on wall-clock time, machine identity, or worker-local random state. Today's scheduler satisfies this; the model treats it as a maintained invariant.
 
 ---
 

--- a/packages/task-graph/src/EXECUTION_MODEL.md
+++ b/packages/task-graph/src/EXECUTION_MODEL.md
@@ -249,10 +249,10 @@ For the `private` slot, the runner constructs a per-run `RunPrivateCacheRepo` wr
 
 ### Run identity (`runId`)
 
-`runId` is an opaque string passed in `TaskGraphRunConfig`:
+`runId` is an opaque string passed in `TaskGraphRunConfig`. `TaskGraph.run` takes `(input, config)` — `runId` lives in the config (second argument), not the input:
 
 ```ts
-graph.run({ runId, registry, ... });
+graph.run({}, { runId, registry, ... });
 ```
 
 The caller owns generation. The contract:
@@ -261,7 +261,7 @@ The caller owns generation. The contract:
 - A restart after a crash uses the **same** `runId` — that is how durable resume works.
 - Concurrent runs of the same workflow get **different** `runId`s.
 
-If the graph contains any `private`-policy task and `runId` is missing, `handleStart` rejects the run synchronously.
+`handleStart` rejects the run synchronously only when **all** of the following hold: a `CACHE_REGISTRY` is registered, its `private` slot is populated, and the graph contains at least one task whose policy may resolve to `kind: "private"` (a static `cachePolicy` of that kind, or a `getCachePolicy(inputs)` override that can return it). Graphs without a private slot — or without any private-policy task — can omit `runId`.
 
 ### Cache key
 
@@ -278,9 +278,9 @@ key = sha256(taskType + getCacheVersion() + fingerprint(inputs))
 | Tier            | Written        | Read                                  | Deleted                                                                                                                                |
 | --------------- | -------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `deterministic` | On task success | On task start                         | Never automatically. App owns invalidation (typically via `version` bumps).                                                            |
-| `private`       | On task success | On task start, filtered to current `runId` | **(a)** `privateRepo.clearRun(runId)` on `succeeded`. **(b)** TTL sweep via `CacheJanitor.sweepStaleRunPrivate(olderThanMs)` for abandoned runs. |
+| `private`       | On task success | On task start, filtered to current `runId` | **(a)** `privateRepo.clearRun()` on `succeeded` (the wrapper already knows its `runId`). **(b)** TTL sweep via `CacheJanitor.sweepStaleRunPrivate(olderThanMs)` for abandoned runs. |
 
-Failed tasks are never cached — only `Ok` results reach `saveOutput`. Both slots are insert-if-absent: a same-key write while the original row exists is dropped silently.
+Failed tasks are never cached — only `Ok` results reach `saveOutput`. `saveOutput` is upsert by primary key (last writer wins) — the underlying `TaskOutputTabularRepository` calls `put()` on its tabular storage, so a same-key write replaces the existing row.
 
 ### Durable execution model
 


### PR DESCRIPTION
## Summary

Replaces the simple `cacheable: boolean` property with a comprehensive `CachePolicy` type system that distinguishes between deterministic, private (run-scoped), and non-cached tasks. Updates documentation and execution model to reflect the new caching architecture, including run identity, durable execution, and cache registry patterns.

## Key Changes

- **Type system**: Introduced `CachePolicy` union type with three kinds:
  - `{ kind: "deterministic" }` — safe to share across runs
  - `{ kind: "private" }` — non-deterministic but cached per-run (namespaced by `runId`)
  - `{ kind: "none" }` — side-effecting tasks, never cached

- **Task API**: 
  - Replaced `static readonly cacheable: boolean` with `static readonly cachePolicy: CachePolicy`
  - Added `getCachePolicy(inputs)` instance method for input-dependent policies
  - Updated all README examples to use new property

- **Cache infrastructure**:
  - Introduced `CacheRegistry` interface with two optional slots (`deterministic` and `private`)
  - Added `RunPrivateCacheRepo` wrapper that namespaces private-tier rows by `runId`
  - Documented `CacheJanitor` for TTL-based cleanup of abandoned run-private entries

- **Run identity & durable execution**:
  - Caller now supplies `runId` to `.run()` — enables restart survival via cache hits
  - Documented contract: fresh runs get new UUID, restarts reuse same `runId`
  - Runner warns if graph contains `private`-policy tasks but repo is non-durable

- **Cache key & versioning**:
  - Key formula: `sha256(taskType + getCacheVersion() + fingerprint(inputs))`
  - `Task.version` (default `1`) feeds `getCacheVersion()` for semantic versioning
  - Documented how to bump version to invalidate stale entries

- **Documentation**:
  - Expanded README "Storage and Caching" section with policy definitions, registry setup, and end-to-end example
  - Added new "Cache, Run Identity, and Durable Execution" section to `EXECUTION_MODEL.md`
  - Clarified lifecycle of cache rows, cleanup semantics, and durability guarantees

## Notable Implementation Details

- Both cache slots are independently optional; missing slots are silent no-ops
- Private-tier rows are prefixed with `__run:${runId}::` by the wrapper, never by the key function
- On successful completion, runner calls `privateRepo.clearRun(runId)` to prevent stale hits on restart
- Deterministic-tier rows are never auto-deleted; app owns invalidation via `version` bumps
- Re-dispatch correctness requires scheduler to be deterministic (no wall-clock, machine ID, or worker-local randomness)

https://claude.ai/code/session_01U7ANHLbd3TALTeScGdQ5SD