### PR TITLE
Fix server-side device resolution to avoid CUDA probing

### DIFF
--- a/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_Device.test.ts
@@ -18,8 +18,8 @@ describe("resolveHftPipelineDevice", () => {
     }
   });
 
-  it("passes auto through on the server", () => {
-    expect(resolveHftPipelineDevice("auto")).toBe("auto");
+  it("resolves auto to undefined on the server", () => {
+    expect(resolveHftPipelineDevice("auto")).toBeUndefined();
     expect(resolveHftPipelineDevice("cpu")).toBe("cpu");
     expect(resolveHftPipelineDevice("gpu")).toBe("gpu");
     expect(resolveHftPipelineDevice(undefined)).toBeUndefined();

--- a/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Device.ts
@@ -18,7 +18,7 @@ export function isHftBrowserEnv(): boolean {
  * Browser builds only accept `wasm` or `webgpu`; `auto` is our cross-platform
  * stored default, and should prefer WebGPU in the browser.
  */
-export function resolveHftPipelineDevice(raw: string | undefined): string {
+export function resolveHftPipelineDevice(raw: string | undefined): string | undefined {
   if (isHftBrowserEnv()) {
     if (raw === "gpu") return "webgpu";
     if (raw === "cpu") return "wasm";
@@ -27,7 +27,10 @@ export function resolveHftPipelineDevice(raw: string | undefined): string {
     return raw;
   }
 
-  // On the server, let transformers.js/onnxruntime-node choose the best EP.
-  if (raw === "wasm" || raw === "webgpu") return "auto";
-  return raw || "auto";
+  // On the server, resolve to undefined so onnxruntime-node defaults to the CPU
+  // execution provider instead of probing CUDA (which throws when the CUDA
+  // shared libraries are absent, e.g. CPU-only CI runners). "wasm"/"webgpu" are
+  // browser-only and stripped here as well.
+  if (!raw || raw === "auto" || raw === "wasm" || raw === "webgpu") return undefined;
+  return raw;
 }


### PR DESCRIPTION
## Summary

Changes the server-side device resolution logic in `resolveHftPipelineDevice()` to return `undefined` instead of `"auto"` for unspecified or browser-only device types. This allows onnxruntime-node to default to the CPU execution provider instead of probing for CUDA, which fails on CPU-only environments (e.g., CI runners without CUDA libraries).

## Key Changes

- **Return type**: Updated `resolveHftPipelineDevice()` to return `string | undefined` instead of `string`
- **Server-side logic**: Changed to return `undefined` for:
  - `undefined` input (was `"auto"`)
  - `"auto"` input (was `"auto"`)
  - `"wasm"` and `"webgpu"` (browser-only, now stripped on server)
- **Fallback behavior**: Non-matching device strings are passed through unchanged
- **Test updates**: Updated test expectations to reflect the new `undefined` return value for `"auto"` on the server

## Implementation Details

The change addresses a runtime issue where onnxruntime-node would attempt CUDA detection when given `"auto"`, causing failures in environments without CUDA libraries installed. By returning `undefined`, the library uses its default CPU execution provider without probing, which is the appropriate behavior for server environments that don't explicitly request GPU acceleration.

https://claude.ai/code/session_01N2vdcSPQJz63DPoiD9JSY2