### PR TITLE
Pin Scaleway provider for Llama 3.1 8B tool-use tests

### DIFF
--- a/packages/test/src/test/ai-provider-api/HFI_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider-api/HFI_Generic.integration.test.ts
@@ -38,7 +38,10 @@ runAiProviderConformance({
         description: "Llama 3.1 8B Instruct via HuggingFace Inference API",
         capabilities: ["text.generation", "text.rewriter", "text.summary", "tool-use"],
         provider: HF_INFERENCE as typeof HF_INFERENCE,
-        provider_config: { model_name: "meta-llama/Llama-3.1-8B-Instruct" },
+        // Pin a router provider that supports tool calling for this model. The
+        // default "auto" policy can route to backends (novita, nscale) that
+        // reject `tools`/`tool_choice` for Llama-3.1-8B-Instruct.
+        provider_config: { model_name: "meta-llama/Llama-3.1-8B-Instruct", provider: "scaleway" },
         metadata: {},
       });
       await getGlobalModelRepository().addModel({


### PR DESCRIPTION
## Summary

Fixed HuggingFace Inference API integration test for Llama 3.1 8B Instruct by pinning the router provider to Scaleway, which reliably supports tool calling for this model.

## Changes

- Updated `HFI_Generic.integration.test.ts` to explicitly set `provider: "scaleway"` in the provider config for the Llama 3.1 8B Instruct model
- Added clarifying comment explaining that the default "auto" routing policy can route to backends (Novita, Nscale) that reject `tools`/`tool_choice` parameters for this model

## Details

The HuggingFace Inference API uses a router that can direct requests to different backend providers. The default "auto" policy was routing Llama-3.1-8B-Instruct requests to backends that don't support tool calling, causing the tool-use capability tests to fail. By explicitly pinning to the Scaleway provider, we ensure consistent test behavior and reliable tool-use support for this model.

https://claude.ai/code/session_0126bRzijfnU1z3DYUESCTV8