### PR TITLE
chore: add job queue homepage metadata

### DIFF
--- a/packages/job-queue/package.json
+++ b/packages/job-queue/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/workglow-dev/libs.git",
     "directory": "packages/job-queue"
   },
+  "homepage": "https://github.com/workglow-dev/libs/tree/main/packages/job-queue",
   "bugs": {
     "url": "https://github.com/workglow-dev/libs/issues"
   },


### PR DESCRIPTION
## Summary

Adds the missing npm `homepage` metadata to `@workglow/job-queue`, pointing to the package directory in this repository.

This is metadata-only; runtime code, dependencies, exports, and build behavior are unchanged.

## Validation

- `npm pkg get name repository homepage bugs --silent`
- `npm pack --dry-run --ignore-scripts --json --silent`
- `git diff --check`
