### PR TITLE
Configure TypeScript typecheck for type-drift detection

### DIFF
--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "incremental": false,
+    "noEmit": true
+  },
+  "include": ["packages/ai/src/**/*"],
+  "exclude": ["**/dist", "**/node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   envDir: __dirname,
   test: {
     setupFiles: ["./vitest.setup.ts"],
+    // The nightly type-drift guard runs `.test-d.ts` files through vitest's
+    // `--typecheck` engine. Scope the tsc program to the package under test so
+    // unrelated source (example UIs needing `jsx`, providers relying on their
+    // own ambient `types`/`lib`) is not swept in and reported as drift.
+    typecheck: {
+      tsconfig: "./tsconfig.typecheck.json",
+    },
     testTimeout: 15000, // 15 second global timeout (WASM Postgres / PGlite init can be slow)
     // Vitest uses hookTimeout for beforeEach/afterAll separately from testTimeout; keep both aligned
     hookTimeout: 15000,


### PR DESCRIPTION
## Summary

Adds TypeScript typecheck configuration for Vitest to enable type-drift detection in `.test-d.ts` files. This isolates the type-checking scope to the `packages/ai` package to prevent unrelated source code (example UIs, provider ambient types) from being swept into type-checking reports.

## Changes

- **tsconfig.typecheck.json** (new): Dedicated TypeScript configuration that extends the base config with `noEmit: true` and scopes type-checking to `packages/ai/src/**/*`
- **vitest.config.ts**: Added `typecheck` configuration block that references the new `tsconfig.typecheck.json`, with explanatory comment about the nightly type-drift guard and why the scope is limited to the package under test

## Implementation Details

The typecheck configuration disables composite and incremental compilation modes while enabling `noEmit` to ensure Vitest's `--typecheck` engine only validates types without generating output. By explicitly including only `packages/ai/src/**/*` and excluding `dist` and `node_modules`, the configuration prevents type-checking from inadvertently reporting drift in unrelated packages that may have their own type requirements (e.g., JSX in example UIs, ambient type declarations in provider packages).

https://claude.ai/code/session_01G6ie5uJvfMpFZrGtrKL1c4