### PR TITLE
feat(storage): add uniqueIndexes parameter for DB-level UNIQUE constraints

### DIFF
--- a/packages/storage/src/tabular/BaseSqlTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseSqlTabularStorage.ts
@@ -52,7 +52,8 @@ export abstract class BaseSqlTabularStorage<
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
     tabularMigrations?: ReadonlyArray<import("../migrations").ITabularMigration>,
-    migrationName?: string
+    migrationName?: string,
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
   ) {
     super(
       schema,
@@ -60,7 +61,8 @@ export abstract class BaseSqlTabularStorage<
       indexes,
       clientProvidedKeys,
       tabularMigrations,
-      migrationName ?? table
+      migrationName ?? table,
+      uniqueIndexes
     );
     this.validateTableAndSchema();
   }

--- a/packages/storage/src/tabular/BaseTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseTabularStorage.ts
@@ -140,6 +140,16 @@ export abstract class BaseTabularStorage<
   protected events = new EventEmitter<TabularEventListeners<PrimaryKey, Entity>>();
 
   protected indexes: Array<keyof Entity>[];
+  /**
+   * Compound column tuples that must each be unique across all rows in the
+   * table. Concrete backends translate these into DB-level UNIQUE indexes
+   * (SQLite / Postgres `CREATE UNIQUE INDEX IF NOT EXISTS`) so the
+   * deduplication invariant survives outside the application-layer code that
+   * upserts canonical rows. Stored separately from {@link indexes} so the
+   * prefix-redundancy filter applied to plain indexes does not collapse a
+   * unique tuple that happens to share a prefix.
+   */
+  protected uniqueIndexes: Array<keyof Entity>[];
   protected primaryKeySchema: DataPortSchemaObject;
   protected valueSchema: DataPortSchemaObject;
 
@@ -168,7 +178,8 @@ export abstract class BaseTabularStorage<
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
     tabularMigrations?: ReadonlyArray<ITabularMigration>,
-    migrationName?: string
+    migrationName?: string,
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
   ) {
     this.tabularMigrations = tabularMigrations;
     if (migrationName) {
@@ -236,6 +247,27 @@ export abstract class BaseTabularStorage<
         ) {
           throw new Error(
             `Searchable column ${String(column)} is not in the primary key schema or value schema`
+          );
+        }
+      }
+    }
+
+    // Unique indexes: NOT prefix-filtered against `indexes` — a tuple that
+    // duplicates a regular index still needs the UNIQUE constraint at the DB
+    // level (the regular index only accelerates lookups; it does not reject
+    // duplicates). Validate column names against the schema the same way.
+    this.uniqueIndexes = uniqueIndexes.map((spec) => [...spec]) as Array<Array<keyof Entity>>;
+    for (const uniqueIndex of this.uniqueIndexes) {
+      if (uniqueIndex.length === 0) {
+        throw new Error("Unique index column list must not be empty");
+      }
+      for (const column of uniqueIndex) {
+        if (
+          !(column in this.primaryKeySchema.properties) &&
+          !(column in this.valueSchema.properties)
+        ) {
+          throw new Error(
+            `Unique-index column ${String(column)} is not in the primary key schema or value schema`
           );
         }
       }

--- a/packages/storage/src/tabular/InMemoryTabularStorage.ts
+++ b/packages/storage/src/tabular/InMemoryTabularStorage.ts
@@ -27,6 +27,7 @@ import {
   TabularChangePayload,
   TabularSubscribeOptions,
 } from "./ITabularStorage";
+import { StorageError } from "./StorageError";
 
 export const MEMORY_TABULAR_REPOSITORY = createServiceToken<AnyTabularStorage>(
   "storage.tabularRepository.inMemory"
@@ -56,9 +57,18 @@ export class InMemoryTabularStorage<
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
     tabularMigrations?: ReadonlyArray<ITabularMigration>,
-    migrationName: string = "inmemory"
+    migrationName: string = "inmemory",
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
   ) {
-    super(schema, primaryKeyNames, indexes, clientProvidedKeys, tabularMigrations, migrationName);
+    super(
+      schema,
+      primaryKeyNames,
+      indexes,
+      clientProvidedKeys,
+      tabularMigrations,
+      migrationName,
+      uniqueIndexes
+    );
   }
 
   override async setupDatabase(): Promise<void> {
@@ -122,6 +132,15 @@ export class InMemoryTabularStorage<
 
     const { key } = this.separateKeyValueFromCombined(entityToStore);
     const id = await makeFingerprint(key);
+
+    // Enforce DB-equivalent UNIQUE constraints at the in-memory tier so test
+    // fixtures fail the same way Postgres/SQLite would. Skip the scan when no
+    // uniqueIndexes are declared — the cost is proportional to row count, and
+    // most stores never need it.
+    if (this.uniqueIndexes.length > 0) {
+      this.assertUniqueIndexes(entityToStore, id);
+    }
+
     this._lastPutWasInsert = !this.values.has(id);
     this.values.set(id, entityToStore);
 
@@ -131,6 +150,37 @@ export class InMemoryTabularStorage<
 
   async putBulk(values: InsertType[]): Promise<Entity[]> {
     return await Promise.all(values.map(async (value) => this.put(value)));
+  }
+
+  /**
+   * Scan the row Map and reject `entityToStore` if any *other* row (different
+   * fingerprint id) already shares the same value tuple for any declared
+   * unique-index tuple. Matches the DB-level `CREATE UNIQUE INDEX` semantics
+   * the SQLite/Postgres backends emit so contract tests can exercise the
+   * constraint without standing up a real DB.
+   */
+  private assertUniqueIndexes(entityToStore: Entity, incomingId: string): void {
+    const incomingRecord = entityToStore as Record<string, unknown>;
+    for (const tuple of this.uniqueIndexes) {
+      const incomingValues = tuple.map((col) => incomingRecord[col as string]);
+      // SQL UNIQUE treats NULL as distinct (one NULL never collides with
+      // another) — match that semantics so a partially-populated tuple with a
+      // null field never trips the constraint.
+      if (incomingValues.some((v) => v === undefined || v === null)) continue;
+      for (const [existingId, existing] of this.values) {
+        if (existingId === incomingId) continue;
+        const existingRecord = existing as Record<string, unknown>;
+        const matches = tuple.every(
+          (col, i) => existingRecord[col as string] === incomingValues[i]
+        );
+        if (matches) {
+          throw new StorageError(
+            `UNIQUE constraint failed: (${tuple.map(String).join(", ")}) ` +
+              `= (${incomingValues.map(String).join(", ")})`
+          );
+        }
+      }
+    }
   }
 
   /**

--- a/packages/test/src/test/storage-tabular/uniqueIndexes.contract.test.ts
+++ b/packages/test/src/test/storage-tabular/uniqueIndexes.contract.test.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PGlite } from "@electric-sql/pglite";
+import { PostgresTabularStorage } from "@workglow/postgres/storage";
+import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
+import { InMemoryTabularStorage, StorageError } from "@workglow/storage";
+import { uuid4 } from "@workglow/util";
+import type { DataPortSchemaObject } from "@workglow/util/schema";
+import type { Pool } from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+
+/**
+ * Contract for the `uniqueIndexes` constructor parameter wired through
+ * BaseTabularStorage. Each backend must reject duplicate inserts whose values
+ * collide on a declared unique tuple, even when the primary key differs.
+ *
+ * Notes on the per-backend implementation that this contract pins:
+ *   - InMemoryTabularStorage scans the live row Map and throws StorageError
+ *     before mutating state.
+ *   - SqliteTabularStorage emits `CREATE UNIQUE INDEX IF NOT EXISTS`; the
+ *     SQLite driver throws on collision.
+ *   - PostgresTabularStorage emits the same DDL via PGlite.
+ *
+ * NULL semantics follow SQL's "NULL never collides with NULL" rule across
+ * all backends — only complete tuples participate in the constraint.
+ */
+
+// Two non-PK columns we want to enforce a UNIQUE constraint on.
+const PersonSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    email: { type: "string" },
+    org_id: { type: "string" },
+    name: { type: "string" },
+  },
+  required: ["id", "email", "org_id", "name"],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+const PersonPK = ["id"] as const;
+
+type PersonEntity = {
+  id: string;
+  email: string;
+  org_id: string;
+  name: string;
+};
+
+interface UniqueIndexBackend {
+  readonly name: string;
+  // The contract operates on shape (put/query/getAll), not the precise generic
+  // type of any one backend, so the helper takes a permissive `any` storage
+  // reference rather than over-constraining to one class.
+  readonly create: (tableSuffix: string) => Promise<any>;
+}
+
+function runContract(backend: UniqueIndexBackend): void {
+  describe(`${backend.name} — uniqueIndexes`, () => {
+    it("rejects a duplicate single-column unique value across different PKs", async () => {
+      const storage = (await backend.create("single")) as any;
+
+      await storage.put({
+        id: "p1",
+        email: "alice@example.com",
+        org_id: "orgA",
+        name: "Alice",
+      } as PersonEntity);
+
+      // Different PK, same email → must throw.
+      await expect(
+        storage.put({
+          id: "p2",
+          email: "alice@example.com",
+          org_id: "orgB",
+          name: "Alice 2",
+        } as PersonEntity)
+      ).rejects.toThrow();
+
+      // The first row is still there; the failed insert did not land.
+      const rowsAfter = await storage.query({ email: "alice@example.com" });
+      expect(rowsAfter).toBeDefined();
+      expect(rowsAfter.length).toBe(1);
+      expect(rowsAfter[0].id).toBe("p1");
+    });
+
+    it("allows re-inserting the same PK (UPSERT) without UNIQUE collision", async () => {
+      const storage = (await backend.create("upsert")) as any;
+
+      await storage.put({
+        id: "p1",
+        email: "alice@example.com",
+        org_id: "orgA",
+        name: "Alice",
+      } as PersonEntity);
+
+      // Same PK, same email → the existing row updates in place, no collision.
+      await storage.put({
+        id: "p1",
+        email: "alice@example.com",
+        org_id: "orgA",
+        name: "Alice (renamed)",
+      } as PersonEntity);
+
+      const rows = await storage.query({ id: "p1" });
+      expect(rows).toBeDefined();
+      expect(rows.length).toBe(1);
+      expect(rows[0].name).toBe("Alice (renamed)");
+    });
+
+    it("rejects a duplicate compound unique tuple across different PKs", async () => {
+      const storage = (await backend.create("compound")) as any;
+
+      await storage.put({
+        id: "p1",
+        email: "alice@example.com",
+        org_id: "orgA",
+        name: "Alice",
+      } as PersonEntity);
+
+      // Same (org_id, name), different PK and email → must throw.
+      await expect(
+        storage.put({
+          id: "p2",
+          email: "alice2@example.com",
+          org_id: "orgA",
+          name: "Alice",
+        } as PersonEntity)
+      ).rejects.toThrow();
+
+      // Differing on either compound column is fine.
+      await storage.put({
+        id: "p3",
+        email: "alice3@example.com",
+        org_id: "orgB",
+        name: "Alice",
+      } as PersonEntity);
+      await storage.put({
+        id: "p4",
+        email: "alice4@example.com",
+        org_id: "orgA",
+        name: "Bob",
+      } as PersonEntity);
+
+      const all = (await storage.getAll())!;
+      expect(all.length).toBe(3);
+    });
+  });
+}
+
+// In-memory backend — exercises the JS-side scan path.
+runContract({
+  name: "InMemoryTabularStorage",
+  create: async () =>
+    new InMemoryTabularStorage<typeof PersonSchema, typeof PersonPK>(
+      PersonSchema,
+      PersonPK,
+      [],
+      "if-missing",
+      undefined,
+      "inmemory",
+      // single-column on email + compound on (org_id, name)
+      [["email"], ["org_id", "name"]]
+    ),
+});
+
+// In-memory backend — surface the exact error type for the upstream check.
+describe("InMemoryTabularStorage — uniqueIndexes error type", () => {
+  it("rejects duplicates with a StorageError instance", async () => {
+    const storage = new InMemoryTabularStorage<typeof PersonSchema, typeof PersonPK>(
+      PersonSchema,
+      PersonPK,
+      [],
+      "if-missing",
+      undefined,
+      "inmemory",
+      [["email"]]
+    );
+
+    await storage.put({
+      id: "p1",
+      email: "alice@example.com",
+      org_id: "orgA",
+      name: "Alice",
+    } as PersonEntity);
+
+    let caught: unknown;
+    try {
+      await storage.put({
+        id: "p2",
+        email: "alice@example.com",
+        org_id: "orgB",
+        name: "Alice 2",
+      } as PersonEntity);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StorageError);
+    expect(String((caught as Error).message)).toMatch(/UNIQUE/);
+  });
+});
+
+// SQLite backend — exercises the `CREATE UNIQUE INDEX` DDL path.
+describe("SqliteTabularStorage — uniqueIndexes", async () => {
+  await Sqlite.init();
+  runContract({
+    name: "SqliteTabularStorage",
+    create: async (suffix) => {
+      const storage = new SqliteTabularStorage<typeof PersonSchema, typeof PersonPK>(
+        ":memory:",
+        `unique_${suffix}_${uuid4().replace(/-/g, "_")}`,
+        PersonSchema,
+        PersonPK,
+        [],
+        "if-missing",
+        undefined,
+        [["email"], ["org_id", "name"]]
+      );
+      await storage.setupDatabase();
+      return storage;
+    },
+  });
+});
+
+// Postgres (PGlite) backend — exercises the parallel Postgres DDL path.
+const pgliteDb = new PGlite() as unknown as Pool;
+afterAll(async () => {
+  await (pgliteDb as unknown as PGlite).close();
+});
+
+runContract({
+  name: "PostgresTabularStorage",
+  create: async (suffix) => {
+    const storage = new PostgresTabularStorage<typeof PersonSchema, typeof PersonPK>(
+      pgliteDb,
+      `unique_${suffix}_${uuid4().replace(/-/g, "_")}`,
+      PersonSchema,
+      PersonPK,
+      [],
+      "if-missing",
+      undefined,
+      [["email"], ["org_id", "name"]]
+    );
+    await storage.setupDatabase();
+    return storage as unknown as InstanceType<typeof InMemoryTabularStorage>;
+  },
+});

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -100,9 +100,19 @@ export class PostgresTabularStorage<
     primaryKeyNames: PrimaryKeyNames,
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
-    tabularMigrations?: ReadonlyArray<ITabularMigration>
+    tabularMigrations?: ReadonlyArray<ITabularMigration>,
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
   ) {
-    super(table, schema, primaryKeyNames, indexes, clientProvidedKeys, tabularMigrations, table);
+    super(
+      table,
+      schema,
+      primaryKeyNames,
+      indexes,
+      clientProvidedKeys,
+      tabularMigrations,
+      table,
+      uniqueIndexes
+    );
     this.db = db;
   }
 
@@ -185,6 +195,24 @@ export class PostgresTabularStorage<
         );
         createdIndexes.add(columnKey);
       }
+    }
+    await this.createDeclaredUniqueIndexes();
+  }
+
+  /**
+   * Emit `CREATE UNIQUE INDEX IF NOT EXISTS` for each declared unique tuple.
+   * Idempotent so migration replays and setup-after-migration re-runs are
+   * safe. Index name: `${table}_uniq_${cols.join("_")}` — distinct from the
+   * non-unique `${table}_${cols.join("_")}` pattern above so a tuple can carry
+   * both a search index and a UNIQUE constraint without name collision.
+   */
+  private async createDeclaredUniqueIndexes(): Promise<void> {
+    for (const columns of this.uniqueIndexes) {
+      const indexName = `${this.table}_uniq_${columns.map(String).join("_")}`;
+      const columnList = columns.map((col) => `"${String(col)}"`).join(", ");
+      await this.db.query(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${indexName}" ON "${this.table}" (${columnList})`
+      );
     }
   }
 

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -85,9 +85,19 @@ export class SqliteTabularStorage<
     primaryKeyNames: PrimaryKeyNames,
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
-    tabularMigrations?: ReadonlyArray<ITabularMigration>
+    tabularMigrations?: ReadonlyArray<ITabularMigration>,
+    uniqueIndexes: readonly (readonly (keyof NoInfer<Entity>)[])[] = []
   ) {
-    super(table, schema, primaryKeyNames, indexes, clientProvidedKeys, tabularMigrations, table);
+    super(
+      table,
+      schema,
+      primaryKeyNames,
+      indexes,
+      clientProvidedKeys,
+      tabularMigrations,
+      table,
+      uniqueIndexes
+    );
     if (typeof dbOrPath === "string") {
       this.db = new Sqlite.Database(dbOrPath);
     } else {
@@ -210,6 +220,24 @@ export class SqliteTabularStorage<
         );
         createdIndexes.add(columnKey);
       }
+    }
+    this.createUniqueIndexes();
+  }
+
+  /**
+   * Emit `CREATE UNIQUE INDEX IF NOT EXISTS` for each declared unique tuple.
+   * Idempotent so re-runs (migration replays, ScopedTabularStorage probes) are
+   * safe. Naming: `${table}_uniq_${cols.join("_")}` — distinct from the
+   * non-unique `${table}_${cols.join("_")}` pattern above so a tuple can carry
+   * both a search index and a UNIQUE constraint without name collision.
+   */
+  private createUniqueIndexes(): void {
+    for (const columns of this.uniqueIndexes) {
+      const indexName = `${this.table}_uniq_${columns.map(String).join("_")}`;
+      const columnList = columns.map((col) => `\`${String(col)}\``).join(", ");
+      this.db.exec(
+        `CREATE UNIQUE INDEX IF NOT EXISTS \`${indexName}\` ON \`${this.table}\` (${columnList})`
+      );
     }
   }
 
@@ -540,11 +568,42 @@ export class SqliteTabularStorage<
     const columnList = columnsToInsert.map((c) => `\`${c}\``).join(", ");
     const placeholders = columnsToInsert.map(() => "?").join(", ");
 
-    const sql = `
-      INSERT OR REPLACE INTO \`${this.table}\` (${columnList})
-      VALUES (${placeholders})
-      RETURNING *
-    `;
+    // INSERT OR REPLACE silently *deletes* rows that conflict on any UNIQUE
+    // index (including the ones we now emit from `uniqueIndexes`), so a
+    // collision quietly mutates the table instead of throwing. When unique
+    // indexes are declared, switch to PK-scoped UPSERT via
+    // `ON CONFLICT(<pk>) DO UPDATE`, which preserves the upsert semantics
+    // callers rely on for re-saving the same row but lets SQLite raise a
+    // `SQLITE_CONSTRAINT_UNIQUE` for any non-PK uniqueness violation.
+    let sql: string;
+    if (this.uniqueIndexes.length > 0) {
+      const pkColumns = this.primaryKeyColumns() as string[];
+      const pkList = pkColumns.map((c) => `\`${c}\``).join(", ");
+      const updateAssignments = columnsToInsert
+        .filter((c) => !pkColumns.includes(c))
+        .map((c) => `\`${c}\` = excluded.\`${c}\``)
+        .join(", ");
+      // No non-PK columns to update → DO NOTHING + RETURNING * still echoes
+      // the original row on a PK collision, which is what the contract returns
+      // ("the row that's there"). With non-PK columns, the standard upsert
+      // applies and RETURNING * yields the post-update row.
+      const conflictClause =
+        updateAssignments.length > 0
+          ? `ON CONFLICT(${pkList}) DO UPDATE SET ${updateAssignments}`
+          : `ON CONFLICT(${pkList}) DO NOTHING`;
+      sql = `
+        INSERT INTO \`${this.table}\` (${columnList})
+        VALUES (${placeholders})
+        ${conflictClause}
+        RETURNING *
+      `;
+    } else {
+      sql = `
+        INSERT OR REPLACE INTO \`${this.table}\` (${columnList})
+        VALUES (${placeholders})
+        RETURNING *
+      `;
+    }
     const stmt = db.prepare(sql);
 
     const params = paramsToInsert;


### PR DESCRIPTION
## Summary
`BaseTabularStorage` accepted an `indexes` parameter and emitted plain `CREATE INDEX IF NOT EXISTS` DDL — there was no way to declare DB-level uniqueness without writing the DDL by hand from a subclass. Downstream projects (e.g. sec's canonical schemas) need UNIQUE so the deduplication invariant survives outside the application layer.

## Changes
- Thread `uniqueIndexes: readonly (readonly (keyof Entity)[])[]` through `BaseTabularStorage` → `BaseSqlTabularStorage` → `{Sqlite,Postgres}TabularStorage`. New `protected uniqueIndexes` field, validated the same way as `indexes` but NOT prefix-filtered against them.
- `SqliteTabularStorage` emits `CREATE UNIQUE INDEX IF NOT EXISTS ${table}_uniq_${cols.join("_")}` in `createIndexes`. When `uniqueIndexes` is non-empty, switch the per-row INSERT from `INSERT OR REPLACE` to `INSERT INTO ... ON CONFLICT(<pk>) DO UPDATE` so PK-scoped upsert is preserved but a UNIQUE collision raises `SQLITE_CONSTRAINT_UNIQUE` instead of silently deleting the colliding row.
- `PostgresTabularStorage` emits the parallel DDL via `createDeclaredUniqueIndexes()`; its existing `ON CONFLICT(<pk>) DO UPDATE` upsert already throws on other constraint violations.
- `InMemoryTabularStorage` scans the live row Map on `put` and throws `StorageError` when any incoming row collides on a declared unique tuple (skip the scan when `uniqueIndexes` is empty). NULL semantics follow SQL — partial tuples never trip the constraint.
- New contract test (`uniqueIndexes.contract.test.ts`) exercises duplicate single-column rejection, PK-only UPSERT allowance, and compound-tuple rejection against InMemory, SQLite, and PGlite. A separate test pins the InMemory error type to `StorageError`.

## Test plan
- [x] `bun scripts/test.ts storage vitest` — 1442 tests pass (10 new)
- [x] `bun run types`

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvgG2Mp6QjSLvF612zd3JR)_