### PR TITLE
ci: build type declarations before nightly type-drift typecheck

### DIFF
--- a/.github/workflows/nightly-typecheck.yml
+++ b/.github/workflows/nightly-typecheck.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           bun-version: latest
       - run: bun i
+      - name: Build type declarations
+        run: bun run build:types
       # `.test-d.ts` files only run in vitest's typecheck mode. `--typecheck.only`
       # disables the runtime test run so this stays cheap.
       - run: bunx vitest run --typecheck --typecheck.only packages/ai/src/task/__tests__/types.test-d.ts


### PR DESCRIPTION
## Summary

- The nightly type-drift workflow added in #565 (`.github/workflows/nightly-typecheck.yml`) runs `bun i` then `bunx vitest --typecheck …`, skipping the build step every other test job uses.
- The drift-guard test imports `FromSchema` from `@workglow/util/schema`, which `packages/util/package.json` resolves only via `./dist/schema-entry.d.ts`. Without `dist/`, TS cannot find the symbol and the nightly fails on its first scheduled run.
- Adds a `bun run build:types` step (cheapest build script — `turbo run build-types --concurrency=15`) between `bun i` and the vitest invocation, matching the named-step form used in `test.yml`.

## Test plan

- [x] `bun i` succeeds locally
- [x] `bun run build:types` succeeds (36/36 tasks)
- [x] `ls packages/util/dist/schema-entry.d.ts` confirms the artifact the test self-verifies exists
- [x] `bunx vitest run --typecheck --typecheck.only packages/ai/src/task/__tests__/types.test-d.ts` passes (3/3 tests, no type errors)
- [ ] Trigger the workflow via `workflow_dispatch` once merged to confirm it now succeeds end-to-end on a runner

https://claude.ai/code/session_017TXwbp2GD6jvXrELz6msZW

---
_Generated by [Claude Code](https://claude.ai/code/session_017TXwbp2GD6jvXrELz6msZW)_