### PR TITLE
Consolidate test-only exports into _testOnly namespace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -709,11 +709,11 @@
     },
   },
   "trustedDependencies": [
-    "node-llama-cpp",
-    "better-sqlite3",
     "protobufjs",
+    "better-sqlite3",
     "sharp",
     "onnxruntime-node",
+    "node-llama-cpp",
   ],
   "catalog": {
     "@anthropic-ai/sdk": "^0.98.0",

--- a/packages/tasks/src/common.ts
+++ b/packages/tasks/src/common.ts
@@ -88,12 +88,7 @@ export * from "./task/vector/VectorSubtractTask";
 export * from "./task/vector/VectorSumTask";
 export * from "./util/SafeFetch";
 export * from "./util/UrlClassifier";
-export {
-  _resetFilterRegistryForTests,
-  applyFilter,
-  hasFilterOp,
-  registerFilterOp,
-} from "@workglow/util/media";
+export { applyFilter, hasFilterOp, registerFilterOp } from "@workglow/util/media";
 export type { FilterOpFn } from "@workglow/util/media";
 
 import { TaskRegistry } from "@workglow/task-graph";

--- a/packages/test/src/test/ai-provider-cactus/CactusProvider.test.ts
+++ b/packages/test/src/test/ai-provider-cactus/CactusProvider.test.ts
@@ -5,8 +5,10 @@
  */
 
 import type { ModelRecord } from "@workglow/ai/worker";
-import { CactusQueuedProvider } from "@workglow/cactus/ai";
+import { _testOnly } from "@workglow/cactus/ai";
 import { describe, expect, it } from "vitest";
+
+const { CactusQueuedProvider } = _testOnly;
 
 function model(): ModelRecord {
   return {

--- a/packages/test/src/test/ai-provider-hft/HuggingFaceTransformersProvider.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HuggingFaceTransformersProvider.test.ts
@@ -10,13 +10,10 @@ import {
   pipelineToTaskTypes,
   taskTypeToPipelines,
 } from "@workglow/ai/provider-utils";
-import {
-  HuggingFaceTransformersQueuedProvider,
-  _testOnly,
-} from "@workglow/huggingface-transformers/ai";
+import { _testOnly } from "@workglow/huggingface-transformers/ai";
 import { describe, expect, it } from "vitest";
 
-const { HFT_RUN_FN_SPECS, HFT_RUN_FNS } = _testOnly;
+const { HuggingFaceTransformersQueuedProvider, HFT_RUN_FN_SPECS, HFT_RUN_FNS } = _testOnly;
 
 function model(
   model_id: string,

--- a/packages/test/src/test/util/GpuDevice.test.ts
+++ b/packages/test/src/test/util/GpuDevice.test.ts
@@ -3,8 +3,10 @@
  * Copyright 2026 Steven Roussey
  * All Rights Reserved
  */
-import { getGpuDevice, resetGpuDeviceForTests } from "@workglow/util/media";
+import { _testOnly, getGpuDevice } from "@workglow/util/media";
 import { beforeEach, describe, expect, test } from "vitest";
+
+const { resetGpuDeviceForTests } = _testOnly;
 
 describe.skipIf(typeof navigator === "undefined" || !("gpu" in navigator))("GpuDevice", () => {
   beforeEach(() => {

--- a/packages/test/src/test/util/WebGpuImage.test.ts
+++ b/packages/test/src/test/util/WebGpuImage.test.ts
@@ -4,15 +4,16 @@
  * All Rights Reserved
  */
 import {
+  _testOnly,
   getGpuDevice,
   imageValueFromBitmap,
   PASSTHROUGH_SHADER_SRC,
-  resetGpuDeviceForTests,
-  resetTexturePoolForTests,
   type ApplyParams,
   type WebGpuImage as WebGpuImageType,
 } from "@workglow/util/media";
 import { beforeEach, describe, expect, test } from "vitest";
+
+const { resetGpuDeviceForTests, resetTexturePoolForTests } = _testOnly;
 
 const isBrowser = typeof window !== "undefined";
 

--- a/packages/util/src/media-browser.ts
+++ b/packages/util/src/media-browser.ts
@@ -19,14 +19,9 @@ export { registerImageDefaults } from "./media/imageHydrationResolver";
 export * from "./media/color";
 export { CpuImage } from "./media/cpuImage";
 export { rawPixelBufferToBlob, rawPixelBufferToDataUri } from "./media/encode";
-export {
-  _resetFilterRegistryForTests,
-  applyFilter,
-  hasFilterOp,
-  registerFilterOp,
-} from "./media/filterRegistry";
+export { applyFilter, hasFilterOp, registerFilterOp } from "./media/filterRegistry";
 export type { FilterOpFn } from "./media/filterRegistry";
-export { getGpuDevice, resetGpuDeviceForTests } from "./media/gpuDevice.browser";
+export { getGpuDevice } from "./media/gpuDevice.browser";
 export {
   getGpuImageFactory,
   GpuImage as GpuImageFactory,
@@ -72,11 +67,7 @@ export {
   VERTEX_PRELUDE,
 } from "./media/shaderRegistry.browser";
 export type { ShaderCache } from "./media/shaderRegistry.browser";
-export {
-  createTexturePool,
-  getTexturePool,
-  resetTexturePoolForTests,
-} from "./media/texturePool.browser";
+export { createTexturePool, getTexturePool } from "./media/texturePool.browser";
 export type { TexturePool, TexturePoolOptions } from "./media/texturePool.browser";
 export { WebGpuImage } from "./media/webGpuImage.browser";
 export type { ApplyParams } from "./media/webGpuImage.browser";
@@ -101,3 +92,16 @@ async function _preferGpu(value: _ImageValue) {
 }
 
 _registerGpuImageFactory("from", _preferGpu);
+
+import { _resetFilterRegistryForTests } from "./media/filterRegistry";
+import { resetGpuDeviceForTests } from "./media/gpuDevice.browser";
+import { resetTexturePoolForTests } from "./media/texturePool.browser";
+
+/**
+ * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
+ */
+export const _testOnly = {
+  _resetFilterRegistryForTests,
+  resetGpuDeviceForTests,
+  resetTexturePoolForTests,
+} as const;

--- a/packages/util/src/media-node.ts
+++ b/packages/util/src/media-node.ts
@@ -13,12 +13,7 @@ export { registerImageDefaults } from "./media/imageHydrationResolver";
 export * from "./media/color";
 export { CpuImage } from "./media/cpuImage";
 export { rawPixelBufferToBlob, rawPixelBufferToDataUri } from "./media/encode";
-export {
-  _resetFilterRegistryForTests,
-  applyFilter,
-  hasFilterOp,
-  registerFilterOp,
-} from "./media/filterRegistry";
+export { applyFilter, hasFilterOp, registerFilterOp } from "./media/filterRegistry";
 export type { FilterOpFn } from "./media/filterRegistry";
 export {
   getGpuImageFactory,
@@ -61,7 +56,6 @@ export type { RawPixelBuffer, RgbaPixelBuffer } from "./media/rawPixelBuffer";
 export async function getGpuDevice(): Promise<null> {
   return null;
 }
-export function resetGpuDeviceForTests(): void {}
 export {
   createShaderCache,
   getShaderCache,
@@ -69,11 +63,7 @@ export {
   VERTEX_PRELUDE,
 } from "./media/shaderRegistry.browser";
 export type { ShaderCache } from "./media/shaderRegistry.browser";
-export {
-  createTexturePool,
-  getTexturePool,
-  resetTexturePoolForTests,
-} from "./media/texturePool.browser";
+export { createTexturePool, getTexturePool } from "./media/texturePool.browser";
 export type { TexturePool, TexturePoolOptions } from "./media/texturePool.browser";
 // WebGpuImage is browser-only at runtime; type-only re-export lets
 // browser-targeted filter files (*.webgpu.ts) type-check under node tsc.
@@ -90,8 +80,19 @@ export type {
 } from "./media/sharpImage.server";
 export type { ApplyParams, WebGpuImage } from "./media/webGpuImage.browser";
 
+import { _resetFilterRegistryForTests } from "./media/filterRegistry";
 import { registerGpuImageFactory as _registerGpuImageFactory } from "./media/gpuImage";
 import type { ImageValue as _ImageValue } from "./media/imageValue";
 import { SharpImage as _SharpImage } from "./media/sharpImage.server";
+import { resetTexturePoolForTests } from "./media/texturePool.browser";
 
 _registerGpuImageFactory("from", (value: _ImageValue) => _SharpImage.from(value));
+
+/**
+ * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
+ */
+export const _testOnly = {
+  _resetFilterRegistryForTests,
+  resetGpuDeviceForTests: (): void => {},
+  resetTexturePoolForTests,
+} as const;

--- a/packages/workglow/src/common.ts
+++ b/packages/workglow/src/common.ts
@@ -27,3 +27,8 @@ export * from "@workglow/util/media";
 export * from "@workglow/util/compress";
 export * from "./logging";
 export * from "./bootstrap";
+
+// Resolve _testOnly ambiguity: multiple sub-packages export _testOnly;
+// the workglow meta-package is not the right place to surface test internals.
+// Consumers should import _testOnly directly from the specific sub-package.
+export { _testOnly } from "@workglow/ai";

--- a/providers/cactus/src/ai.browser.ts
+++ b/providers/cactus/src/ai.browser.ts
@@ -16,7 +16,6 @@ export * from "./ai/common/Cactus_ModelSchema";
 // on one would not see writes from the other. Import runtime state from
 // `@workglow/cactus/ai-runtime` instead.
 export * from "./ai/CactusProvider.browser";
-export * from "./ai/CactusQueuedProvider.browser";
 export * from "./ai/registerCactus.browser";
 
 import { CactusQueuedProvider } from "./ai/CactusQueuedProvider.browser";

--- a/providers/cactus/src/ai.ts
+++ b/providers/cactus/src/ai.ts
@@ -16,7 +16,6 @@ export * from "./ai/common/Cactus_ModelSchema";
 // on one would not see writes from the other. Import runtime state from
 // `@workglow/cactus/ai-runtime` instead.
 export * from "./ai/CactusProvider";
-export * from "./ai/CactusQueuedProvider";
 export * from "./ai/registerCactus";
 
 import { CactusQueuedProvider } from "./ai/CactusQueuedProvider";

--- a/providers/huggingface-transformers/src/ai/index.ts
+++ b/providers/huggingface-transformers/src/ai/index.ts
@@ -11,16 +11,17 @@ export * from "./common/HFT_ModelSchema";
 export * from "./common/HFT_OnnxDtypes";
 export * from "./common/HFT_ToolMarkup";
 export * from "./HuggingFaceTransformersProvider";
-export * from "./HuggingFaceTransformersQueuedProvider";
 export * from "./registerHuggingFaceTransformers";
 
 import { HFT_RUN_FN_SPECS } from "./common/HFT_Capabilities";
 import { HFT_RUN_FNS } from "./common/HFT_JobRunFns";
+import { HuggingFaceTransformersQueuedProvider } from "./HuggingFaceTransformersQueuedProvider";
 
 /**
  * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
  */
 export const _testOnly = {
+  HuggingFaceTransformersQueuedProvider,
   HFT_RUN_FN_SPECS,
   HFT_RUN_FNS,
 } as const;


### PR DESCRIPTION
## Summary

Refactors test-only exports across the codebase to use a dedicated `_testOnly` namespace object, improving API clarity by explicitly marking internal testing utilities as unstable and not part of the public API.

## Key Changes

- **@workglow/util/media** (`media-browser.ts`, `media-node.ts`):
  - Removed direct exports of `_resetFilterRegistryForTests`, `resetGpuDeviceForTests`, and `resetTexturePoolForTests`
  - Created `_testOnly` namespace object exporting these test utilities with JSDoc marking them `@internal`
  - Maintains public API exports for `applyFilter`, `hasFilterOp`, `registerFilterOp`

- **@workglow/huggingface-transformers/ai** (`index.ts`):
  - Removed direct export of `HuggingFaceTransformersQueuedProvider`
  - Moved to `_testOnly` namespace alongside `HFT_RUN_FN_SPECS` and `HFT_RUN_FNS`

- **@workglow/cactus/ai** (`ai.ts`, `ai.browser.ts`):
  - Removed direct export of `CactusQueuedProvider`
  - Moved to `_testOnly` namespace

- **@workglow/tasks/common.ts**:
  - Removed `_resetFilterRegistryForTests` from public exports (now accessed via `_testOnly`)

- **@workglow/workglow/common.ts**:
  - Added explicit re-export of `_testOnly` from `@workglow/ai` with comment explaining the ambiguity resolution

- **Test files** (`HuggingFaceTransformersProvider.test.ts`, `WebGpuImage.test.ts`, `GpuDevice.test.ts`, `CactusProvider.test.ts`):
  - Updated imports to destructure test utilities from `_testOnly` namespace
  - Maintains same functionality with clearer intent

## Implementation Details

- All test-only symbols are now grouped under a single `_testOnly` export marked with `@internal` JSDoc
- The namespace is exported as `as const` for type safety
- Public API surface remains unchanged for stable exports
- Test infrastructure utilities are now explicitly marked as unstable and not part of the public contract

https://claude.ai/code/session_01CCFxf9TuJBwMzfLVH8Uonr