### PR TITLE
Add @workglow/mcp npm bugs metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/workglow-dev/libs.git",
     "directory": "packages/mcp"
   },
+  "bugs": {
+    "url": "https://github.com/workglow-dev/libs/issues"
+  },
   "description": "Model Context Protocol tasks and plumbing for Workglow.",
   "scripts": {
     "watch": "concurrently -c 'auto' 'bun:watch-*'",


### PR DESCRIPTION
## What changed

Adds the standard npm `bugs.url` metadata field to the `@workglow/mcp` package.

## Why

The published `@workglow/mcp@0.3.13` package currently exposes `repository` metadata, but `npm view @workglow/mcp@0.3.13 bugs --json` returns no issue tracker metadata. Adding `bugs.url` gives npm users and package tooling a direct issue-reporting link.

## Verification

```sh
npm view @workglow/mcp@0.3.13 name version repository bugs --json
node -e "const p=require('./packages/mcp/package.json'); if(!p.repository?.url||!p.bugs?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs.url);"
npm pack --dry-run --ignore-scripts ./packages/mcp
git diff --check
```
