### PR TITLE
fix(storage,ai): SQL operator allow-list + baseURL validation + credential-store passphrase sentinel

### DIFF
--- a/.changeset/baseurl-validation.md
+++ b/.changeset/baseurl-validation.md
@@ -1,0 +1,22 @@
+---
+"@workglow/ai": patch
+"@workglow/openai": patch
+"@workglow/anthropic": patch
+---
+
+#### ai / openai / anthropic (security, L-MAIN-02)
+
+- Add `validateProviderBaseUrl` to `@workglow/ai/provider-utils`. Cloud
+  SDKs send the API key in `Authorization: Bearer` to whatever
+  `baseURL` they are constructed with, so an attacker-controlled
+  `provider_config.base_url` (marketplace model definitions, workflow
+  imports) could exfiltrate the key.
+- `OpenAI_Client.getClient` and `Anthropic_Client.getClient` now reject
+  any `base_url` whose hostname is not in the per-vendor allow-list
+  (`api.openai.com`, `*.openai.azure.com` for OpenAI;
+  `api.anthropic.com` for Anthropic) before constructing the SDK
+  client. Only HTTPS is permitted (HTTP is rejected outright, even for
+  loopback hosts, unless the explicit opt-out below is set).
+- Add `trustedBaseUrl` (boolean, default `false`, hidden in UI) to both
+  provider config schemas. Operators can set it to allow a known-good
+  enterprise gateway; the URL must still parse and use HTTPS.

--- a/.changeset/baseurl-validation.md
+++ b/.changeset/baseurl-validation.md
@@ -15,8 +15,11 @@
   any `base_url` whose hostname is not in the per-vendor allow-list
   (`api.openai.com`, `*.openai.azure.com` for OpenAI;
   `api.anthropic.com` for Anthropic) before constructing the SDK
-  client. Only HTTPS is permitted (HTTP is rejected outright, even for
-  loopback hosts, unless the explicit opt-out below is set).
+  client. HTTPS is required, except that loopback hostnames
+  (`localhost`, `127.0.0.1`, `[::1]`) auto-allow plain HTTP for the
+  canonical local-gateway scenario (Ollama / LM Studio / vLLM with
+  OpenAI shim) — the user cannot exfiltrate their own key to their
+  own machine.
 - Add `trustedBaseUrl` (boolean, default `false`, hidden in UI) to both
   provider config schemas. Operators can set it to allow a known-good
   enterprise gateway; the URL must still parse and use HTTPS.

--- a/.changeset/credstore-passphrase-sentinel.md
+++ b/.changeset/credstore-passphrase-sentinel.md
@@ -1,0 +1,30 @@
+---
+"@workglow/storage": minor
+---
+
+#### storage (security, L-MAIN-03)
+
+- `LazyEncryptedCredentialStore.unlock(passphrase)` is now `async` and
+  verifies the passphrase via a sentinel marker before assigning the
+  inner `EncryptedKvCredentialStore`. Previously a mistyped passphrase
+  silently "unlocked" the store, and subsequent `put()` calls encrypted
+  new entries under the wrong key — irreversibly diverging from
+  existing entries.
+- Behaviour:
+  - sentinel present + correct passphrase → unlocks.
+  - sentinel present + wrong passphrase → throws
+    `Invalid passphrase for credential store.`
+  - sentinel absent + empty KV (first-time init) → writes sentinel and
+    unlocks.
+  - sentinel absent + existing rows (legacy migration) → probes one
+    existing row; on successful decrypt writes the sentinel and
+    unlocks, on failure throws.
+- `EncryptedKvCredentialStore` exposes `writeSentinel()` and
+  `verifyPassphrase()` and now hides the reserved
+  `__credstore_sentinel__` key from `keys()`, `has()`, and `delete()`;
+  `deleteAll()` rewrites the sentinel after the clear so future unlocks
+  keep verifying.
+
+**Breaking** (storage minor): `LazyEncryptedCredentialStore.unlock`
+returns `Promise<void>` rather than `void`. In-tree consumers in the
+`@workglow/libs` repo have been updated.

--- a/.changeset/operator-allowlist.md
+++ b/.changeset/operator-allowlist.md
@@ -1,0 +1,15 @@
+---
+"@workglow/storage": patch
+---
+
+#### storage (security, L-MAIN-01)
+
+- Tighten `isSearchCondition` to also verify the operator is one of
+  `=`, `<`, `<=`, `>`, `>=` — the closed allow-list. A forged
+  `SearchCondition` smuggled past TypeScript (e.g. parsed from JSON
+  at an HTTP boundary) can no longer interpolate arbitrary SQL into
+  a WHERE clause via `buildSearchWhere`.
+- Add `ALLOWED_SEARCH_OPERATORS` and `SEARCH_OPERATOR_SET` exports as
+  the single source of truth for the allow-list.
+- `buildSearchWhere` now performs a defense-in-depth check on the
+  operator immediately before concatenating it into SQL.

--- a/docs/technical/15-credential-management.md
+++ b/docs/technical/15-credential-management.md
@@ -202,7 +202,7 @@ import { LazyEncryptedCredentialStore } from "@workglow/storage";
 const lazy = new LazyEncryptedCredentialStore(kvStorage);
 await lazy.get("key"); // undefined (locked)
 
-lazy.unlock("user-passphrase");
+await lazy.unlock("user-passphrase");
 await lazy.get("key"); // decrypted value
 
 lazy.lock(); // discards inner store and derived key cache

--- a/examples/cli/src/keyring.ts
+++ b/examples/cli/src/keyring.ts
@@ -173,12 +173,12 @@ export async function ensureCredentialStoreUnlocked(): Promise<void> {
   // Try OTP cache first
   const cached = passphraseCache.retrieve();
   if (cached) {
-    lazyStore.unlock(cached);
+    await lazyStore.unlock(cached);
     return;
   }
 
   // Resolve from keyring / file / generate
   const passphrase = await resolvePassphraseFromKeyring();
   passphraseCache.store(passphrase);
-  lazyStore.unlock(passphrase);
+  await lazyStore.unlock(passphrase);
 }

--- a/packages/ai/src/provider-utils/CloudProviderClient.ts
+++ b/packages/ai/src/provider-utils/CloudProviderClient.ts
@@ -83,13 +83,15 @@ export interface ValidateProviderBaseUrlArgs {
  * exfiltrate the key by pointing `base_url` at their own server. This
  * helper enforces two defenses before construction:
  *
- *   - The URL must parse and use HTTPS (HTTP is allowed only for
- *     `localhost` / `127.0.0.1`, where the request never leaves the
- *     machine and is presumed to be a local gateway).
+ *   - The URL must parse and use HTTPS (HTTP is allowed only for the
+ *     loopback hostnames `localhost` / `127.0.0.1` / `[::1]`, where the
+ *     request never leaves the machine and is presumed to be a local
+ *     gateway such as Ollama / LM Studio / vLLM).
  *   - The hostname must match an entry in {@link ValidateProviderBaseUrlArgs.allowHosts}
  *     by exact equality or by suffix (so subdomains of e.g. `openai.azure.com`
- *     are permitted), unless the model is explicitly flagged as
- *     `trustedBaseUrl`.
+ *     are permitted), unless the host is a loopback address (auto-allowed:
+ *     the user can't exfiltrate their own key to their own machine) or
+ *     the model is explicitly flagged as `trustedBaseUrl`.
  *
  * Returns the normalized string form. Returns `undefined` for an empty /
  * undefined input so the SDK falls back to its default base URL.
@@ -113,14 +115,14 @@ export function validateProviderBaseUrl(
   }
 
   const hostname = parsed.hostname.toLowerCase();
-  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1";
+  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
   if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
     throw new Error(
       `${opts.providerLabel} provider base_url must use https:// (http:// allowed only for localhost): ${trimmed}`
     );
   }
 
-  if (opts.trustedBaseUrl) {
+  if (isLoopback || opts.trustedBaseUrl) {
     return parsed.toString();
   }
 

--- a/packages/ai/src/provider-utils/CloudProviderClient.ts
+++ b/packages/ai/src/provider-utils/CloudProviderClient.ts
@@ -54,3 +54,86 @@ export function resolveApiKey(args: ResolveApiKeyArgs): string {
 export function isBrowserLike(): boolean {
   return typeof globalThis.document !== "undefined" || "WorkerGlobalScope" in globalThis;
 }
+
+export interface ValidateProviderBaseUrlArgs {
+  /** Discriminator used only for error messages. */
+  readonly vendor: "openai" | "anthropic";
+  /**
+   * Allow-list of acceptable hostnames or hostname suffixes. A hostname
+   * matches if it is equal to the entry or ends with the entry (so
+   * `.openai.azure.com` matches any subdomain of `openai.azure.com`).
+   */
+  readonly allowHosts: readonly string[];
+  /**
+   * When `true`, the caller has explicitly opted out of host validation
+   * (e.g. an enterprise gateway with a custom domain). The URL still has
+   * to parse and use a safe scheme.
+   */
+  readonly trustedBaseUrl?: boolean;
+  /** Human-friendly provider label used in error messages. */
+  readonly providerLabel: string;
+}
+
+/**
+ * Validate a provider `base_url` before handing it to the SDK.
+ *
+ * Cloud SDKs send the API key in `Authorization: Bearer` to whatever
+ * `baseURL` they are constructed with. In multi-tenant scenarios
+ * (marketplace model definitions, workflow imports) an attacker can
+ * exfiltrate the key by pointing `base_url` at their own server. This
+ * helper enforces two defenses before construction:
+ *
+ *   - The URL must parse and use HTTPS (HTTP is allowed only for
+ *     `localhost` / `127.0.0.1`, where the request never leaves the
+ *     machine and is presumed to be a local gateway).
+ *   - The hostname must match an entry in {@link ValidateProviderBaseUrlArgs.allowHosts}
+ *     by exact equality or by suffix (so subdomains of e.g. `openai.azure.com`
+ *     are permitted), unless the model is explicitly flagged as
+ *     `trustedBaseUrl`.
+ *
+ * Returns the normalized string form. Returns `undefined` for an empty /
+ * undefined input so the SDK falls back to its default base URL.
+ *
+ * @throws when the URL fails to parse, uses an unsafe scheme, or points
+ *   at a non-allow-listed host without `trustedBaseUrl`.
+ */
+export function validateProviderBaseUrl(
+  baseUrl: string | undefined,
+  opts: ValidateProviderBaseUrlArgs
+): string | undefined {
+  if (!baseUrl) return undefined;
+  const trimmed = baseUrl.trim();
+  if (trimmed === "") return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`${opts.providerLabel} provider base_url is not a valid URL: ${trimmed}`);
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1";
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && isLoopback)) {
+    throw new Error(
+      `${opts.providerLabel} provider base_url must use https:// (http:// allowed only for localhost): ${trimmed}`
+    );
+  }
+
+  if (opts.trustedBaseUrl) {
+    return parsed.toString();
+  }
+
+  const allowed = opts.allowHosts.some((host) => {
+    const lower = host.toLowerCase();
+    return hostname === lower || hostname.endsWith(lower);
+  });
+  if (!allowed) {
+    throw new Error(
+      `${opts.providerLabel} provider base_url host "${hostname}" is not in the allow-list. ` +
+        `Set provider_config.trustedBaseUrl = true to opt out of host validation for a known-good custom gateway.`
+    );
+  }
+
+  return parsed.toString();
+}

--- a/packages/storage/src/credentials/EncryptedKvCredentialStore.ts
+++ b/packages/storage/src/credentials/EncryptedKvCredentialStore.ts
@@ -22,6 +22,37 @@ interface StoredCredential {
 }
 
 /**
+ * Reserved KV key holding a marker entry encrypted with the store's
+ * passphrase. Used by {@link EncryptedKvCredentialStore.verifyPassphrase}
+ * to detect mistyped passphrases before they silently encrypt new entries
+ * under the wrong key and irreversibly diverge from existing entries.
+ *
+ * The sentinel is hidden from {@link EncryptedKvCredentialStore.keys},
+ * {@link EncryptedKvCredentialStore.has}, and {@link EncryptedKvCredentialStore.delete};
+ * {@link EncryptedKvCredentialStore.deleteAll} rewrites it after clearing.
+ */
+export const CREDSTORE_SENTINEL_KEY = "__credstore_sentinel__";
+
+/**
+ * Plaintext that is encrypted and stored under {@link CREDSTORE_SENTINEL_KEY}.
+ * The exact value is irrelevant — AES-GCM authentication makes any deviation
+ * fail decryption — but a stable string is useful for diagnostics.
+ */
+export const SENTINEL_PLAINTEXT = "workglow:credstore:v1";
+
+/**
+ * Outcome of a sentinel-based passphrase check.
+ *
+ * - `"match"`     — sentinel present and decrypts successfully; passphrase is correct.
+ * - `"mismatch"`  — sentinel present but decryption fails (AES-GCM auth-tag failure).
+ *                   The supplied passphrase does not match the one that wrote the sentinel.
+ * - `"absent"`    — no sentinel row. Caller decides whether this is a first-time
+ *                   init (write a sentinel) or a legacy migration (try decrypting
+ *                   one existing row before committing to this passphrase).
+ */
+export type PassphraseVerification = "match" | "mismatch" | "absent";
+
+/**
  * Credential store that encrypts values with AES-256-GCM before persisting
  * them to an {@link IKvStorage} backend.
  *
@@ -64,6 +95,48 @@ export class EncryptedKvCredentialStore implements ICredentialStore {
     return decrypt(raw.encrypted, raw.iv, this.passphrase, this.keyCache);
   }
 
+  /**
+   * Encrypt {@link SENTINEL_PLAINTEXT} under the store's passphrase and
+   * persist it at {@link CREDSTORE_SENTINEL_KEY}. Idempotent: a second call
+   * overwrites the existing sentinel.
+   */
+  async writeSentinel(): Promise<void> {
+    const now = new Date().toISOString();
+    const { encrypted, iv } = await encrypt(SENTINEL_PLAINTEXT, this.passphrase, this.keyCache);
+    const stored: StoredCredential = {
+      encrypted,
+      iv,
+      label: undefined,
+      provider: undefined,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: undefined,
+    };
+    await this.kv.put(CREDSTORE_SENTINEL_KEY, stored);
+  }
+
+  /**
+   * Check whether the store's passphrase matches the one that wrote the
+   * sentinel.
+   *
+   * @see {@link PassphraseVerification}
+   */
+  async verifyPassphrase(): Promise<PassphraseVerification> {
+    const raw = (await this.kv.get(CREDSTORE_SENTINEL_KEY)) as StoredCredential | undefined;
+    if (!raw) return "absent";
+    try {
+      const plaintext = await decrypt(raw.encrypted, raw.iv, this.passphrase, this.keyCache);
+      // Defense in depth: AES-GCM authentication already gates this, but
+      // require the expected plaintext too so a future format bump is
+      // detected explicitly rather than silently treated as a match.
+      return plaintext === SENTINEL_PLAINTEXT ? "match" : "mismatch";
+    } catch {
+      // crypto.subtle.decrypt throws on AES-GCM auth-tag failure (the
+      // signal for "wrong key / tampered ciphertext").
+      return "mismatch";
+    }
+  }
+
   async put(key: string, value: string, options?: CredentialPutOptions): Promise<void> {
     const now = new Date();
     const existing = (await this.kv.get(key)) as StoredCredential | undefined;
@@ -84,6 +157,9 @@ export class EncryptedKvCredentialStore implements ICredentialStore {
   }
 
   async delete(key: string): Promise<boolean> {
+    // The sentinel is an implementation detail; callers must not be able to
+    // remove it through the ICredentialStore surface.
+    if (key === CREDSTORE_SENTINEL_KEY) return false;
     const exists = (await this.kv.get(key)) !== undefined;
     if (exists) {
       await this.kv.delete(key);
@@ -92,6 +168,7 @@ export class EncryptedKvCredentialStore implements ICredentialStore {
   }
 
   async has(key: string): Promise<boolean> {
+    if (key === CREDSTORE_SENTINEL_KEY) return false;
     const raw = (await this.kv.get(key)) as StoredCredential | undefined;
     if (!raw) return false;
 
@@ -109,6 +186,7 @@ export class EncryptedKvCredentialStore implements ICredentialStore {
     const now = new Date();
     const result: string[] = [];
     for (const entry of all) {
+      if (entry.key === CREDSTORE_SENTINEL_KEY) continue;
       if (entry.value.expiresAt && new Date(entry.value.expiresAt) <= now) {
         await this.kv.delete(entry.key);
         continue;
@@ -118,7 +196,15 @@ export class EncryptedKvCredentialStore implements ICredentialStore {
     return result;
   }
 
+  /**
+   * Delete every credential in the store and rewrite the sentinel so the
+   * passphrase verification path keeps working after the clear. (Without
+   * the rewrite, the store would slip back into {@link PassphraseVerification}
+   * `"absent"` and a subsequent mistyped passphrase could re-init the
+   * store under the wrong key.)
+   */
   async deleteAll(): Promise<void> {
     await this.kv.deleteAll();
+    await this.writeSentinel();
   }
 }

--- a/packages/storage/src/credentials/LazyEncryptedCredentialStore.ts
+++ b/packages/storage/src/credentials/LazyEncryptedCredentialStore.ts
@@ -6,7 +6,7 @@
 
 import type { CredentialPutOptions, ICredentialStore } from "@workglow/util";
 import type { IKvStorage } from "../kv/IKvStorage";
-import { EncryptedKvCredentialStore } from "./EncryptedKvCredentialStore";
+import { CREDSTORE_SENTINEL_KEY, EncryptedKvCredentialStore } from "./EncryptedKvCredentialStore";
 
 /**
  * An {@link ICredentialStore} wrapper that starts in a locked state and defers
@@ -29,7 +29,7 @@ import { EncryptedKvCredentialStore } from "./EncryptedKvCredentialStore";
  * const lazy = new LazyEncryptedCredentialStore(kvStorage);
  * await lazy.get("key"); // undefined (locked)
  *
- * lazy.unlock("my-passphrase");
+ * await lazy.unlock("my-passphrase");
  * await lazy.get("key"); // decrypted value
  *
  * lazy.lock(); // discards inner store
@@ -49,13 +49,73 @@ export class LazyEncryptedCredentialStore implements ICredentialStore {
   }
 
   /**
-   * Unlock the store by providing a passphrase. Creates the underlying
-   * {@link EncryptedKvCredentialStore} using the same KV backend.
+   * Unlock the store by providing a passphrase. Verifies the passphrase
+   * against a sentinel marker before assigning the inner store so a
+   * mistyped passphrase cannot silently encrypt new entries under the
+   * wrong key and diverge from existing entries.
    *
-   * @throws if the passphrase is empty
+   * Behaviour by KV state:
+   *  - **sentinel present + correct passphrase** → unlocks.
+   *  - **sentinel present + wrong passphrase**   → throws
+   *    `Invalid passphrase for credential store.`
+   *  - **sentinel absent + empty KV**            → first-time init: write
+   *    the sentinel and unlock.
+   *  - **sentinel absent + non-empty KV (legacy migration)** → try to
+   *    decrypt one existing row with this passphrase. Success → write
+   *    the sentinel and unlock. Failure → throw (legacy rows present and
+   *    the supplied passphrase cannot decrypt them, so accepting would
+   *    silently fork the store).
+   *
+   * @throws if the passphrase is empty (`EncryptedKvCredentialStore`),
+   *   does not decrypt the sentinel, or fails to decrypt any existing
+   *   legacy row during migration.
    */
-  unlock(passphrase: string): void {
-    this.inner = new EncryptedKvCredentialStore(this.kv as IKvStorage<string, any>, passphrase);
+  async unlock(passphrase: string): Promise<void> {
+    const candidate = new EncryptedKvCredentialStore(
+      this.kv as IKvStorage<string, any>,
+      passphrase
+    );
+    const verdict = await candidate.verifyPassphrase();
+    if (verdict === "match") {
+      this.inner = candidate;
+      return;
+    }
+    if (verdict === "mismatch") {
+      throw new Error("Invalid passphrase for credential store.");
+    }
+    // verdict === "absent" — either first-time init or legacy migration.
+    const existing = await this.kv.getAll();
+    const otherRows = existing
+      ? existing.filter((entry) => entry.key !== CREDSTORE_SENTINEL_KEY)
+      : [];
+    if (otherRows.length === 0) {
+      // First-time init: write the sentinel under the supplied passphrase.
+      await candidate.writeSentinel();
+      this.inner = candidate;
+      return;
+    }
+    // Legacy migration: try decrypting one existing row to validate the
+    // passphrase before committing.
+    const probe = otherRows[0];
+    try {
+      const decrypted = await candidate.get(probe.key);
+      if (decrypted === undefined) {
+        // Row expired between getAll() and decrypt — treat as no-data init.
+        await candidate.writeSentinel();
+        this.inner = candidate;
+        return;
+      }
+    } catch {
+      // Existing rows present and the supplied passphrase cannot decrypt
+      // them. Fail closed so we never silently fork the store.
+      throw new Error(
+        "Invalid passphrase for credential store: existing entries cannot be decrypted."
+      );
+    }
+    // Probe row decrypted successfully — passphrase matches legacy data.
+    // Write the sentinel so subsequent unlocks take the fast path.
+    await candidate.writeSentinel();
+    this.inner = candidate;
   }
 
   /**

--- a/packages/storage/src/sql/PredicateBuilder.ts
+++ b/packages/storage/src/sql/PredicateBuilder.ts
@@ -7,6 +7,7 @@
 import {
   type DeleteSearchCriteria,
   isSearchCondition,
+  SEARCH_OPERATOR_SET,
   type SearchOperator,
   type ValueOptionType,
 } from "../tabular/ITabularStorage";
@@ -59,6 +60,15 @@ export function buildSearchWhere<Entity>(
       value = criterion.value as Entity[keyof Entity];
     } else {
       value = criterion as Entity[keyof Entity];
+    }
+
+    // Defense-in-depth: `isSearchCondition` already gates `operator` to the
+    // allow-list, but this is the spot where the operator is interpolated
+    // raw into SQL, so re-verify here. Unreachable from typed callers; this
+    // catches `as unknown as` bypasses and any future refactor that loosens
+    // `isSearchCondition` before the operator reaches the builder.
+    if (!SEARCH_OPERATOR_SET.has(operator)) {
+      throw new Error(`Unsupported SearchCondition operator: ${String(operator)}`);
     }
 
     conditions.push(

--- a/packages/storage/src/tabular/ITabularStorage.ts
+++ b/packages/storage/src/tabular/ITabularStorage.ts
@@ -74,6 +74,21 @@ export type JSONValue =
 export type SearchOperator = "=" | "<" | "<=" | ">" | ">=";
 
 /**
+ * Closed allow-list of SQL comparison operators that can be interpolated
+ * into a WHERE clause. This is the single source of truth: if
+ * {@link SearchOperator} changes, this constant and {@link SEARCH_OPERATOR_SET}
+ * must update in lockstep so SQL builders cannot accidentally accept a value
+ * outside the union (defense in depth at the JSON trust boundary used by
+ * HTTP-proxied storage backends).
+ */
+export const ALLOWED_SEARCH_OPERATORS = ["=", "<", "<=", ">", ">="] as const;
+
+/**
+ * Set form of {@link ALLOWED_SEARCH_OPERATORS} for O(1) membership checks.
+ */
+export const SEARCH_OPERATOR_SET: ReadonlySet<SearchOperator> = new Set(ALLOWED_SEARCH_OPERATORS);
+
+/**
  * A search condition with a value and comparison operator
  */
 export interface SearchCondition<T> {
@@ -179,16 +194,18 @@ export interface Page<Entity> {
 }
 
 /**
- * Type guard to check if a value is a SearchCondition
+ * Type guard to check if a value is a SearchCondition.
+ *
+ * Verifies the operator is a member of {@link ALLOWED_SEARCH_OPERATORS} so a
+ * forged criterion (e.g. one decoded from JSON at an HTTP boundary) cannot
+ * smuggle an arbitrary string into SQL via {@link buildSearchWhere}.
  */
 export function isSearchCondition<T>(value: unknown): value is SearchCondition<T> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "value" in value &&
-    "operator" in value &&
-    typeof (value as SearchCondition<T>).operator === "string"
-  );
+  if (typeof value !== "object" || value === null) return false;
+  if (!("value" in value) || !("operator" in value)) return false;
+  const operator = (value as SearchCondition<T>).operator;
+  if (typeof operator !== "string") return false;
+  return SEARCH_OPERATOR_SET.has(operator as SearchOperator);
 }
 
 /**

--- a/packages/test/src/test/ai-provider-api/baseUrlValidation.test.ts
+++ b/packages/test/src/test/ai-provider-api/baseUrlValidation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { validateProviderBaseUrl } from "@workglow/ai/provider-utils";
+import { ANTHROPIC_ALLOWED_HOSTS } from "@workglow/anthropic/ai";
+import { OPENAI_ALLOWED_HOSTS } from "@workglow/openai/ai";
+import { describe, expect, it } from "vitest";
+
+describe("validateProviderBaseUrl (L-MAIN-02)", () => {
+  describe("openai vendor", () => {
+    const opts = {
+      vendor: "openai" as const,
+      allowHosts: OPENAI_ALLOWED_HOSTS,
+      providerLabel: "OpenAI",
+    };
+
+    it("returns undefined for undefined input (SDK default)", () => {
+      expect(validateProviderBaseUrl(undefined, opts)).toBeUndefined();
+    });
+
+    it("returns undefined for empty / whitespace input", () => {
+      expect(validateProviderBaseUrl("", opts)).toBeUndefined();
+      expect(validateProviderBaseUrl("   ", opts)).toBeUndefined();
+    });
+
+    it("accepts the official OpenAI host", () => {
+      const result = validateProviderBaseUrl("https://api.openai.com/v1", opts);
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("api.openai.com");
+    });
+
+    it("accepts any Azure OpenAI subdomain via suffix match", () => {
+      const result = validateProviderBaseUrl(
+        "https://my-tenant.openai.azure.com/openai/deployments",
+        opts
+      );
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("my-tenant.openai.azure.com");
+    });
+
+    it("rejects HTTP for non-loopback hosts (prevents cleartext key)", () => {
+      expect(() => validateProviderBaseUrl("http://api.openai.com/v1", opts)).toThrow(/https:\/\//);
+    });
+
+    it("rejects an unrelated host (prevents key exfiltration)", () => {
+      expect(() => validateProviderBaseUrl("https://attacker.example.com/v1", opts)).toThrow(
+        /not in the allow-list/
+      );
+    });
+
+    it("rejects a host that only contains the allow-listed string", () => {
+      // Suffix match must anchor at the right edge: an attacker host
+      // ending with the legitimate domain (e.g. "evil-api.openai.com.attacker.io")
+      // must NOT pass. URL parsing places the rightmost label as the TLD,
+      // so hostname.endsWith("api.openai.com") would only match true suffixes.
+      expect(() => validateProviderBaseUrl("https://evil-openai.com.attacker.io/v1", opts)).toThrow(
+        /not in the allow-list/
+      );
+    });
+
+    it("rejects an unparseable URL", () => {
+      expect(() => validateProviderBaseUrl("not a url", opts)).toThrow(/not a valid URL/);
+    });
+
+    it("accepts an arbitrary host when trustedBaseUrl is true", () => {
+      const result = validateProviderBaseUrl("https://gateway.example.com/openai/v1", {
+        ...opts,
+        trustedBaseUrl: true,
+      });
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("gateway.example.com");
+    });
+
+    it("still rejects HTTP under trustedBaseUrl (defense in depth)", () => {
+      expect(() =>
+        validateProviderBaseUrl("http://gateway.example.com/openai/v1", {
+          ...opts,
+          trustedBaseUrl: true,
+        })
+      ).toThrow(/https:\/\//);
+    });
+
+    it("rejects http://localhost without trustedBaseUrl (host still not allow-listed)", () => {
+      expect(() => validateProviderBaseUrl("http://localhost:8080/v1", opts)).toThrow(
+        /not in the allow-list/
+      );
+    });
+
+    it("accepts http://localhost only with trustedBaseUrl", () => {
+      const result = validateProviderBaseUrl("http://localhost:8080/v1", {
+        ...opts,
+        trustedBaseUrl: true,
+      });
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("localhost");
+    });
+
+    it("accepts http://127.0.0.1 only with trustedBaseUrl", () => {
+      const result = validateProviderBaseUrl("http://127.0.0.1:8080/v1", {
+        ...opts,
+        trustedBaseUrl: true,
+      });
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("127.0.0.1");
+    });
+  });
+
+  describe("anthropic vendor", () => {
+    const opts = {
+      vendor: "anthropic" as const,
+      allowHosts: ANTHROPIC_ALLOWED_HOSTS,
+      providerLabel: "Anthropic",
+    };
+
+    it("accepts the official Anthropic host", () => {
+      const result = validateProviderBaseUrl("https://api.anthropic.com", opts);
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("api.anthropic.com");
+    });
+
+    it("rejects an OpenAI host for Anthropic", () => {
+      expect(() => validateProviderBaseUrl("https://api.openai.com/v1", opts)).toThrow(
+        /not in the allow-list/
+      );
+    });
+
+    it("accepts an arbitrary enterprise gateway with trustedBaseUrl", () => {
+      const result = validateProviderBaseUrl("https://anthropic.internal.corp/v1", {
+        ...opts,
+        trustedBaseUrl: true,
+      });
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/packages/test/src/test/ai-provider-api/baseUrlValidation.test.ts
+++ b/packages/test/src/test/ai-provider-api/baseUrlValidation.test.ts
@@ -83,28 +83,22 @@ describe("validateProviderBaseUrl (L-MAIN-02)", () => {
       ).toThrow(/https:\/\//);
     });
 
-    it("rejects http://localhost without trustedBaseUrl (host still not allow-listed)", () => {
-      expect(() => validateProviderBaseUrl("http://localhost:8080/v1", opts)).toThrow(
-        /not in the allow-list/
-      );
-    });
-
-    it("accepts http://localhost only with trustedBaseUrl", () => {
-      const result = validateProviderBaseUrl("http://localhost:8080/v1", {
-        ...opts,
-        trustedBaseUrl: true,
-      });
+    it("auto-allows http://localhost without trustedBaseUrl (local-gateway use)", () => {
+      const result = validateProviderBaseUrl("http://localhost:8080/v1", opts);
       expect(result).toBeDefined();
       expect(new URL(result!).hostname).toBe("localhost");
     });
 
-    it("accepts http://127.0.0.1 only with trustedBaseUrl", () => {
-      const result = validateProviderBaseUrl("http://127.0.0.1:8080/v1", {
-        ...opts,
-        trustedBaseUrl: true,
-      });
+    it("auto-allows http://127.0.0.1 without trustedBaseUrl", () => {
+      const result = validateProviderBaseUrl("http://127.0.0.1:8080/v1", opts);
       expect(result).toBeDefined();
       expect(new URL(result!).hostname).toBe("127.0.0.1");
+    });
+
+    it("auto-allows http://[::1] without trustedBaseUrl", () => {
+      const result = validateProviderBaseUrl("http://[::1]:8080/v1", opts);
+      expect(result).toBeDefined();
+      expect(new URL(result!).hostname).toBe("[::1]");
     });
   });
 

--- a/packages/test/src/test/storage-tabular/PredicateBuilder.test.ts
+++ b/packages/test/src/test/storage-tabular/PredicateBuilder.test.ts
@@ -116,7 +116,7 @@ describe("PredicateBuilder operator allow-list (L-MAIN-01)", () => {
       expect(result.params).toEqual(["abc", "2025-01-01T00:00:00Z"]);
     });
 
-    it("throws on a forged operator that bypasses the type guard", () => {
+    it("treats a forged operator as a literal value (no SQL injection)", () => {
       // Simulate JSON arriving from an HTTP boundary that smuggles an
       // unsafe operator past the type system (e.g. `as unknown as`).
       // `isSearchCondition` rejects the forged criterion, so it is treated

--- a/packages/test/src/test/storage-tabular/PredicateBuilder.test.ts
+++ b/packages/test/src/test/storage-tabular/PredicateBuilder.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ALLOWED_SEARCH_OPERATORS,
+  buildSearchWhere,
+  isSearchCondition,
+  PostgresDialect,
+  SEARCH_OPERATOR_SET,
+  SqliteDialect,
+  type SearchCondition,
+  type ValueOptionType,
+} from "@workglow/storage";
+import { describe, expect, it } from "vitest";
+
+interface Row {
+  readonly id: string;
+  readonly value: number;
+  readonly createdAt: string;
+}
+
+const schemaProps: Record<string, unknown> = {
+  id: { type: "string" },
+  value: { type: "number" },
+  createdAt: { type: "string" },
+};
+
+const passthroughConvert = (_column: string, value: Row[keyof Row]): ValueOptionType =>
+  value as ValueOptionType;
+
+describe("PredicateBuilder operator allow-list (L-MAIN-01)", () => {
+  describe("ALLOWED_SEARCH_OPERATORS / SEARCH_OPERATOR_SET", () => {
+    it("contains exactly the five SQL comparison operators", () => {
+      expect([...ALLOWED_SEARCH_OPERATORS].sort()).toEqual(["<", "<=", "=", ">", ">="]);
+    });
+
+    it("SEARCH_OPERATOR_SET mirrors ALLOWED_SEARCH_OPERATORS", () => {
+      for (const op of ALLOWED_SEARCH_OPERATORS) {
+        expect(SEARCH_OPERATOR_SET.has(op)).toBe(true);
+      }
+      expect(SEARCH_OPERATOR_SET.size).toBe(ALLOWED_SEARCH_OPERATORS.length);
+    });
+  });
+
+  describe("isSearchCondition", () => {
+    it("accepts every allowed operator", () => {
+      for (const operator of ALLOWED_SEARCH_OPERATORS) {
+        const candidate = { value: 1, operator };
+        expect(isSearchCondition(candidate)).toBe(true);
+      }
+    });
+
+    it("rejects a forged operator (e.g. SQL injection attempt)", () => {
+      const forged = { value: 1, operator: "OR 1=1 --" };
+      expect(isSearchCondition(forged)).toBe(false);
+    });
+
+    it("rejects a LIKE operator that is not in the allow-list", () => {
+      const forged = { value: "x", operator: "LIKE" };
+      expect(isSearchCondition(forged)).toBe(false);
+    });
+
+    it("rejects non-object values", () => {
+      expect(isSearchCondition(null)).toBe(false);
+      expect(isSearchCondition("=")).toBe(false);
+      expect(isSearchCondition(42)).toBe(false);
+    });
+
+    it("rejects objects missing value or operator", () => {
+      expect(isSearchCondition({ value: 1 })).toBe(false);
+      expect(isSearchCondition({ operator: "=" })).toBe(false);
+    });
+  });
+
+  describe("buildSearchWhere", () => {
+    it("round-trips equality with SQLite placeholders", () => {
+      const result = buildSearchWhere<Row>(
+        SqliteDialect,
+        { id: "abc" },
+        schemaProps,
+        passthroughConvert
+      );
+      expect(result.whereClause).toBe("`id` = ?");
+      expect(result.params).toEqual(["abc"]);
+    });
+
+    it("round-trips a non-equality SearchCondition with Postgres placeholders", () => {
+      const criterion: SearchCondition<number> = { value: 100, operator: "<" };
+      const result = buildSearchWhere<Row>(
+        PostgresDialect,
+        { value: criterion },
+        schemaProps,
+        passthroughConvert
+      );
+      expect(result.whereClause).toBe('"value" < $1');
+      expect(result.params).toEqual([100]);
+    });
+
+    it("AND-joins multiple columns and increments the parameter index", () => {
+      const criterion: SearchCondition<string> = {
+        value: "2025-01-01T00:00:00Z",
+        operator: "<=",
+      };
+      const result = buildSearchWhere<Row>(
+        PostgresDialect,
+        { id: "abc", createdAt: criterion },
+        schemaProps,
+        passthroughConvert,
+        5
+      );
+      // First column "id" → $5 (=), second column "createdAt" → $6 (<=)
+      expect(result.whereClause).toBe('"id" = $5 AND "createdAt" <= $6');
+      expect(result.params).toEqual(["abc", "2025-01-01T00:00:00Z"]);
+    });
+
+    it("throws on a forged operator that bypasses the type guard", () => {
+      // Simulate JSON arriving from an HTTP boundary that smuggles an
+      // unsafe operator past the type system (e.g. `as unknown as`).
+      // `isSearchCondition` rejects the forged criterion, so it is treated
+      // as a literal equality value rather than a SearchCondition. The raw
+      // SQL injection attempt becomes the parameter for `=`, not part of
+      // the operator slot — which is what we want.
+      const forged = { value: 1, operator: "OR 1=1 --" } as unknown as SearchCondition<number>;
+      const result = buildSearchWhere<Row>(
+        SqliteDialect,
+        { value: forged },
+        schemaProps,
+        passthroughConvert
+      );
+      expect(result.whereClause).toBe("`value` = ?");
+      // The whole forged object is the bound value — no SQL injection.
+      expect(result.params).toEqual([forged]);
+    });
+
+    it("throws when the column is not present in the schema", () => {
+      expect(() =>
+        buildSearchWhere<Row>(
+          SqliteDialect,
+          { unknownColumn: "x" } as never,
+          schemaProps,
+          passthroughConvert
+        )
+      ).toThrow(/Schema must have a "unknownColumn" field/);
+    });
+  });
+});

--- a/packages/test/src/test/storage-util/LazyEncryptedCredentialStore.test.ts
+++ b/packages/test/src/test/storage-util/LazyEncryptedCredentialStore.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IKvStorage } from "@workglow/storage";
 import { InMemoryKvStorage, LazyEncryptedCredentialStore } from "@workglow/storage";
 import { setLogger } from "@workglow/util";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -53,37 +54,37 @@ describe("LazyEncryptedCredentialStore", () => {
   });
 
   describe("unlock / lock transitions", () => {
-    it("isUnlocked is true after unlock()", () => {
-      store.unlock(passphrase);
+    it("isUnlocked is true after unlock()", async () => {
+      await store.unlock(passphrase);
       expect(store.isUnlocked).toBe(true);
     });
 
-    it("isUnlocked is false after lock()", () => {
-      store.unlock(passphrase);
+    it("isUnlocked is false after lock()", async () => {
+      await store.unlock(passphrase);
       store.lock();
       expect(store.isUnlocked).toBe(false);
     });
 
     it("get() returns undefined again after re-locking", async () => {
-      store.unlock(passphrase);
+      await store.unlock(passphrase);
       await store.put("key", "value");
       store.lock();
       expect(await store.get("key")).toBeUndefined();
     });
 
     it("can unlock, lock, and unlock again to access the same data", async () => {
-      store.unlock(passphrase);
+      await store.unlock(passphrase);
       await store.put("key", "value");
       store.lock();
 
-      store.unlock(passphrase);
+      await store.unlock(passphrase);
       expect(await store.get("key")).toBe("value");
     });
   });
 
   describe("unlocked behavior (delegates to EncryptedKvCredentialStore)", () => {
-    beforeEach(() => {
-      store.unlock(passphrase);
+    beforeEach(async () => {
+      await store.unlock(passphrase);
     });
 
     it("should store and retrieve a credential", async () => {
@@ -121,13 +122,98 @@ describe("LazyEncryptedCredentialStore", () => {
       expect([...(await store.keys())]).toEqual([]);
     });
 
-    it("should not decrypt with a different passphrase", async () => {
+    it("should not decrypt with a different passphrase (fails at unlock)", async () => {
       await store.put("key", "secret");
       store.lock();
 
       const otherStore = new LazyEncryptedCredentialStore(kv);
-      otherStore.unlock("wrong-passphrase");
-      await expect(otherStore.get("key")).rejects.toThrow();
+      await expect(otherStore.unlock("wrong-passphrase")).rejects.toThrow(/Invalid passphrase/);
+      expect(otherStore.isUnlocked).toBe(false);
+    });
+  });
+
+  describe("passphrase sentinel (L-MAIN-03)", () => {
+    it("first-time unlock on an empty KV writes the sentinel and succeeds", async () => {
+      await store.unlock(passphrase);
+      expect(store.isUnlocked).toBe(true);
+      // Re-opening with the same passphrase against a fresh wrapper should
+      // now take the sentinel-match fast path.
+      const second = new LazyEncryptedCredentialStore(kv);
+      await second.unlock(passphrase);
+      expect(second.isUnlocked).toBe(true);
+    });
+
+    it("rejects a wrong passphrase at unlock time (not on first get())", async () => {
+      await store.unlock(passphrase);
+      await store.put("api-key", "sk-secret");
+      store.lock();
+
+      const wrong = new LazyEncryptedCredentialStore(kv);
+      await expect(wrong.unlock("wrong-passphrase")).rejects.toThrow(/Invalid passphrase/);
+      expect(wrong.isUnlocked).toBe(false);
+    });
+
+    it("migrates a legacy KV (no sentinel) when given the correct passphrase", async () => {
+      const { EncryptedKvCredentialStore: Inner } = await import("@workglow/storage");
+      // Simulate a legacy store: write one credential directly through the
+      // inner store without ever calling unlock() on the lazy wrapper.
+      const legacy = new Inner(kv as IKvStorage<string, any>, passphrase);
+      await legacy.put("legacy-key", "legacy-value");
+
+      // No sentinel yet — verifyPassphrase would return "absent" and the
+      // wrapper takes the migration path.
+      const lazy = new LazyEncryptedCredentialStore(kv);
+      await lazy.unlock(passphrase);
+      expect(lazy.isUnlocked).toBe(true);
+      expect(await lazy.get("legacy-key")).toBe("legacy-value");
+
+      // A second unlock with a wrong passphrase must now fail via the
+      // sentinel that the migration wrote.
+      lazy.lock();
+      const wrong = new LazyEncryptedCredentialStore(kv);
+      await expect(wrong.unlock("definitely-wrong")).rejects.toThrow(/Invalid passphrase/);
+    });
+
+    it("rejects a wrong passphrase against a legacy KV (fail closed)", async () => {
+      const { EncryptedKvCredentialStore: Inner } = await import("@workglow/storage");
+      const legacy = new Inner(kv as IKvStorage<string, any>, "real-passphrase");
+      await legacy.put("legacy-key", "legacy-value");
+
+      const lazy = new LazyEncryptedCredentialStore(kv);
+      await expect(lazy.unlock("wrong-passphrase")).rejects.toThrow(/Invalid passphrase/);
+      expect(lazy.isUnlocked).toBe(false);
+    });
+
+    it("hides the sentinel from keys()", async () => {
+      await store.unlock(passphrase);
+      await store.put("real-key", "value");
+      const keys = await store.keys();
+      expect([...keys]).toEqual(["real-key"]);
+      // Should never leak the internal sentinel key name.
+      expect([...keys]).not.toContain("__credstore_sentinel__");
+    });
+
+    it("hides the sentinel from has()", async () => {
+      await store.unlock(passphrase);
+      expect(await store.has("__credstore_sentinel__")).toBe(false);
+    });
+
+    it("deleteAll() rewrites the sentinel so future unlocks still verify", async () => {
+      await store.unlock(passphrase);
+      await store.put("k1", "v1");
+      await store.deleteAll();
+      expect([...(await store.keys())]).toEqual([]);
+      store.lock();
+
+      // A correct re-unlock must still succeed (sentinel was rewritten).
+      const reopened = new LazyEncryptedCredentialStore(kv);
+      await reopened.unlock(passphrase);
+      expect(reopened.isUnlocked).toBe(true);
+
+      // And a wrong passphrase must still be rejected.
+      reopened.lock();
+      const wrong = new LazyEncryptedCredentialStore(kv);
+      await expect(wrong.unlock("wrong-passphrase")).rejects.toThrow(/Invalid passphrase/);
     });
   });
 });

--- a/packages/test/src/test/util/TestCredentialPreload.test.ts
+++ b/packages/test/src/test/util/TestCredentialPreload.test.ts
@@ -17,7 +17,7 @@ interface TestCredentialsModule {
   buildCredentialStore: (
     passphrase: string | undefined,
     secretsDir?: string
-  ) => { readonly encrypted: { put(k: string, v: string): Promise<void> } };
+  ) => Promise<{ readonly encrypted: { put(k: string, v: string): Promise<void> } }>;
   CREDENTIAL_TO_ENV: Readonly<Record<string, string>>;
   installAndHydrate: (
     passphrase: string | undefined,
@@ -65,7 +65,7 @@ describe("installAndHydrate", () => {
 
   it("decrypts and hydrates env vars under the correct passphrase", async () => {
     const passphrase = "correct-horse-battery-staple";
-    const { encrypted } = buildCredentialStore(passphrase, secretsDir);
+    const { encrypted } = await buildCredentialStore(passphrase, secretsDir);
     await encrypted.put("anthropic-api-key", "sk-ant-test");
     await encrypted.put("openai-api-key", "sk-oai-test");
 
@@ -78,7 +78,7 @@ describe("installAndHydrate", () => {
 
   it("does not overwrite env vars already set in the shell", async () => {
     const passphrase = "p";
-    const { encrypted } = buildCredentialStore(passphrase, secretsDir);
+    const { encrypted } = await buildCredentialStore(passphrase, secretsDir);
     await encrypted.put("anthropic-api-key", "sk-ant-from-store");
     process.env.ANTHROPIC_API_KEY = "sk-ant-from-shell";
 
@@ -89,7 +89,7 @@ describe("installAndHydrate", () => {
   });
 
   it("leaves env untouched when the passphrase is wrong", async () => {
-    const { encrypted } = buildCredentialStore("real-passphrase", secretsDir);
+    const { encrypted } = await buildCredentialStore("real-passphrase", secretsDir);
     await encrypted.put("anthropic-api-key", "sk-ant-test");
 
     const result = await installAndHydrate("wrong-passphrase", secretsDir);

--- a/providers/anthropic/src/ai/common/Anthropic_Client.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_Client.ts
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isBrowserLike, resolveApiKey } from "@workglow/ai/provider-utils";
+import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
 import type { AnthropicModelConfig } from "./Anthropic_ModelSchema";
+
+/**
+ * Hostnames (or hostname suffixes) accepted for Anthropic `base_url` without
+ * the explicit `trustedBaseUrl` opt-out.
+ */
+export const ANTHROPIC_ALLOWED_HOSTS: readonly string[] = ["api.anthropic.com"];
 
 type AnthropicSDKModule = typeof import("@anthropic-ai/sdk");
 type AnthropicClientClass = AnthropicSDKModule["default"];
@@ -31,6 +37,12 @@ interface ResolvedProviderConfig {
   readonly model_name?: string;
   readonly base_url?: string;
   readonly max_tokens?: number;
+  /**
+   * When `true`, accept the `base_url` even if its hostname is not in
+   * {@link ANTHROPIC_ALLOWED_HOSTS}. Use only for known-good custom
+   * enterprise gateways. The URL still has to parse and use a safe scheme.
+   */
+  readonly trustedBaseUrl?: boolean;
 }
 
 export async function getClient(model: AnthropicModelConfig | undefined) {
@@ -41,10 +53,18 @@ export async function getClient(model: AnthropicModelConfig | undefined) {
     envVar: "ANTHROPIC_API_KEY",
     providerLabel: "Anthropic",
   });
+  // Throw before SDK construction on a rejected base_url so the API key is
+  // never sent to an unvalidated host.
+  const baseURL = validateProviderBaseUrl(config?.base_url, {
+    vendor: "anthropic",
+    allowHosts: ANTHROPIC_ALLOWED_HOSTS,
+    trustedBaseUrl: config?.trustedBaseUrl,
+    providerLabel: "Anthropic",
+  });
   try {
     return new Anthropic({
       apiKey,
-      baseURL: config?.base_url || undefined,
+      baseURL,
       dangerouslyAllowBrowser: isBrowserLike(),
     });
   } catch (err) {

--- a/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
+++ b/providers/anthropic/src/ai/common/Anthropic_ModelSchema.ts
@@ -34,6 +34,13 @@ export const AnthropicModelSchema = {
           type: "string",
           description: "Base URL for the Anthropic API (optional).",
         },
+        trustedBaseUrl: {
+          type: "boolean",
+          description:
+            "When true, accept a base_url whose hostname is not in the built-in allow-list. Use only for known-good custom enterprise gateways — otherwise an attacker can exfiltrate the API key by pointing base_url at their own server.",
+          default: false,
+          "x-ui-hidden": true,
+        },
         max_tokens: {
           type: "integer",
           description: "Default max tokens for responses. Anthropic requires this parameter.",

--- a/providers/anthropic/src/ai/index.ts
+++ b/providers/anthropic/src/ai/index.ts
@@ -6,6 +6,7 @@
 
 // organize-imports-ignore
 
+export { ANTHROPIC_ALLOWED_HOSTS } from "./common/Anthropic_Client";
 export * from "./common/Anthropic_Constants";
 export * from "./common/Anthropic_ModelSchema";
 export * from "./common/Anthropic_ModelSearch";

--- a/providers/openai/src/ai/common/OpenAI_Client.ts
+++ b/providers/openai/src/ai/common/OpenAI_Client.ts
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isBrowserLike, resolveApiKey } from "@workglow/ai/provider-utils";
+import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
+
+/**
+ * Hostnames (or hostname suffixes) accepted for OpenAI `base_url` without
+ * the explicit `trustedBaseUrl` opt-out. Includes Azure OpenAI tenants.
+ */
+export const OPENAI_ALLOWED_HOSTS: readonly string[] = ["api.openai.com", ".openai.azure.com"];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type OpenAIClientClass = new (config: any) => any;
@@ -30,6 +36,12 @@ interface ResolvedProviderConfig {
   readonly model_name?: string;
   readonly base_url?: string;
   readonly organization?: string;
+  /**
+   * When `true`, accept the `base_url` even if its hostname is not in
+   * {@link OPENAI_ALLOWED_HOSTS}. Use only for known-good custom enterprise
+   * gateways. The URL still has to parse and use a safe scheme.
+   */
+  readonly trustedBaseUrl?: boolean;
 }
 
 export async function getClient(model: OpenAiModelConfig | undefined) {
@@ -40,10 +52,18 @@ export async function getClient(model: OpenAiModelConfig | undefined) {
     envVar: "OPENAI_API_KEY",
     providerLabel: "OpenAI",
   });
+  // Throw before SDK construction on a rejected base_url so the API key is
+  // never sent to an unvalidated host.
+  const baseURL = validateProviderBaseUrl(config?.base_url, {
+    vendor: "openai",
+    allowHosts: OPENAI_ALLOWED_HOSTS,
+    trustedBaseUrl: config?.trustedBaseUrl,
+    providerLabel: "OpenAI",
+  });
   try {
     return new OpenAI({
       apiKey,
-      baseURL: config?.base_url || undefined,
+      baseURL,
       organization: config?.organization || undefined,
       dangerouslyAllowBrowser: isBrowserLike(),
     });

--- a/providers/openai/src/ai/common/OpenAI_ModelSchema.ts
+++ b/providers/openai/src/ai/common/OpenAI_ModelSchema.ts
@@ -34,6 +34,13 @@ export const OpenAiModelSchema = {
           description: "Base URL for the OpenAI API. Useful for Azure OpenAI or proxy servers.",
           default: "https://api.openai.com/v1",
         },
+        trustedBaseUrl: {
+          type: "boolean",
+          description:
+            "When true, accept a base_url whose hostname is not in the built-in allow-list. Use only for known-good custom enterprise gateways — otherwise an attacker can exfiltrate the API key by pointing base_url at their own server.",
+          default: false,
+          "x-ui-hidden": true,
+        },
         organization: {
           type: "string",
           description: "OpenAI organization ID (optional).",

--- a/providers/openai/src/ai/index.browser.ts
+++ b/providers/openai/src/ai/index.browser.ts
@@ -6,6 +6,7 @@
 
 // organize-imports-ignore
 
+export { OPENAI_ALLOWED_HOSTS } from "./common/OpenAI_Client";
 export * from "./common/OpenAI_Constants";
 export * from "./common/OpenAI_ModelSchema";
 export * from "./registerOpenAi";

--- a/providers/openai/src/ai/index.ts
+++ b/providers/openai/src/ai/index.ts
@@ -6,6 +6,7 @@
 
 // organize-imports-ignore
 
+export { OPENAI_ALLOWED_HOSTS } from "./common/OpenAI_Client";
 export * from "./common/OpenAI_Constants";
 export * from "./common/OpenAI_ImageValidation";
 export * from "./common/OpenAI_ModelSchema";

--- a/scripts/credentials.ts
+++ b/scripts/credentials.ts
@@ -149,14 +149,14 @@ async function cmdSet(key: string): Promise<void> {
   mkdirSync(SECRETS_DIR, { recursive: true });
   const value = await readSecretInteractive(`Enter value for "${key}" (input hidden): `);
   if (!value) fail("empty value");
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   await encrypted.put(key, value, { provider: providerForKey(key) });
   console.log(`stored "${key}"`);
 }
 
 async function cmdGet(key: string): Promise<void> {
   const passphrase = requirePassphrase();
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   const value = await encrypted.get(key);
   if (value === undefined) fail(`no such key: ${key}`);
   process.stdout.write(value);
@@ -165,7 +165,7 @@ async function cmdGet(key: string): Promise<void> {
 
 async function cmdList(): Promise<void> {
   const passphrase = requirePassphrase();
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   const keys = await encrypted.keys();
   if (keys.length === 0) {
     console.log("(no credentials stored)");
@@ -179,7 +179,7 @@ async function cmdList(): Promise<void> {
 
 async function cmdDelete(key: string): Promise<void> {
   const passphrase = requirePassphrase();
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   const ok = await encrypted.delete(key);
   console.log(ok ? `deleted "${key}"` : `no such key: ${key}`);
 }
@@ -187,7 +187,7 @@ async function cmdDelete(key: string): Promise<void> {
 async function cmdImportEnv(): Promise<void> {
   const passphrase = requirePassphrase();
   mkdirSync(SECRETS_DIR, { recursive: true });
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   const imported: string[] = [];
   for (const [credKey, envVar] of Object.entries(CREDENTIAL_TO_ENV)) {
     const v = process.env[envVar];
@@ -226,7 +226,7 @@ async function cmdImportDotEnv(file: string): Promise<void> {
   );
 
   mkdirSync(SECRETS_DIR, { recursive: true });
-  const { encrypted } = buildCredentialStore(passphrase);
+  const { encrypted } = await buildCredentialStore(passphrase);
   const imported: string[] = [];
   const skipped: string[] = [];
   for (const [envVar, value] of parsed) {
@@ -296,7 +296,7 @@ async function cmdRotate(): Promise<void> {
     }
   }
 
-  const { encrypted: oldStore } = buildCredentialStore(oldPassphrase);
+  const { encrypted: oldStore } = await buildCredentialStore(oldPassphrase);
   const keys = await oldStore.keys();
   if (keys.length === 0) {
     console.log("(no credentials stored — nothing to rotate)");
@@ -329,7 +329,7 @@ async function cmdRotate(): Promise<void> {
       copyFileSync(join(SECRETS_DIR, file), join(stagingDir, file));
     }
   }
-  const { encrypted: newStore } = buildCredentialStore(newPassphrase, stagingDir);
+  const { encrypted: newStore } = await buildCredentialStore(newPassphrase, stagingDir);
   for (const [k, v] of decrypted) {
     await newStore.put(k, v, { provider: providerForKey(k) });
   }
@@ -350,7 +350,7 @@ async function cmdRotate(): Promise<void> {
  * Returns false if any decryption fails or the store is empty.
  */
 async function canDecryptStore(dir: string, passphrase: string): Promise<boolean> {
-  const { encrypted } = buildCredentialStore(passphrase, dir);
+  const { encrypted } = await buildCredentialStore(passphrase, dir);
   const keys = await encrypted.keys();
   if (keys.length === 0) return false;
   for (const k of keys) {

--- a/scripts/lib/test-credentials.ts
+++ b/scripts/lib/test-credentials.ts
@@ -35,13 +35,21 @@ export interface BuiltStore {
  * `secretsDir` defaults to the canonical {@link SECRETS_DIR}; tests can pass
  * a temp directory to exercise the store in isolation.
  */
-export function buildCredentialStore(
+export async function buildCredentialStore(
   passphrase: string | undefined,
   secretsDir: string = SECRETS_DIR
-): BuiltStore {
+): Promise<BuiltStore> {
   const kv = new FsFolderJsonKvStorage(secretsDir);
   const encrypted = new LazyEncryptedCredentialStore(kv);
-  if (passphrase) encrypted.unlock(passphrase);
+  if (passphrase) {
+    try {
+      await encrypted.unlock(passphrase);
+    } catch {
+      // Match prior best-effort behaviour: a wrong passphrase leaves the
+      // store locked and the caller logs a warning. (`installAndHydrate`
+      // and CLI subcommands both already gate on `encrypted.isUnlocked`.)
+    }
+  }
   return { encrypted, unlocked: encrypted.isUnlocked };
 }
 
@@ -69,7 +77,7 @@ export async function installAndHydrate(
 }> {
   if (!passphrase) return { unlocked: false, hydrated: [] };
 
-  const { encrypted } = buildCredentialStore(passphrase, secretsDir);
+  const { encrypted } = await buildCredentialStore(passphrase, secretsDir);
   if (!encrypted.isUnlocked) return { unlocked: false, hydrated: [] };
 
   // Decrypt into a temporary map first; only if every existing ciphertext


### PR DESCRIPTION
## Summary

Three security/correctness fixes, one commit per finding.

### L-MAIN-01 — SQL operator allow-list in `PredicateBuilder`
`packages/storage/src/sql/PredicateBuilder.ts` interpolated `criterion.operator` raw into the WHERE clause, and `isSearchCondition` only checked `typeof operator === "string"`. A `SearchCondition` decoded from JSON at an HTTP boundary (e.g. the planned `HttpTabularProxyStorage` server path) could smuggle arbitrary SQL into that operator slot.

- New `ALLOWED_SEARCH_OPERATORS` / `SEARCH_OPERATOR_SET` exports in `ITabularStorage.ts` as the single source of truth (`=`, `<`, `<=`, `>`, `>=`).
- `isSearchCondition` now requires the operator to be a member of that set.
- `buildSearchWhere` re-verifies right before concatenating into SQL — defense in depth for any future loosening of the type guard.

### L-MAIN-02 — Provider baseURL validation
`providers/openai/src/ai/common/OpenAI_Client.ts` and `providers/anthropic/src/ai/common/Anthropic_Client.ts` passed `provider_config.base_url` unvalidated to the SDK. The SDK then sends the API key in `Authorization: Bearer` to that host, so a marketplace model definition or imported workflow with an attacker-controlled `base_url` exfiltrates the key.

- New `validateProviderBaseUrl` in `@workglow/ai/provider-utils`. Parses the URL, requires HTTPS, and checks the hostname against a per-vendor allow-list (`api.openai.com`, `*.openai.azure.com` for OpenAI; `api.anthropic.com` for Anthropic).
- Both clients call it **before** SDK construction, so a rejected URL never receives the key.
- Added `trustedBaseUrl` (boolean, `x-ui-hidden: true`, default `false`) to both `*_ModelSchema.ts` files for operators with a known-good enterprise gateway. HTTPS is still required even when the flag is set.

### L-MAIN-03 — Passphrase sentinel for `LazyEncryptedCredentialStore`
`LazyEncryptedCredentialStore.unlock` performed no verification: a mistyped passphrase silently "unlocked" the store, and subsequent `put()` calls encrypted new entries under the wrong key — irreversibly diverging from existing entries.

- `EncryptedKvCredentialStore` now exposes `writeSentinel()` and `verifyPassphrase()`. Sentinel lives at the reserved `__credstore_sentinel__` key, hidden from `keys()`, `has()`, and `delete()`. `deleteAll()` rewrites it.
- `LazyEncryptedCredentialStore.unlock` is now `async` and runs the sentinel check before assigning the inner store:
  - sentinel present + match → unlock
  - sentinel present + mismatch → throw `Invalid passphrase for credential store.`
  - sentinel absent + empty KV → first-time init (write sentinel, unlock)
  - sentinel absent + existing rows (legacy migration) → probe-decrypt one row; success → write sentinel + unlock, failure → throw (fail closed)
- In-tree callers updated for the now-async signature (`scripts/credentials.ts`, `scripts/lib/test-credentials.ts`, `examples/cli/src/keyring.ts`, plus the matching tests).

## Test plan

- [x] `bunx vitest run packages/test/src/test/storage-tabular/PredicateBuilder.test.ts` — 12 new tests (operator allow-list, `isSearchCondition` rejects forged operators, `buildSearchWhere` SQL shape)
- [x] `bunx vitest run packages/test/src/test/ai-provider-api/baseUrlValidation.test.ts` — 16 new tests covering undefined / official hosts / Azure subdomain suffix / HTTP rejection / off-vendor rejection / spoofed suffix / `trustedBaseUrl` opt-out / loopback behaviour
- [x] `bunx vitest run packages/test/src/test/storage-util/LazyEncryptedCredentialStore.test.ts packages/test/src/test/storage-util/EncryptedKvCredentialStore.test.ts` — 39 tests, including new sentinel coverage (wrong-passphrase rejection at unlock, legacy migration with correct & wrong passphrases, sentinel hidden from `keys()` / `has()`, `deleteAll()` rewrites sentinel)
- [x] `bunx vitest run packages/test/src/test/storage-tabular/ packages/test/src/test/storage-util/` — full storage suite green (1154 passed, 13 skipped)
- [x] `bunx vitest run packages/test/src/test/ai-provider-api/` — full provider API suite green (310 passed, 58 skipped)
- [x] `bunx vitest run packages/test/src/test/util/TestCredentialPreload.test.ts` — passes against the now-async `buildCredentialStore`

Changesets added: `.changeset/operator-allowlist.md` (`@workglow/storage` patch), `.changeset/baseurl-validation.md` (`@workglow/ai` / `@workglow/openai` / `@workglow/anthropic` patch), `.changeset/credstore-passphrase-sentinel.md` (`@workglow/storage` minor — `unlock` signature change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VF4sE9UoHhdChYmm8zYx6y)_