### PR TITLE
Add model caching and secrets passphrase to CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,6 +263,13 @@ jobs:
         with:
           bun-version: latest
       - run: bun i
+      - name: Cache Hugging Face model downloads
+        uses: actions/cache@v4
+        with:
+          path: models
+          key: hf-models-rag-${{ runner.os }}-${{ hashFiles('packages/test/src/samples/**') }}
+          restore-keys: |
+            hf-models-rag-${{ runner.os }}-
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
@@ -293,12 +300,21 @@ jobs:
         with:
           bun-version: latest
       - run: bun i
+      - name: Cache Hugging Face model downloads
+        uses: actions/cache@v4
+        with:
+          path: models
+          key: hf-models-hft-${{ runner.os }}-${{ hashFiles('packages/test/src/samples/**') }}
+          restore-keys: |
+            hf-models-hft-${{ runner.os }}-
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: build-output
           path: .
       - name: Run HuggingFace Transformers provider tests via vitest
+        env:
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:vitest:ai-provider-hft
       - name: Copy Vitest coverage fragment
         run: cp coverage/coverage-final.json vitest-ai-provider-hft-coverage.json
@@ -321,12 +337,21 @@ jobs:
         with:
           bun-version: latest
       - run: bun i
+      - name: Cache Hugging Face / GGUF model downloads
+        uses: actions/cache@v4
+        with:
+          path: models
+          key: hf-models-nodellama-${{ runner.os }}-${{ hashFiles('packages/test/src/samples/**') }}
+          restore-keys: |
+            hf-models-nodellama-${{ runner.os }}-
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:
           name: build-output
           path: .
       - name: Run LlamaCpp provider tests via vitest
+        env:
+          WORKGLOW_SECRETS_PASSPHRASE: ${{ secrets.WORKGLOW_SECRETS_PASSPHRASE }}
         run: bun run test:vitest:ai-provider-nodellama
       - name: Copy Vitest coverage fragment
         run: cp coverage/coverage-final.json vitest-ai-provider-nodellama-coverage.json

--- a/.secrets/credentials/26f1356ad1fd23bad72f47e1cafd32b3886e57b1701ac6fbaaf4f2aa0ba2bb8a.json
+++ b/.secrets/credentials/26f1356ad1fd23bad72f47e1cafd32b3886e57b1701ac6fbaaf4f2aa0ba2bb8a.json
@@ -1,0 +1,1 @@
+{"key":"hf-token","value":"{\"encrypted\":\"pkdH1J0oiGVQ6u6wt3T8VxW1rM2LBGksRUBtD8OIw1QicrhzxzqGDyw3fiuMY/yLGohtQADIGY6YJS1hMNzTmWCTXQFv\",\"iv\":\"Qp3YbU0UR5H/c05J\",\"provider\":\"huggingface\",\"createdAt\":\"2026-06-10T14:33:08.480Z\",\"updatedAt\":\"2026-06-10T14:33:08.480Z\"}"}


### PR DESCRIPTION
## Summary

This PR improves CI/CD efficiency and security by adding caching for Hugging Face model downloads and injecting the secrets passphrase environment variable into test workflows.

## Key Changes

- **Model caching**: Added `actions/cache@v4` steps to three test jobs (RAG, HuggingFace Transformers, and LlamaCpp provider tests) to cache downloaded models in the `models/` directory. Each job uses a unique cache key (`hf-models-rag-`, `hf-models-hft-`, `hf-models-nodellama-`) scoped by OS and keyed on sample file changes.

- **Secrets passphrase injection**: Added `WORKGLOW_SECRETS_PASSPHRASE` environment variable (from GitHub secrets) to the HuggingFace Transformers and LlamaCpp provider test jobs, enabling decryption of encrypted credentials during test execution.

- **Encrypted credentials**: Added encrypted HuggingFace token credential file (`.secrets/credentials/26f1356ad1fd23bad72f47e1cafd32b3886e57b1701ac6fbaaf4f2aa0ba2bb8a.json`) for use in tests requiring HuggingFace API access.

## Implementation Details

- Cache keys include `hashFiles('packages/test/src/samples/**')` to invalidate when test samples change
- Fallback restore keys allow partial cache hits across OS variants
- Secrets passphrase is only injected into jobs that need credential decryption, not all test jobs

https://claude.ai/code/session_013CxVhBFku7dJvm7Bwucn1z