### PR TITLE
Scope MCP credential resolution to run registries

### DIFF
--- a/packages/mcp/src/tasks/McpListTask.ts
+++ b/packages/mcp/src/tasks/McpListTask.ts
@@ -284,7 +284,11 @@ export class McpListTask extends Task<McpListTaskInput, McpListTaskOutput, TaskC
     const serverConfig = getMcpServerConfig(input as Record<string, unknown>);
 
     const { mcpClientFactory } = getMcpTaskDeps();
-    const { client } = await mcpClientFactory.create(serverConfig, context.signal);
+    const { client } = await mcpClientFactory.create(
+      serverConfig,
+      context.signal,
+      context.registry
+    );
     const listType = input.list_type;
     try {
       switch (listType) {

--- a/packages/mcp/src/tasks/McpPromptGetTask.ts
+++ b/packages/mcp/src/tasks/McpPromptGetTask.ts
@@ -290,7 +290,11 @@ export class McpPromptGetTask extends Task<
     await this.discoverSchemas(context.signal, serverConfig);
 
     const { mcpClientFactory } = getMcpTaskDeps();
-    const { client } = await mcpClientFactory.create(serverConfig, context.signal);
+    const { client } = await mcpClientFactory.create(
+      serverConfig,
+      context.signal,
+      context.registry
+    );
     try {
       const result = await client.getPrompt({
         name: String(this.config.prompt_name ?? ""),

--- a/packages/mcp/src/tasks/McpResourceReadTask.ts
+++ b/packages/mcp/src/tasks/McpResourceReadTask.ts
@@ -147,7 +147,11 @@ export class McpResourceReadTask extends Task<
     const serverConfig = getMcpServerConfig(this.config as Record<string, unknown>);
 
     const { mcpClientFactory } = getMcpTaskDeps();
-    const { client } = await mcpClientFactory.create(serverConfig, context.signal);
+    const { client } = await mcpClientFactory.create(
+      serverConfig,
+      context.signal,
+      context.registry
+    );
     try {
       const result = await client.readResource({
         uri: String(this.config.resource_uri ?? ""),

--- a/packages/mcp/src/tasks/McpToolCallTask.ts
+++ b/packages/mcp/src/tasks/McpToolCallTask.ts
@@ -276,7 +276,11 @@ export class McpToolCallTask extends Task<
     await this.discoverSchemas(context.signal, serverConfig);
 
     const { mcpClientFactory } = getMcpTaskDeps();
-    const { client } = await mcpClientFactory.create(serverConfig, context.signal);
+    const { client } = await mcpClientFactory.create(
+      serverConfig,
+      context.signal,
+      context.registry
+    );
     try {
       const result = await client.callTool({
         name: String(this.config.tool_name ?? ""),

--- a/packages/mcp/src/util/McpClientUtil.ts
+++ b/packages/mcp/src/util/McpClientUtil.ts
@@ -12,6 +12,7 @@ import { Client } from "@modelcontextprotocol/sdk/client";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { ServiceRegistry } from "@workglow/util";
 import { getGlobalCredentialStore, getLogger } from "@workglow/util";
 import { createAuthProvider, resolveAuthSecrets } from "./McpAuthProvider";
 import type { McpAuthConfig } from "./McpAuthTypes";
@@ -76,31 +77,52 @@ export const mcpServerConfigSchema = {
 
 export type McpTransportType = (typeof mcpTransportTypes)[number];
 
-export async function createMcpClient(
+/**
+ * Resolves a server config's auth into the pieces a transport needs.
+ *
+ * `registry` scopes credential-key resolution: graph runs register their
+ * per-(tenant, project) store on the run's child registry, so MCP auth must
+ * read through it — the process-global store is empty (or another scope's)
+ * in hosts that isolate runs. When omitted, falls back to the global store.
+ */
+export async function resolveMcpClientAuth(
   config: McpServerConfig,
-  signal?: AbortSignal
-): Promise<{ client: Client; transport: Transport }> {
-  let transport: Transport;
-
+  registry?: ServiceRegistry
+): Promise<{
+  auth: McpAuthConfig | undefined;
+  authProvider: McpServerConfig["authProvider"];
+  headers: Record<string, string>;
+}> {
   // Resolve auth config: prefer structured `auth` object, fall back to flat props
   let auth: McpAuthConfig | undefined = config.auth ?? buildAuthConfig({ ...config });
 
   // Resolve credential store keys to actual secret values
   if (auth && auth.type !== "none") {
-    auth = await resolveAuthSecrets(auth, getGlobalCredentialStore());
+    auth = await resolveAuthSecrets(auth, getGlobalCredentialStore(registry));
   }
 
   // Build auth provider for OAuth flows (external provider takes precedence)
   const authProvider =
     config.authProvider ??
     (auth && auth.type !== "none" && auth.type !== "bearer"
-      ? createAuthProvider(auth, config.server_url ?? "", getGlobalCredentialStore())
+      ? createAuthProvider(auth, config.server_url ?? "", getGlobalCredentialStore(registry))
       : undefined);
 
   // Build request headers (SDK sets MCP-Protocol-Version automatically)
   const headers: Record<string, string> = {
     ...(auth?.type === "bearer" ? { Authorization: `Bearer ${auth.token}` } : {}),
   };
+  return { auth, authProvider, headers };
+}
+
+export async function createMcpClient(
+  config: McpServerConfig,
+  signal?: AbortSignal,
+  registry?: ServiceRegistry
+): Promise<{ client: Client; transport: Transport }> {
+  let transport: Transport;
+
+  const { auth, authProvider, headers } = await resolveMcpClientAuth(config, registry);
   const requestInit = { headers };
 
   switch (config.transport) {

--- a/packages/mcp/src/util/McpTaskDeps.ts
+++ b/packages/mcp/src/util/McpTaskDeps.ts
@@ -10,6 +10,7 @@
 import type { Client } from "@modelcontextprotocol/sdk/client";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { ServiceRegistry } from "@workglow/util";
 import { createServiceToken, globalServiceRegistry } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 import type { McpAuthConfig } from "./McpAuthTypes";
@@ -31,9 +32,16 @@ export interface McpServerConfig {
 
 export interface McpTaskDeps {
   readonly mcpClientFactory: {
+    /**
+     * `registry` carries the run-scoped service registry (from the task's
+     * execute context) so credential-store keys in the server config resolve
+     * against the run's per-(tenant, project) store, not the process-global
+     * one — which is empty in hosts that isolate runs.
+     */
     readonly create: (
       config: McpServerConfig,
-      signal?: AbortSignal
+      signal?: AbortSignal,
+      registry?: ServiceRegistry
     ) => Promise<{ client: Client; transport: Transport }>;
   };
   readonly mcpServerConfigSchema: {

--- a/packages/test/src/test/mcp/McpClientUtil.test.ts
+++ b/packages/test/src/test/mcp/McpClientUtil.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { resolveMcpClientAuth } from "@workglow/mcp/util";
+import {
+  globalServiceRegistry,
+  InMemoryCredentialStore,
+  ServiceRegistry,
+  setGlobalCredentialStore,
+} from "@workglow/util";
+import { describe, expect, it } from "vitest";
+
+function scopedRegistry(): ServiceRegistry {
+  return new ServiceRegistry(globalServiceRegistry.container.createChildContainer());
+}
+
+describe("resolveMcpClientAuth credential scoping", () => {
+  it("resolves bearer credential keys through the provided run registry", async () => {
+    const registry = scopedRegistry();
+    const store = new InMemoryCredentialStore();
+    await store.put("mcp-token-key", "sekret-value");
+    setGlobalCredentialStore(store, registry);
+
+    const { auth, headers } = await resolveMcpClientAuth(
+      {
+        transport: "streamable-http",
+        server_url: "https://mcp.example.com",
+        auth: { type: "bearer", token: "mcp-token-key" },
+      },
+      registry
+    );
+
+    expect(auth).toEqual({ type: "bearer", token: "sekret-value" });
+    expect(headers.Authorization).toBe("Bearer sekret-value");
+  });
+
+  it("keeps the literal token when the scoped store has no such key", async () => {
+    const registry = scopedRegistry();
+    setGlobalCredentialStore(new InMemoryCredentialStore(), registry);
+
+    const { headers } = await resolveMcpClientAuth(
+      {
+        transport: "streamable-http",
+        server_url: "https://mcp.example.com",
+        auth: { type: "bearer", token: "literal-token" },
+      },
+      registry
+    );
+
+    expect(headers.Authorization).toBe("Bearer literal-token");
+  });
+
+  it("does not leak credentials across scoped registries", async () => {
+    const registryA = scopedRegistry();
+    const storeA = new InMemoryCredentialStore();
+    await storeA.put("shared-key", "alpha");
+    setGlobalCredentialStore(storeA, registryA);
+
+    const registryB = scopedRegistry();
+    const storeB = new InMemoryCredentialStore();
+    await storeB.put("shared-key", "bravo");
+    setGlobalCredentialStore(storeB, registryB);
+
+    const config = {
+      transport: "streamable-http",
+      server_url: "https://mcp.example.com",
+      auth: { type: "bearer", token: "shared-key" } as const,
+    };
+    const a = await resolveMcpClientAuth(config, registryA);
+    const b = await resolveMcpClientAuth(config, registryB);
+
+    expect(a.headers.Authorization).toBe("Bearer alpha");
+    expect(b.headers.Authorization).toBe("Bearer bravo");
+  });
+});


### PR DESCRIPTION
## Summary

Refactors MCP client authentication to resolve credential-store keys through a scoped service registry, enabling proper credential isolation in multi-tenant or multi-run environments where each run has its own per-(tenant, project) credential store.

## Changes

- **Extract `resolveMcpClientAuth()`**: New public function that resolves a server config's auth into auth object, authProvider, and headers. Accepts an optional `registry` parameter to scope credential-store lookups.

- **Update `createMcpClient()`**: Now accepts an optional `registry` parameter and delegates auth resolution to `resolveMcpClientAuth()`.

- **Update MCP task interface**: `McpTaskDeps.mcpClientFactory.create()` now accepts an optional `registry` parameter with documentation explaining its purpose.

- **Pass registry through all MCP tasks**: `McpListTask`, `McpPromptGetTask`, `McpResourceReadTask`, and `McpToolCallTask` now pass `context.registry` when creating MCP clients.

- **Add comprehensive tests**: New test suite (`McpClientUtil.test.ts`) verifies:
  - Bearer token credential keys resolve through the provided registry
  - Literal tokens are preserved when no matching key exists in the store
  - Credentials don't leak across scoped registries

## Implementation Details

The `registry` parameter is optional and defaults to the global service registry for backward compatibility. When provided, it's passed to `getGlobalCredentialStore(registry)` to ensure credential resolution respects the run's isolated credential store rather than the process-global one. This is critical in hosts that isolate runs (e.g., multi-tenant deployments) where the process-global store is empty or contains another scope's credentials.

https://claude.ai/code/session_012BeAYKHFK1uHGTMSHEy1gV