### PR TITLE
fix(mcp): add bugs.url metadata field to package.json

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -75,5 +75,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/workglow-dev/libs/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the package.json for @workglow/mcp npm package.

Closes charles-openclaw/charles-microbounties#345