### PR TITLE
fix(mcp,supabase): credential-leak fail-closed + vector dim validation (2 HIGH from code review)

### DIFF
--- a/docs/technical/22-mcp-integration.md
+++ b/docs/technical/22-mcp-integration.md
@@ -183,7 +183,7 @@ Secret values in auth configurations can reference the global `ICredentialStore`
 const resolved = await resolveAuthSecrets(authConfig, credentialStore);
 ```
 
-If a key is not found in the credential store, the original value is kept (it may be a literal secret rather than a store key).
+When an explicit credential store is passed, resolution is **strict by default** and a missing key throws `MissingCredentialError` — this prevents the literal key name from silently flowing through as a bearer token. The legacy literal-passthrough behaviour is preserved for the no-argument form (which falls back to the global store) and can be re-enabled per call via the `{ strict: false }` option.
 
 ### Auth Provider Factory
 

--- a/packages/mcp/src/util/McpAuthProvider.ts
+++ b/packages/mcp/src/util/McpAuthProvider.ts
@@ -24,7 +24,7 @@ import type {
   OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { ICredentialStore } from "@workglow/util";
-import { getGlobalCredentialStore } from "@workglow/util";
+import { getGlobalCredentialStore, MissingCredentialError } from "@workglow/util";
 import type { McpAuthConfig } from "./McpAuthTypes";
 
 export { UnauthorizedError };
@@ -368,47 +368,65 @@ export function createAuthProvider(
 /**
  * Resolves credential-store keys in auth config to actual secret values.
  *
- * This is needed for the standalone MCP task path where config properties
- * are NOT auto-resolved by `resolveSchemaInputs`. For the AgentTask path,
- * credential resolution happens automatically via `format: "credential"`.
+ * Strictness defaults to whether the caller passed an explicit `credentialStore`:
+ * an explicit store implies the caller manages credentials and a missing key is
+ * an error (fail closed → throw `MissingCredentialError`); the no-argument form
+ * falls back to the global store and the legacy literal-passthrough behaviour
+ * (treat the value as a literal secret). Passing `{ strict: false }` together
+ * with a store is the documented escape hatch for callers that intentionally
+ * want literal passthrough.
+ *
+ * Failing closed matters: when a credential key is missing in strict mode, the
+ * literal key name (e.g. `"MY_API_KEY"`) used to flow through to the remote
+ * server as `Authorization: Bearer MY_API_KEY`, exposing the key name as if it
+ * were a bearer token. Resolution now either returns the real secret or throws.
  */
+export interface ResolveAuthSecretsOptions {
+  readonly strict?: boolean;
+}
+
 export async function resolveAuthSecrets(
   auth: McpAuthConfig,
-  credentialStore?: ICredentialStore
+  credentialStore?: ICredentialStore,
+  options: ResolveAuthSecretsOptions = {}
 ): Promise<McpAuthConfig> {
   if (auth.type === "none") return auth;
 
+  const explicitStore = credentialStore !== undefined;
   const store = credentialStore ?? getGlobalCredentialStore();
+  const strict = options.strict ?? explicitStore;
 
+  async function resolve(value: string): Promise<string>;
+  async function resolve(value: string | undefined): Promise<string | undefined>;
   async function resolve(value: string | undefined): Promise<string | undefined> {
     if (!value) return value;
     const resolved = await store.get(value);
-    // If the store returns a value, use it; otherwise keep the original
-    // (it may be a literal secret, not a key).
-    return resolved ?? value;
+    if (resolved !== undefined) return resolved;
+    if (strict) throw new MissingCredentialError(value);
+    // Non-strict (legacy) mode: treat the value as a literal secret.
+    return value;
   }
 
   switch (auth.type) {
     case "bearer":
-      return { ...auth, token: (await resolve(auth.token)) ?? auth.token };
+      return { ...auth, token: await resolve(auth.token) };
 
     case "client_credentials":
       return {
         ...auth,
-        client_secret: (await resolve(auth.client_secret)) ?? auth.client_secret,
+        client_secret: await resolve(auth.client_secret),
       };
 
     case "private_key_jwt":
       return {
         ...auth,
-        private_key: (await resolve(auth.private_key)) ?? auth.private_key,
+        private_key: await resolve(auth.private_key),
       };
 
     case "static_private_key_jwt":
       return {
         ...auth,
-        jwt_bearer_assertion:
-          (await resolve(auth.jwt_bearer_assertion)) ?? auth.jwt_bearer_assertion,
+        jwt_bearer_assertion: await resolve(auth.jwt_bearer_assertion),
       };
 
     case "authorization_code":

--- a/packages/test/src/test/mcp/McpClientUtil.test.ts
+++ b/packages/test/src/test/mcp/McpClientUtil.test.ts
@@ -8,6 +8,7 @@ import { resolveMcpClientAuth } from "@workglow/mcp/util";
 import {
   globalServiceRegistry,
   InMemoryCredentialStore,
+  MissingCredentialError,
   ServiceRegistry,
   setGlobalCredentialStore,
 } from "@workglow/util";
@@ -37,20 +38,20 @@ describe("resolveMcpClientAuth credential scoping", () => {
     expect(headers.Authorization).toBe("Bearer sekret-value");
   });
 
-  it("keeps the literal token when the scoped store has no such key", async () => {
+  it("fails closed (no literal-token bearer leak) when the scoped store has no such key", async () => {
     const registry = scopedRegistry();
     setGlobalCredentialStore(new InMemoryCredentialStore(), registry);
 
-    const { headers } = await resolveMcpClientAuth(
-      {
-        transport: "streamable-http",
-        server_url: "https://mcp.example.com",
-        auth: { type: "bearer", token: "literal-token" },
-      },
-      registry
-    );
-
-    expect(headers.Authorization).toBe("Bearer literal-token");
+    await expect(
+      resolveMcpClientAuth(
+        {
+          transport: "streamable-http",
+          server_url: "https://mcp.example.com",
+          auth: { type: "bearer", token: "literal-token" },
+        },
+        registry
+      )
+    ).rejects.toBeInstanceOf(MissingCredentialError);
   });
 
   it("does not leak credentials across scoped registries", async () => {

--- a/packages/test/src/test/mcp/createAuthProvider.test.ts
+++ b/packages/test/src/test/mcp/createAuthProvider.test.ts
@@ -10,7 +10,7 @@ import {
   CredentialStoreOAuthProvider,
   resolveAuthSecrets,
 } from "@workglow/mcp/util";
-import { InMemoryCredentialStore } from "@workglow/util";
+import { InMemoryCredentialStore, MissingCredentialError } from "@workglow/util";
 import { describe, expect, it } from "vitest";
 
 const SERVER_URL = "https://mcp.example.com/api";
@@ -154,11 +154,50 @@ describe("resolveAuthSecrets", () => {
     expect(resolved).toEqual({ type: "bearer", token: "actual-secret-value" });
   });
 
-  it("keeps literal value when not found in store", async () => {
+  it("throws MissingCredentialError when an explicit store is passed and the key is absent", async () => {
+    const store = new InMemoryCredentialStore();
+    const calls: string[] = [];
+    const recorderGet = store.get.bind(store);
+    store.get = async (k: string) => {
+      calls.push(k);
+      return recorderGet(k);
+    };
+
+    const config: McpAuthConfig = { type: "bearer", token: "sk-missing-key" };
+    await expect(resolveAuthSecrets(config, store)).rejects.toBeInstanceOf(MissingCredentialError);
+
+    // The literal credential-key name must not be returned anywhere as a bearer:
+    // the call site recorded only the lookup; the literal key never flowed back
+    // into a resolved config.
+    expect(calls).toContain("sk-missing-key");
+  });
+
+  it("falls back to literal value when no store argument is provided (legacy)", async () => {
+    const config: McpAuthConfig = { type: "bearer", token: "sk-literal-key" };
+    const resolved = await resolveAuthSecrets(config);
+    expect(resolved).toEqual({ type: "bearer", token: "sk-literal-key" });
+  });
+
+  it("falls back to literal value when explicit strict:false is opted into", async () => {
     const store = new InMemoryCredentialStore();
     const config: McpAuthConfig = { type: "bearer", token: "sk-literal-key" };
-    const resolved = await resolveAuthSecrets(config, store);
+    const resolved = await resolveAuthSecrets(config, store, { strict: false });
     expect(resolved).toEqual({ type: "bearer", token: "sk-literal-key" });
+  });
+
+  it("MissingCredentialError message does not leak the resolved value (key only)", async () => {
+    const store = new InMemoryCredentialStore();
+    const config: McpAuthConfig = { type: "bearer", token: "AUTH_KEY_NAME" };
+    try {
+      await resolveAuthSecrets(config, store);
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingCredentialError);
+      const err = e as MissingCredentialError;
+      expect(err.key).toBe("AUTH_KEY_NAME");
+      expect(err.message).toContain("AUTH_KEY_NAME");
+      expect(err.message).not.toMatch(/Bearer/i);
+    }
   });
 
   it("resolves client_secret for client_credentials", async () => {

--- a/packages/test/src/test/storage-vector/SupabaseVectorStorage.validation.test.ts
+++ b/packages/test/src/test/storage-vector/SupabaseVectorStorage.validation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { StorageValidationError } from "@workglow/storage";
+import { SupabaseVectorStorage } from "@workglow/supabase/storage";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import { TypedArraySchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Unit-level validation tests: every rejection here must happen *before* the
+ * Supabase client is touched. The stub asserts that by exploding on any
+ * unexpected method call — pgvector and the network are out of scope for this
+ * suite.
+ */
+const VecSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    vector: TypedArraySchema(),
+    metadata: { type: "object", format: "metadata", additionalProperties: true },
+  },
+  required: ["id", "vector", "metadata"],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+const VecPK = ["id"] as const;
+const DIM = 4;
+
+interface StubClient {
+  readonly rpcCalls: string[];
+  readonly fromCalls: string[];
+  readonly client: SupabaseClient;
+}
+
+function makeStubClient(): StubClient {
+  const rpcCalls: string[] = [];
+  const fromCalls: string[] = [];
+
+  const client = {
+    rpc: (name: string) => {
+      rpcCalls.push(name);
+      throw new Error(`unexpected rpc(${name}) — validation should reject first`);
+    },
+    from: (table: string) => {
+      fromCalls.push(table);
+      throw new Error(`unexpected from(${table}) — validation should reject first`);
+    },
+    channel: () => {
+      throw new Error("unexpected channel() call in validation test");
+    },
+    removeChannel: () => undefined,
+  } as unknown as SupabaseClient;
+
+  return { rpcCalls, fromCalls, client };
+}
+
+function newStore(client: SupabaseClient): SupabaseVectorStorage<
+  typeof VecSchema,
+  typeof VecPK
+> {
+  return new SupabaseVectorStorage(client, "vec_items", VecSchema, VecPK, [], DIM);
+}
+
+describe("SupabaseVectorStorage validation", () => {
+  describe("put / putBulk vector-shape validation (write context)", () => {
+    it("rejects a vector that is one entry short", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const short = new Float32Array([1, 2, 3]); // dim 3, expected 4
+      await expect(
+        store.put({ id: "x", vector: short, metadata: {} } as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      await expect(
+        store.put({ id: "x", vector: short, metadata: {} } as never)
+      ).rejects.toThrow(/Vector dimension mismatch on write: expected 4, got 3/);
+      expect(stub.fromCalls).toEqual([]);
+    });
+
+    it("rejects a vector that is one entry too long", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const long = new Float32Array([1, 2, 3, 4, 5]);
+      await expect(
+        store.put({ id: "x", vector: long, metadata: {} } as never)
+      ).rejects.toThrow(/expected 4, got 5/);
+      expect(stub.fromCalls).toEqual([]);
+    });
+
+    it("rejects a vector containing NaN with the index", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const bad = new Float32Array([1, NaN, 3, 4]);
+      await expect(
+        store.put({ id: "x", vector: bad, metadata: {} } as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      await expect(
+        store.put({ id: "x", vector: bad, metadata: {} } as never)
+      ).rejects.toThrow(/index 1 is not a finite number/);
+      expect(stub.fromCalls).toEqual([]);
+    });
+
+    it("rejects a vector containing Infinity", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      // Float32Array clamps, so use a plain array to keep Infinity.
+      const bad = [1, 2, Number.POSITIVE_INFINITY, 4];
+      await expect(
+        store.put({ id: "x", vector: bad as unknown as Float32Array, metadata: {} } as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      await expect(
+        store.put({ id: "x", vector: bad as unknown as Float32Array, metadata: {} } as never)
+      ).rejects.toThrow(/index 2 is not a finite number/);
+      expect(stub.fromCalls).toEqual([]);
+    });
+
+    it("rejects null / undefined vector values", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      await expect(
+        store.put({ id: "x", vector: null, metadata: {} } as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      await expect(
+        store.put({ id: "x", vector: undefined, metadata: {} } as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      expect(stub.fromCalls).toEqual([]);
+    });
+
+    it("putBulk rejects when any vector is malformed and never partially writes", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const good = new Float32Array([1, 2, 3, 4]);
+      const bad = new Float32Array([1, 2, 3]); // wrong dim
+      await expect(
+        store.putBulk([
+          { id: "a", vector: good, metadata: {} },
+          { id: "b", vector: bad, metadata: {} },
+        ] as never)
+      ).rejects.toBeInstanceOf(StorageValidationError);
+      expect(stub.fromCalls).toEqual([]);
+      expect(stub.rpcCalls).toEqual([]);
+    });
+  });
+
+  describe("similaritySearch vector-shape validation (query context)", () => {
+    it("rejects a query of wrong dimension before invoking rpc()", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const wrongDim = new Float32Array([1, 2]);
+      await expect(store.similaritySearch(wrongDim)).rejects.toBeInstanceOf(StorageValidationError);
+      await expect(store.similaritySearch(wrongDim)).rejects.toThrow(
+        /Vector dimension mismatch on query: expected 4, got 2/
+      );
+      expect(stub.rpcCalls).toEqual([]);
+    });
+
+    it("rejects NaN in the query vector before invoking rpc()", async () => {
+      const stub = makeStubClient();
+      const store = newStore(stub.client);
+      const badQuery = new Float32Array([0, NaN, 0, 0]);
+      await expect(store.similaritySearch(badQuery)).rejects.toThrow(
+        /index 1 is not a finite number/
+      );
+      expect(stub.rpcCalls).toEqual([]);
+    });
+  });
+});

--- a/packages/util/src/credentials/MissingCredentialError.ts
+++ b/packages/util/src/credentials/MissingCredentialError.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BaseError } from "../utilities/BaseError";
+
+/**
+ * Thrown when a credential lookup against an `ICredentialStore` fails to find
+ * the requested key in strict resolution mode.
+ *
+ * The constructor accepts the credential **key** that was looked up — never the
+ * resolved or candidate secret value. The error message is built from the key
+ * only and intentionally does not interpolate any value-shaped data, so this
+ * error is safe to log and surface to operators without leaking secrets.
+ */
+export class MissingCredentialError extends BaseError {
+  public static override readonly type: string = "MissingCredentialError";
+  public readonly key: string;
+
+  constructor(key: string) {
+    super(`Credential "${key}" not found in configured store`);
+    this.key = key;
+  }
+}

--- a/packages/util/src/credentials/index.ts
+++ b/packages/util/src/credentials/index.ts
@@ -13,4 +13,5 @@ export * from "./CredentialStoreRegistry";
 export * from "./EnvCredentialStore";
 export * from "./ICredentialStore";
 export * from "./InMemoryCredentialStore";
+export * from "./MissingCredentialError";
 export * from "./OtpPassphraseCache";

--- a/providers/supabase/src/storage/SupabaseVectorStorage.ts
+++ b/providers/supabase/src/storage/SupabaseVectorStorage.ts
@@ -138,7 +138,43 @@ export class SupabaseVectorStorage<
     return record as InsertType;
   }
 
+  /**
+   * Validate vector shape before handing it to pgvector. Length must match the
+   * dimension this store was constructed with; every entry must be a finite
+   * number (no `NaN` / `±Infinity` / non-numeric). The driver rejects malformed
+   * pgvector text only after a round-trip with an opaque error — fail fast here
+   * with a clear `StorageValidationError` instead.
+   */
+  private assertVectorShape(arr: unknown, context: "write" | "query"): void {
+    if (arr === null || arr === undefined) {
+      throw new StorageValidationError(
+        `Vector value missing on ${context}: expected an array-like of ${this.vectorDimensions} finite numbers, got ${arr === null ? "null" : "undefined"}.`
+      );
+    }
+    const lengthValue = (arr as { length?: unknown }).length;
+    if (typeof lengthValue !== "number") {
+      throw new StorageValidationError(
+        `Vector value invalid on ${context}: expected an array-like with a numeric length, got ${typeof arr}.`
+      );
+    }
+    if (lengthValue !== this.vectorDimensions) {
+      throw new StorageValidationError(
+        `Vector dimension mismatch on ${context}: expected ${this.vectorDimensions}, got ${lengthValue}.`
+      );
+    }
+    const view = arr as ArrayLike<number>;
+    for (let i = 0; i < lengthValue; i++) {
+      const v = view[i];
+      if (typeof v !== "number" || !Number.isFinite(v)) {
+        throw new StorageValidationError(
+          `Vector value invalid on ${context}: entry at index ${i} is not a finite number (got ${String(v)}).`
+        );
+      }
+    }
+  }
+
   protected toPgVectorText(value: unknown): string {
+    this.assertVectorShape(value, "write");
     const arr = value as ArrayLike<number>;
     return `[${Array.from(arr).join(",")}]`;
   }
@@ -201,6 +237,8 @@ export class SupabaseVectorStorage<
         );
       }
     }
+
+    this.assertVectorShape(query, "query");
 
     const { data, error } = await this.client.rpc(
       `match_${this.tableName}`,


### PR DESCRIPTION
Two HIGH-severity fixes from a recent code review.

## HIGH-1: MCP credential-leak fail-closed

`resolveAuthSecrets` previously did `return resolved ?? value`, so when a credential-store key was not found, the literal key name was returned as the secret. That key then flowed downstream into `Authorization: Bearer <key>` headers when the resolved config was used by `resolveMcpClientAuth` / `createMcpClient`, leaking the key name to remote MCP servers as if it were a bearer token. PR #577 fixed the registry-threading half of the bug but left this fallback intact.

Changes:

- New `MissingCredentialError` (`BaseError` subclass) — `packages/util/src/credentials/MissingCredentialError.ts`. Key-only message; never interpolates the resolved value. Re-exported from `packages/util/src/credentials/index.ts`.
- `resolveAuthSecrets` in `packages/mcp/src/util/McpAuthProvider.ts` now takes an optional `{ strict?: boolean }` option. `strict` defaults to "did the caller pass an explicit credential store?" — explicit store ⇒ fail closed (`throw MissingCredentialError`); no-argument call ⇒ legacy literal passthrough. Callers can opt back into the legacy form with `{ strict: false }`. The secondary `?? auth.token` / `?? auth.client_secret` fallbacks inside the switch are removed so the resolved config can no longer fall back to the key after `resolve(...)` rejected.
- Tests in `packages/test/src/test/mcp/createAuthProvider.test.ts`:
  - explicit store + missing key → rejects with `MissingCredentialError`; recorder confirms the literal key was looked up but never re-emitted as a bearer value;
  - no-store form still returns the literal (legacy);
  - `strict: false` escape hatch returns the literal;
  - `MissingCredentialError.message` contains the key but no "Bearer" substring (no value-shaped leakage).
- `packages/test/src/test/mcp/McpClientUtil.test.ts`: updated the "scoped store has no such key" case from "keeps the literal token" to "fails closed with `MissingCredentialError`" — that is exactly the leak path we are closing.
- `docs/technical/22-mcp-integration.md` updated to describe the new strict-by-default behaviour.

## HIGH-2: Supabase vector dimension / finiteness validation

`prepareForWrite` did `Array.from(arr).join(",")` with no length check and no `NaN` / `Infinity` rejection, so the pgvector driver would throw an opaque error on round-trip instead of a clear `StorageValidationError`. Same risk on the query path — a wrong-dimension query would be sent to the `match_<table>` RPC and fail server-side.

Changes:

- New private `assertVectorShape(arr, context: "write" | "query")` on `SupabaseVectorStorage` in `providers/supabase/src/storage/SupabaseVectorStorage.ts`. Rejects null / undefined / non-array-like inputs; rejects length mismatches with both expected and actual sizes; rejects non-finite entries with the offending index. Reuses `StorageValidationError`, matching the existing filter-key validation contract.
- Wired into `toPgVectorText` (covers `put` and `putBulk`) and into `similaritySearch` immediately after the filter-key check, before the `.rpc(...)` call.
- New unit tests at `packages/test/src/test/storage-vector/SupabaseVectorStorage.validation.test.ts` use a stub Supabase client that throws if `from()` or `rpc()` is called. Tests cover:
  - length mismatch (write) — expected and actual sizes in message;
  - `NaN` (write) — offending index in message;
  - `Infinity` (write);
  - `null` / `undefined` (write);
  - `putBulk` with one bad row — entire call rejects, no `from()` or `rpc()` reached, no partial write;
  - similarity-search with wrong-dim query — rejects before `.rpc()` (stub records no calls).

## Verification

- `bun scripts/test.ts mcp vitest` — 109 / 109 pass (7 files, including the existing `McpDiscoveryRegistry.test.ts` discovery-leak guard).
- `bun scripts/test.ts storage vitest` — 1384 / 1384 pass (49 files, includes the new validation suite).
- `bun run build:types` — 36 / 36 packages typecheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1jTfnsRppCiLTof7ifSxV)_