### PR TITLE
fix: address HIGH-priority review findings in cloud adapters, cache policy, worker errors

### DIFF
--- a/packages/job-queue/src/queue-storage/IJobStore.ts
+++ b/packages/job-queue/src/queue-storage/IJobStore.ts
@@ -139,4 +139,28 @@ export interface IJobStore<Input, Output> {
     id: MessageId,
     opts: { readonly visible_at: Date; readonly errorCode: string }
   ): Promise<void>;
+
+  /**
+   * Batch counterpart to {@link markEnqueueDeferred}. Used by cloud-queue
+   * adapters whose `sendBatch` may throw with N rows already inserted:
+   * a serial `for...await markEnqueueDeferred` loop turns one transient
+   * network failure into N sequential DB round-trips and often outlives
+   * the caller's deadline.
+   *
+   * The default {@link WrappedJobStore} implementation uses
+   * `Promise.allSettled` to fan out the per-id writes in parallel and
+   * returns a structured `{ failed }` list rather than throwing on the
+   * first error — callers (sendBatch) log each failed id and surface the
+   * aggregate via their existing `AggregateError`. Native SQL backends may
+   * override with a single `UPDATE ... WHERE id = ANY($1)` round-trip.
+   *
+   * Optional: the wrapper layer provides a default implementation so
+   * adapters can call this method as `jobStore.markEnqueueDeferredMany!`
+   * confident a fallback is present even if a custom IJobStore doesn't
+   * implement it natively.
+   */
+  markEnqueueDeferredMany?(
+    ids: readonly MessageId[],
+    opts: { readonly visible_at: Date; readonly errorCode: string }
+  ): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }>;
 }

--- a/packages/job-queue/src/queue-storage/IQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/IQueueStorage.ts
@@ -262,6 +262,25 @@ export interface IQueueStorage<Input, Output> {
   ): Promise<void>;
 
   /**
+   * Optional native fingerprint dedup lookup. Returns the active
+   * (PENDING or PROCESSING) row for the given fingerprint within this
+   * queue, if any. Backends with a partial unique index on
+   * `(queue, fingerprint) WHERE status IN ('PENDING','PROCESSING')`
+   * SHOULD implement this for O(1) lookup; the wrapper layer delegates
+   * to it when present and falls back to a bounded peek-and-scan
+   * otherwise. The scan fallback is O(N) in the active queue size
+   * and bounded — see WrappedJobStore.findActiveByFingerprint.
+   *
+   * @param fingerprint - The fingerprint to look up
+   * @param queueName - The queue name (storage is already scoped, used
+   *                    for parity with the IJobStore signature)
+   */
+  findActiveByFingerprint?(
+    fingerprint: string,
+    queueName: string
+  ): Promise<JobStorageFormat<Input, Output> | undefined>;
+
+  /**
    * Deletes all jobs from the queue storage
    */
   deleteAll(): Promise<void>;

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger } from "@workglow/util";
 import type { IClaim } from "./IClaim";
 import type { IJobStore, JobRecord } from "./IJobStore";
 import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
@@ -15,23 +14,6 @@ import type {
   QueueChangePayload,
   QueueSubscribeOptions,
 } from "./IQueueStorage";
-
-/**
- * Upper bound on the number of PENDING + PROCESSING rows scanned by the
- * wrapper-fallback {@link WrappedJobStore.findActiveByFingerprint}. The
- * native storage path (Postgres/SQLite/Supabase) uses a partial unique
- * index for O(1) lookup; this wrapper fallback only runs for backends
- * that don't expose `findActiveByFingerprint` on the storage layer
- * (in-memory, IndexedDB). 10k is enough to keep dedup correct for any
- * realistic single-queue working set without unbounded scans under load.
- */
-const MAX_FINGERPRINT_SCAN = 10_000;
-
-/**
- * One-shot warning gate for the bounded-scan exhaustion path so a hot
- * queue doesn't flood logs with the same message every send.
- */
-let __fingerprintScanExhaustedWarned = false;
 
 /**
  * Transient per-id buffer of outputs / errors written via
@@ -331,52 +313,15 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     fingerprint: string,
     _queueName: string
   ): Promise<JobRecord<Input, Output> | undefined> {
-    // Prefer the native storage implementation when available (Postgres,
-    // SQLite, Supabase): those backends have a partial unique index on
-    // (queue, fingerprint) WHERE status IN ('PENDING','PROCESSING') for
-    // O(1) lookup. Falling through to a peek-and-scan would be a perf
-    // regression on the hot dedup path.
-    const native = (this.storage as Partial<IQueueStorage<Input, Output>> & {
-      findActiveByFingerprint?: (
-        fp: string,
-        queueName: string
-      ) => Promise<JobRecord<Input, Output> | undefined>;
-    }).findActiveByFingerprint;
-    if (typeof native === "function") {
-      return native.call(this.storage, fingerprint, _queueName);
-    }
-
-    // Fallback for backends without a native implementation (in-memory,
-    // IndexedDB): page through PENDING then PROCESSING with a hard cap. The
-    // wrapped storage is already scoped to a single queue, so any row found
-    // here is in "this" queue — the queueName parameter is accepted for
-    // interface compatibility but not used for filtering.
-    let scanned = 0;
-    const pageSize = 1000;
-    for (const status of ["PENDING", "PROCESSING"] as const) {
-      // peek() implementations cap their `num` arg internally, so we ask for
-      // pageSize at a time. Most in-memory implementations ignore offset and
-      // just return the first N — so we accept O(MAX_FINGERPRINT_SCAN) worst
-      // case and rely on the cap to bound it.
-      const remaining = MAX_FINGERPRINT_SCAN - scanned;
-      if (remaining <= 0) break;
-      const rows = await this.storage.peek(status, Math.min(pageSize, remaining));
-      for (const r of rows) {
-        scanned += 1;
-        if (r.fingerprint === fingerprint) return r;
-        if (scanned >= MAX_FINGERPRINT_SCAN) break;
-      }
-      // If peek returned fewer rows than requested, we've exhausted this status.
-      if (rows.length < pageSize) continue;
-    }
-
-    if (scanned >= MAX_FINGERPRINT_SCAN && !__fingerprintScanExhaustedWarned) {
-      __fingerprintScanExhaustedWarned = true;
-      getLogger().warn(
-        "WrappedJobStore.findActiveByFingerprint: scanned MAX_FINGERPRINT_SCAN rows without a match; dedup may be best-effort under load"
-      );
-    }
-    return undefined;
+    // The wrapped storage is already scoped to a single queue, so any
+    // PENDING/PROCESSING row found here is in "this" queue. The queueName
+    // parameter is accepted for interface compatibility but not used for
+    // filtering — the storage instance boundary provides the scope.
+    const [pending, processing] = await Promise.all([
+      this.storage.peek("PENDING"),
+      this.storage.peek("PROCESSING"),
+    ]);
+    return [...pending, ...processing].find((j) => j.fingerprint === fingerprint);
   }
 
   async getMany(
@@ -428,21 +373,6 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
       visible_at: opts.visible_at.toISOString(),
       error_code: opts.errorCode,
     });
-  }
-
-  async markEnqueueDeferredMany(
-    ids: readonly MessageId[],
-    opts: { readonly visible_at: Date; readonly errorCode: string }
-  ): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }> {
-    // Default impl: fan out the per-id calls and surface a structured
-    // failure list rather than throwing on the first error. Backends with
-    // bulk-update support can override on the storage layer for a single
-    // round-trip; this fallback keeps the contract uniform.
-    const results = await Promise.allSettled(ids.map((id) => this.markEnqueueDeferred(id, opts)));
-    const failed = results.flatMap((r, i) =>
-      r.status === "rejected" ? [{ id: ids[i]!, err: r.reason }] : []
-    );
-    return { failed };
   }
 }
 

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from "@workglow/util";
 import type { IClaim } from "./IClaim";
 import type { IJobStore, JobRecord } from "./IJobStore";
 import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
@@ -14,6 +15,23 @@ import type {
   QueueChangePayload,
   QueueSubscribeOptions,
 } from "./IQueueStorage";
+
+/**
+ * Upper bound on the number of PENDING + PROCESSING rows scanned by the
+ * wrapper-fallback {@link WrappedJobStore.findActiveByFingerprint}. The
+ * native storage path (Postgres/SQLite/Supabase) uses a partial unique
+ * index for O(1) lookup; this wrapper fallback only runs for backends
+ * that don't expose `findActiveByFingerprint` on the storage layer
+ * (in-memory, IndexedDB). 10k is enough to keep dedup correct for any
+ * realistic single-queue working set without unbounded scans under load.
+ */
+const MAX_FINGERPRINT_SCAN = 10_000;
+
+/**
+ * One-shot warning gate for the bounded-scan exhaustion path so a hot
+ * queue doesn't flood logs with the same message every send.
+ */
+let __fingerprintScanExhaustedWarned = false;
 
 /**
  * Transient per-id buffer of outputs / errors written via
@@ -313,15 +331,43 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     fingerprint: string,
     _queueName: string
   ): Promise<JobRecord<Input, Output> | undefined> {
-    // The wrapped storage is already scoped to a single queue, so any
-    // PENDING/PROCESSING row found here is in "this" queue. The queueName
-    // parameter is accepted for interface compatibility but not used for
-    // filtering — the storage instance boundary provides the scope.
-    const [pending, processing] = await Promise.all([
-      this.storage.peek("PENDING"),
-      this.storage.peek("PROCESSING"),
-    ]);
-    return [...pending, ...processing].find((j) => j.fingerprint === fingerprint);
+    // Prefer the native storage implementation when available (Postgres,
+    // SQLite, Supabase): those backends have a partial unique index on
+    // (queue, fingerprint) WHERE status IN ('PENDING','PROCESSING') for
+    // O(1) lookup. Falling through to a peek-and-scan would be a perf
+    // regression on the hot dedup path.
+    const native = this.storage.findActiveByFingerprint;
+    if (typeof native === "function") {
+      return native.call(this.storage, fingerprint, _queueName);
+    }
+
+    // Fallback for backends without a native implementation (in-memory,
+    // IndexedDB): page through PENDING then PROCESSING with a hard cap. The
+    // wrapped storage is already scoped to a single queue, so any row found
+    // here is in "this" queue — the queueName parameter is accepted for
+    // interface compatibility but not used for filtering.
+    let scanned = 0;
+    const pageSize = 1000;
+    for (const status of ["PENDING", "PROCESSING"] as const) {
+      const remaining = MAX_FINGERPRINT_SCAN - scanned;
+      if (remaining <= 0) break;
+      const rows = await this.storage.peek(status, Math.min(pageSize, remaining));
+      for (const r of rows) {
+        scanned += 1;
+        if (r.fingerprint === fingerprint) return r;
+        if (scanned >= MAX_FINGERPRINT_SCAN) break;
+      }
+      // peek() implementations cap their `num` arg internally so we accept
+      // the bounded scan and rely on MAX_FINGERPRINT_SCAN as a hard ceiling.
+    }
+
+    if (scanned >= MAX_FINGERPRINT_SCAN && !__fingerprintScanExhaustedWarned) {
+      __fingerprintScanExhaustedWarned = true;
+      getLogger().warn(
+        "WrappedJobStore.findActiveByFingerprint: scanned MAX_FINGERPRINT_SCAN rows without a match; dedup may be best-effort under load"
+      );
+    }
+    return undefined;
   }
 
   async getMany(

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -420,6 +420,22 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
       error_code: opts.errorCode,
     });
   }
+
+  async markEnqueueDeferredMany(
+    ids: readonly MessageId[],
+    opts: { readonly visible_at: Date; readonly errorCode: string }
+  ): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }> {
+    // H4: default impl — fan out the per-id writes in parallel rather than
+    // forcing callers into a serial for/await loop. allSettled so a single
+    // failed id doesn't tank the rest of the batch; structured failure list
+    // surfaces to the caller's AggregateError handling. SQL backends can
+    // override with a single bulk UPDATE for a one-round-trip path.
+    const results = await Promise.allSettled(ids.map((id) => this.markEnqueueDeferred(id, opts)));
+    const failed = results.flatMap((r, i) =>
+      r.status === "rejected" ? [{ id: ids[i]!, err: r.reason }] : []
+    );
+    return { failed };
+  }
 }
 
 function applySendOptions<Input, Output>(

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -69,8 +69,7 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
     // do not fall back to current — that's the prior attempt's value and finalize() must overwrite it
-    const output =
-      result !== undefined ? result : buf?.output !== undefined ? buf.output : null;
+    const output = result !== undefined ? result : buf?.output !== undefined ? buf.output : null;
     await this.storage.finalize(this.id, {
       // `output` cast — finalize is typed against Output but receives the
       // result the worker passed in; the queue body's Output and the claim's
@@ -342,23 +341,25 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     }
 
     // Fallback for backends without a native implementation (in-memory,
-    // IndexedDB): page through PENDING then PROCESSING with a hard cap. The
-    // wrapped storage is already scoped to a single queue, so any row found
-    // here is in "this" queue — the queueName parameter is accepted for
-    // interface compatibility but not used for filtering.
+    // IndexedDB): single bounded peek per status, up to MAX_FINGERPRINT_SCAN
+    // total rows across PENDING + PROCESSING. The actual cap is the minimum
+    // of MAX_FINGERPRINT_SCAN and whatever the underlying peek() impl
+    // chooses to cap `num` at internally. We rely on MAX_FINGERPRINT_SCAN as
+    // a hard ceiling and surface a one-shot warning when we exhaust it
+    // without finding a match. The wrapped storage is already scoped to a
+    // single queue, so any row found here is in "this" queue — the
+    // queueName parameter is accepted for interface compatibility but not
+    // used for filtering.
     let scanned = 0;
-    const pageSize = 1000;
     for (const status of ["PENDING", "PROCESSING"] as const) {
       const remaining = MAX_FINGERPRINT_SCAN - scanned;
       if (remaining <= 0) break;
-      const rows = await this.storage.peek(status, Math.min(pageSize, remaining));
+      const rows = await this.storage.peek(status, remaining);
       for (const r of rows) {
         scanned += 1;
         if (r.fingerprint === fingerprint) return r;
         if (scanned >= MAX_FINGERPRINT_SCAN) break;
       }
-      // peek() implementations cap their `num` arg internally so we accept
-      // the bounded scan and rely on MAX_FINGERPRINT_SCAN as a hard ceiling.
     }
 
     if (scanned >= MAX_FINGERPRINT_SCAN && !__fingerprintScanExhaustedWarned) {

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from "@workglow/util";
 import type { IClaim } from "./IClaim";
 import type { IJobStore, JobRecord } from "./IJobStore";
 import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
@@ -14,6 +15,23 @@ import type {
   QueueChangePayload,
   QueueSubscribeOptions,
 } from "./IQueueStorage";
+
+/**
+ * Upper bound on the number of PENDING + PROCESSING rows scanned by the
+ * wrapper-fallback {@link WrappedJobStore.findActiveByFingerprint}. The
+ * native storage path (Postgres/SQLite/Supabase) uses a partial unique
+ * index for O(1) lookup; this wrapper fallback only runs for backends
+ * that don't expose `findActiveByFingerprint` on the storage layer
+ * (in-memory, IndexedDB). 10k is enough to keep dedup correct for any
+ * realistic single-queue working set without unbounded scans under load.
+ */
+const MAX_FINGERPRINT_SCAN = 10_000;
+
+/**
+ * One-shot warning gate for the bounded-scan exhaustion path so a hot
+ * queue doesn't flood logs with the same message every send.
+ */
+let __fingerprintScanExhaustedWarned = false;
 
 /**
  * Transient per-id buffer of outputs / errors written via
@@ -50,12 +68,9 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
+    // do not fall back to current — that's the prior attempt's value and finalize() must overwrite it
     const output =
-      result !== undefined
-        ? result
-        : buf?.output !== undefined
-          ? buf.output
-          : (current.output ?? null);
+      result !== undefined ? result : buf?.output !== undefined ? buf.output : null;
     await this.storage.finalize(this.id, {
       // `output` cast — finalize is typed against Output but receives the
       // result the worker passed in; the queue body's Output and the claim's
@@ -103,18 +118,16 @@ class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Outp
     const buf = this.pending.get(this.id);
     this.pending.delete(this.id);
     const current = (await this.storage.get(this.id)) ?? this.body;
+    // do not fall back to current — that's the prior attempt's value and finalize() must overwrite it
     const error =
-      opts?.error !== undefined
-        ? opts.error
-        : buf?.error !== undefined
-          ? buf.error
-          : (current.error ?? null);
+      opts?.error !== undefined ? opts.error : buf?.error !== undefined ? buf.error : null;
+    // do not fall back to current — that's the prior attempt's value and finalize() must overwrite it
     const errorCode =
       opts?.errorCode !== undefined
         ? opts.errorCode
         : buf?.errorCode !== undefined
           ? buf.errorCode
-          : (current.error_code ?? null);
+          : null;
     const abortRequested =
       opts?.abortRequested !== undefined ? opts.abortRequested : (buf?.abortRequested ?? false);
     await this.storage.finalize(this.id, {
@@ -318,15 +331,52 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     fingerprint: string,
     _queueName: string
   ): Promise<JobRecord<Input, Output> | undefined> {
-    // The wrapped storage is already scoped to a single queue, so any
-    // PENDING/PROCESSING row found here is in "this" queue. The queueName
-    // parameter is accepted for interface compatibility but not used for
-    // filtering — the storage instance boundary provides the scope.
-    const [pending, processing] = await Promise.all([
-      this.storage.peek("PENDING"),
-      this.storage.peek("PROCESSING"),
-    ]);
-    return [...pending, ...processing].find((j) => j.fingerprint === fingerprint);
+    // Prefer the native storage implementation when available (Postgres,
+    // SQLite, Supabase): those backends have a partial unique index on
+    // (queue, fingerprint) WHERE status IN ('PENDING','PROCESSING') for
+    // O(1) lookup. Falling through to a peek-and-scan would be a perf
+    // regression on the hot dedup path.
+    const native = (this.storage as Partial<IQueueStorage<Input, Output>> & {
+      findActiveByFingerprint?: (
+        fp: string,
+        queueName: string
+      ) => Promise<JobRecord<Input, Output> | undefined>;
+    }).findActiveByFingerprint;
+    if (typeof native === "function") {
+      return native.call(this.storage, fingerprint, _queueName);
+    }
+
+    // Fallback for backends without a native implementation (in-memory,
+    // IndexedDB): page through PENDING then PROCESSING with a hard cap. The
+    // wrapped storage is already scoped to a single queue, so any row found
+    // here is in "this" queue — the queueName parameter is accepted for
+    // interface compatibility but not used for filtering.
+    let scanned = 0;
+    const pageSize = 1000;
+    for (const status of ["PENDING", "PROCESSING"] as const) {
+      // peek() implementations cap their `num` arg internally, so we ask for
+      // pageSize at a time. Most in-memory implementations ignore offset and
+      // just return the first N — so we accept O(MAX_FINGERPRINT_SCAN) worst
+      // case and rely on the cap to bound it.
+      const remaining = MAX_FINGERPRINT_SCAN - scanned;
+      if (remaining <= 0) break;
+      const rows = await this.storage.peek(status, Math.min(pageSize, remaining));
+      for (const r of rows) {
+        scanned += 1;
+        if (r.fingerprint === fingerprint) return r;
+        if (scanned >= MAX_FINGERPRINT_SCAN) break;
+      }
+      // If peek returned fewer rows than requested, we've exhausted this status.
+      if (rows.length < pageSize) continue;
+    }
+
+    if (scanned >= MAX_FINGERPRINT_SCAN && !__fingerprintScanExhaustedWarned) {
+      __fingerprintScanExhaustedWarned = true;
+      getLogger().warn(
+        "WrappedJobStore.findActiveByFingerprint: scanned MAX_FINGERPRINT_SCAN rows without a match; dedup may be best-effort under load"
+      );
+    }
+    return undefined;
   }
 
   async getMany(
@@ -378,6 +428,21 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
       visible_at: opts.visible_at.toISOString(),
       error_code: opts.errorCode,
     });
+  }
+
+  async markEnqueueDeferredMany(
+    ids: readonly MessageId[],
+    opts: { readonly visible_at: Date; readonly errorCode: string }
+  ): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }> {
+    // Default impl: fan out the per-id calls and surface a structured
+    // failure list rather than throwing on the first error. Backends with
+    // bulk-update support can override on the storage layer for a single
+    // round-trip; this fallback keeps the contract uniform.
+    const results = await Promise.allSettled(ids.map((id) => this.markEnqueueDeferred(id, opts)));
+    const failed = results.flatMap((r, i) =>
+      r.status === "rejected" ? [{ id: ids[i]!, err: r.reason }] : []
+    );
+    return { failed };
   }
 }
 

--- a/packages/task-graph/src/task/Task.ts
+++ b/packages/task-graph/src/task/Task.ts
@@ -135,6 +135,10 @@ export class Task<
   /**
    * Tracks task types that have already received the legacy `cacheable = false` deprecation
    * warning, so the warning fires only once per task type across the process lifetime.
+   *
+   * H7: keyed by a synthetic typeKey (see {@link getCachePolicy}) — when a
+   * subclass leaves the static `type` at the base "Task" value, the key
+   * is `Task#<ClassName>` so subclasses don't silence each other.
    */
   private static __cacheableDeprecationWarned = new Set<string>();
 
@@ -392,10 +396,21 @@ export class Task<
     const hasPolicyOverride = Object.prototype.hasOwnProperty.call(ctor, "cachePolicy");
 
     if (hasLegacyOverride && !hasPolicyOverride) {
-      if (!Task.__cacheableDeprecationWarned.has(ctor.type)) {
-        Task.__cacheableDeprecationWarned.add(ctor.type);
+      // H7: keying the dedup Set by `ctor.type` alone collapsed every subclass
+      // that hadn't overridden the static `type` (which still reads "Task"
+      // from the base) into a single warning — the first offender silenced
+      // the rest. Fall back to the subclass's runtime `name` when `type` is
+      // still the base value so each distinct class gets its own warning.
+      // The verbose env override exists for one-shot diagnostic runs where
+      // an operator wants every occurrence (not just the first per class)
+      // surfaced — e.g., grepping CI logs to find every legacy site.
+      const typeKey = ctor.type === "Task" ? `Task#${ctor.name}` : ctor.type;
+      const verbose =
+        typeof process !== "undefined" && process.env?.WORKGLOW_CACHE_DEPRECATION === "verbose";
+      if (verbose || !Task.__cacheableDeprecationWarned.has(typeKey)) {
+        Task.__cacheableDeprecationWarned.add(typeKey);
         getLogger().warn(
-          `Task "${ctor.type}": static \`cacheable = false\` is deprecated. ` +
+          `Task "${typeKey}": static \`cacheable = false\` is deprecated. ` +
             `Use \`static cachePolicy: CachePolicy = { kind: "none" }\` instead.`
         );
       }
@@ -1245,4 +1260,15 @@ export class Task<
     }
     this.events.emit("regenerate");
   }
+}
+
+/**
+ * Test helper: clear the H7 dedup Set so each test case can re-trigger the
+ * one-time legacy-`cacheable` deprecation warning. Lives in production code
+ * (not a __tests__ file) so it's reachable from outside the package's test
+ * harness; the leading double-underscore signals "do not rely on this in
+ * application code".
+ */
+export function __resetCacheableDeprecationWarnings(): void {
+  (Task as unknown as { __cacheableDeprecationWarned: Set<string> }).__cacheableDeprecationWarned.clear();
 }

--- a/packages/util/src/worker-entry.ts
+++ b/packages/util/src/worker-entry.ts
@@ -29,6 +29,10 @@ export * from "./logging";
 // the side-effect that registers the WorkerServer implementation.
 export * from "./worker/WorkerServerBase";
 export * from "./worker/WorkerManager";
+// H8: scrubStack helper for sanitizing absolute filesystem paths out of
+// worker error stacks. Exported here so third-party worker code in the
+// same process can apply the same sanitizer to its own error reporting.
+export * from "./worker/scrubStack";
 
 // Partial JSON parsing for streaming AI responses (zero deps)
 export * from "./json-schema/parsePartialJson";

--- a/packages/util/src/worker/WorkerManager.ts
+++ b/packages/util/src/worker/WorkerManager.ts
@@ -6,6 +6,7 @@
 
 import { createServiceToken, globalServiceRegistry } from "../di";
 import { getLogger } from "../logging";
+import { scrubStack } from "./scrubStack";
 
 export class WorkerManager {
   private workers: Map<string, Worker> = new Map();
@@ -271,11 +272,22 @@ export class WorkerManager {
           } else if (type === "error") {
             cleanup();
             getLogger().debug(`Worker ${workerName} function ${functionName} error.`, { data });
+            // H8: defense-in-depth — a third-party worker that didn't go
+            // through our scrubbing postError may still ship absolute paths
+            // in `data.stack`. Re-scrub with the manager process's cwd
+            // before handing the rehydrated Error to the caller.
+            const scrubbedStack =
+              typeof data === "object" && data !== null && typeof data.stack === "string"
+                ? scrubStack(
+                    data.stack,
+                    [typeof process !== "undefined" ? process.cwd() : ""].filter(Boolean)
+                  )
+                : undefined;
             const err =
               typeof data === "object" && data !== null
                 ? Object.assign(new Error(data.message ?? String(data)), {
                     name: data.name ?? "Error",
-                    ...(typeof data.stack === "string" ? { stack: data.stack } : {}),
+                    ...(scrubbedStack !== undefined ? { stack: scrubbedStack } : {}),
                   })
                 : new Error(String(data));
             reject(err);

--- a/packages/util/src/worker/WorkerServerBase.ts
+++ b/packages/util/src/worker/WorkerServerBase.ts
@@ -5,6 +5,7 @@
  */
 
 import { createServiceToken } from "../di";
+import { scrubStack } from "./scrubStack";
 
 /** Service token for the platform-specific WorkerServer instance. */
 export const WORKER_SERVER = createServiceToken<WorkerServerBase>("worker.server");
@@ -203,11 +204,25 @@ export class WorkerServerBase {
       return; // Already responded to this request
     }
     this.completedRequests.add(id);
+    // H8: scrub absolute paths from any stack we ship to the parent and
+    // omit the stack entirely in production unless the operator opts in
+    // via WORKGLOW_INCLUDE_STACKS=1. Without this, build-server / container
+    // / customer-deployment roots leaked through every UI that rendered
+    // the rejected promise.
+    const roots = [typeof process !== "undefined" ? process.cwd() : ""].filter(Boolean);
+    const includeStack =
+      typeof process === "undefined" ||
+      process.env?.NODE_ENV !== "production" ||
+      process.env?.WORKGLOW_INCLUDE_STACKS === "1";
     let data: { message: string; name: string; stack?: string };
     if (typeof error === "string") {
       data = { message: error, name: "Error" };
     } else if (error instanceof Error) {
-      data = { message: error.message, name: error.name, stack: error.stack };
+      data = { message: error.message, name: error.name };
+      if (includeStack) {
+        const scrubbed = scrubStack(error.stack, roots);
+        if (scrubbed !== undefined) data.stack = scrubbed;
+      }
     } else {
       data = { message: String(error), name: "Error" };
     }

--- a/packages/util/src/worker/scrubStack.ts
+++ b/packages/util/src/worker/scrubStack.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Replace each `root` prefix in `stack` with the literal placeholder
+ * `<root>` so absolute filesystem paths (build-server home dirs, container
+ * layouts, customer-specific deployment roots) don't leak through error
+ * surfaces.
+ *
+ * Pure helper — returns the input unchanged when `stack` is undefined or
+ * the `roots` list is empty. Multiple roots are applied in order;
+ * empty-string roots are skipped (avoids replacing every empty position
+ * with `<root>`).
+ */
+export function scrubStack(
+  stack: string | undefined,
+  roots: readonly string[]
+): string | undefined {
+  if (!stack) return stack;
+  let out = stack;
+  for (const root of roots) {
+    if (!root) continue;
+    out = out.split(root).join("<root>");
+  }
+  return out;
+}

--- a/providers/aws/src/job-queue/SqsClaim.ts
+++ b/providers/aws/src/job-queue/SqsClaim.ts
@@ -18,6 +18,7 @@ import {
   type MessageId,
   JobStatus,
 } from "@workglow/job-queue";
+import { persistWithRetry } from "./persistWithRetry";
 
 const SQS_MAX_VISIBILITY_FROM_FIRST_RECEIVE_MS = 12 * 60 * 60 * 1000;
 
@@ -63,7 +64,9 @@ export class SqsClaim<Input, Output> implements IClaim<JobStorageFormat<Input, O
   // If the store write throws, the SQS message is already gone — the row
   // stays PROCESSING but no redelivery is possible; the lease-expiry sweep
   // eventually marks it FAILED/PENDING. Reversing the order would risk
-  // double-delivery, which is the worse failure mode.
+  // double-delivery, which is the worse failure mode. The JobStore write is
+  // wrapped in persistWithRetry so a transient DB blip doesn't strand the
+  // row — lease-expiry remains the worst-case safety net.
   async ack(result?: unknown): Promise<void> {
     await this.sqs.send(
       new DeleteMessageCommand({
@@ -72,9 +75,15 @@ export class SqsClaim<Input, Output> implements IClaim<JobStorageFormat<Input, O
       })
     );
     if (result !== undefined) {
-      await this.jobStore.completeWithResult(this.id, result as Output);
+      await persistWithRetry(
+        () => this.jobStore.completeWithResult(this.id, result as Output),
+        "SqsClaim.ack"
+      );
     } else {
-      await this.jobStore.saveStatus(this.id, JobStatus.COMPLETED);
+      await persistWithRetry(
+        () => this.jobStore.saveStatus(this.id, JobStatus.COMPLETED),
+        "SqsClaim.ack"
+      );
     }
   }
 
@@ -85,11 +94,15 @@ export class SqsClaim<Input, Output> implements IClaim<JobStorageFormat<Input, O
         ReceiptHandle: this.receiptHandle,
       })
     );
-    await this.jobStore.failWithError(this.id, {
-      error: opts?.error,
-      errorCode: opts?.errorCode,
-      abortRequested: opts?.abortRequested,
-    });
+    await persistWithRetry(
+      () =>
+        this.jobStore.failWithError(this.id, {
+          error: opts?.error,
+          errorCode: opts?.errorCode,
+          abortRequested: opts?.abortRequested,
+        }),
+      "SqsClaim.fail"
+    );
   }
 
   async retry(opts?: { delaySeconds?: number }): Promise<void> {

--- a/providers/aws/src/job-queue/SqsMessageQueue.ts
+++ b/providers/aws/src/job-queue/SqsMessageQueue.ts
@@ -172,13 +172,20 @@ export class SqsMessageQueue<Input, Output> implements IMessageQueue<
       // forward and error_code set, instead of FAILING (which would
       // permanently drop the work for any consumer that's polling for
       // PENDING). Successful rows in the batch keep their original PENDING +
-      // visible_at = now from create().
+      // visible_at = now from create(). Use the batched many-variant so we
+      // do one parallel fan-out rather than a serial per-id round-trip
+      // storm; the WrappedJobStore default impl is always present.
       const defer = new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS);
-      for (const { id } of failures) {
-        await this.jobStore.markEnqueueDeferred(id, {
-          visible_at: defer,
-          errorCode: "ENQUEUE_FAILED",
-        });
+      const failedIds = failures.map((f) => f.id);
+      const deferResult = await this.jobStore.markEnqueueDeferredMany!(failedIds, {
+        visible_at: defer,
+        errorCode: "ENQUEUE_FAILED",
+      });
+      for (const { id, err } of deferResult.failed) {
+        getLogger().error(
+          `[SqsMessageQueue] markEnqueueDeferred failed id=${String(id)}`,
+          { err }
+        );
       }
       throw new AggregateError(
         failures.map((f) => (f.err instanceof Error ? f.err : new Error(String(f.err)))),

--- a/providers/aws/src/job-queue/SqsMessageQueue.ts
+++ b/providers/aws/src/job-queue/SqsMessageQueue.ts
@@ -37,6 +37,23 @@ const SQS_MAX_RECEIVE = 10;
 const ENQUEUE_DEFER_BACKOFF_MS = 30_000;
 
 /**
+ * H5: clamp the defer interval to the original `delaySeconds` floor so a row
+ * with a legitimate large delay (e.g. 1h scheduled work) is NOT pulled
+ * forward to now + 30s by a producer-side blip. Returns the maximum of the
+ * original delay and the producer-retry backoff so:
+ *   - delaySeconds = 0   → wait 30s before next producer attempt
+ *   - delaySeconds = 3600 → wait 3600s (the original schedule)
+ *
+ * TODO: full exponential backoff requires a new enqueue_defer_attempts field;
+ * see follow-up issue. Today's mitigation just prevents the bug where a
+ * scheduled row is silently re-delivered ahead of schedule.
+ */
+function computeDeferDelayMs(originalDelaySeconds: number | undefined): number {
+  const original = originalDelaySeconds != null ? originalDelaySeconds * 1000 : 0;
+  return Math.max(original, ENQUEUE_DEFER_BACKOFF_MS);
+}
+
+/**
  * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
  * WeakSet so we don't pin store instances in memory — the warning fires
  * once per process per store, then the store's lifecycle is unaffected.
@@ -108,8 +125,10 @@ export class SqsMessageQueue<Input, Output> implements IMessageQueue<
       // H4: a producer-side throw is transient — leave the row PENDING so a
       // retry or a polling consumer can pick it back up. We shift visible_at
       // forward and stamp error_code; status/attempts are untouched.
+      // H5: clamp to the original delaySeconds floor so a scheduled row is
+      // not pulled forward by the producer-retry backoff.
       await this.jobStore.markEnqueueDeferred(id, {
-        visible_at: new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS),
+        visible_at: new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds)),
         errorCode: "ENQUEUE_FAILED",
       });
       throw err;
@@ -175,7 +194,8 @@ export class SqsMessageQueue<Input, Output> implements IMessageQueue<
       // visible_at = now from create(). Use the batched many-variant so we
       // do one parallel fan-out rather than a serial per-id round-trip
       // storm; the WrappedJobStore default impl is always present.
-      const defer = new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS);
+      // H5: clamp to the original delaySeconds floor.
+      const defer = new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds));
       const failedIds = failures.map((f) => f.id);
       const deferResult = await this.jobStore.markEnqueueDeferredMany!(failedIds, {
         visible_at: defer,

--- a/providers/aws/src/job-queue/SqsMessageQueue.ts
+++ b/providers/aws/src/job-queue/SqsMessageQueue.ts
@@ -36,6 +36,13 @@ const SQS_MAX_RECEIVE = 10;
  */
 const ENQUEUE_DEFER_BACKOFF_MS = 30_000;
 
+/**
+ * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
+ * WeakSet so we don't pin store instances in memory — the warning fires
+ * once per process per store, then the store's lifecycle is unaffected.
+ */
+const __warnedInMemoryStores = new WeakSet<object>();
+
 export class SqsMessageQueue<Input, Output> implements IMessageQueue<
   JobStorageFormat<Input, Output>
 > {
@@ -51,6 +58,21 @@ export class SqsMessageQueue<Input, Output> implements IMessageQueue<
     this.queueUrl = opts.queueUrl;
     this.queueName = opts.queueName;
     this.jobStore = opts.jobStore;
+
+    // H3: warn loudly (once per store) when paired with InMemoryJobStore.
+    // SQS at-least-once + an in-memory store means partial-failure rows
+    // strand forever (no shared lease-expiry sweep across processes).
+    const storeCtor = (opts.jobStore as unknown as { constructor?: { name?: string } })
+      ?.constructor;
+    if (
+      storeCtor?.name === "InMemoryJobStore" &&
+      !__warnedInMemoryStores.has(opts.jobStore as unknown as object)
+    ) {
+      __warnedInMemoryStores.add(opts.jobStore as unknown as object);
+      getLogger().warn(
+        "[SqsMessageQueue] InMemoryJobStore detected — cloud adapters require a lease-sweeping JobStore (Postgres/Supabase/SQLite). Rows may strand on partial failures."
+      );
+    }
   }
 
   async send(body: JobStorageFormat<Input, Output>, opts: SendOptions = {}): Promise<MessageId> {

--- a/providers/aws/src/job-queue/SqsMessageQueue.ts
+++ b/providers/aws/src/job-queue/SqsMessageQueue.ts
@@ -54,6 +54,24 @@ function computeDeferDelayMs(originalDelaySeconds: number | undefined): number {
 }
 
 /**
+ * Fallback used when the underlying `IJobStore` does not implement the
+ * optional `markEnqueueDeferredMany` (bare InMemoryJobStore, etc.). Mirrors
+ * the WrappedJobStore default impl: parallel per-id writes via
+ * `Promise.allSettled` so a single transient failure doesn't tank the rest.
+ */
+async function markEnqueueDeferredManyFallback<Input, Output>(
+  jobStore: IJobStore<Input, Output>,
+  ids: readonly MessageId[],
+  opts: { readonly visible_at: Date; readonly errorCode: string }
+): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }> {
+  const results = await Promise.allSettled(ids.map((id) => jobStore.markEnqueueDeferred(id, opts)));
+  const failed = results.flatMap((r, i) =>
+    r.status === "rejected" ? [{ id: ids[i]!, err: r.reason }] : []
+  );
+  return { failed };
+}
+
+/**
  * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
  * WeakSet so we don't pin store instances in memory — the warning fires
  * once per process per store, then the store's lifecycle is unaffected.
@@ -191,21 +209,21 @@ export class SqsMessageQueue<Input, Output> implements IMessageQueue<
       // forward and error_code set, instead of FAILING (which would
       // permanently drop the work for any consumer that's polling for
       // PENDING). Successful rows in the batch keep their original PENDING +
-      // visible_at = now from create(). Use the batched many-variant so we
-      // do one parallel fan-out rather than a serial per-id round-trip
-      // storm; the WrappedJobStore default impl is always present.
+      // visible_at = now from create(). Prefer the batched many-variant when
+      // the IJobStore exposes it (WrappedJobStore ships a Promise.allSettled
+      // default; native SQL backends can override with a single bulk UPDATE).
+      // Fall back to a per-id allSettled fan-out for bare IJobStore impls
+      // (e.g. InMemoryJobStore in tests) that don't implement the optional
+      // method.
       // H5: clamp to the original delaySeconds floor.
       const defer = new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds));
       const failedIds = failures.map((f) => f.id);
-      const deferResult = await this.jobStore.markEnqueueDeferredMany!(failedIds, {
-        visible_at: defer,
-        errorCode: "ENQUEUE_FAILED",
-      });
+      const deferOpts = { visible_at: defer, errorCode: "ENQUEUE_FAILED" };
+      const deferResult = this.jobStore.markEnqueueDeferredMany
+        ? await this.jobStore.markEnqueueDeferredMany(failedIds, deferOpts)
+        : await markEnqueueDeferredManyFallback(this.jobStore, failedIds, deferOpts);
       for (const { id, err } of deferResult.failed) {
-        getLogger().error(
-          `[SqsMessageQueue] markEnqueueDeferred failed id=${String(id)}`,
-          { err }
-        );
+        getLogger().error(`[SqsMessageQueue] markEnqueueDeferred failed id=${String(id)}`, { err });
       }
       throw new AggregateError(
         failures.map((f) => (f.err instanceof Error ? f.err : new Error(String(f.err)))),

--- a/providers/aws/src/job-queue/persistWithRetry.ts
+++ b/providers/aws/src/job-queue/persistWithRetry.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+
+/**
+ * Run `op` with bounded exponential backoff. Used by SqsClaim.ack / .fail
+ * to make the JobStore terminal write resilient to transient failures —
+ * the SQS message has already been deleted by the time we get here, so a
+ * single thrown write would strand the row in PROCESSING until the
+ * lease-expiry sweep notices.
+ *
+ * Defaults: 3 attempts, 200ms base → 200ms / 400ms / 800ms backoffs.
+ * Logs at error and rethrows the last error if every attempt fails so
+ * the caller still sees the failure surface.
+ */
+export async function persistWithRetry(
+  op: () => Promise<void>,
+  ctx: string,
+  maxAttempts = 3,
+  baseDelayMs = 200
+): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await op();
+      return;
+    } catch (e) {
+      lastErr = e;
+      // Don't sleep after the final attempt — we're about to throw.
+      if (i < maxAttempts - 1) {
+        await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** i));
+      }
+    }
+  }
+  getLogger().error(`[${ctx}] persistence failed after retries`, { err: lastErr });
+  throw lastErr;
+}

--- a/providers/cloudflare/src/job-queue/CloudflareClaim.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareClaim.ts
@@ -14,6 +14,7 @@ import {
   type MessageId,
 } from "@workglow/job-queue";
 import type { CloudMessageBody } from "./types";
+import { persistWithRetry } from "./persistWithRetry";
 
 export interface CloudflareClaimOptions<Input, Output> {
   readonly message: Message<CloudMessageBody>;
@@ -51,23 +52,34 @@ export class CloudflareClaim<Input, Output> implements IClaim<JobStorageFormat<I
   // Reversing the order would risk double-delivery, which is worse.
   // CloudflareClaim.fail() also calls message.ack() (NOT message.retry()):
   // terminal failures must not be redelivered by CFQ; the worker decides
-  // retry policy via attempts/max_attempts.
+  // retry policy via attempts/max_attempts. The JobStore write is wrapped
+  // in persistWithRetry so a transient DB blip doesn't strand the row.
   async ack(result?: unknown): Promise<void> {
     this.message.ack();
     if (result !== undefined) {
-      await this.jobStore.completeWithResult(this.id, result as Output);
+      await persistWithRetry(
+        () => this.jobStore.completeWithResult(this.id, result as Output),
+        "CloudflareClaim.ack"
+      );
     } else {
-      await this.jobStore.saveStatus(this.id, JobStatus.COMPLETED);
+      await persistWithRetry(
+        () => this.jobStore.saveStatus(this.id, JobStatus.COMPLETED),
+        "CloudflareClaim.ack"
+      );
     }
   }
 
   async fail(opts?: ClaimFailOptions): Promise<void> {
     this.message.ack();
-    await this.jobStore.failWithError(this.id, {
-      error: opts?.error,
-      errorCode: opts?.errorCode,
-      abortRequested: opts?.abortRequested,
-    });
+    await persistWithRetry(
+      () =>
+        this.jobStore.failWithError(this.id, {
+          error: opts?.error,
+          errorCode: opts?.errorCode,
+          abortRequested: opts?.abortRequested,
+        }),
+      "CloudflareClaim.fail"
+    );
   }
 
   async retry(opts?: { delaySeconds?: number }): Promise<void> {

--- a/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
@@ -42,6 +42,24 @@ function computeDeferDelayMs(originalDelaySeconds: number | undefined): number {
 }
 
 /**
+ * Fallback used when the underlying `IJobStore` does not implement the
+ * optional `markEnqueueDeferredMany` (bare InMemoryJobStore, etc.). Mirrors
+ * the WrappedJobStore default impl: parallel per-id writes via
+ * `Promise.allSettled` so a single transient failure doesn't tank the rest.
+ */
+async function markEnqueueDeferredManyFallback<Input, Output>(
+  jobStore: IJobStore<Input, Output>,
+  ids: readonly MessageId[],
+  opts: { readonly visible_at: Date; readonly errorCode: string }
+): Promise<{ failed: readonly { id: MessageId; err: unknown }[] }> {
+  const results = await Promise.allSettled(ids.map((id) => jobStore.markEnqueueDeferred(id, opts)));
+  const failed = results.flatMap((r, i) =>
+    r.status === "rejected" ? [{ id: ids[i]!, err: r.reason }] : []
+  );
+  return { failed };
+}
+
+/**
  * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
  * WeakSet so we don't pin store instances in memory — the warning fires
  * once per process per store, then the store's lifecycle is unaffected.
@@ -163,21 +181,22 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
       await this.queue.sendBatch(messages);
     } catch (err) {
       // H4: transient — keep every row PENDING with visible_at pushed forward
-      // and error_code set. Re-throw so the caller sees the failure. Use the
-      // batched many-variant so we fan out the per-id writes in parallel
-      // rather than serializing them; the WrappedJobStore default impl is
-      // always present.
+      // and error_code set. Re-throw so the caller sees the failure. Prefer
+      // the batched many-variant when the IJobStore exposes it (WrappedJobStore
+      // ships a Promise.allSettled default; native SQL backends can override
+      // with a single bulk UPDATE). Fall back to a per-id allSettled fan-out
+      // for bare IJobStore impls (e.g. InMemoryJobStore in tests) that don't
+      // implement the optional method.
       // H5: clamp to the original delaySeconds floor.
       const defer = new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds));
-      const deferResult = await this.jobStore.markEnqueueDeferredMany!(ids, {
-        visible_at: defer,
-        errorCode: "ENQUEUE_FAILED",
-      });
+      const deferOpts = { visible_at: defer, errorCode: "ENQUEUE_FAILED" };
+      const deferResult = this.jobStore.markEnqueueDeferredMany
+        ? await this.jobStore.markEnqueueDeferredMany(ids, deferOpts)
+        : await markEnqueueDeferredManyFallback(this.jobStore, ids, deferOpts);
       for (const { id, err: deferErr } of deferResult.failed) {
-        getLogger().error(
-          `[CloudflareMessageQueue] markEnqueueDeferred failed id=${String(id)}`,
-          { err: deferErr }
-        );
+        getLogger().error(`[CloudflareMessageQueue] markEnqueueDeferred failed id=${String(id)}`, {
+          err: deferErr,
+        });
       }
       throw err;
     }

--- a/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
@@ -13,6 +13,7 @@ import {
   type QueueStorageScope,
   type SendOptions,
 } from "@workglow/job-queue";
+import { getLogger } from "@workglow/util";
 import type { CloudMessageBody, CloudflareQueueOptions } from "./types";
 
 const CF_MAX_DELAY_SECONDS = 12 * 60 * 60;
@@ -22,6 +23,13 @@ const CF_MAX_DELAY_SECONDS = 12 * 60 * 60;
  * instead of marking it FAILED on the first network blip. See H4.
  */
 const ENQUEUE_DEFER_BACKOFF_MS = 30_000;
+
+/**
+ * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
+ * WeakSet so we don't pin store instances in memory — the warning fires
+ * once per process per store, then the store's lifecycle is unaffected.
+ */
+const __warnedInMemoryStores = new WeakSet<object>();
 
 /**
  * `IMessageQueue` adapter backed by a Cloudflare Queues producer binding.
@@ -44,6 +52,21 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
     this.queue = opts.queue;
     this.queueName = opts.queueName;
     this.jobStore = opts.jobStore;
+
+    // H3: warn loudly (once per store) when paired with InMemoryJobStore.
+    // CFQ delivers to a Worker invocation — across invocations, an in-memory
+    // store loses partial-failure rows entirely.
+    const storeCtor = (opts.jobStore as unknown as { constructor?: { name?: string } })
+      ?.constructor;
+    if (
+      storeCtor?.name === "InMemoryJobStore" &&
+      !__warnedInMemoryStores.has(opts.jobStore as unknown as object)
+    ) {
+      __warnedInMemoryStores.add(opts.jobStore as unknown as object);
+      getLogger().warn(
+        "[CloudflareMessageQueue] InMemoryJobStore detected — cloud adapters require a lease-sweeping JobStore (Postgres/Supabase/SQLite). Rows may strand on partial failures."
+      );
+    }
   }
 
   async send(body: JobStorageFormat<Input, Output>, opts: SendOptions = {}): Promise<MessageId> {

--- a/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
@@ -135,13 +135,20 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
       await this.queue.sendBatch(messages);
     } catch (err) {
       // H4: transient — keep every row PENDING with visible_at pushed forward
-      // and error_code set. Re-throw so the caller sees the failure.
+      // and error_code set. Re-throw so the caller sees the failure. Use the
+      // batched many-variant so we fan out the per-id writes in parallel
+      // rather than serializing them; the WrappedJobStore default impl is
+      // always present.
       const defer = new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS);
-      for (const id of ids) {
-        await this.jobStore.markEnqueueDeferred(id, {
-          visible_at: defer,
-          errorCode: "ENQUEUE_FAILED",
-        });
+      const deferResult = await this.jobStore.markEnqueueDeferredMany!(ids, {
+        visible_at: defer,
+        errorCode: "ENQUEUE_FAILED",
+      });
+      for (const { id, err: deferErr } of deferResult.failed) {
+        getLogger().error(
+          `[CloudflareMessageQueue] markEnqueueDeferred failed id=${String(id)}`,
+          { err: deferErr }
+        );
       }
       throw err;
     }

--- a/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
@@ -25,6 +25,23 @@ const CF_MAX_DELAY_SECONDS = 12 * 60 * 60;
 const ENQUEUE_DEFER_BACKOFF_MS = 30_000;
 
 /**
+ * H5: clamp the defer interval to the original `delaySeconds` floor so a row
+ * with a legitimate large delay (e.g. 1h scheduled work) is NOT pulled
+ * forward to now + 30s by a producer-side blip. Returns the maximum of the
+ * original delay and the producer-retry backoff so:
+ *   - delaySeconds = 0   → wait 30s before next producer attempt
+ *   - delaySeconds = 3600 → wait 3600s (the original schedule)
+ *
+ * TODO: full exponential backoff requires a new enqueue_defer_attempts field;
+ * see follow-up issue. Today's mitigation just prevents the bug where a
+ * scheduled row is silently re-delivered ahead of schedule.
+ */
+function computeDeferDelayMs(originalDelaySeconds: number | undefined): number {
+  const original = originalDelaySeconds != null ? originalDelaySeconds * 1000 : 0;
+  return Math.max(original, ENQUEUE_DEFER_BACKOFF_MS);
+}
+
+/**
  * Module-level dedupe set for the InMemoryJobStore-pairing warning (H3).
  * WeakSet so we don't pin store instances in memory — the warning fires
  * once per process per store, then the store's lifecycle is unaffected.
@@ -99,8 +116,10 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
       // H4: a producer-side throw is transient — leave the row PENDING so a
       // retry or a polling consumer can pick it back up. We shift visible_at
       // forward and stamp error_code; status/attempts are untouched.
+      // H5: clamp to the original delaySeconds floor so a scheduled row is
+      // not pulled forward by the producer-retry backoff.
       await this.jobStore.markEnqueueDeferred(id, {
-        visible_at: new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS),
+        visible_at: new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds)),
         errorCode: "ENQUEUE_FAILED",
       });
       throw err;
@@ -139,7 +158,8 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
       // batched many-variant so we fan out the per-id writes in parallel
       // rather than serializing them; the WrappedJobStore default impl is
       // always present.
-      const defer = new Date(Date.now() + ENQUEUE_DEFER_BACKOFF_MS);
+      // H5: clamp to the original delaySeconds floor.
+      const defer = new Date(Date.now() + computeDeferDelayMs(opts.delaySeconds));
       const deferResult = await this.jobStore.markEnqueueDeferredMany!(ids, {
         visible_at: defer,
         errorCode: "ENQUEUE_FAILED",

--- a/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
+++ b/providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts
@@ -139,6 +139,15 @@ export class CloudflareMessageQueue<Input, Output> implements IMessageQueue<
         "sendBatch does not accept a single fingerprint applied to all bodies; use send() per body for fingerprinted dedup"
       );
     }
+    // H6: mirror the send() check before the jobStore.create loop. Without
+    // this, an over-limit delaySeconds would create N PENDING rows and only
+    // fail at the queue.sendBatch boundary — leaving the rows stranded via
+    // the H4 defer path even though the call was structurally invalid.
+    if (opts.delaySeconds != null && opts.delaySeconds > CF_MAX_DELAY_SECONDS) {
+      throw new RangeError(
+        `Cloudflare Queues sendBatch delaySeconds=${opts.delaySeconds} exceeds the 12h maximum (${CF_MAX_DELAY_SECONDS}s)`
+      );
+    }
     const ids: MessageId[] = [];
     for (const body of bodies) {
       const resolved = await this.jobStore.create(body, opts);

--- a/providers/cloudflare/src/job-queue/persistWithRetry.ts
+++ b/providers/cloudflare/src/job-queue/persistWithRetry.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util";
+
+/**
+ * Run `op` with bounded exponential backoff. Used by CloudflareClaim.ack /
+ * .fail to make the JobStore terminal write resilient to transient failures
+ * — the Cloudflare Queues message has already been `ack`'d by the time we
+ * get here, so a single thrown write would strand the row in PROCESSING
+ * until the lease-expiry sweep notices.
+ *
+ * Defaults: 3 attempts, 200ms base → 200ms / 400ms / 800ms backoffs.
+ * Logs at error and rethrows the last error if every attempt fails so
+ * the caller still sees the failure surface.
+ */
+export async function persistWithRetry(
+  op: () => Promise<void>,
+  ctx: string,
+  maxAttempts = 3,
+  baseDelayMs = 200
+): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await op();
+      return;
+    } catch (e) {
+      lastErr = e;
+      if (i < maxAttempts - 1) {
+        await new Promise((r) => setTimeout(r, baseDelayMs * 2 ** i));
+      }
+    }
+  }
+  getLogger().error(`[${ctx}] persistence failed after retries`, { err: lastErr });
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary

Lands 8 HIGH-priority fixes from the review queue. Each fix is a self-contained commit; the bulk of the diff is in the job-queue wrapper, the AWS/Cloudflare adapters, the Task base class, and the worker IPC layer.

| # | Fix | Files | Commit |
|---|-----|-------|--------|
| H-1 | WrappedClaim.ack/fail no longer inherits prior-attempt output on a reclaimed lease | `packages/job-queue/src/queue-storage/wrapQueueStorage.ts` | [091cbbd](https://github.com/workglow-dev/libs/commit/091cbbdb5557b51d73f8f7fa09c8fb7b842dd7a7) |
| H-2 | `findActiveByFingerprint` scans past the first 100 rows with a bounded cap; delegates to native storage when present | `packages/job-queue/src/queue-storage/IQueueStorage.ts`, `wrapQueueStorage.ts` | [1c7e171](https://github.com/workglow-dev/libs/commit/1c7e1712ad696c2d4831bbb04c6f0f0f5ee22f43) |
| H-3 | Retry JobStore writes in cloud `Claim.ack`/`.fail` so transient DB blips don't strand rows in PROCESSING; add InMemoryJobStore-pairing warning | `providers/{aws,cloudflare}/src/job-queue/{SqsClaim,SqsMessageQueue,CloudflareClaim,CloudflareMessageQueue,persistWithRetry}.ts` | [f784fa3](https://github.com/workglow-dev/libs/commit/f784fa35d3ffcc36501376a0e16e9a324a0d8748) |
| H-4 | Batch `markEnqueueDeferred` to avoid serial DB hits on `sendBatch` failure | `packages/job-queue/src/queue-storage/{IJobStore,wrapQueueStorage}.ts`, `providers/{aws,cloudflare}/src/job-queue/*MessageQueue.ts` | [2749d71](https://github.com/workglow-dev/libs/commit/2749d71e9be7cca0042cfa8ac1785347e2375bf7) |
| H-5 | Clamp deferred re-delivery to original `delaySeconds` so scheduled work isn't pulled forward (mitigation; full exponential backoff deferred) | `providers/{aws,cloudflare}/src/job-queue/*MessageQueue.ts` | [82ed4de](https://github.com/workglow-dev/libs/commit/82ed4de6fa9c2c2382e06070196e0f1cb43c2c22) |
| H-6 | Validate `delaySeconds` in `CloudflareMessageQueue.sendBatch` before creating job rows (SQS already correct) | `providers/cloudflare/src/job-queue/CloudflareMessageQueue.ts` | [30e7967](https://github.com/workglow-dev/libs/commit/30e7967a4ed57a8b6ef9458d11d9d9a9e21ac9b0) |
| H-7 | `cacheable` deprecation gate keys by class name when `type` unset; add `WORKGLOW_CACHE_DEPRECATION=verbose` env override | `packages/task-graph/src/task/Task.ts` | [1f88b8d](https://github.com/workglow-dev/libs/commit/1f88b8d704f5abda39644af18436a43787ccecfc) |
| H-8 | Scrub absolute paths from worker error stacks; omit in production unless `WORKGLOW_INCLUDE_STACKS=1` | `packages/util/src/worker/{scrubStack,WorkerServerBase,WorkerManager}.ts`, `packages/util/src/worker-entry.ts` | [5b82c0a](https://github.com/workglow-dev/libs/commit/5b82c0a853c0f4edb6e974fd64a6698e73a7c1c3) |

## Notes / deviations from the plan

- **Stray initial commit (`66ebc6e`).** The first H-1 commit accidentally folded the H-2 wrapper changes into the same file. The follow-up H-1 commit (`091cbbd`) restores the wrapQueueStorage.ts to a pure H-1 diff before H-2 layers its changes back on top in `1c7e171`. Net diff per file across the branch is correct; the extra commit is noise that would be tidied by a squash-merge.
- **H-2 native SQL backends.** `SqliteQueueStorage` and `PostgresQueueStorage` already implement `findActiveByFingerprint` natively on their core. They are wired through `SqliteJobStore` / `PostgresJobStore`, so the wrapper-delegation path picks them up automatically through the new optional method on `IQueueStorage`. No SQL backend changes were needed.
- **H-5 `min` vs `max`.** The plan literal said `min(originalDelaySeconds * 1000, ENQUEUE_DEFER_BACKOFF_MS)` but the stated intent is "a row with a legitimate large delay isn't pulled forward by the defer." With `min`, a 1h delay collapses to 30s — which IS the bug. I used `max(...)` to honor the stated intent; the literal `min` is mentioned in the commit message as a deliberate deviation.
- **H-7 export path.** The plan said to re-export from `packages/task-graph/src/index.ts`, but the package uses `common.ts` / `node.ts` / `browser.ts` / `bun.ts` — there is no `index.ts`. `__resetCacheableDeprecationWarnings` is exported from `Task.ts`, which is already re-exported through the existing `task/index.ts -> common.ts -> {node,browser,bun}.ts` barrel chain via `export *`.
- **H-8 export path.** Similarly there is no `packages/util/src/worker/index.ts`. `scrubStack` is re-exported from `worker-entry.ts`, which is the real barrel that `worker-node.ts` / `worker-bun.ts` / `worker-browser.ts` re-export from.
- **No tests in this PR per the brief.** Each fix's behavior is well-described enough to add tests in a follow-up.

## Test plan

- [ ] H-1: reclaim a PROCESSING row via lease expiry, second worker ack's with a fresh result — confirm the row's `output` is the new attempt's value (not the prior attempt's `current.output`).
- [ ] H-2: insert > 100 PENDING rows in a single in-memory queue with one matching fingerprint at position 200+; `send()` with that fingerprint must return the existing row's id (not create a new row).
- [ ] H-3: stub `jobStore.completeWithResult` to throw transiently 1-2x then succeed; `SqsClaim.ack` resolves and the row reaches COMPLETED. Stub to throw 4x; `ack` rejects after ~1.4s of backoff and the row remains PROCESSING (lease-expiry sweep recovers).
- [ ] H-3 warning: construct `new SqsMessageQueue({ jobStore: new InMemoryJobStore(), ... })` — confirm one log warning, then a second construction with the same store produces no second warning.
- [ ] H-4: send a 50-row batch where 30 fail; confirm the 30 `markEnqueueDeferred` writes happen in parallel (single round-trip wall-clock) rather than serial.
- [ ] H-5: send a 3600s-delayed message; force the SQS send to throw; inspect the row's `visible_at` — should be ≥ now+3600s, not now+30s.
- [ ] H-6: call `CloudflareMessageQueue.sendBatch([...100 bodies], { delaySeconds: 50000 })` — must throw `RangeError` synchronously with zero rows created.
- [ ] H-7: load two subclasses that both `static cacheable = false` and inherit `type = "Task"`; instantiate + `getCachePolicy` each — confirm two warnings, one per `Task#<ClassName>`. With `WORKGLOW_CACHE_DEPRECATION=verbose`, every call warns.
- [ ] H-8: throw an Error from inside a worker fn; on the main thread inspect the rejected promise's `.stack` — must contain `<root>` placeholder, not `/home/...` or `/var/...`. With `NODE_ENV=production` and no opt-in, `.stack` should be undefined.

https://claude.ai/code/session_01RJswKVMwGAbeSyThh2cxoK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJswKVMwGAbeSyThh2cxoK)_