### PR TITLE
fix(task-graph): stamp saturating depth on over-cap bridge + dedupe warn per parent

### DIFF
--- a/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
+++ b/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
@@ -26,6 +26,14 @@ const DEFAULT_MAX_BRIDGE_DEPTH = 16;
 const BRIDGE_DEPTH = Symbol.for("@workglow/task-graph/SubGraphEventBridge.depth");
 
 /**
+ * Track parent graphs that have already emitted the depth-cap warning so a
+ * pathologically nested compound (e.g. an iterator with 1k iterations all at
+ * over-cap) does not spam one warn per iteration. Held weakly so an evicted
+ * parent graph can still be garbage-collected.
+ */
+const warnedParents = new WeakSet<TaskGraph>();
+
+/**
  * Forward a subgraph's per-task events (task_complete, task_progress, and the
  * task_stream_* trio) up to the parent graph, so tasks nested inside a compound
  * task (GraphAsTask / FallbackTask / WhileTask / ...) surface as individual
@@ -53,10 +61,18 @@ export function bridgeSubGraphTaskEvents(
   // instances) but guard anyway so a malformed hierarchy degrades to a no-op.
   if (subGraph === parentGraph) return () => {};
   if (depth >= maxDepth) {
-    getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
-      depth,
-      maxDepth,
-    });
+    // Stamp the subgraph at the cap so any nested bridge call (whose
+    // parentGraph is this subgraph) derives `depth >= maxDepth` and also
+    // short-circuits — otherwise the depth counter resets at the next level
+    // and the cap leaks downstream.
+    (subGraph as unknown as Record<symbol, number>)[BRIDGE_DEPTH] = maxDepth;
+    if (!warnedParents.has(parentGraph)) {
+      warnedParents.add(parentGraph);
+      getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
+        depth,
+        maxDepth,
+      });
+    }
     return () => {};
   }
 

--- a/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
+++ b/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
@@ -509,4 +509,85 @@ describe("bridgeSubGraphTaskEvents depth cap", () => {
 
     unbridges.forEach((off) => off());
   });
+
+  it("stamped over-cap subgraph prevents downstream bridges from restarting depth", () => {
+    installStubLogger();
+    // Build a 5-level chain with maxDepth=2. Bridges install left-to-right
+    // (outermost first). The first call to exceed the cap MUST stamp the
+    // subgraph so the next bridge (whose parent is that subgraph) also sees
+    // depth >= maxDepth — otherwise the parent's BRIDGE_DEPTH reads as
+    // undefined, depth resets to 0, and the cap leaks downstream.
+    const maxDepth = 2;
+    const N = 5;
+    const graphs: TaskGraph[] = [];
+    for (let i = 0; i <= N; i++) graphs.push(new TaskGraph());
+
+    const reached: number[] = [];
+    for (let i = 0; i < graphs.length; i++) {
+      const depth = i;
+      graphs[i].subscribe("task_progress", () => {
+        reached.push(depth);
+      });
+    }
+
+    const unbridges: Array<() => void> = [];
+    for (let i = 1; i <= N; i++) {
+      unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1], undefined, maxDepth));
+    }
+
+    // graphs[1] and graphs[2] install (depth 0, 1). graphs[3] hits cap and
+    // stamps itself at maxDepth so graphs[4] and graphs[5] also no-op. Emit
+    // from the innermost graph: only its own subscriber should fire — every
+    // bridge i=3..5 short-circuited, so no event propagates outward at all.
+    graphs[N].emit("task_progress", "inner-id", 42, "msg");
+
+    // No bridge from level 2 onward installed, so only the innermost graph
+    // (depth N) saw the emit. depth=0 (outermost) must NOT be reached.
+    expect(reached).toEqual([N]);
+    expect(reached).not.toContain(0);
+
+    unbridges.forEach((off) => off());
+  });
+
+  it("warn fires exactly once per parentGraph at over-cap", () => {
+    installStubLogger();
+    const parent = new TaskGraph();
+    // Call 50 times with the same parent at over-cap (depth seeded above cap).
+    const teardowns: Array<() => void> = [];
+    for (let i = 0; i < 50; i++) {
+      const sub = new TaskGraph();
+      teardowns.push(bridgeSubGraphTaskEvents(sub, parent, 16, 16));
+    }
+
+    const capCalls = warnSpy.mock.calls.filter(
+      (c) => c[0] === "bridgeSubGraphTaskEvents depth cap hit; dropping bridge"
+    );
+    expect(capCalls).toHaveLength(1);
+
+    teardowns.forEach((off) => off());
+  });
+
+  it("distinct parents at over-cap each warn once", () => {
+    installStubLogger();
+    const parentA = new TaskGraph();
+    const parentB = new TaskGraph();
+    const subA = new TaskGraph();
+    const subB = new TaskGraph();
+
+    const off1 = bridgeSubGraphTaskEvents(subA, parentA, 16, 16);
+    const off2 = bridgeSubGraphTaskEvents(subB, parentB, 16, 16);
+    // Repeat each parent a few more times — should not produce additional warns.
+    const off3 = bridgeSubGraphTaskEvents(new TaskGraph(), parentA, 16, 16);
+    const off4 = bridgeSubGraphTaskEvents(new TaskGraph(), parentB, 16, 16);
+
+    const capCalls = warnSpy.mock.calls.filter(
+      (c) => c[0] === "bridgeSubGraphTaskEvents depth cap hit; dropping bridge"
+    );
+    expect(capCalls).toHaveLength(2);
+
+    off1();
+    off2();
+    off3();
+    off4();
+  });
 });


### PR DESCRIPTION
Stacks on #601. Two follow-up fixes to `SubGraphEventBridge`.

## 1. Saturating depth stamp on over-cap

The existing depth cap (`DEFAULT_MAX_BRIDGE_DEPTH = 16`) is derived from the parent graph's `BRIDGE_DEPTH` marker. When the cap fires, the code returns early without stamping the subgraph — so the **next** bridge call (whose `parentGraph` is this just-skipped subgraph) reads `BRIDGE_DEPTH` as `undefined`, falls back to `0`, and reinstalls listeners. The cap leaks downstream.

Fix: stamp `subGraph[BRIDGE_DEPTH] = maxDepth` **before** returning the no-op teardown. Every nested bridge whose parent is an over-cap subgraph now also short-circuits.

## 2. Warn deduplication per parent graph

Without dedupe, an iterator with N iterations at over-cap emits N warns per run (1k iterations = 1k warns). Gate the `getLogger().warn(...)` through a module-level `WeakSet<TaskGraph>` keyed by `parentGraph` so each unique parent warns at most once. Held weakly so an evicted parent is still GC-able.

## Tests

- `stamped over-cap subgraph prevents downstream bridges from restarting depth` — maxDepth=2, 5-level chain; verifies no event escapes past the cap (without the stamp, depth resets and the event leaks 3 levels outward).
- `warn fires exactly once per parentGraph at over-cap` — 50 over-cap calls with the same parent; expects exactly 1 warn.
- `distinct parents at over-cap each warn once` — two parents → two warns.

All 731 graph-section vitest tests pass; `build:types` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERWJJbFgDbPokzJCBsFMdE)_