### PR TITLE
fix(huggingface-transformers): align HFT_Device tests with auto-resolve semantics

### DIFF
--- a/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
@@ -22,12 +22,12 @@ describe("resolveHftPipelineDevice", () => {
     expect(resolveHftPipelineDevice("auto")).toBe("auto");
     expect(resolveHftPipelineDevice("cpu")).toBe("cpu");
     expect(resolveHftPipelineDevice("gpu")).toBe("gpu");
-    expect(resolveHftPipelineDevice(undefined)).toBeUndefined();
+    expect(resolveHftPipelineDevice(undefined)).toBe("auto");
   });
 
-  it("strips browser-only devices on the server", () => {
-    expect(resolveHftPipelineDevice("webgpu")).toBeUndefined();
-    expect(resolveHftPipelineDevice("wasm")).toBeUndefined();
+  it("normalizes browser-only devices to auto on the server", () => {
+    expect(resolveHftPipelineDevice("webgpu")).toBe("auto");
+    expect(resolveHftPipelineDevice("wasm")).toBe("auto");
   });
 
   it("defaults auto to WebGPU in the browser", () => {

--- a/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
@@ -16,7 +16,9 @@ export function isHftBrowserEnv(): boolean {
  * Resolve the stored high-level HFT device into the concrete value passed to transformers.js.
  *
  * Browser builds only accept `wasm` or `webgpu`; `auto` is our cross-platform
- * stored default, and should prefer WebGPU in the browser.
+ * stored default, and should prefer WebGPU in the browser. On the server,
+ * missing/browser-only inputs normalize to `"auto"`, which transformers.js
+ * delegates to onnxruntime-node for EP auto-selection.
  */
 export function resolveHftPipelineDevice(raw: string | undefined): string {
   if (isHftBrowserEnv()) {


### PR DESCRIPTION
## Problem

`resolveHftPipelineDevice` (in `providers/huggingface-transformers/src/ai/common/HFT_Device.ts`) deliberately normalizes server-side `undefined` / `"wasm"` / `"webgpu"` inputs to `"auto"` so transformers.js can delegate EP selection to onnxruntime-node. The accompanying unit tests in `packages/test/src/test/ai-provider-hft/HFT_Device.test.ts` shipped in 0.3.18/0.3.19 asserting `toBeUndefined()` for those same cases — the tests were carried over from the deleted `HFT_Pipeline.ts` and never updated. The test/source mismatch shipped as a latent bug.

## Decision

**Source is the spec; rewrite the tests.** Downstream consumer `builder` flipped `"webgpu"` → `"auto"` in commit `dd2acdc` because the auto-resolve path is the intended runtime behavior. The source matches the downstream consumer's runtime intent, so the source stays and the tests are corrected.

## Files changed

- `packages/test/src/test/ai-provider-hft/HFT_Device.test.ts`
  - In `"passes auto through on the server"`: `resolveHftPipelineDevice(undefined)` now asserts `.toBe("auto")` instead of `.toBeUndefined()`.
  - Renamed the second `it("strips browser-only devices on the server", ...)` to `it("normalizes browser-only devices to auto on the server", ...)`, with both assertions changed to `.toBe("auto")`.
  - Browser block left untouched.
- `providers/huggingface-transformers/src/ai/common/HFT_Device.ts`
  - Extended the JSDoc above `resolveHftPipelineDevice` with a one-line note that on the server, missing/browser-only inputs normalize to `"auto"` (which transformers.js delegates to onnxruntime-node for EP auto-selection).

## Verification

| Command | Result |
| --- | --- |
| `bunx vitest run packages/test/src/test/ai-provider-hft/HFT_Device.test.ts` | 3 passed (3) |
| `bun run build:types` (turbo, 36 packages) | 36 successful, 36 cached, FULL TURBO |

No source semantics changed; only the tests and JSDoc were corrected to reflect the existing runtime behavior already in use by the downstream `builder` consumer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJqKUg6YCfJsqiKqFgMTva)_