### PR TITLE
fix: bridge depth cap (#601) + janitor/Container/vector/StreamPump fixes (#604), reviewed

### DIFF
--- a/packages/indexeddb/src/storage/IndexedDbVectorStorage.ts
+++ b/packages/indexeddb/src/storage/IndexedDbVectorStorage.ts
@@ -132,10 +132,11 @@ export class IndexedDbVectorStorage<
     options: VectorSearchOptions<Record<string, unknown>> = {}
   ) {
     assertVectorShape(query, this.vectorDimensions, "query");
-    // Default to no floor: cosine similarity ranges over [-1, 1], so a default
-    // of 0 would silently drop negatively-correlated hits and return fewer than
-    // `topK`. Callers opt into a relevance floor explicitly via `scoreThreshold`.
-    const { topK = 10, filter, scoreThreshold = -Infinity } = options;
+    // Default to 0 to match every SQL backend (Sqlite / Postgres / Supabase /
+    // SqliteAi). Cosine similarity ranges over [-1, 1]; a negatively-correlated
+    // hit is "not a match" for relevance retrieval. Callers that want every
+    // result regardless of correlation pass `scoreThreshold: -Infinity`.
+    const { topK = 10, filter, scoreThreshold = 0 } = options;
     const results: Array<Entity & { score: number }> = [];
 
     const allEntities = (await this.getAll()) || [];

--- a/packages/storage/src/vector/InMemoryVectorStorage.ts
+++ b/packages/storage/src/vector/InMemoryVectorStorage.ts
@@ -139,10 +139,11 @@ export class InMemoryVectorStorage<
     options: VectorSearchOptions<Record<string, unknown>> = {}
   ) {
     assertVectorShape(query, this.vectorDimensions, "query");
-    // Default to no floor: cosine similarity ranges over [-1, 1], so a default
-    // of 0 would silently drop negatively-correlated hits and return fewer than
-    // `topK`. Callers opt into a relevance floor explicitly via `scoreThreshold`.
-    const { topK = 10, filter, scoreThreshold = -Infinity } = options;
+    // Default to 0 to match every SQL backend (Sqlite / Postgres / Supabase /
+    // SqliteAi). Cosine similarity ranges over [-1, 1]; a negatively-correlated
+    // hit is "not a match" for relevance retrieval. Callers that want every
+    // result regardless of correlation pass `scoreThreshold: -Infinity`.
+    const { topK = 10, filter, scoreThreshold = 0 } = options;
     const results: Array<Entity & { score: number }> = [];
 
     const allEntities = (await this.getAll()) || [];

--- a/packages/storage/src/vector/README.md
+++ b/packages/storage/src/vector/README.md
@@ -278,7 +278,7 @@ destroy(): void;
 interface VectorSearchOptions<Metadata = Record<string, unknown>> {
   readonly topK?: number; // Number of results (default: 10)
   readonly filter?: Partial<Metadata>; // Filter by metadata fields
-  readonly scoreThreshold?: number; // Minimum cosine score in [-1, 1]; default -Infinity (no floor, pure topK)
+  readonly scoreThreshold?: number; // Minimum cosine score in [-1, 1]; default 0 (parity across backends); pass -Infinity for no floor (pure topK)
 }
 
 interface HybridSearchOptions<Metadata> extends VectorSearchOptions<Metadata> {

--- a/packages/task-graph/README.md
+++ b/packages/task-graph/README.md
@@ -832,7 +832,13 @@ If the registered `private` slot is present and the graph contains any task whos
 ```typescript
 import { CacheJanitor } from "@workglow/task-graph";
 
-const janitor = new CacheJanitor({ privateBacking });
+const janitor = new CacheJanitor({
+  privateBacking,
+  // Snapshot of currently-live run IDs; the janitor excludes these from the
+  // sweep so a long-running in-flight run does not have its cache rows deleted.
+  // Pass `() => []` if no run is ever concurrent with the sweep.
+  liveRunIds: () => runner.activeRunIds(),
+});
 // Sweep run-private rows older than 24 hours.
 await janitor.sweepStaleRunPrivate(24 * 60 * 60 * 1000);
 ```

--- a/packages/task-graph/src/cache/CacheJanitor.ts
+++ b/packages/task-graph/src/cache/CacheJanitor.ts
@@ -19,11 +19,11 @@ export interface CacheJanitorOptions {
    * in-flight long-running run cannot have its cache rows deleted out from
    * under it (a row's `createdAt` predates the run's age, not its current
    * activity, so a still-running run started days ago would otherwise be
-   * reaped). Default returns an empty list AND emits a one-time `console.warn`
-   * — defaulting is only safe when no run is ever active concurrent with the
-   * sweep.
+   * reaped). Callers that never sweep concurrent with a live run should pass
+   * `() => []` explicitly — the argument is required so the empty case is a
+   * conscious choice at the call site rather than a silent default.
    */
-  liveRunIds?: () => Iterable<string>;
+  liveRunIds: () => Iterable<string>;
 }
 
 /**
@@ -41,23 +41,10 @@ export interface CacheJanitorOptions {
 export class CacheJanitor {
   private readonly privateBacking: RunPrivateTaskOutputRepository;
   private readonly liveRunIds: () => Iterable<string>;
-  private static defaultLiveRunIdsWarned = false;
 
   constructor({ privateBacking, liveRunIds }: CacheJanitorOptions) {
     this.privateBacking = privateBacking;
-    if (liveRunIds === undefined) {
-      if (!CacheJanitor.defaultLiveRunIdsWarned) {
-        CacheJanitor.defaultLiveRunIdsWarned = true;
-        // No logger dependency here (task-graph keeps its log surface narrow);
-        // a one-time console.warn is enough to surface the misconfiguration.
-        console.warn(
-          "CacheJanitor: no liveRunIds callback provided — sweeps may delete cache rows for in-flight runs. Pass `liveRunIds: () => activeRunIdSnapshot` to suppress."
-        );
-      }
-      this.liveRunIds = () => [];
-    } else {
-      this.liveRunIds = liveRunIds;
-    }
+    this.liveRunIds = liveRunIds;
   }
 
   async sweepStaleRunPrivate(olderThanMs: number): Promise<void> {

--- a/packages/task-graph/src/cache/CacheJanitor.ts
+++ b/packages/task-graph/src/cache/CacheJanitor.ts
@@ -13,6 +13,17 @@ export interface CacheJanitorOptions {
    * other runs' stale rows un-swept).
    */
   privateBacking: RunPrivateTaskOutputRepository;
+  /**
+   * Snapshot accessor for currently-live run IDs. The janitor invokes this at
+   * the start of each sweep and excludes the returned IDs from deletion so an
+   * in-flight long-running run cannot have its cache rows deleted out from
+   * under it (a row's `createdAt` predates the run's age, not its current
+   * activity, so a still-running run started days ago would otherwise be
+   * reaped). Default returns an empty list AND emits a one-time `console.warn`
+   * — defaulting is only safe when no run is ever active concurrent with the
+   * sweep.
+   */
+  liveRunIds?: () => Iterable<string>;
 }
 
 /**
@@ -29,12 +40,28 @@ export interface CacheJanitorOptions {
  */
 export class CacheJanitor {
   private readonly privateBacking: RunPrivateTaskOutputRepository;
+  private readonly liveRunIds: () => Iterable<string>;
+  private static defaultLiveRunIdsWarned = false;
 
-  constructor({ privateBacking }: CacheJanitorOptions) {
+  constructor({ privateBacking, liveRunIds }: CacheJanitorOptions) {
     this.privateBacking = privateBacking;
+    if (liveRunIds === undefined) {
+      if (!CacheJanitor.defaultLiveRunIdsWarned) {
+        CacheJanitor.defaultLiveRunIdsWarned = true;
+        // No logger dependency here (task-graph keeps its log surface narrow);
+        // a one-time console.warn is enough to surface the misconfiguration.
+        console.warn(
+          "CacheJanitor: no liveRunIds callback provided — sweeps may delete cache rows for in-flight runs. Pass `liveRunIds: () => activeRunIdSnapshot` to suppress."
+        );
+      }
+      this.liveRunIds = () => [];
+    } else {
+      this.liveRunIds = liveRunIds;
+    }
   }
 
   async sweepStaleRunPrivate(olderThanMs: number): Promise<void> {
-    await this.privateBacking.clearOlderThan(olderThanMs);
+    const live = new Set<string>(this.liveRunIds());
+    await this.privateBacking.clearOlderThan(olderThanMs, live);
   }
 }

--- a/packages/task-graph/src/common.ts
+++ b/packages/task-graph/src/common.ts
@@ -16,6 +16,7 @@ export * from "./task-graph/ITaskGraph";
 export * from "./task-graph/RunContext";
 export * from "./task-graph/RunScheduler";
 export * from "./task-graph/StreamPump";
+export * from "./task-graph/SubGraphEventBridge";
 export * from "./task-graph/TaskGraph";
 export * from "./task-graph/TaskGraphEvents";
 export * from "./task-graph/TaskGraphRunner";

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITabularStorage } from "@workglow/storage";
+import type { ITabularStorage, PageCursor } from "@workglow/storage";
 import { makeFingerprint } from "@workglow/util";
 import type { TaskInput, TaskOutput } from "../task/TaskTypes";
 import {
@@ -99,8 +99,19 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
 
   override async deleteRunOlderThan(runId: string, olderThanInMs: number): Promise<void> {
     const cutoff = new Date(Date.now() - olderThanInMs).toISOString();
-    await this.storage.deleteSearch({ runId, createdAt: { value: cutoff, operator: "<" } });
+    await this.deleteRunOlderThanAt(runId, cutoff);
     this.emit("output_pruned");
+  }
+
+  /**
+   * Internal — timestamp-parameterized older-than delete used by both
+   * {@link deleteRunOlderThan} (which computes the cutoff from `olderThanInMs`
+   * on entry) and the all-runs sweep (which computes the cutoff once). Does
+   * NOT emit `output_pruned`; callers own the event so the sweep can emit
+   * exactly once at the end.
+   */
+  private async deleteRunOlderThanAt(runId: string, cutoff: string): Promise<void> {
+    await this.storage.deleteSearch({ runId, createdAt: { value: cutoff, operator: "<" } });
   }
 
   override async sizeForRun(runId: string): Promise<number> {
@@ -117,25 +128,41 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
    * a run that started long ago but is still active must not have its cache rows
    * deleted out from under it. The tabular surface has no `NOT IN` operator
    * ({@link SearchOperator} is `=/</<=/>/>=` only), so the implementation
-   * enumerates distinct old `runId`s and calls {@link deleteRunOlderThan} per
-   * runId not in the exclude set.
+   * enumerates distinct old `runId`s via cursor-paginated `queryPage` — bounded
+   * page reads instead of materializing the full stale row set in memory — and
+   * calls {@link deleteRunOlderThan} per runId not in the exclude set.
    */
   async clearOlderThan(
     olderThanInMs: number,
     excludeRunIds: ReadonlySet<string> = new Set()
   ): Promise<void> {
     const cutoff = new Date(Date.now() - olderThanInMs).toISOString();
-    const oldRows = await this.storage.query({
-      createdAt: { value: cutoff, operator: "<" },
-    });
-    const oldRunIds = new Set<string>();
-    for (const row of oldRows ?? []) {
-      const runId = (row as { runId?: unknown }).runId;
-      if (typeof runId === "string") oldRunIds.add(runId);
-    }
-    for (const runId of oldRunIds) {
+    const criteria = { createdAt: { value: cutoff, operator: "<" as const } };
+    const seenRunIds = new Set<string>();
+
+    // Default PK ordering (`runId` ASC — leading PK column) groups a run's rows
+    // contiguously, so distinct runIds accumulate quickly on typical data. The
+    // page size caps per-batch memory; `seenRunIds` is bounded by distinct
+    // runId count, not row count.
+    const pageLimit = 500;
+    let cursor: PageCursor | undefined;
+    // Termination follows the ITabularStorage contract: bail on empty page or
+    // undefined nextCursor (whichever comes first).
+    do {
+      const page = await this.storage.queryPage(criteria, { limit: pageLimit, cursor });
+      for (const row of page.items) {
+        const runId = (row as { runId?: unknown }).runId;
+        if (typeof runId === "string") seenRunIds.add(runId);
+      }
+      if (page.items.length === 0) break;
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
+
+    for (const runId of seenRunIds) {
       if (excludeRunIds.has(runId)) continue;
-      await this.deleteRunOlderThan(runId, olderThanInMs);
+      // Route through the internal helper so per-run delete does NOT emit
+      // `output_pruned`; the sweep emits once at the end below.
+      await this.deleteRunOlderThanAt(runId, cutoff);
     }
     this.emit("output_pruned");
   }

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -112,10 +112,36 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
    * All-runs age sweep for the janitor. The private table holds only run-private
    * rows, so deleting everything older than the cutoff is the correct stale-row
    * reap — served by the `createdAt` index.
+   *
+   * `excludeRunIds` (the janitor's live-run snapshot) protects in-flight runs:
+   * a run that started long ago but is still active must not have its cache rows
+   * deleted out from under it. The tabular surface has no `NOT IN` operator
+   * ({@link SearchOperator} is `=/</<=/>/>=` only), so the implementation
+   * enumerates distinct old `runId`s and calls {@link deleteRunOlderThan} per
+   * runId not in the exclude set.
    */
-  async clearOlderThan(olderThanInMs: number): Promise<void> {
+  async clearOlderThan(
+    olderThanInMs: number,
+    excludeRunIds: ReadonlySet<string> = new Set()
+  ): Promise<void> {
     const cutoff = new Date(Date.now() - olderThanInMs).toISOString();
-    await this.storage.deleteSearch({ createdAt: { value: cutoff, operator: "<" } });
+    if (excludeRunIds.size === 0) {
+      await this.storage.deleteSearch({ createdAt: { value: cutoff, operator: "<" } });
+      this.emit("output_pruned");
+      return;
+    }
+    const oldRows = await this.storage.search({
+      createdAt: { value: cutoff, operator: "<" },
+    });
+    const oldRunIds = new Set<string>();
+    for (const row of oldRows ?? []) {
+      const runId = (row as { runId?: unknown }).runId;
+      if (typeof runId === "string") oldRunIds.add(runId);
+    }
+    for (const runId of oldRunIds) {
+      if (excludeRunIds.has(runId)) continue;
+      await this.deleteRunOlderThan(runId, olderThanInMs);
+    }
     this.emit("output_pruned");
   }
 

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -125,11 +125,6 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
     excludeRunIds: ReadonlySet<string> = new Set()
   ): Promise<void> {
     const cutoff = new Date(Date.now() - olderThanInMs).toISOString();
-    if (excludeRunIds.size === 0) {
-      await this.storage.deleteSearch({ createdAt: { value: cutoff, operator: "<" } });
-      this.emit("output_pruned");
-      return;
-    }
     const oldRows = await this.storage.query({
       createdAt: { value: cutoff, operator: "<" },
     });

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -127,10 +127,13 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
    * `excludeRunIds` (the janitor's live-run snapshot) protects in-flight runs:
    * a run that started long ago but is still active must not have its cache rows
    * deleted out from under it. The tabular surface has no `NOT IN` operator
-   * ({@link SearchOperator} is `=/</<=/>/>=` only), so the implementation
-   * enumerates distinct old `runId`s via cursor-paginated `queryPage` — bounded
-   * page reads instead of materializing the full stale row set in memory — and
-   * calls {@link deleteRunOlderThan} per runId not in the exclude set.
+   * ({@link SearchOperator} is `=/</<=/>/>=` only), so when there is anything to
+   * exclude the implementation enumerates distinct old `runId`s via
+   * cursor-paginated `queryPage` — bounded page reads instead of materializing
+   * the full stale row set in memory — and calls {@link deleteRunOlderThan} per
+   * runId not in the exclude set. With nothing to exclude (the common idle
+   * sweep) it takes the original single indexed bulk delete instead of paging
+   * and deleting per-run.
    */
   async clearOlderThan(
     olderThanInMs: number,
@@ -138,6 +141,16 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
   ): Promise<void> {
     const cutoff = new Date(Date.now() - olderThanInMs).toISOString();
     const criteria = { createdAt: { value: cutoff, operator: "<" as const } };
+
+    // Fast path: with no live runs to protect, a single indexed delete reaps
+    // every stale row — no need to page the whole table (loading each row's
+    // encoded output blob) just to collect runIds we would not exclude.
+    if (excludeRunIds.size === 0) {
+      await this.storage.deleteSearch(criteria);
+      this.emit("output_pruned");
+      return;
+    }
+
     const seenRunIds = new Set<string>();
 
     // Default PK ordering (`runId` ASC — leading PK column) groups a run's rows

--- a/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/RunPrivateTaskOutputRepository.ts
@@ -130,7 +130,7 @@ export class RunPrivateTaskOutputRepository extends TaskOutputRepository {
       this.emit("output_pruned");
       return;
     }
-    const oldRows = await this.storage.search({
+    const oldRows = await this.storage.query({
       createdAt: { value: cutoff, operator: "<" },
     });
     const oldRunIds = new Set<string>();

--- a/packages/task-graph/src/task-graph/StreamPump.ts
+++ b/packages/task-graph/src/task-graph/StreamPump.ts
@@ -294,6 +294,10 @@ export class StreamPump {
     portId: string | undefined,
     edgesForGroup: ReadonlyArray<Dataflow>
   ): ReadableStream<StreamEvent> {
+    // Shared teardown closure — hoisted out of start() so cancel() (which the
+    // ReadableStream invokes on reader.cancel()) can call it too. Without this,
+    // a downstream that aborts mid-stream leaves every listener still attached.
+    let cleanup: () => void = () => {};
     return new ReadableStream<StreamEvent>({
       start: (controller) => {
         // Single teardown path: closes the controller and detaches every
@@ -303,7 +307,7 @@ export class StreamPump {
         // fallback the controller and listeners would leak (and a downstream
         // consumer awaiting `done` would hang) on failed/aborted source tasks.
         let closed = false;
-        const cleanup = () => {
+        cleanup = () => {
           if (closed) return;
           closed = true;
           try {
@@ -358,6 +362,16 @@ export class StreamPump {
         task.on("stream_chunk", onChunk);
         task.on("stream_end", onEnd);
         task.on("status", onStatus);
+      },
+      cancel: (_reason) => {
+        // Reader cancellation MUST release the listeners. Without this, a
+        // downstream that aborts mid-stream (e.g. a consumer hit its limit,
+        // an upstream task failed and tore down its child stream) leaves
+        // every listener still attached — the task continues to emit events
+        // into a closed controller and the leaked listeners pin GC. `cleanup`
+        // is idempotent (the `closed` flag), so concurrent cancel + stream_end
+        // is safe.
+        cleanup();
       },
     });
   }

--- a/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
+++ b/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
@@ -60,12 +60,29 @@ export function bridgeSubGraphTaskEvents(
   // composition (a compound task's subGraph and parentGraph are distinct
   // instances) but guard anyway so a malformed hierarchy degrades to a no-op.
   if (subGraph === parentGraph) return () => {};
+
+  // Capture the subgraph's prior depth marker up front so BOTH the over-cap and
+  // the active-bridge paths can restore it on teardown. Restoring is what keeps
+  // a later, independently-rooted bridge of the same (reused) subgraph instance
+  // from inheriting a stale counter.
+  const subGraphWithDepth = subGraph as unknown as Record<symbol, number>;
+  const previousDepth = subGraphWithDepth[BRIDGE_DEPTH];
+  const restoreDepth = () => {
+    if (previousDepth === undefined) {
+      delete subGraphWithDepth[BRIDGE_DEPTH];
+    } else {
+      subGraphWithDepth[BRIDGE_DEPTH] = previousDepth;
+    }
+  };
+
   if (depth >= maxDepth) {
     // Stamp the subgraph at the cap so any nested bridge call (whose
     // parentGraph is this subgraph) derives `depth >= maxDepth` and also
     // short-circuits — otherwise the depth counter resets at the next level
-    // and the cap leaks downstream.
-    (subGraph as unknown as Record<symbol, number>)[BRIDGE_DEPTH] = maxDepth;
+    // and the cap leaks downstream. The teardown restores the prior marker so
+    // the stamp does not persist past this bridge's lifetime on a reused
+    // subgraph instance.
+    subGraphWithDepth[BRIDGE_DEPTH] = maxDepth;
     if (!warnedParents.has(parentGraph)) {
       warnedParents.add(parentGraph);
       getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
@@ -73,13 +90,11 @@ export function bridgeSubGraphTaskEvents(
         maxDepth,
       });
     }
-    return () => {};
+    return restoreDepth;
   }
 
   // Stamp the subgraph with its bridge depth so any nested bridge call (whose
   // parentGraph is this subgraph) derives `depth + 1` automatically.
-  const subGraphWithDepth = subGraph as unknown as Record<symbol, number>;
-  const previousDepth = subGraphWithDepth[BRIDGE_DEPTH];
   subGraphWithDepth[BRIDGE_DEPTH] = depth + 1;
 
   const offs = [
@@ -99,10 +114,6 @@ export function bridgeSubGraphTaskEvents(
     offs.forEach((off) => off());
     // Restore the previous depth marker so a later, independently-rooted bridge
     // of the same subgraph instance does not inherit a stale counter.
-    if (previousDepth === undefined) {
-      delete subGraphWithDepth[BRIDGE_DEPTH];
-    } else {
-      subGraphWithDepth[BRIDGE_DEPTH] = previousDepth;
-    }
+    restoreDepth();
   };
 }

--- a/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
+++ b/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
@@ -26,6 +26,14 @@ const DEFAULT_MAX_BRIDGE_DEPTH = 16;
 const BRIDGE_DEPTH = Symbol.for("@workglow/task-graph/SubGraphEventBridge.depth");
 
 /**
+ * Track parent graphs that have already emitted the depth-cap warning so a
+ * pathologically nested compound (e.g. an iterator with 1k iterations all at
+ * over-cap) does not spam one warn per iteration. Held weakly so an evicted
+ * parent graph can still be garbage-collected.
+ */
+const warnedParents = new WeakSet<TaskGraph>();
+
+/**
  * Forward a subgraph's per-task events (task_complete, task_progress, and the
  * task_stream_* trio) up to the parent graph, so tasks nested inside a compound
  * task (GraphAsTask / FallbackTask / WhileTask / ...) surface as individual
@@ -53,10 +61,18 @@ export function bridgeSubGraphTaskEvents(
   // instances) but guard anyway so a malformed hierarchy degrades to a no-op.
   if (subGraph === parentGraph) return () => {};
   if (depth >= maxDepth) {
-    getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
-      depth,
-      maxDepth,
-    });
+    // Stamp the subgraph at the cap so any nested bridge call (whose
+    // parentGraph is this subgraph) derives `depth >= maxDepth` and also
+    // short-circuits — otherwise the depth counter resets at the next level
+    // and the cap leaks downstream.
+    (subGraph as unknown as Record<symbol, number>)[BRIDGE_DEPTH] = maxDepth;
+    if (!warnedParents.has(parentGraph)) {
+      warnedParents.add(parentGraph);
+      getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
+        depth,
+        maxDepth,
+      });
+    }
     return () => {};
   }
 

--- a/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
+++ b/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
@@ -4,7 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getLogger } from "@workglow/util";
 import type { TaskGraph } from "./TaskGraph";
+
+/**
+ * Default maximum bridge nesting depth before re-emit listeners are dropped.
+ * Each level installs one listener per event type and re-emits up; without a
+ * cap, a pathologically nested compound task (e.g. a MapTask containing a
+ * GraphAsTask containing a MapTask…) amplifies a single inner emit into N
+ * parent emits before reaching any wire subscriber, and downstream consumers
+ * with a bounded event log can evict legitimate events under sustained
+ * fan-out.
+ */
+const DEFAULT_MAX_BRIDGE_DEPTH = 16;
+
+/**
+ * Symbol-keyed marker we attach to each subgraph so nested calls can derive
+ * the current depth from the parent without changing call sites. Stored on a
+ * symbol to avoid colliding with any user-set property.
+ */
+const BRIDGE_DEPTH = Symbol.for("@workglow/task-graph/SubGraphEventBridge.depth");
 
 /**
  * Forward a subgraph's per-task events (task_complete, task_progress, and the
@@ -14,16 +33,39 @@ import type { TaskGraph } from "./TaskGraph";
  * and progress. Bubbles recursively: a nested compound forwards its own
  * subgraph to its parent, which forwards onward.
  *
+ * Depth is tracked on the parent graph via a symbol-keyed marker so callers do
+ * not need to thread a counter through. Once `depth >= maxDepth` the call
+ * degrades to a no-op (with a single warn log) — see {@link DEFAULT_MAX_BRIDGE_DEPTH}.
+ *
  * @returns a teardown that unsubscribes every bridged listener. Callers MUST
  *   invoke it in a `finally` so a rejecting/aborted/early-terminated subgraph
  *   run cannot leak subscriptions (which would double-emit on a later run).
  */
-export function bridgeSubGraphTaskEvents(subGraph: TaskGraph, parentGraph: TaskGraph): () => void {
+export function bridgeSubGraphTaskEvents(
+  subGraph: TaskGraph,
+  parentGraph: TaskGraph,
+  depth: number = (parentGraph as unknown as Record<symbol, number>)[BRIDGE_DEPTH] ?? 0,
+  maxDepth: number = DEFAULT_MAX_BRIDGE_DEPTH
+): () => void {
   // A subgraph bridging to itself would re-emit each event back onto the same
   // graph it just observed, looping forever. This cannot arise from normal
   // composition (a compound task's subGraph and parentGraph are distinct
   // instances) but guard anyway so a malformed hierarchy degrades to a no-op.
   if (subGraph === parentGraph) return () => {};
+  if (depth >= maxDepth) {
+    getLogger().warn("bridgeSubGraphTaskEvents depth cap hit; dropping bridge", {
+      depth,
+      maxDepth,
+    });
+    return () => {};
+  }
+
+  // Stamp the subgraph with its bridge depth so any nested bridge call (whose
+  // parentGraph is this subgraph) derives `depth + 1` automatically.
+  const subGraphWithDepth = subGraph as unknown as Record<symbol, number>;
+  const previousDepth = subGraphWithDepth[BRIDGE_DEPTH];
+  subGraphWithDepth[BRIDGE_DEPTH] = depth + 1;
+
   const offs = [
     subGraph.subscribe("task_complete", (id, out) => parentGraph.emit("task_complete", id, out)),
     subGraph.subscribe("task_progress", (id, p, m, ...a) =>
@@ -37,5 +79,14 @@ export function bridgeSubGraphTaskEvents(subGraph: TaskGraph, parentGraph: TaskG
       parentGraph.emit("task_stream_end", id, out)
     ),
   ];
-  return () => offs.forEach((off) => off());
+  return () => {
+    offs.forEach((off) => off());
+    // Restore the previous depth marker so a later, independently-rooted bridge
+    // of the same subgraph instance does not inherit a stale counter.
+    if (previousDepth === undefined) {
+      delete subGraphWithDepth[BRIDGE_DEPTH];
+    } else {
+      subGraphWithDepth[BRIDGE_DEPTH] = previousDepth;
+    }
+  };
 }

--- a/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
@@ -30,7 +30,7 @@ describe("CacheJanitor", () => {
     );
     expect(await backing.size()).toBe(2);
 
-    const janitor = new CacheJanitor({ privateBacking: backing });
+    const janitor = new CacheJanitor({ privateBacking: backing, liveRunIds: () => [] });
     await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
 
     expect(await backing.size()).toBe(1);
@@ -46,7 +46,7 @@ describe("CacheJanitor", () => {
     await backing.saveOutputForRun("rX", "T", { x: 1 }, { ok: "x" }, old);
     await backing.saveOutputForRun("rY", "T", { x: 1 }, { ok: "y" }, old);
 
-    const janitor = new CacheJanitor({ privateBacking: backing });
+    const janitor = new CacheJanitor({ privateBacking: backing, liveRunIds: () => [] });
     await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
 
     // Every row is run-private; all are older than the cutoff, so all are reaped.
@@ -65,5 +65,36 @@ describe("CacheJanitor", () => {
     await backing.saveOutputForRun("stale", "T", { x: 1 }, { ok: "stale" }, old);
 
     await expect(backing.clearOlderThan(1, new Set(["live"]))).resolves.not.toThrow();
+  });
+
+  it("omitting liveRunIds is a compile-time error", () => {
+    const backing = new RunPrivateInMemoryTaskOutputRepository();
+    // @ts-expect-error - liveRunIds is a required option.
+    const janitor = new CacheJanitor({ privateBacking: backing });
+    expect(janitor).toBeInstanceOf(CacheJanitor);
+  });
+
+  it("empty liveRunIds still respects the per-run indexed delete path", async () => {
+    // Seed 3 stale runs + 1 live-but-excluded run. All rows are older than the
+    // cutoff; the excluded live-run rows must survive and only the 3 stale
+    // runs' rows should be reaped.
+    const backing = new RunPrivateInMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const old = new Date(Date.now() - 30 * 24 * 3600_000);
+    await backing.saveOutputForRun("stale-1", "T", { x: 1 }, { ok: 1 }, old);
+    await backing.saveOutputForRun("stale-2", "T", { x: 1 }, { ok: 2 }, old);
+    await backing.saveOutputForRun("stale-3", "T", { x: 1 }, { ok: 3 }, old);
+    await backing.saveOutputForRun("live", "T", { x: 1 }, { ok: "live" }, old);
+    expect(await backing.size()).toBe(4);
+
+    const janitor = new CacheJanitor({ privateBacking: backing, liveRunIds: () => ["live"] });
+    await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
+
+    expect(await backing.sizeForRun("stale-1")).toBe(0);
+    expect(await backing.sizeForRun("stale-2")).toBe(0);
+    expect(await backing.sizeForRun("stale-3")).toBe(0);
+    expect(await backing.sizeForRun("live")).toBe(1);
+    expect(await backing.getOutputForRun("live", "T", { x: 1 })).toEqual({ ok: "live" });
   });
 });

--- a/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
@@ -52,4 +52,18 @@ describe("CacheJanitor", () => {
     // Every row is run-private; all are older than the cutoff, so all are reaped.
     expect(await backing.size()).toBe(0);
   });
+
+  it("clearOlderThan with a non-empty excludeRunIds does not throw", async () => {
+    // Regression: clearOlderThan called this.storage.search(...) which does not
+    // exist on ITabularStorage — the correct method is query(). This smoke test
+    // exercises the non-empty-excludeRunIds branch so the fix stays regressed.
+    const backing = new RunPrivateInMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const old = new Date(Date.now() - 30 * 24 * 3600_000);
+    await backing.saveOutputForRun("live", "T", { x: 1 }, { ok: "live" }, old);
+    await backing.saveOutputForRun("stale", "T", { x: 1 }, { ok: "stale" }, old);
+
+    await expect(backing.clearOlderThan(1, new Set(["live"]))).resolves.not.toThrow();
+  });
 });

--- a/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
@@ -74,6 +74,61 @@ describe("CacheJanitor", () => {
     expect(janitor).toBeInstanceOf(CacheJanitor);
   });
 
+  it("sweepStaleRunPrivate does not materialize the full stale row set at once", async () => {
+    // Regression: the previous implementation called `storage.query({...})`
+    // for ALL stale rows in a single call. The new implementation drives
+    // distinct-runId collection through cursor-paginated `queryPage` with a
+    // bounded `limit`, so SQL backends (which push both the WHERE and the
+    // keyset predicate into the SELECT) issue O(pageSize) round-trips.
+    //
+    // We seed 5000 stale rows across 3 runs and assert:
+    //   (a) `queryPage` is invoked repeatedly (≥10 calls, matching the 500-row
+    //       page size against 5000 rows), i.e. it truly paginates instead of
+    //       one-shotting.
+    //   (b) Every `queryPage` call carries a `request.limit`, so the memory
+    //       profile is bounded per call.
+    //   (c) The sweep completes and reaps all stale rows.
+    //
+    // (The `BaseTabularStorage` fallback engine used by InMemoryTabularStorage
+    // still fetches the underlying rows in one `query()` for composite-PK
+    // tables — that is a backend-level concern; SQL backends override
+    // `queryPage` with pushdown. What we're pinning here is the
+    // repository-level contract: it must ask for pages, not the whole table.)
+    const backing = new RunPrivateInMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const old = new Date(Date.now() - 30 * 24 * 3600_000);
+    const runIds = ["r-a", "r-b", "r-c"];
+    for (let i = 0; i < 5000; i++) {
+      const runId = runIds[i % runIds.length];
+      await backing.saveOutputForRun(runId, "T", { i }, { ok: i }, old);
+    }
+    expect(await backing.size()).toBe(5000);
+
+    const storage = backing.storage as any;
+    const originalQueryPage = storage.queryPage.bind(storage);
+    const queryPageCalls: Array<{ limit: number | undefined }> = [];
+    storage.queryPage = (criteria: unknown, request: { limit?: number } = {}) => {
+      queryPageCalls.push({ limit: request.limit });
+      return originalQueryPage(criteria, request);
+    };
+
+    try {
+      const janitor = new CacheJanitor({ privateBacking: backing, liveRunIds: () => [] });
+      await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
+    } finally {
+      storage.queryPage = originalQueryPage;
+    }
+
+    expect(queryPageCalls.length).toBeGreaterThanOrEqual(10);
+    // Every page fetch carries a bounded limit — no unbounded reads.
+    for (const call of queryPageCalls) {
+      expect(call.limit).toBeTypeOf("number");
+      expect(call.limit).toBeGreaterThan(0);
+    }
+    expect(await backing.size()).toBe(0);
+  });
+
   it("empty liveRunIds still respects the per-run indexed delete path", async () => {
     // Seed 3 stale runs + 1 live-but-excluded run. All rows are older than the
     // cutoff; the excluded live-run rows must survive and only the 3 stale

--- a/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
+++ b/packages/test/src/test/task-graph-cache/CacheJanitor.test.ts
@@ -76,10 +76,13 @@ describe("CacheJanitor", () => {
 
   it("sweepStaleRunPrivate does not materialize the full stale row set at once", async () => {
     // Regression: the previous implementation called `storage.query({...})`
-    // for ALL stale rows in a single call. The new implementation drives
-    // distinct-runId collection through cursor-paginated `queryPage` with a
-    // bounded `limit`, so SQL backends (which push both the WHERE and the
-    // keyset predicate into the SELECT) issue O(pageSize) round-trips.
+    // for ALL stale rows in a single call. When there is a live run to exclude,
+    // the implementation drives distinct-runId collection through
+    // cursor-paginated `queryPage` with a bounded `limit`, so SQL backends
+    // (which push both the WHERE and the keyset predicate into the SELECT) issue
+    // O(pageSize) round-trips. (With nothing to exclude, `clearOlderThan` takes
+    // a single indexed bulk delete instead — see the empty-exclude fast path —
+    // so we pass a non-empty exclude set here to exercise the paging path.)
     //
     // We seed 5000 stale rows across 3 runs and assert:
     //   (a) `queryPage` is invoked repeatedly (≥10 calls, matching the 500-row
@@ -114,7 +117,13 @@ describe("CacheJanitor", () => {
     };
 
     try {
-      const janitor = new CacheJanitor({ privateBacking: backing, liveRunIds: () => [] });
+      // Exclude a runId that matches none of the seeded runs so every stale row
+      // is still reaped, but `clearOlderThan` takes the paging path (the set is
+      // non-empty) rather than the single-delete fast path.
+      const janitor = new CacheJanitor({
+        privateBacking: backing,
+        liveRunIds: () => ["not-a-seeded-run"],
+      });
       await janitor.sweepStaleRunPrivate(7 * 24 * 3600_000);
     } finally {
       storage.queryPage = originalQueryPage;
@@ -129,7 +138,7 @@ describe("CacheJanitor", () => {
     expect(await backing.size()).toBe(0);
   });
 
-  it("empty liveRunIds still respects the per-run indexed delete path", async () => {
+  it("excludes live runs while reaping the rest via the per-run indexed delete path", async () => {
     // Seed 3 stale runs + 1 live-but-excluded run. All rows are older than the
     // cutoff; the excluded live-run rows must survive and only the 3 stale
     // runs' rows should be reaped.

--- a/packages/test/src/test/task-graph-output-cache/RunPrivateTaskOutputRepository.test.ts
+++ b/packages/test/src/test/task-graph-output-cache/RunPrivateTaskOutputRepository.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { RunPrivateInMemoryTaskOutputRepository } from "../../binding/RunPrivateInMemoryTaskOutputRepository";
+
+describe("RunPrivateTaskOutputRepository.clearOlderThan", () => {
+  it("preserves live runs even when they have stale rows", async () => {
+    // Regression: the sweep must exclude runIds in `excludeRunIds` even when
+    // every row on that run is older than the cutoff (a still-running job that
+    // started long ago would otherwise have its cache reaped mid-flight).
+    const backing = new RunPrivateInMemoryTaskOutputRepository();
+    await (backing as any).setupDatabase?.();
+
+    const old = new Date(Date.now() - 30 * 24 * 3600_000);
+    // Stale run with several rows.
+    await backing.saveOutputForRun("stale", "T", { x: 1 }, { ok: 1 }, old);
+    await backing.saveOutputForRun("stale", "T", { x: 2 }, { ok: 2 }, old);
+    await backing.saveOutputForRun("stale", "T", { x: 3 }, { ok: 3 }, old);
+    // Live run whose rows also predate the cutoff.
+    await backing.saveOutputForRun("live", "T", { x: 1 }, { ok: "l1" }, old);
+    await backing.saveOutputForRun("live", "T", { x: 2 }, { ok: "l2" }, old);
+
+    expect(await backing.sizeForRun("stale")).toBe(3);
+    expect(await backing.sizeForRun("live")).toBe(2);
+
+    await backing.clearOlderThan(7 * 24 * 3600_000, new Set(["live"]));
+
+    expect(await backing.sizeForRun("stale")).toBe(0);
+    expect(await backing.sizeForRun("live")).toBe(2);
+    // Every live-run row still readable end-to-end.
+    expect(await backing.getOutputForRun("live", "T", { x: 1 })).toEqual({ ok: "l1" });
+    expect(await backing.getOutputForRun("live", "T", { x: 2 })).toEqual({ ok: "l2" });
+  });
+});

--- a/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
+++ b/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
@@ -6,6 +6,7 @@
 
 import type { IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import {
+  bridgeSubGraphTaskEvents,
   Dataflow,
   FallbackTask,
   GraphAsTask,
@@ -16,8 +17,10 @@ import {
   WhileTask,
   Workflow,
 } from "@workglow/task-graph";
+import type { ILogger } from "@workglow/util";
+import { NullLogger, setLogger } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 class TCEAddOne extends Task<{ value: number }, { value: number }> {
   static override readonly type = "TCEAddOne";
@@ -396,5 +399,114 @@ describe("task_complete graph event", () => {
     unsub();
 
     expect(seen.filter((id) => id === "leaky")).toHaveLength(1);
+  });
+});
+
+describe("bridgeSubGraphTaskEvents depth cap", () => {
+  // Each test installs a stub logger and restores a NullLogger after, so warn
+  // spies do not leak into other tests (and we never emit to the real console).
+  let warnSpy: ReturnType<typeof vi.fn>;
+
+  function installStubLogger(): void {
+    warnSpy = vi.fn();
+    const stub: ILogger = {
+      debug: () => {},
+      info: () => {},
+      warn: warnSpy as unknown as ILogger["warn"],
+      error: () => {},
+      fatal: () => {},
+      child() {
+        return stub;
+      },
+      time: () => {},
+      timeEnd: () => {},
+      group: () => {},
+      groupEnd: () => {},
+    };
+    setLogger(stub);
+  }
+
+  afterEach(() => {
+    setLogger(new NullLogger());
+  });
+
+  it("stops bridging past maxDepth (default 16)", () => {
+    installStubLogger();
+    // Build a chain of TaskGraphs: g0 (top) -> g1 -> g2 -> ... -> gN (innermost).
+    // Bridging is chained so each gK forwards into gK-1, mirroring how a stack
+    // of GraphAsTask wrappers nests bridges at run time.
+    const N = 20;
+    const graphs: TaskGraph[] = [];
+    for (let i = 0; i <= N; i++) graphs.push(new TaskGraph());
+
+    const unbridges: Array<() => void> = [];
+    for (let i = 1; i <= N; i++) {
+      // graphs[i] is the inner subgraph; graphs[i-1] is its parent.
+      unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1]));
+    }
+
+    // Emit a task_progress from the innermost graph and count how many bridges
+    // it traversed up to the outermost. Without the cap this would re-emit N
+    // times (once per parent); with the cap of 16 it stops after 16 hops.
+    const reachedDepths: number[] = [];
+    for (let i = 0; i < graphs.length; i++) {
+      const depth = i;
+      graphs[i].subscribe("task_progress", () => {
+        reachedDepths.push(depth);
+      });
+    }
+
+    graphs[N].emit("task_progress", "inner-id", 42, "msg");
+
+    // Innermost (depth N) saw the original emit; bridges propagate up at most
+    // 16 levels (the default cap), so the highest depth reached is N - 16.
+    const minReached = Math.min(...reachedDepths);
+    expect(minReached).toBeGreaterThanOrEqual(N - 16);
+    // The cap fired (depth reached 16), producing at least one warn.
+    expect(warnSpy).toHaveBeenCalled();
+
+    unbridges.forEach((off) => off());
+  });
+
+  it("logs warning with depth fields when the cap is hit", () => {
+    installStubLogger();
+    const N = 18;
+    const graphs: TaskGraph[] = [];
+    for (let i = 0; i <= N; i++) graphs.push(new TaskGraph());
+    const unbridges: Array<() => void> = [];
+    for (let i = 1; i <= N; i++) {
+      unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1]));
+    }
+
+    expect(warnSpy).toHaveBeenCalled();
+    const firstCall = warnSpy.mock.calls[0];
+    expect(firstCall[0]).toBe("bridgeSubGraphTaskEvents depth cap hit; dropping bridge");
+    expect(firstCall[1]).toEqual({ depth: 16, maxDepth: 16 });
+
+    unbridges.forEach((off) => off());
+  });
+
+  it("accepts a custom maxDepth override", () => {
+    installStubLogger();
+    const N = 6;
+    const graphs: TaskGraph[] = [];
+    for (let i = 0; i <= N; i++) graphs.push(new TaskGraph());
+
+    const unbridges: Array<() => void> = [];
+    for (let i = 1; i <= N; i++) {
+      // Explicitly pass maxDepth=4 to each level. Depth is derived from the
+      // parent's stamped marker, so the first call to exceed the cap is the
+      // bridge whose computed depth is 4.
+      unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1], undefined, 4));
+    }
+
+    expect(warnSpy).toHaveBeenCalled();
+    const firstCall = warnSpy.mock.calls.find(
+      (c) => c[0] === "bridgeSubGraphTaskEvents depth cap hit; dropping bridge"
+    );
+    expect(firstCall).toBeDefined();
+    expect(firstCall![1]).toEqual({ depth: 4, maxDepth: 4 });
+
+    unbridges.forEach((off) => off());
   });
 });

--- a/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
+++ b/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
@@ -445,10 +445,11 @@ describe("bridgeSubGraphTaskEvents depth cap", () => {
       unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1]));
     }
 
-    // Emit a task_progress from the innermost graph and count how many bridges
-    // it traversed up to the outermost. Without the cap this would re-emit N
-    // times (once per parent); with the cap of 16 it stops after 16 hops.
-    const reachedDepths: number[] = [];
+    // Bridges install outermost-first, so the levels that hit the cap are the
+    // innermost ones (i = 17..N): those bridges are dropped and install no
+    // listeners. The deepest level whose outgoing bridge is still active is
+    // graphs[16] (bridge i=16, depth 15 < 16). Track where an emit lands.
+    let reachedDepths: number[] = [];
     for (let i = 0; i < graphs.length; i++) {
       const depth = i;
       graphs[i].subscribe("task_progress", () => {
@@ -456,12 +457,19 @@ describe("bridgeSubGraphTaskEvents depth cap", () => {
       });
     }
 
-    graphs[N].emit("task_progress", "inner-id", 42, "msg");
+    // Emit from the deepest still-bridged node: it must propagate through all 16
+    // active bridges down to the outermost graph (g0), reaching levels 0..16.
+    graphs[16].emit("task_progress", "inner-id", 42, "msg");
+    expect(reachedDepths.slice().sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 17 }, (_, k) => k)
+    );
 
-    // Innermost (depth N) saw the original emit; bridges propagate up at most
-    // 16 levels (the default cap), so the highest depth reached is N - 16.
-    const minReached = Math.min(...reachedDepths);
-    expect(minReached).toBeGreaterThanOrEqual(N - 16);
+    // Emit from the innermost (over-cap) node: its bridge was dropped, so the
+    // event reaches only that node — it does not propagate up at all.
+    reachedDepths = [];
+    graphs[N].emit("task_progress", "inner-id", 7, "msg");
+    expect(reachedDepths).toEqual([N]);
+
     // The cap fired (depth reached 16), producing at least one warn.
     expect(warnSpy).toHaveBeenCalled();
 

--- a/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
+++ b/packages/test/src/test/task-graph/TaskCompleteEvent.test.ts
@@ -509,4 +509,85 @@ describe("bridgeSubGraphTaskEvents depth cap", () => {
 
     unbridges.forEach((off) => off());
   });
+
+  it("stamped over-cap subgraph prevents downstream bridges from restarting depth", () => {
+    installStubLogger();
+    // Build a 5-level chain with maxDepth=2. Bridges install left-to-right
+    // (outermost first). The first call to exceed the cap MUST stamp the
+    // subgraph so the next bridge (whose parent is that subgraph) also sees
+    // depth >= maxDepth — otherwise the parent's BRIDGE_DEPTH reads as
+    // undefined, depth resets to 0, and the cap leaks downstream.
+    const maxDepth = 2;
+    const N = 5;
+    const graphs: TaskGraph[] = [];
+    for (let i = 0; i <= N; i++) graphs.push(new TaskGraph());
+
+    const reached: number[] = [];
+    for (let i = 0; i < graphs.length; i++) {
+      const depth = i;
+      graphs[i].subscribe("task_progress", () => {
+        reached.push(depth);
+      });
+    }
+
+    const unbridges: Array<() => void> = [];
+    for (let i = 1; i <= N; i++) {
+      unbridges.push(bridgeSubGraphTaskEvents(graphs[i], graphs[i - 1], undefined, maxDepth));
+    }
+
+    // graphs[1] and graphs[2] install (depth 0, 1). graphs[3] hits cap and
+    // stamps itself at maxDepth so graphs[4] and graphs[5] also no-op. Emit
+    // from the innermost graph: only its own subscriber should fire — every
+    // bridge i=3..5 short-circuited, so no event propagates outward at all.
+    graphs[N].emit("task_progress", "inner-id", 42, "msg");
+
+    // No bridge from level 2 onward installed, so only the innermost graph
+    // (depth N) saw the emit. depth=0 (outermost) must NOT be reached.
+    expect(reached).toEqual([N]);
+    expect(reached).not.toContain(0);
+
+    unbridges.forEach((off) => off());
+  });
+
+  it("warn fires exactly once per parentGraph at over-cap", () => {
+    installStubLogger();
+    const parent = new TaskGraph();
+    // Call 50 times with the same parent at over-cap (depth seeded above cap).
+    const teardowns: Array<() => void> = [];
+    for (let i = 0; i < 50; i++) {
+      const sub = new TaskGraph();
+      teardowns.push(bridgeSubGraphTaskEvents(sub, parent, 16, 16));
+    }
+
+    const capCalls = warnSpy.mock.calls.filter(
+      (c) => c[0] === "bridgeSubGraphTaskEvents depth cap hit; dropping bridge"
+    );
+    expect(capCalls).toHaveLength(1);
+
+    teardowns.forEach((off) => off());
+  });
+
+  it("distinct parents at over-cap each warn once", () => {
+    installStubLogger();
+    const parentA = new TaskGraph();
+    const parentB = new TaskGraph();
+    const subA = new TaskGraph();
+    const subB = new TaskGraph();
+
+    const off1 = bridgeSubGraphTaskEvents(subA, parentA, 16, 16);
+    const off2 = bridgeSubGraphTaskEvents(subB, parentB, 16, 16);
+    // Repeat each parent a few more times — should not produce additional warns.
+    const off3 = bridgeSubGraphTaskEvents(new TaskGraph(), parentA, 16, 16);
+    const off4 = bridgeSubGraphTaskEvents(new TaskGraph(), parentB, 16, 16);
+
+    const capCalls = warnSpy.mock.calls.filter(
+      (c) => c[0] === "bridgeSubGraphTaskEvents depth cap hit; dropping bridge"
+    );
+    expect(capCalls).toHaveLength(2);
+
+    off1();
+    off2();
+    off3();
+    off4();
+  });
 });

--- a/packages/test/src/test/task-graph/runner-internals.test.ts
+++ b/packages/test/src/test/task-graph/runner-internals.test.ts
@@ -204,6 +204,49 @@ describe("StreamPump", () => {
     expect((sp as any).taskNeedsAccumulation(a, undefined, false)).toBe(false);
   });
 
+  it("cleans up listeners when the reader cancels mid-stream", async () => {
+    const graph = new TaskGraph();
+    const a = new RunnerInternalsSourceTask({ id: "a" });
+    const b = new RunnerInternalsSinkTask({ id: "b" });
+    graph.addTask(a);
+    graph.addTask(b);
+    // One edge — `createStreamFromTaskEvents` requires at least one
+    // dataflow group to be exercised via `pushStreamToEdges`. We invoke the
+    // private method directly via bracket access so the test exercises the
+    // cancel handler without needing a fully-running graph.
+    graph.addDataflow(new Dataflow(a.id, "value", b.id, "value"));
+
+    const runner = new TaskGraphRunner(graph);
+    const em = new EdgeMaterializer(graph, runner);
+    const sp = new StreamPump(graph, (runner as any).processScheduler, em);
+
+    const edges = graph.getTargetDataflows(a.id);
+    const stream: ReadableStream = (sp as any).createStreamFromTaskEvents(a, "value", edges);
+
+    // Sanity: the start() callback wires up listeners synchronously when the
+    // stream is constructed (ReadableStream calls start eagerly). But pull is
+    // lazy in some implementations — fetch a reader to ensure the start hook
+    // ran before we assert.
+    const reader = stream.getReader();
+
+    // Emit one chunk so the consumer sees at least one event before cancel.
+    a.emit("stream_chunk", { type: "text-delta", port: "value", textDelta: "hi" } as any);
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+
+    expect(a.events.listenerCount("stream_chunk")).toBeGreaterThanOrEqual(1);
+    expect(a.events.listenerCount("stream_end")).toBeGreaterThanOrEqual(1);
+    expect(a.events.listenerCount("status")).toBeGreaterThanOrEqual(1);
+
+    await reader.cancel();
+
+    // After cancellation, the cleanup handler must have detached every
+    // listener createStreamFromTaskEvents installed.
+    expect(a.events.listenerCount("stream_chunk")).toBe(0);
+    expect(a.events.listenerCount("stream_end")).toBe(0);
+    expect(a.events.listenerCount("status")).toBe(0);
+  });
+
   it("prepareStreamingInputs tees upstream stream into task.runner.inputStreams", () => {
     const graph = new TaskGraph();
     const a = new RunnerInternalsSourceTask({ id: "a" });

--- a/packages/test/src/test/util/Container.test.ts
+++ b/packages/test/src/test/util/Container.test.ts
@@ -224,6 +224,52 @@ describe("Container", () => {
       expect(disposeCalled).toBe(true);
     });
 
+    it("dispose() still awaits an earlier disposal after the same token is replaced again", async () => {
+      // Rapid same-token re-replace must not drop the first in-flight disposal
+      // from the drain set: with two gated disposers pending under one token,
+      // resolving only the SECOND must leave dispose() blocked on the FIRST.
+      let resolveA: (() => void) | undefined;
+      let resolveB: (() => void) | undefined;
+      const gateA = new Promise<void>((resolve) => (resolveA = resolve));
+      const gateB = new Promise<void>((resolve) => (resolveB = resolve));
+      let disposedA = false;
+      let disposedB = false;
+
+      container.register("svc", () => ({
+        async dispose() {
+          await gateA;
+          disposedA = true;
+        },
+      }));
+      container.get("svc"); // cache instance A
+      container.register("svc", () => ({
+        async dispose() {
+          await gateB;
+          disposedB = true;
+        },
+      }));
+      container.get("svc"); // cache instance B; schedules disposal of A (awaits gateA)
+      container.register("svc", () => ({ value: "third" })); // schedules disposal of B (awaits gateB)
+
+      const disposePromise = container.dispose();
+      let disposeSettled = false;
+      void disposePromise.then(() => {
+        disposeSettled = true;
+      });
+
+      // Release only B's disposer. If A's disposal had been orphaned by the
+      // second replacement, dispose() would resolve here — it must not.
+      resolveB!();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(disposedB).toBe(true);
+      expect(disposeSettled).toBe(false);
+
+      resolveA!();
+      await disposePromise;
+      expect(disposedA).toBe(true);
+      expect(disposeSettled).toBe(true);
+    });
+
     it("registerInstance eviction is drained by awaitReplacement", async () => {
       let resolveGate: (() => void) | undefined;
       const gate = new Promise<void>((resolve) => {

--- a/packages/test/src/test/util/Container.test.ts
+++ b/packages/test/src/test/util/Container.test.ts
@@ -93,6 +93,106 @@ describe("Container", () => {
       container.registerInstance("myService", instance);
       expect(container.get("myService")).toBe(container.get("myService"));
     });
+
+    it("disposes the previous cached instance when registerInstance overwrites", async () => {
+      let disposed = 0;
+      const first = {
+        dispose() {
+          disposed++;
+        },
+      };
+      const second = {
+        dispose() {
+          disposed++;
+        },
+      };
+      container.registerInstance("svc", first);
+      container.registerInstance("svc", second);
+      // Disposer runs asynchronously inside `void this.disposeService(...)`;
+      // a microtask flush is sufficient.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(disposed).toBe(1);
+      expect(container.get("svc")).toBe(second);
+    });
+
+    it("does not re-dispose when registerInstance receives the same instance", async () => {
+      let disposed = 0;
+      const instance = {
+        dispose() {
+          disposed++;
+        },
+      };
+      container.registerInstance("svc", instance);
+      container.registerInstance("svc", instance);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(disposed).toBe(0);
+    });
+  });
+
+  describe("register dispose-on-replace", () => {
+    it("disposes the previously cached singleton when register replaces a factory", async () => {
+      let disposed = 0;
+      container.register("svc", () => ({
+        value: "first",
+        dispose() {
+          disposed++;
+        },
+      }));
+      // Force instantiation so the singleton is cached.
+      expect(container.get<{ value: string }>("svc").value).toBe("first");
+
+      container.register("svc", () => ({ value: "second" }));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(disposed).toBe(1);
+      expect(container.get<{ value: string }>("svc").value).toBe("second");
+    });
+
+    it("does not throw when a previously cached singleton has no disposer", () => {
+      container.register("svc", () => ({ value: "first" }));
+      container.get("svc");
+      expect(() => container.register("svc", () => ({ value: "second" }))).not.toThrow();
+    });
+
+    it("does not dispose if the previously cached singleton was inherited from parent", async () => {
+      let disposed = 0;
+      const parent = new Container();
+      parent.register("svc", () => ({
+        dispose() {
+          disposed++;
+        },
+      }));
+      parent.get("svc"); // instantiate
+      const child = parent.createChildContainer();
+      // Re-register on the child; the cached instance is parent-owned and
+      // must NOT be disposed by the child's eviction path.
+      child.register("svc", () => ({}));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(disposed).toBe(0);
+    });
+
+    it("survives a buggy disposer on the eviction path", async () => {
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      try {
+        container.register("svc", () => ({
+          dispose() {
+            throw new Error("boom");
+          },
+        }));
+        container.get("svc");
+        // Re-registering must not throw — the new factory must still take effect.
+        expect(() => container.register("svc", () => ({ value: "second" }))).not.toThrow();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(container.get<{ value: string }>("svc").value).toBe("second");
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
   });
 
   describe("has", () => {

--- a/packages/test/src/test/util/Container.test.ts
+++ b/packages/test/src/test/util/Container.test.ts
@@ -174,6 +174,87 @@ describe("Container", () => {
       expect(disposed).toBe(0);
     });
 
+    it("register schedules eviction dispose and awaitReplacement resolves after it completes", async () => {
+      // Deferred pattern so we can observe: (1) disposer hasn't run yet
+      // synchronously after `register`, (2) resolving lets awaitReplacement
+      // settle, (3) `disposeCalled` is only true after that.
+      let resolveGate: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        resolveGate = resolve;
+      });
+      let disposeCalled = false;
+      container.register("svc", () => ({
+        async dispose() {
+          await gate;
+          disposeCalled = true;
+        },
+      }));
+      // Force instantiation so the singleton is cached.
+      container.get("svc");
+
+      container.register("svc", () => ({ value: "second" }));
+      // Disposer is still awaiting the gate; nothing has completed yet.
+      expect(disposeCalled).toBe(false);
+
+      resolveGate!();
+      await container.awaitReplacement("svc");
+      expect(disposeCalled).toBe(true);
+    });
+
+    it("container.dispose() drains pending disposals from prior register replacements", async () => {
+      let resolveGate: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        resolveGate = resolve;
+      });
+      let disposeCalled = false;
+      container.register("svc", () => ({
+        async dispose() {
+          await gate;
+          disposeCalled = true;
+        },
+      }));
+      container.get("svc");
+
+      container.register("svc", () => ({ value: "second" }));
+      // Kick off dispose(); it must wait for the pending eviction disposer.
+      const disposePromise = container.dispose();
+      expect(disposeCalled).toBe(false);
+      resolveGate!();
+      await disposePromise;
+      expect(disposeCalled).toBe(true);
+    });
+
+    it("registerInstance eviction is drained by awaitReplacement", async () => {
+      let resolveGate: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        resolveGate = resolve;
+      });
+      let disposeCalled = false;
+      const first = {
+        async dispose() {
+          await gate;
+          disposeCalled = true;
+        },
+      };
+      container.registerInstance("svc", first);
+      container.registerInstance("svc", { value: "second" });
+      expect(disposeCalled).toBe(false);
+      resolveGate!();
+      await container.awaitReplacement("svc");
+      expect(disposeCalled).toBe(true);
+    });
+
+    it("registerInstance clears any previously-registered factory for the token", () => {
+      container.register("svc", () => ({ value: "from-factory" }));
+      // Do not force-instantiate; the factory sits in `factories` with no
+      // cached entry in `services`.
+      container.registerInstance("svc", { value: "from-instance" });
+      // The factory must be cleared so a subsequent remove() → get() cannot
+      // resurrect the factory-built object.
+      expect((container as any).factories.has("svc")).toBe(false);
+      expect(container.get<{ value: string }>("svc").value).toBe("from-instance");
+    });
+
     it("survives a buggy disposer on the eviction path", async () => {
       const originalWarn = console.warn;
       console.warn = () => {};

--- a/packages/test/src/test/vector/InMemoryVectorStorage.validation.test.ts
+++ b/packages/test/src/test/vector/InMemoryVectorStorage.validation.test.ts
@@ -122,28 +122,40 @@ describe("InMemoryVectorStorage validation", () => {
   });
 
   describe("similaritySearch result behavior", () => {
-    it("returns negatively-correlated hits by default (no implicit score floor)", async () => {
-      // Store a vector that is the exact opposite of the query so cosine
-      // similarity is -1. The default scoreThreshold must not drop it.
+    it("drops negatively-correlated hits by default (parity with SQL backends)", async () => {
+      // Default scoreThreshold is 0 — matches Sqlite/Postgres/Supabase. The
+      // opposite vector (cosine = -1) is excluded as "not a match".
       await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
       await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
 
       const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]));
 
-      // Both rows come back; the negatively-correlated one is not silently
-      // filtered out (topK is honored regardless of sign).
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("same");
+    });
+
+    it("retains negatively-correlated hits when scoreThreshold: -Infinity is passed", async () => {
+      // Opt-in escape hatch for callers that want every result regardless of
+      // correlation (e.g. K-NN with no relevance filter).
+      await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
+      await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
+
+      const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]), {
+        scoreThreshold: -Infinity,
+      });
+
       expect(results).toHaveLength(2);
       const opposite = results.find((r) => r.id === "opposite");
       expect(opposite).toBeDefined();
       expect(opposite!.score).toBeCloseTo(-1, 5);
     });
 
-    it("still honors an explicit scoreThreshold floor", async () => {
-      await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
+    it("still honors an explicit scoreThreshold floor above the default", async () => {
+      await storage.put({ id: "weak", vector: new Float32Array([0, 1, 0, 0]), metadata: {} });
       await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
 
       const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]), {
-        scoreThreshold: 0,
+        scoreThreshold: 0.5,
       });
 
       expect(results).toHaveLength(1);

--- a/packages/test/src/test/vector/IndexedDbVectorStorage.validation.test.ts
+++ b/packages/test/src/test/vector/IndexedDbVectorStorage.validation.test.ts
@@ -132,13 +132,25 @@ describe("IndexedDbVectorStorage validation", () => {
   });
 
   describe("similaritySearch result behavior", () => {
-    it("returns negatively-correlated hits by default (no implicit score floor)", async () => {
-      // A vector opposite to the query has cosine similarity -1; the default
-      // (no floor) must not silently drop it.
+    it("drops negatively-correlated hits by default (parity with SQL backends)", async () => {
+      // Default scoreThreshold is 0 — matches Sqlite/Postgres/Supabase. The
+      // opposite vector (cosine = -1) is excluded as "not a match".
       await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
       await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
 
       const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]));
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("same");
+    });
+
+    it("retains negatively-correlated hits when scoreThreshold: -Infinity is passed", async () => {
+      await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
+      await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
+
+      const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]), {
+        scoreThreshold: -Infinity,
+      });
 
       expect(results).toHaveLength(2);
       const opposite = results.find((r) => r.id === "opposite");
@@ -146,12 +158,12 @@ describe("IndexedDbVectorStorage validation", () => {
       expect(opposite!.score).toBeCloseTo(-1, 5);
     });
 
-    it("still honors an explicit scoreThreshold floor", async () => {
-      await storage.put({ id: "opposite", vector: new Float32Array([-1, 0, 0, 0]), metadata: {} });
+    it("still honors an explicit scoreThreshold floor above the default", async () => {
+      await storage.put({ id: "weak", vector: new Float32Array([0, 1, 0, 0]), metadata: {} });
       await storage.put({ id: "same", vector: new Float32Array([1, 0, 0, 0]), metadata: {} });
 
       const results = await storage.similaritySearch(new Float32Array([1, 0, 0, 0]), {
-        scoreThreshold: 0,
+        scoreThreshold: 0.5,
       });
 
       expect(results).toHaveLength(1);

--- a/packages/util/src/di/Container.ts
+++ b/packages/util/src/di/Container.ts
@@ -18,6 +18,15 @@ export class Container {
    * disposing this container must NOT dispose them.
    */
   private inheritedServices: Set<string> = new Set();
+  /**
+   * In-flight eviction disposals keyed by token. `register()` and
+   * `registerInstance()` invoke the previous singleton's disposer without
+   * blocking the registration; the returned promise lives here so
+   * {@link dispose} and {@link awaitReplacement} can drain it. Entries are
+   * identity-guarded so a subsequent replacement's promise doesn't get erased
+   * by an earlier disposer's `.finally()`.
+   */
+  private pendingDisposals: Map<string, Promise<void>> = new Map();
 
   /**
    * Register a service factory. Replacing a factory disposes the previously
@@ -36,7 +45,7 @@ export class Container {
     // stale cached instance and the re-registration would be silently dead.
     const previous = this.services.get(token);
     if (previous != null && !this.inheritedServices.has(token)) {
-      void this.disposeService(token, previous);
+      this.trackDisposal(token, this.disposeService(token, previous));
     }
     this.services.delete(token);
     this.inheritedServices.delete(token);
@@ -71,11 +80,15 @@ export class Container {
   registerInstance<T>(token: string, instance: T): void {
     const previous = this.services.get(token);
     if (previous != null && previous !== instance && !this.inheritedServices.has(token)) {
-      void this.disposeService(token, previous);
+      this.trackDisposal(token, this.disposeService(token, previous));
     }
     this.services.set(token, instance);
     this.singletons.add(token);
-    // An explicitly registered instance is owned by this container.
+    // An explicitly registered instance is owned by this container. A stale
+    // factory left behind by a prior register() would let a subsequent
+    // remove() → get() race resurrect the factory-built object instead of
+    // failing loudly; clear it.
+    this.factories.delete(token);
     this.inheritedServices.delete(token);
   }
 
@@ -136,9 +149,19 @@ export class Container {
   /**
    * Dispose all instantiated singleton services and clear registrations.
    * Services implementing dispose(), Symbol.asyncDispose, or Symbol.dispose will be cleaned up.
+   *
+   * Also drains any eviction disposals scheduled by prior `register` /
+   * `registerInstance` replacements — otherwise the container would clear its
+   * state (and reject subsequent lookups) while asynchronous disposers were
+   * still holding resources open.
    */
   async dispose(): Promise<void> {
     const errors: unknown[] = [];
+    try {
+      await this.awaitRegistrations();
+    } catch (err) {
+      errors.push(err);
+    }
     try {
       for (const [token, service] of this.services) {
         if (service == null) continue;
@@ -156,10 +179,45 @@ export class Container {
       this.factories.clear();
       this.singletons.clear();
       this.inheritedServices.clear();
+      this.pendingDisposals.clear();
     }
     if (errors.length > 0) {
       throw new AggregateError(errors, "One or more services failed to dispose");
     }
+  }
+
+  /**
+   * Resolves once the in-flight eviction disposal for `token` (if any) has
+   * settled. Callers that immediately re-`register` and then need to observe
+   * side effects of the prior disposer (e.g. a released DB connection) can
+   * `await awaitReplacement(token)` between the two operations.
+   */
+  async awaitReplacement(token: string): Promise<void> {
+    const pending = this.pendingDisposals.get(token);
+    if (pending) await pending;
+  }
+
+  /** Drains every in-flight eviction disposal. */
+  async awaitRegistrations(): Promise<void> {
+    // Snapshot: entries `.finally()` themselves out of the map, but a race
+    // between iteration and settlement could otherwise skip pending entries.
+    const pending = Array.from(this.pendingDisposals.values());
+    await Promise.allSettled(pending);
+  }
+
+  /**
+   * Track an in-flight eviction disposal so callers (and {@link dispose}) can
+   * drain it. Identity-guarded: if a later replacement schedules another
+   * disposal for the same token, this promise's `.finally()` doesn't erase the
+   * newer entry.
+   */
+  private trackDisposal(token: string, promise: Promise<void>): void {
+    this.pendingDisposals.set(token, promise);
+    void promise.finally(() => {
+      if (this.pendingDisposals.get(token) === promise) {
+        this.pendingDisposals.delete(token);
+      }
+    });
   }
 
   /**

--- a/packages/util/src/di/Container.ts
+++ b/packages/util/src/di/Container.ts
@@ -20,7 +20,11 @@ export class Container {
   private inheritedServices: Set<string> = new Set();
 
   /**
-   * Register a service factory
+   * Register a service factory. Replacing a factory disposes the previously
+   * cached singleton (if any) so a held resource — DB connection, file
+   * handle, subscriber — is released before the new factory takes effect.
+   * Inherited (parent-owned) instances are skipped here; the parent owns the
+   * lifetime.
    * @param token The identifier token for the service
    * @param factory A factory function that creates the service
    * @param singleton Whether the service should be a singleton (created once)
@@ -30,6 +34,10 @@ export class Container {
     // Evict any previously instantiated singleton so the new factory actually
     // takes effect on the next get(). Otherwise get() would keep returning the
     // stale cached instance and the re-registration would be silently dead.
+    const previous = this.services.get(token);
+    if (previous != null && !this.inheritedServices.has(token)) {
+      void this.disposeService(token, previous);
+    }
     this.services.delete(token);
     this.inheritedServices.delete(token);
     if (singleton) {
@@ -54,11 +62,17 @@ export class Container {
   }
 
   /**
-   * Register an instance as a service
+   * Register an instance as a service. If a previously cached singleton exists
+   * under this token (and was not inherited from a parent), it is disposed
+   * before being overwritten.
    * @param token The identifier token for the service
    * @param instance The instance to register
    */
   registerInstance<T>(token: string, instance: T): void {
+    const previous = this.services.get(token);
+    if (previous != null && previous !== instance && !this.inheritedServices.has(token)) {
+      void this.disposeService(token, previous);
+    }
     this.services.set(token, instance);
     this.singletons.add(token);
     // An explicitly registered instance is owned by this container.
@@ -132,13 +146,7 @@ export class Container {
         // disposing them here would leave the parent holding a disposed object.
         if (this.inheritedServices.has(token)) continue;
         try {
-          if (typeof service[Symbol.asyncDispose] === "function") {
-            await service[Symbol.asyncDispose]();
-          } else if (typeof service[Symbol.dispose] === "function") {
-            service[Symbol.dispose]();
-          } else if (typeof service.dispose === "function") {
-            await service.dispose();
-          }
+          await this.invokeDisposer(service);
         } catch (err) {
           errors.push(err);
         }
@@ -151,6 +159,31 @@ export class Container {
     }
     if (errors.length > 0) {
       throw new AggregateError(errors, "One or more services failed to dispose");
+    }
+  }
+
+  /**
+   * Eviction-path disposer used by {@link register} and {@link registerInstance}
+   * when a cached singleton is replaced. Errors are caught here so a buggy
+   * disposer cannot prevent the new registration from taking effect — util has
+   * no logger dependency, hence console.warn.
+   */
+  private async disposeService(token: string, service: any): Promise<void> {
+    try {
+      await this.invokeDisposer(service);
+    } catch (err) {
+      console.warn(`Container: disposer for ${String(token)} threw`, err);
+    }
+  }
+
+  /** Invoke whichever disposer protocol the service implements. */
+  private async invokeDisposer(service: any): Promise<void> {
+    if (typeof service[Symbol.asyncDispose] === "function") {
+      await service[Symbol.asyncDispose]();
+    } else if (typeof service[Symbol.dispose] === "function") {
+      service[Symbol.dispose]();
+    } else if (typeof service.dispose === "function") {
+      await service.dispose();
     }
   }
 

--- a/packages/util/src/di/Container.ts
+++ b/packages/util/src/di/Container.ts
@@ -22,11 +22,14 @@ export class Container {
    * In-flight eviction disposals keyed by token. `register()` and
    * `registerInstance()` invoke the previous singleton's disposer without
    * blocking the registration; the returned promise lives here so
-   * {@link dispose} and {@link awaitReplacement} can drain it. Entries are
+   * {@link dispose} and {@link awaitReplacement} can drain it. When the same
+   * token is replaced again while its prior disposal is still running, the new
+   * entry chains onto the prior one (see {@link trackDisposal}) so a rapid
+   * re-replace never drops an in-flight disposer from the drain set. Entries are
    * identity-guarded so a subsequent replacement's promise doesn't get erased
    * by an earlier disposer's `.finally()`.
    */
-  private pendingDisposals: Map<string, Promise<void>> = new Map();
+  private readonly pendingDisposals: Map<string, Promise<void>> = new Map();
 
   /**
    * Register a service factory. Replacing a factory disposes the previously
@@ -207,14 +210,20 @@ export class Container {
 
   /**
    * Track an in-flight eviction disposal so callers (and {@link dispose}) can
-   * drain it. Identity-guarded: if a later replacement schedules another
-   * disposal for the same token, this promise's `.finally()` doesn't erase the
-   * newer entry.
+   * drain it. If a prior disposal for the same token is still in flight, the new
+   * one chains onto it so the map's single per-token entry settles only once
+   * BOTH have settled — otherwise a rapid re-replace would overwrite (and thus
+   * orphan) the earlier disposer, and `dispose()`/`awaitRegistrations` would
+   * resolve while it still held its resource open. Identity-guarded: the
+   * `.finally()` only clears the entry if it is still the tracked promise, so a
+   * later replacement's promise is never erased.
    */
   private trackDisposal(token: string, promise: Promise<void>): void {
-    this.pendingDisposals.set(token, promise);
-    void promise.finally(() => {
-      if (this.pendingDisposals.get(token) === promise) {
+    const prior = this.pendingDisposals.get(token);
+    const tracked = prior ? Promise.allSettled([prior, promise]).then(() => undefined) : promise;
+    this.pendingDisposals.set(token, tracked);
+    void tracked.finally(() => {
+      if (this.pendingDisposals.get(token) === tracked) {
         this.pendingDisposals.delete(token);
       }
     });


### PR DESCRIPTION
Combined branch cherry-picking **#601** and **#604** onto a fresh `main`, then hardened with an extra-high-effort code review (`--fix`). Supersedes and closes both.

## What's included

### From #601 — cap `bridgeSubGraphTaskEvents` depth
Deeply nested compound tasks bridge one re-emit listener per level, amplifying a single inner event into N parent emits. Adds a defense-in-depth depth cap (default 16, overridable via `maxDepth`), auto-derived from a symbol-keyed marker on the parent graph so existing call sites compile unchanged. Over-cap installs no listeners and warns once per parent.

### From #604 — four independent fixes
1. **`CacheJanitor` live-run guard.** `clearOlderThan` now takes a live-run exclude set; the janitor requires an explicit `liveRunIds` snapshot so a long-running in-flight run whose rows predate the cutoff is not reaped mid-flight. The tabular surface has no `NOT IN`, so exclusions enumerate distinct old runIds via cursor-paginated `queryPage` and delete per-run.
2. **`Container` dispose-on-replace.** `register` / `registerInstance` dispose the previously-cached singleton before overwriting it (releasing DB connections, file handles, subscribers), via an extracted `invokeDisposer` + error-catching `disposeService`; parent-owned instances are skipped.
3. **Vector default `scoreThreshold` parity.** In-memory + IndexedDB now default to `0`, matching every SQL backend. Pass `-Infinity` to opt back into pure top-K.
4. **`StreamPump.createStreamFromTaskEvents` cancel handler.** `reader.cancel()` mid-stream now releases every listener (idempotent `cleanup` hoisted out of `start()`).

## Code-review fixes applied on top
- **SubGraphEventBridge (correctness):** the over-cap branch stamped the depth marker but returned a no-op teardown, leaking a stale cap onto a *reused* subgraph instance (later shallow bridges wrongly dropped). Both branches now share a `restoreDepth` teardown.
- **Container (correctness):** `pendingDisposals` was keyed by token, so a rapid same-token re-replace orphaned an in-flight disposal and `dispose()` could resolve while it still held its resource. New disposals now chain onto any prior in-flight one; added a deterministic regression test. Field is now `readonly`.
- **`clearOlderThan` (efficiency):** restored the single indexed bulk delete for the empty-exclude case (the common idle sweep) instead of paging the whole table and deleting per-run.
- **Docs/tests:** corrected the vector README default (`0`, not `-Infinity`); renamed a `CacheJanitor` case that claimed "empty liveRunIds" while passing a non-empty set; made the depth-cap propagation assertion meaningful (emit from the deepest still-bridged node); updated the pagination test to drive the exclude-set path now that the empty case short-circuits.

## Verification
- `bun run build:packages` + `bun run build:types` — clean (71/71, 36/36).
- `bun scripts/test.ts graph vitest` — 747 passed.
- `bun scripts/test.ts util vitest` — 653 passed, 10 skipped.
- `bun scripts/test.ts storage vitest` — 1484 passed, 13 skipped.
- Vector validation suites — 26 passed.

Closes #601. Closes #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6NLGK5pCbpYq4syP7ZFLy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6NLGK5pCbpYq4syP7ZFLy)_