### PR TITLE
fix(mcp): thread run-scoped registry through discoverSchemas

### DIFF
--- a/packages/mcp/src/tasks/McpListTask.ts
+++ b/packages/mcp/src/tasks/McpListTask.ts
@@ -10,7 +10,7 @@ import {
   getMcpTaskDeps,
   TypeMcpServer,
 } from "@workglow/mcp/util";
-import type { CachePolicy, TaskEntitlements } from "@workglow/task-graph";
+import type { CachePolicy, IRunConfig, TaskEntitlements } from "@workglow/task-graph";
 import {
   CreateWorkflow,
   Entitlements,
@@ -315,9 +315,10 @@ export class McpListTask extends Task<McpListTaskInput, McpListTaskOutput, TaskC
 
 export const mcpList = async (
   input: McpListTaskInput,
-  config: TaskConfig = {}
+  config: TaskConfig = {},
+  runConfig: Partial<IRunConfig> = {}
 ): Promise<McpListTaskOutput> => {
-  return new McpListTask(config).run(input);
+  return new McpListTask(config).run(input, runConfig);
 };
 
 declare module "@workglow/task-graph" {

--- a/packages/mcp/src/tasks/McpPromptGetTask.ts
+++ b/packages/mcp/src/tasks/McpPromptGetTask.ts
@@ -22,6 +22,7 @@ import {
   TaskConfigSchema,
   Workflow,
 } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
 import { DataPortSchema, DataPortSchemaObject, FromSchema } from "@workglow/util/schema";
 import type { McpListTaskInput } from "./McpListTask";
 import { mcpList } from "./McpListTask";
@@ -241,7 +242,11 @@ export class McpPromptGetTask extends Task<
 
   private _schemasDiscoveringPromise: Promise<void> | undefined;
 
-  async discoverSchemas(_signal?: AbortSignal, serverConfig?: McpServerConfig): Promise<void> {
+  async discoverSchemas(
+    _signal?: AbortSignal,
+    serverConfig?: McpServerConfig,
+    registry?: ServiceRegistry
+  ): Promise<void> {
     if (this.config.inputSchema) return;
     if (this._schemasDiscoveringPromise) return this._schemasDiscoveringPromise;
     const resolved = serverConfig ?? getMcpServerConfig(this.config as Record<string, unknown>);
@@ -249,10 +254,14 @@ export class McpPromptGetTask extends Task<
 
     this._schemasDiscoveringPromise = (async () => {
       try {
-        const result = await mcpList({
-          server: resolved,
-          list_type: "prompts",
-        } as McpListTaskInput);
+        const result = await mcpList(
+          {
+            server: resolved,
+            list_type: "prompts",
+          } as McpListTaskInput,
+          {},
+          registry ? { registry } : {}
+        );
 
         const prompt = result.prompts?.find((p) => p.name === this.config.prompt_name);
         if (prompt) {
@@ -287,7 +296,7 @@ export class McpPromptGetTask extends Task<
   ): Promise<McpPromptGetTaskOutput> {
     const serverConfig = getMcpServerConfig(this.config as Record<string, unknown>);
 
-    await this.discoverSchemas(context.signal, serverConfig);
+    await this.discoverSchemas(context.signal, serverConfig, context.registry);
 
     const { mcpClientFactory } = getMcpTaskDeps();
     const { client } = await mcpClientFactory.create(

--- a/packages/mcp/src/tasks/McpToolCallTask.ts
+++ b/packages/mcp/src/tasks/McpToolCallTask.ts
@@ -22,6 +22,7 @@ import {
   TaskConfigSchema,
   Workflow,
 } from "@workglow/task-graph";
+import type { ServiceRegistry } from "@workglow/util";
 import { DataPortSchema, DataPortSchemaObject } from "@workglow/util/schema";
 import type { McpListTaskInput } from "./McpListTask";
 import { mcpList } from "./McpListTask";
@@ -237,7 +238,11 @@ export class McpToolCallTask extends Task<
 
   private _schemasDiscoveringPromise: Promise<void> | undefined;
 
-  async discoverSchemas(_signal?: AbortSignal, serverConfig?: McpServerConfig): Promise<void> {
+  async discoverSchemas(
+    _signal?: AbortSignal,
+    serverConfig?: McpServerConfig,
+    registry?: ServiceRegistry
+  ): Promise<void> {
     if (this.config.inputSchema && this.config.outputSchema) return;
     if (this._schemasDiscoveringPromise) return this._schemasDiscoveringPromise;
     const resolved = serverConfig ?? getMcpServerConfig(this.config as Record<string, unknown>);
@@ -245,10 +250,14 @@ export class McpToolCallTask extends Task<
 
     this._schemasDiscoveringPromise = (async () => {
       try {
-        const result = await mcpList({
-          server: resolved,
-          list_type: "tools",
-        } as McpListTaskInput);
+        const result = await mcpList(
+          {
+            server: resolved,
+            list_type: "tools",
+          } as McpListTaskInput,
+          {},
+          registry ? { registry } : {}
+        );
 
         const tool = result.tools?.find((t) => t.name === this.config.tool_name);
         if (tool) {
@@ -273,7 +282,7 @@ export class McpToolCallTask extends Task<
   ): Promise<McpToolCallTaskOutput> {
     const serverConfig = getMcpServerConfig(this.config as Record<string, unknown>);
 
-    await this.discoverSchemas(context.signal, serverConfig);
+    await this.discoverSchemas(context.signal, serverConfig, context.registry);
 
     const { mcpClientFactory } = getMcpTaskDeps();
     const { client } = await mcpClientFactory.create(

--- a/packages/test/src/test/mcp/McpDiscoveryRegistry.test.ts
+++ b/packages/test/src/test/mcp/McpDiscoveryRegistry.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { McpPromptGetTask, McpToolCallTask } from "@workglow/mcp/tasks";
+import { mcpClientFactory, resolveMcpClientAuth } from "@workglow/mcp/util";
+import {
+  globalServiceRegistry,
+  InMemoryCredentialStore,
+  ServiceRegistry,
+  setGlobalCredentialStore,
+} from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+function scopedRegistry(): ServiceRegistry {
+  return new ServiceRegistry(globalServiceRegistry.container.createChildContainer());
+}
+
+type FactoryCall = {
+  readonly registry: ServiceRegistry | undefined;
+  readonly bearer: string | undefined;
+};
+
+function recordingFactory(): {
+  readonly calls: FactoryCall[];
+  readonly install: () => void;
+  readonly restore: () => void;
+} {
+  const calls: FactoryCall[] = [];
+  const original = mcpClientFactory.create;
+
+  const mockListTools = async () => ({
+    tools: [{ name: "greet", inputSchema: { type: "object", properties: {} } }],
+  });
+  const mockListPrompts = async () => ({
+    prompts: [{ name: "hello", arguments: [] }],
+  });
+  const mockCallTool = async () => ({
+    content: [{ type: "text", text: "ok" }],
+    isError: false,
+  });
+  const mockGetPrompt = async () => ({
+    messages: [{ role: "user" as const, content: { type: "text" as const, text: "hi" } }],
+    description: "test prompt",
+  });
+
+  const fakeClient = {
+    listTools: mockListTools,
+    listPrompts: mockListPrompts,
+    callTool: mockCallTool,
+    getPrompt: mockGetPrompt,
+    close: async () => undefined,
+  };
+
+  const install = (): void => {
+    mcpClientFactory.create = (async (
+      config: { auth?: { type?: string; token?: string } },
+      _signal?: AbortSignal,
+      registry?: ServiceRegistry
+    ) => {
+      const { headers } = await resolveMcpClientAuth(
+        config as Parameters<typeof resolveMcpClientAuth>[0],
+        registry
+      );
+      const bearer = headers.Authorization?.startsWith("Bearer ")
+        ? headers.Authorization.slice("Bearer ".length)
+        : undefined;
+      calls.push({ registry, bearer });
+      return { client: fakeClient as never, transport: {} as never };
+    }) as typeof mcpClientFactory.create;
+  };
+
+  const restore = (): void => {
+    mcpClientFactory.create = original;
+  };
+
+  return { calls, install, restore };
+}
+
+const httpServer = {
+  transport: "streamable-http" as const,
+  server_url: "https://mcp.example.com",
+  auth_type: "bearer" as const,
+  auth_token: "scoped-key",
+};
+
+describe("MCP discoverSchemas registry threading", () => {
+  let recorder: ReturnType<typeof recordingFactory>;
+
+  beforeEach(() => {
+    recorder = recordingFactory();
+    recorder.install();
+  });
+
+  afterEach(() => {
+    recorder.restore();
+  });
+
+  it("McpToolCallTask: discovery hop resolves bearer through the run-scoped registry", async () => {
+    const globalReg = scopedRegistry();
+    const globalStore = new InMemoryCredentialStore();
+    await globalStore.put("scoped-key", "WRONG-global-value");
+    setGlobalCredentialStore(globalStore, globalReg);
+
+    const runReg = scopedRegistry();
+    const runStore = new InMemoryCredentialStore();
+    await runStore.put("scoped-key", "RIGHT-run-value");
+    setGlobalCredentialStore(runStore, runReg);
+
+    const task = new McpToolCallTask({ server: httpServer, tool_name: "greet" });
+    await task.run({}, { registry: runReg });
+
+    expect(recorder.calls.length).toBeGreaterThanOrEqual(2);
+    // The discovery (list-tools) hop is the first client.create — that's the one
+    // the bug-fix targets. It must resolve the bearer against the run registry.
+    const discoveryCall = recorder.calls[0];
+    expect(discoveryCall.bearer).toBe("RIGHT-run-value");
+    expect(discoveryCall.bearer).not.toBe("scoped-key");
+
+    // Sanity check: the subsequent tool-call hop also resolves through the run registry.
+    const toolCall = recorder.calls[recorder.calls.length - 1];
+    expect(toolCall.bearer).toBe("RIGHT-run-value");
+  });
+
+  it("McpPromptGetTask: discovery hop resolves bearer through the run-scoped registry", async () => {
+    const globalReg = scopedRegistry();
+    const globalStore = new InMemoryCredentialStore();
+    await globalStore.put("scoped-key", "WRONG-global-value");
+    setGlobalCredentialStore(globalStore, globalReg);
+
+    const runReg = scopedRegistry();
+    const runStore = new InMemoryCredentialStore();
+    await runStore.put("scoped-key", "RIGHT-run-value");
+    setGlobalCredentialStore(runStore, runReg);
+
+    const task = new McpPromptGetTask({ server: httpServer, prompt_name: "hello" });
+    await task.run({}, { registry: runReg });
+
+    expect(recorder.calls.length).toBeGreaterThanOrEqual(2);
+    const discoveryCall = recorder.calls[0];
+    expect(discoveryCall.bearer).toBe("RIGHT-run-value");
+    expect(discoveryCall.bearer).not.toBe("scoped-key");
+  });
+
+  it("discovery does not leak the literal credential key as a bearer (client_credentials path)", async () => {
+    // The same fallback (`resolved ?? value`) applies to client_credentials' client_secret.
+    // When the discovery hop misses the scoped store and falls back, it must not send the
+    // literal key. This guards the secret slot — auth.type "client_credentials" carries an
+    // OAuth-provider path that never produces a bearer header, so we assert via the resolver.
+    const runReg = scopedRegistry();
+    const runStore = new InMemoryCredentialStore();
+    await runStore.put("ccred-secret-key", "real-client-secret");
+    setGlobalCredentialStore(runStore, runReg);
+
+    const { auth } = await resolveMcpClientAuth(
+      {
+        transport: "streamable-http",
+        server_url: "https://mcp.example.com",
+        auth: {
+          type: "client_credentials",
+          client_id: "id",
+          client_secret: "ccred-secret-key",
+        },
+      },
+      runReg
+    );
+
+    expect(auth?.type).toBe("client_credentials");
+    if (auth?.type === "client_credentials") {
+      expect(auth.client_secret).toBe("real-client-secret");
+      expect(auth.client_secret).not.toBe("ccred-secret-key");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Commit `07389b9` ("fix(mcp): resolve auth credentials through the run-scoped registry") wired `context.registry` into `mcpClientFactory.create(...)` inside `McpToolCallTask.execute` / `McpPromptGetTask.execute`. But both tasks' `execute()` first calls `this.discoverSchemas(context.signal, serverConfig)`, which internally calls `mcpList(...)` — a fresh `new McpListTask(config).run(input)` with NO run config. The nested run defaulted `TaskRunner.runner.registry` to `globalServiceRegistry` (`packages/task-graph/src/task/TaskRunner.ts:94, 629`), so in hosts that isolate per-(tenant, project) credential stores on the run-scoped registry, the *discovery* hop's bearer key never resolved against the right store.

Combined with the `resolved ?? value` fallback in `resolveAuthSecrets` (`packages/mcp/src/util/McpAuthProvider.ts:388`), the discovery `listTools` / `listPrompts` request sends the **literal credential key name** to the remote MCP server as a bearer token — leaking an internal identifier and breaking discovery against any server that gates list endpoints behind auth.

## Fix (option a)

Picked option (a) — kept the `mcpList(...)` call inside `discoverSchemas` and threaded a registry through it:

- `mcpList(input, config, runConfig)` — new optional third arg, forwarded into `McpListTask.run(input, runConfig)`. Keeps the standalone task as the single source of truth for client construction.
- `McpToolCallTask.discoverSchemas(_signal, serverConfig, registry)` and `McpPromptGetTask.discoverSchemas(_signal, serverConfig, registry)` accept the registry and forward it via `mcpList(..., { registry })`.
- Both `execute()` methods pass `context.registry` into `discoverSchemas(...)`.

Option (b) — open the client inline and skip `mcpList` entirely — would have moved logic out of the task layer and duplicated the close/error handling. Option (a) is a strictly smaller change.

## Test

New `packages/test/src/test/mcp/McpDiscoveryRegistry.test.ts` exercises the **full discovery → list-tools → call-tool chain** with a run-scoped credential store. Pattern follows the existing `McpClientUtil.test.ts`:

- Creates two scoped `ServiceRegistry` instances — a global with a `WRONG-global-value` bearer, a run-scoped with `RIGHT-run-value`.
- Stubs `mcpClientFactory.create` so that every client construction (discovery + main call) calls back into `resolveMcpClientAuth(config, registry)` and records the bearer header.
- Runs `McpToolCallTask` and `McpPromptGetTask` with `task.run({}, { registry: runScoped })` and asserts the **discovery** hop's recorded bearer equals the run-scoped value, never the literal key.
- Adds a third case pinning the `client_credentials` `client_secret` resolution against the run-scoped registry — the same `resolved ?? value` fallback applies to that auth type, so the reviewer's coverage-gap concern is closed.

## Test plan

- [x] `bun scripts/test.ts mcp vitest` — 7 files, 106 tests, all pass (3 new tests in `McpDiscoveryRegistry.test.ts`).
- [x] `bunx tsgo -b packages/mcp packages/test` — clean typecheck.
- [ ] CI green on `main`-targeted PR.

https://claude.ai/code/session_012goPYgXU4i7BF2k8aDatKP

---
_Generated by [Claude Code](https://claude.ai/code/session_012goPYgXU4i7BF2k8aDatKP)_