### PR TITLE
fix(providers/sqlite): wrap putBulk vectors with vector_as_*() to match put

### DIFF
--- a/packages/test/src/test/vector/SqliteAiVectorStorage.integration.test.ts
+++ b/packages/test/src/test/vector/SqliteAiVectorStorage.integration.test.ts
@@ -171,6 +171,120 @@ describe.skipIf(!sqliteVectorAvailable)("SqliteAiVectorStorage", async () => {
     });
   });
 
+  describe("putBulk vector encoding", () => {
+    // Regression: previously, putBulk fell through to the base-class path which
+    // binds vectors as JSON strings (no vector_as_${suffix} wrap), so
+    // vector_full_scan could not decode them and similaritySearch silently
+    // fell back to in-memory cosine. These tests pin the
+    // vector_as_${suffix}(?)-wrapped INSERT and the round-trip via getAll().
+
+    it("putBulk + similaritySearch returns inserted vectors at distance 0", async () => {
+      await storage.putBulk([
+        {
+          chunk_id: "bulk1",
+          doc_id: "docB1",
+          vector: new Float32Array([1.0, 0.0, 0.0]),
+          metadata: { tag: "bulk" },
+        },
+        {
+          chunk_id: "bulk2",
+          doc_id: "docB2",
+          vector: new Float32Array([0.0, 1.0, 0.0]),
+          metadata: { tag: "bulk" },
+        },
+      ]);
+
+      const results = await storage.similaritySearch(new Float32Array([1.0, 0.0, 0.0]), {
+        topK: 2,
+      });
+
+      // The exact match must rank first with score ~1.0; if vectors had landed
+      // as JSON BLOBs, vector_full_scan would have failed and we'd silently
+      // fall back to the in-memory cosine path (which would happen to give the
+      // right ordering — so we pin the score to ensure the native path ran).
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results[0].chunk_id).toBe("bulk1");
+      expect(results[0].score).toBeGreaterThanOrEqual(0.999);
+    });
+
+    it("putBulk persists vectors as Float32Array via getAll", async () => {
+      // Direct encoding check — vectors must come back as TypedArrays with
+      // their original values, not as raw JSON strings or Buffers.
+      await storage.putBulk([
+        {
+          chunk_id: "enc1",
+          doc_id: "docE1",
+          vector: new Float32Array([0.5, 0.5, 0.5]),
+          metadata: {},
+        },
+        {
+          chunk_id: "enc2",
+          doc_id: "docE2",
+          vector: new Float32Array([0.1, 0.2, 0.3]),
+          metadata: {},
+        },
+      ]);
+
+      const all = await storage.getAll();
+      expect(all).toBeDefined();
+      const byId = new Map(all!.map((r) => [r.chunk_id, r]));
+
+      const r1 = byId.get("enc1")!;
+      expect(r1).toBeDefined();
+      expect(r1.vector).toBeInstanceOf(Float32Array);
+      expect(r1.vector.length).toBe(3);
+      expect(r1.vector[0]).toBeCloseTo(0.5, 5);
+      expect(r1.vector[1]).toBeCloseTo(0.5, 5);
+      expect(r1.vector[2]).toBeCloseTo(0.5, 5);
+
+      const r2 = byId.get("enc2")!;
+      expect(r2).toBeDefined();
+      expect(r2.vector).toBeInstanceOf(Float32Array);
+      expect(r2.vector[0]).toBeCloseTo(0.1, 5);
+      expect(r2.vector[1]).toBeCloseTo(0.2, 5);
+      expect(r2.vector[2]).toBeCloseTo(0.3, 5);
+    });
+
+    it("mixed put + putBulk yields identical similaritySearch ordering", async () => {
+      // A row written through `put` and another through `putBulk` must encode
+      // their vectors identically — otherwise the bulk-encoded row would be
+      // unsearchable while the single-row write would rank correctly.
+      await storage.put({
+        chunk_id: "single",
+        doc_id: "docS",
+        vector: new Float32Array([1.0, 0.0, 0.0]),
+        metadata: { source: "put" },
+      });
+      await storage.putBulk([
+        {
+          chunk_id: "bulk-a",
+          doc_id: "docBA",
+          vector: new Float32Array([0.9, 0.1, 0.0]),
+          metadata: { source: "bulk" },
+        },
+        {
+          chunk_id: "bulk-b",
+          doc_id: "docBB",
+          vector: new Float32Array([0.0, 0.0, 1.0]),
+          metadata: { source: "bulk" },
+        },
+      ]);
+
+      const results = await storage.similaritySearch(new Float32Array([1.0, 0.0, 0.0]), {
+        topK: 3,
+      });
+
+      expect(results.length).toBe(3);
+      // Exact match first (from `put`), near-match second (from `putBulk`),
+      // orthogonal vector last.
+      expect(results[0].chunk_id).toBe("single");
+      expect(results[1].chunk_id).toBe("bulk-a");
+      expect(results[2].chunk_id).toBe("bulk-b");
+      expect(results[0].score).toBeGreaterThan(results[1].score);
+      expect(results[1].score).toBeGreaterThan(results[2].score);
+    });
+  });
+
   describe("similaritySearch", () => {
     beforeEach(async () => {
       await populateStorage();

--- a/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
@@ -291,22 +291,14 @@ export class SqliteAiVectorStorage<
   }
 
   /**
-   * Override put to use sqlite-vector encoding for vector data.
-   * Builds a custom INSERT OR REPLACE that wraps the vector column
-   * with vector_as_fXX() to encode as a native vector BLOB.
-   * Falls back to base class put() if the extension is not available.
+   * Build the INSERT OR REPLACE SQL + bound params for a single entity, wrapping
+   * the vector column with `vector_as_${suffix}(?)` so sqlite-vector encodes it
+   * as a native vector BLOB rather than a JSON string. Shared by `put` and
+   * `putBulk` so both paths go through the same encoding — without this, bulk
+   * vectors used to fall through `super.putBulk` and land as raw JSON, which
+   * `vector_full_scan` cannot decode.
    */
-  public override async put(entity: any): Promise<Entity> {
-    validateVectorEntities(
-      [entity as Record<string, unknown>],
-      this.vectorPropertyName as string,
-      this.vectorDimensions
-    );
-    if (!this.extensionLoaded) {
-      return super.put(entity);
-    }
-
-    const db = this.database;
+  private buildVectorInsertSql(entity: any): { sql: string; params: any[] } {
     const vectorCol = String(this.vectorPropertyName);
 
     // Handle auto-generated keys (UUID generation)
@@ -393,14 +385,41 @@ export class SqliteAiVectorStorage<
       }
     }
 
-    const stmt = db.prepare(sql);
-    const updatedEntity = stmt.get(...params) as Entity;
+    return { sql, params };
+  }
 
-    // Convert all columns according to schema
+  /**
+   * Decode all columns of a row returned from the vector INSERT's RETURNING
+   * clause via `sqlToJsValue`, so the vector column comes back as a TypedArray
+   * (not a raw Buffer) and any other JSON-encoded columns deserialize.
+   */
+  private decodeReturnedEntity(updatedEntity: Entity): Entity {
     const updatedRecord = updatedEntity as Record<string, unknown>;
     for (const k in this.schema.properties) {
       updatedRecord[k] = this.sqlToJsValue(k, updatedRecord[k] as any);
     }
+    return updatedEntity;
+  }
+
+  /**
+   * Override put to use sqlite-vector encoding for vector data.
+   * Builds a custom INSERT OR REPLACE that wraps the vector column
+   * with vector_as_fXX() to encode as a native vector BLOB.
+   * Falls back to base class put() if the extension is not available.
+   */
+  public override async put(entity: any): Promise<Entity> {
+    validateVectorEntities(
+      [entity as Record<string, unknown>],
+      this.vectorPropertyName as string,
+      this.vectorDimensions
+    );
+    if (!this.extensionLoaded) {
+      return super.put(entity);
+    }
+
+    const { sql, params } = this.buildVectorInsertSql(entity);
+    const stmt = this.database.prepare(sql);
+    const updatedEntity = this.decodeReturnedEntity(stmt.get(...params) as Entity);
 
     this.events.emit("put", updatedEntity);
     return updatedEntity;
@@ -408,7 +427,15 @@ export class SqliteAiVectorStorage<
 
   /**
    * Validate every entry up front so a single malformed vector rejects the
-   * whole batch before any row is encoded for sqlite-vector.
+   * whole batch before any row is encoded for sqlite-vector, then route the
+   * batch through the same `vector_as_${suffix}(?)`-wrapped INSERT as `put`
+   * inside a SQLite transaction. Without this, the inherited bulk path binds
+   * vectors as plain JSON strings, so `vector_full_scan` cannot decode them
+   * and similarity search silently falls back to the in-memory cosine path.
+   *
+   * `put` events are deferred until after the transaction commits (mirrors
+   * {@link SqliteTabularStorage._putBulkInternal}) so listeners never observe
+   * rows that are about to roll back.
    */
   public override async putBulk(entities: any[]): Promise<Entity[]> {
     validateVectorEntities(
@@ -416,7 +443,24 @@ export class SqliteAiVectorStorage<
       this.vectorPropertyName as string,
       this.vectorDimensions
     );
-    return super.putBulk(entities);
+    if (entities.length === 0) return [];
+    if (!this.extensionLoaded) {
+      return super.putBulk(entities);
+    }
+
+    const updatedEntities: Entity[] = [];
+    const transaction = this.database.transaction((items: any[]) => {
+      for (const item of items) {
+        const { sql, params } = this.buildVectorInsertSql(item);
+        const stmt = this.database.prepare(sql);
+        const row = stmt.get(...params) as Entity;
+        updatedEntities.push(this.decodeReturnedEntity(row));
+      }
+    });
+    transaction(entities);
+
+    for (const entity of updatedEntities) this.events.emit("put", entity);
+    return updatedEntities;
   }
 
   /**


### PR DESCRIPTION
## Summary
`SqliteAiVectorStorage.putBulk` validated vectors then delegated to the base-class `putBulk`, which binds values as JSON strings without the `vector_as_${suffix}(?)` SQL wrapper that single-row `put` uses. Bulk-written vectors landed as raw JSON BLOBs that `vector_full_scan` cannot decode, so every `similaritySearch` silently fell back to in-memory cosine — RAG ingestion through `ChunkVectorUpsertTask` was producing an unsearchable native index.

## Changes
- Extract `buildVectorInsertSql(entity)` as a private helper covering autogen-key handling, column/placeholder/params arrays, the `vector_as_${suffix}` wrap, and SQLite-compat coercion.
- Route both `put` and `putBulk` through the helper; the bulk path runs inside `database.transaction(...)` so N writes share one fsync (matching the base class contract).
- Defer `put` events on the bulk path until after the transaction commits so listeners never observe rows that may roll back.
- Add three regression tests in `SqliteAiVectorStorage.integration.test.ts` (gated on `sqliteVectorAvailable`):
  - `putBulk + similaritySearch` round-trip — exact match scores ≥ 0.999.
  - `putBulk` persists vectors as `Float32Array` via `getAll` — the load-bearing encoding check.
  - mixed `put + putBulk` yield identical `similaritySearch` ordering.

## Test plan
- [x] `bun scripts/test.ts storage vitest` — 1432 tests pass
- [x] `bun scripts/test.ts rag vitest` — 225 tests pass
- [x] `bun run types`

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvgG2Mp6QjSLvF612zd3JR)_