### PR TITLE
fix(ai): export ChunkRetrievalInputSchema + nightly schema-vs-type drift guard

### DIFF
--- a/.github/workflows/nightly-typecheck.yml
+++ b/.github/workflows/nightly-typecheck.yml
@@ -1,0 +1,26 @@
+name: Nightly type-drift guard
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+env:
+  CI: "true"
+  DO_NOT_TRACK: "1"
+  TURBO_TELEMETRY_DISABLED: "1"
+jobs:
+  type-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun i
+      # `.test-d.ts` files only run in vitest's typecheck mode. `--typecheck.only`
+      # disables the runtime test run so this stays cheap.
+      - run: bunx vitest run --typecheck --typecheck.only packages/ai/src/task/__tests__/types.test-d.ts

--- a/bun.lock
+++ b/bun.lock
@@ -757,11 +757,11 @@
     },
   },
   "trustedDependencies": [
-    "node-llama-cpp",
-    "better-sqlite3",
     "protobufjs",
+    "better-sqlite3",
     "sharp",
     "onnxruntime-node",
+    "node-llama-cpp",
   ],
   "catalog": {
     "@anthropic-ai/sdk": "^0.101.0",

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -150,6 +150,10 @@ export const AiChatOutputSchema = {
 // Runtime types
 // ========================================================================
 
+// `prompt` is manually inlined as the `FromSchema` resolution of `ContentBlockSchema`
+// for type-instantiation-budget reasons. The nightly drift guard in
+// `__tests__/types.test-d.ts` asserts equality so a schema edit trips a test
+// instead of silently drifting the runtime type.
 export type AiChatTaskInput = Omit<
   {
     systemPrompt?: string | undefined;

--- a/packages/ai/src/task/ChunkRetrievalTask.ts
+++ b/packages/ai/src/task/ChunkRetrievalTask.ts
@@ -14,7 +14,7 @@ import type { ModelConfig } from "../model/ModelSchema";
 import { TypeModel } from "./base/AiTaskSchemas";
 import { TextEmbeddingTask } from "./TextEmbeddingTask";
 
-const inputSchema = {
+export const ChunkRetrievalInputSchema = {
   type: "object",
   properties: {
     knowledgeBase: TypeKnowledgeBase({
@@ -174,6 +174,12 @@ const outputSchema = {
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
+/**
+ * Intentionally tighter than `FromSchema`'s resolution: encodes the schema's
+ * `if/then/else` (when `query: string`, `model` is required) which
+ * `json-schema-to-ts` ignores. The nightly drift type-test pins this
+ * divergence by asserting one-way assignability rather than equality.
+ */
 export type ChunkRetrievalTaskInput =
   | {
       filter?: { [x: string]: unknown } | undefined;
@@ -228,7 +234,7 @@ export class ChunkRetrievalTask extends Task<
   public static override cacheable = true;
 
   public static override inputSchema(): DataPortSchema {
-    return inputSchema as DataPortSchema;
+    return ChunkRetrievalInputSchema as DataPortSchema;
   }
 
   public static override outputSchema(): DataPortSchema {

--- a/packages/ai/src/task/ToolCallingTask.ts
+++ b/packages/ai/src/task/ToolCallingTask.ts
@@ -233,6 +233,10 @@ export const ToolCallingOutputSchema = {
   additionalProperties: false,
 } as const satisfies DataPortSchema;
 
+// `prompt` is manually inlined as the `FromSchema` resolution of the schema's
+// array-item `oneOf` for type-instantiation-budget reasons. The nightly drift
+// guard in `__tests__/types.test-d.ts` asserts equality so a schema edit trips
+// a test instead of silently drifting the runtime type.
 /**
  * Runtime input type for ToolCallingTask.
  *

--- a/packages/ai/src/task/__tests__/types.test-d.ts
+++ b/packages/ai/src/task/__tests__/types.test-d.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FromSchema } from "@workglow/util/schema";
+import { describe, expectTypeOf, it } from "vitest";
+import { AiChatInputSchema, type AiChatTaskInput } from "../AiChatTask";
+import { ChunkRetrievalInputSchema, type ChunkRetrievalTaskInput } from "../ChunkRetrievalTask";
+import { ToolCallingInputSchema, type ToolCallingTaskInput } from "../ToolCallingTask";
+
+/**
+ * Drift guard between the JSON schemas in `packages/ai/src/task/*.ts` and
+ * the hand-written runtime input types alongside them.
+ *
+ * - **AiChat / ToolCalling** — The runtime input types manually inline the
+ *   resolved `FromSchema` literal to avoid the `json-schema-to-ts`
+ *   instantiation cost on every consumer that imports the type. The cost
+ *   shows up only here, in a `.test-d.ts` file excluded from
+ *   `packages/ai/tsconfig.json` so the per-PR `typecheck:budget` gate never
+ *   sees it. The nightly workflow runs vitest's `--typecheck` engine over
+ *   this file. The moment a schema edit (e.g. adding an `audio` variant to
+ *   `ContentBlockSchema`) ships without a matching literal update, the
+ *   equality assertion fails and the nightly turns red.
+ *
+ * - **ChunkRetrieval** — `FromSchema` ignores `if/then/else`, so the
+ *   discriminated union the runtime type encodes is strictly tighter than
+ *   what `FromSchema` would resolve to. The non-equality assertion pins this
+ *   intentional divergence; the moment they become equal, `FromSchema` has
+ *   started honouring `if/then/else` and the runtime type can switch to a
+ *   `FromSchema`-derived form.
+ */
+describe("schema-vs-type drift guard", () => {
+  it("AiChat: prompt equals FromSchema resolution", () => {
+    expectTypeOf<AiChatTaskInput["prompt"]>().toEqualTypeOf<
+      FromSchema<typeof AiChatInputSchema>["prompt"]
+    >();
+  });
+
+  it("ToolCalling: prompt equals FromSchema resolution", () => {
+    expectTypeOf<ToolCallingTaskInput["prompt"]>().toEqualTypeOf<
+      FromSchema<typeof ToolCallingInputSchema>["prompt"]
+    >();
+  });
+
+  it("ChunkRetrieval: hand-written discriminated union is stricter than FromSchema", () => {
+    type Schema = FromSchema<typeof ChunkRetrievalInputSchema>;
+    type Runtime = ChunkRetrievalTaskInput;
+    expectTypeOf<Runtime>().not.toEqualTypeOf<Schema>();
+    expectTypeOf<Schema>().not.toEqualTypeOf<never>();
+    expectTypeOf<Runtime>().not.toEqualTypeOf<never>();
+  });
+});

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": ["src/worker.ts", "src/common.ts", "src/provider-utils.ts", "src/*/**/*"],
   "files": ["./src/worker.ts", "./src/browser.ts", "./src/node.ts", "./src/bun.ts", "./src/provider-utils.ts"],
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["dist", "node_modules", "src/**/*.test-d.ts"],
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Cherry-picks the applicable fixes from PRs #557, #558, and #559 (those three are being closed).

**What's included (from PR #558):**

- **`ChunkRetrievalTask.ts`** — rename module-private `inputSchema` to exported `ChunkRetrievalInputSchema` so the drift test can reference it; add JSDoc documenting the intentional `if/then/else` tightening over `FromSchema`.
- **`types.test-d.ts`** — new vitest typecheck-mode drift guard: asserts AiChat/ToolCalling `prompt` types equal their `FromSchema` resolution (catches schema edits that forget to update the inlined literal), and pins ChunkRetrieval's stricter discriminated union as intentional.
- **`packages/ai/tsconfig.json`** — exclude `*.test-d.ts` so the per-PR `typecheck:budget` gate stays fast.
- **`.github/workflows/nightly-typecheck.yml`** — nightly + `workflow_dispatch` job running `bunx vitest run --typecheck --typecheck.only` over the drift test file.

**What's NOT included (from PR #557 / #559):**

PRs #557 and #559 fix the binary-streaming framework (CacheRef branding, `BinaryStreamRouter` backpressure, legacy unbranded `{$ref}` rewrap). That framework lives on `claude/stoic-bell-RLJWT` (PR #545), which hasn't merged to `main` yet — those fixes will flow in with their base PR.

## Test plan

- [x] `bun scripts/test.ts ai vitest` — 238/238 pass
- [ ] Nightly workflow verifies on first scheduled run after merge
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013v3PWUAdtJBnWKLbzF8nfe)_