### PR TITLE
Consolidate hardcoded limits into DEFAULT_LIMITS/SECURITY_LIMITS

### DIFF
--- a/packages/ai/src/provider-utils/localOnlyFetch.ts
+++ b/packages/ai/src/provider-utils/localOnlyFetch.ts
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_LIMITS } from "@workglow/util";
 import { extractRawHost, isLoopbackHostname } from "./localUrl";
-
-const MAX_REDIRECTS = 5;
 
 /**
  * Standard HTTP redirect status codes per the Fetch/HTTP specs. A 3xx that is
@@ -98,7 +97,8 @@ function assertLoopbackTarget(
 export async function localOnlyFetch(
   input: string,
   init?: RequestInit,
-  label = "localOnlyFetch"
+  label = "localOnlyFetch",
+  maxRedirects: number = DEFAULT_LIMITS.aiLocalFetchMaxRedirects
 ): Promise<Response> {
   // Defensively validate the initial URL BEFORE issuing any request. A bad
   // initial URL must throw before fetch is ever called (zero network calls).
@@ -121,7 +121,7 @@ export async function localOnlyFetch(
   assertLoopbackTarget(initialUrl, label, "initial URL", rawHost);
 
   let current = initialUrl.href;
-  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+  for (let hop = 0; hop <= maxRedirects; hop++) {
     const res = await fetch(current, { ...init, redirect: "manual" });
     if (!isRedirectResponse(res)) return res;
     const location = res.headers.get("location");
@@ -130,5 +130,5 @@ export async function localOnlyFetch(
     assertLoopbackTarget(next, label, "redirect");
     current = next.href;
   }
-  throw new Error(`${label}: too many redirects (> ${MAX_REDIRECTS}).`);
+  throw new Error(`${label}: too many redirects (> ${maxRedirects}).`);
 }

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -7,7 +7,7 @@
 import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
-import { resolveHumanConnector } from "@workglow/util";
+import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { AiEmit } from "../capability/AiEmit";
 import type { Capability } from "../capability/Capabilities";
@@ -280,7 +280,7 @@ export class AiChatTask extends StreamingAiTask<AiChatTaskInput, AiChatTaskOutpu
     const workingInput: AiChatTaskInput = { ...input, messages: history };
     await this.getJobInput(workingInput);
     const strategy = getAiProviderRegistry().getStrategy(model);
-    const maxIterations = input.maxIterations ?? 100;
+    const maxIterations = input.maxIterations ?? DEFAULT_LIMITS.aiChatMaxIterations;
 
     if (context.resourceScope && this._sessionId) {
       const sessionId = this._sessionId;

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -9,7 +9,7 @@ import { getKnowledgeBase, slugifyHeading } from "@workglow/knowledge-base";
 import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
 import { TaskConfigSchema } from "@workglow/task-graph";
 import type { IHumanRequest } from "@workglow/util";
-import { resolveHumanConnector } from "@workglow/util";
+import { DEFAULT_LIMITS, resolveHumanConnector } from "@workglow/util";
 import type { DataPortSchema } from "@workglow/util/schema";
 import type { AiEmit } from "../capability/AiEmit";
 import type { Capability } from "../capability/Capabilities";
@@ -388,7 +388,7 @@ export class AiChatWithKbTask extends StreamingAiTask<
     // Initialize _sessionId before the loop.
     const workingInput: AiChatWithKbTaskInput = { ...input, messages: history };
     await this.getJobInput(workingInput);
-    const maxIterations = input.maxIterations ?? 100;
+    const maxIterations = input.maxIterations ?? DEFAULT_LIMITS.aiChatMaxIterations;
 
     if (context.resourceScope && this._sessionId) {
       const sessionId = this._sessionId;

--- a/packages/ai/src/task/StructuredGenerationTask.ts
+++ b/packages/ai/src/task/StructuredGenerationTask.ts
@@ -6,6 +6,7 @@
 
 import type { IExecuteContext, IRunConfig, StreamEvent, TaskConfig } from "@workglow/task-graph";
 import { CreateWorkflow, TaskConfigurationError, TaskError, Workflow } from "@workglow/task-graph";
+import { DEFAULT_LIMITS } from "@workglow/util";
 import type { DataPortSchema, SchemaNode } from "@workglow/util/schema";
 import { compileSchema } from "@workglow/util/schema";
 import type { Capability } from "../capability/Capabilities";
@@ -185,7 +186,7 @@ export class StructuredGenerationTask extends StreamingAiTask<
       throw configErr;
     }
 
-    const maxRetries = Math.max(0, input.maxRetries ?? 2);
+    const maxRetries = Math.max(0, input.maxRetries ?? DEFAULT_LIMITS.structuredGenMaxRetries);
     const maxAttempts = maxRetries + 1;
     const attempts: StructuredOutputValidationAttempt[] = [];
     let currentInput = input;

--- a/packages/job-queue/src/job/Job.ts
+++ b/packages/job-queue/src/job/Job.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_LIMITS } from "@workglow/util";
 import { JobStatus } from "../queue-storage/IQueueStorage";
 import { JobError } from "./JobError";
 import type { JobProgressListener } from "./JobQueueEventListeners";
@@ -99,7 +100,7 @@ export class Job<Input, Output> {
     errorCode = null,
     fingerprint = undefined,
     output = null,
-    maxAttempts = 10,
+    maxAttempts = DEFAULT_LIMITS.jobMaxAttempts,
     createdAt = new Date(),
     completedAt = null,
     status = JobStatus.PENDING,

--- a/packages/job-queue/src/job/JobErrorDiagnostics.ts
+++ b/packages/job-queue/src/job/JobErrorDiagnostics.ts
@@ -4,21 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_LIMITS } from "@workglow/util";
+
 /** Appended to job error messages; {@link JobQueueClient.buildErrorFromCode} maps this back onto `.stack`. */
 export const JOB_ERROR_DIAGNOSTICS_MARKER = "\n\n--- Error diagnostics ---\n";
-
-const DEFAULT_MAX_DIAGNOSTICS_CHARS = 48_000;
 
 /**
  * Formats an error and its `.cause` chain (name, message, stack) for logs and persisted job errors.
  */
 export function formatErrorChainForDiagnostics(
   err: unknown,
-  maxChars: number = DEFAULT_MAX_DIAGNOSTICS_CHARS
+  maxChars: number = DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars,
+  maxCauseChainDepth: number = DEFAULT_LIMITS.jobErrorMaxCauseChainDepth
 ): string {
   const lines: string[] = [];
   let current: unknown = err;
-  for (let depth = 0; depth < 8 && current != null; depth++) {
+  for (let depth = 0; depth < maxCauseChainDepth && current != null; depth++) {
     if (current instanceof Error) {
       lines.push(`${current.name}: ${current.message}`);
       if (current.stack) {

--- a/packages/job-queue/src/job/JobQueueClient.ts
+++ b/packages/job-queue/src/job/JobQueueClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EventEmitter, getLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, EventEmitter, getLogger } from "@workglow/util";
 import type { IJobStore } from "../queue-storage/IJobStore";
 import type { IMessageQueue } from "../queue-storage/IMessageQueue";
 import type { JobStorageFormat, QueueChangePayload } from "../queue-storage/IQueueStorage";
@@ -251,7 +251,7 @@ export class JobQueueClient<Input, Output> {
       input,
       job_run_id: options?.jobRunId,
       fingerprint: options?.fingerprint,
-      max_attempts: options?.maxAttempts ?? 10,
+      max_attempts: options?.maxAttempts ?? DEFAULT_LIMITS.jobMaxAttempts,
       visible_at:
         options?.delaySeconds != null
           ? new Date(Date.now() + options.delaySeconds * 1000).toISOString()

--- a/packages/job-queue/src/job/JobQueueWorker.ts
+++ b/packages/job-queue/src/job/JobQueueWorker.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  DEFAULT_LIMITS,
   EventEmitter,
   getLogger,
   getTelemetryProvider,
@@ -34,27 +35,12 @@ import { withJobErrorDiagnostics } from "./JobErrorDiagnostics";
 import { storageToClass } from "./JobStorageConverters";
 
 /**
- * Upper bound on {@link JobQueueWorker.getLimiterWakeDelay}. Prevents a
- * misconfigured or stuck limiter (e.g. one whose `getNextAvailableTime`
- * returns hours in the future) from making the worker unresponsive — it
- * wakes at least this often regardless of what the limiter says.
- */
-const MAX_LIMITER_WAKE_MS = 30_000;
-
-/**
  * Minimum interval between {@link JobQueueWorker.processJobs} loop-error logs.
  * A persistent storage failure throws every iteration; without rate-limiting
  * that would flood the log at the poll rate. We still log the first occurrence
  * immediately so operators get a prompt signal.
  */
 const LOOP_ERROR_LOG_INTERVAL_MS = 5_000;
-
-/**
- * Size of the recent-window ring buffer feeding
- * {@link JobQueueWorker.getAverageProcessingTime}. Bounds memory and keeps the
- * reported average representative of recent throughput.
- */
-const MAX_PROCESSING_TIME_SAMPLES = 1_000;
 
 /**
  * Events emitted by JobQueueWorker
@@ -105,9 +91,24 @@ export interface JobQueueWorkerOptions<Input, Output> {
    * How long (ms) the worker's lease on a claimed job lasts before another
    * worker may re-claim it. Must be long enough to cover the maximum
    * expected job duration if extendLeaseWhileRunning is false.
-   * Defaults to max(30_000, pollIntervalMs * 60).
+   * Defaults to max(DEFAULT_LIMITS.jobQueueLeaseFloorMs, pollIntervalMs * 60).
    */
   readonly leaseMs?: number;
+  /**
+   * Upper bound (ms) on {@link JobQueueWorker.getLimiterWakeDelay}. Prevents a
+   * misconfigured or stuck limiter (e.g. one whose `getNextAvailableTime`
+   * returns hours in the future) from making the worker unresponsive — it
+   * wakes at least this often regardless of what the limiter says.
+   * Defaults to {@link DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs}.
+   */
+  readonly limiterMaxWakeMs?: number;
+  /**
+   * Size of the recent-window ring buffer feeding
+   * {@link JobQueueWorker.getAverageProcessingTime}. Bounds memory and keeps
+   * the reported average representative of recent throughput. Defaults to
+   * {@link DEFAULT_LIMITS.jobQueueMaxProcessingTimeSamples}.
+   */
+  readonly maxProcessingTimeSamples?: number;
   /**
    * Dead-letter queue to forward exhausted jobs to, or "discard" to drop them.
    * Default: "discard".
@@ -141,6 +142,8 @@ export class JobQueueWorker<
   protected readonly stopTimeoutMs: number;
   protected readonly extendLeaseWhileRunning: boolean;
   protected readonly leaseMs: number;
+  protected readonly limiterMaxWakeMs: number;
+  protected readonly maxProcessingTimeSamples: number;
   protected readonly events = new EventEmitter<JobQueueWorkerEventListeners<Input, Output>>();
   protected readonly deadLetter: IMessageQueue<DeadLetter<Input>> | "discard";
   protected readonly prefetch: number;
@@ -196,7 +199,7 @@ export class JobQueueWorker<
   /**
    * Recent per-job processing durations (ms) used for
    * {@link getAverageProcessingTime}. Bounded to the most recent
-   * {@link MAX_PROCESSING_TIME_SAMPLES} entries so a long-lived worker doesn't
+   * {@link JobQueueWorker.maxProcessingTimeSamples} entries so a long-lived worker doesn't
    * accumulate one entry per distinct job id forever, and so the reported
    * average reflects a recent window rather than all-time.
    */
@@ -215,10 +218,14 @@ export class JobQueueWorker<
     this.jobStore = options.jobStore;
     this.jobClass = jobClass;
     this.limiter = options.limiter ?? new NullLimiter();
-    this.pollIntervalMs = options.pollIntervalMs ?? 100;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_LIMITS.jobQueuePollIntervalMs;
     this.stopTimeoutMs = options.stopTimeoutMs ?? 30_000;
     this.extendLeaseWhileRunning = options.extendLeaseWhileRunning ?? false;
-    this.leaseMs = options.leaseMs ?? Math.max(30_000, this.pollIntervalMs * 60);
+    this.leaseMs =
+      options.leaseMs ?? Math.max(DEFAULT_LIMITS.jobQueueLeaseFloorMs, this.pollIntervalMs * 60);
+    this.limiterMaxWakeMs = options.limiterMaxWakeMs ?? DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs;
+    this.maxProcessingTimeSamples =
+      options.maxProcessingTimeSamples ?? DEFAULT_LIMITS.jobQueueMaxProcessingTimeSamples;
     this.deadLetter = options.deadLetter ?? "discard";
     this.prefetch = Math.max(1, options.prefetch ?? 1);
   }
@@ -350,7 +357,7 @@ export class JobQueueWorker<
 
   /**
    * Average processing time over the most recent
-   * {@link MAX_PROCESSING_TIME_SAMPLES} completed jobs (a recent window, not
+   * {@link JobQueueWorker.maxProcessingTimeSamples} completed jobs (a recent window, not
    * the worker's all-time history). Returns undefined until at least one job
    * has completed.
    */
@@ -610,7 +617,7 @@ export class JobQueueWorker<
    * How long to sleep when the limiter rejected an acquire. Reads the limiter's
    * own next-available time so we wake exactly when capacity opens, instead of
    * polling every {@link pollIntervalMs}. Clamped to {@link pollIntervalMs}
-   * (lower bound) and {@link MAX_LIMITER_WAKE_MS} (upper bound) so a
+   * (lower bound) and {@link JobQueueWorker.limiterMaxWakeMs} (upper bound) so a
    * misconfigured/stuck limiter still wakes occasionally.
    */
   private async getLimiterWakeDelay(): Promise<number> {
@@ -618,7 +625,7 @@ export class JobQueueWorker<
       const next = await this.limiter.getNextAvailableTime();
       const delay = next.getTime() - Date.now();
       if (delay <= 0) return this.pollIntervalMs;
-      return Math.min(Math.max(delay, this.pollIntervalMs), MAX_LIMITER_WAKE_MS);
+      return Math.min(Math.max(delay, this.pollIntervalMs), this.limiterMaxWakeMs);
     } catch {
       return this.pollIntervalMs;
     }
@@ -773,7 +780,7 @@ export class JobQueueWorker<
 
       const elapsed = Date.now() - startTime;
       this.processingTimes.push(elapsed);
-      if (this.processingTimes.length > MAX_PROCESSING_TIME_SAMPLES) {
+      if (this.processingTimes.length > this.maxProcessingTimeSamples) {
         this.processingTimes.shift();
       }
 

--- a/packages/job-queue/src/job/JobStorageConverters.ts
+++ b/packages/job-queue/src/job/JobStorageConverters.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_LIMITS } from "@workglow/util";
 import type { JobStorageFormat } from "../queue-storage/IQueueStorage";
 import { JobStatus } from "../queue-storage/IQueueStorage";
 import { Job, JobClass } from "./Job";
@@ -43,7 +44,7 @@ export function storageToClass<Input, Output>(
     error: details.error ?? null,
     errorCode: details.error_code ?? null,
     attempts: details.attempts ?? 0,
-    maxAttempts: details.max_attempts ?? 10,
+    maxAttempts: details.max_attempts ?? DEFAULT_LIMITS.jobMaxAttempts,
     leaseOwner: details.lease_owner ?? null,
     abort_requested_at: details.abort_requested_at ?? null,
     lease_expires_at: details.lease_expires_at ?? null,

--- a/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
+++ b/packages/job-queue/src/queue-storage/wrapQueueStorage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, getLogger } from "@workglow/util";
 import type { IClaim } from "./IClaim";
 import type { IJobStore, JobRecord } from "./IJobStore";
 import type { IMessageQueue, MessageId, SendOptions } from "./IMessageQueue";
@@ -15,17 +15,6 @@ import type {
   QueueChangePayload,
   QueueSubscribeOptions,
 } from "./IQueueStorage";
-
-/**
- * Upper bound on the number of PENDING + PROCESSING rows scanned by the
- * wrapper-fallback {@link WrappedJobStore.findActiveByFingerprint}. The
- * native storage path (Postgres/SQLite/Supabase) uses a partial unique
- * index for O(1) lookup; this wrapper fallback only runs for backends
- * that don't expose `findActiveByFingerprint` on the storage layer
- * (in-memory, IndexedDB). 10k is enough to keep dedup correct for any
- * realistic single-queue working set without unbounded scans under load.
- */
-const MAX_FINGERPRINT_SCAN = 10_000;
 
 class WrappedClaim<Input, Output> implements IClaim<JobStorageFormat<Input, Output>> {
   constructor(
@@ -202,7 +191,10 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
    */
   private fingerprintScanExhaustedWarned = false;
 
-  constructor(private readonly storage: IQueueStorage<Input, Output>) {}
+  constructor(
+    private readonly storage: IQueueStorage<Input, Output>,
+    private readonly maxFingerprintScan: number = DEFAULT_LIMITS.jobQueueMaxFingerprintScan
+  ) {}
 
   get(id: MessageId): Promise<JobRecord<Input, Output> | undefined> {
     return this.storage.get(id);
@@ -265,10 +257,10 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     }
 
     // Fallback for backends without a native implementation (in-memory,
-    // IndexedDB): single bounded peek per status, up to MAX_FINGERPRINT_SCAN
+    // IndexedDB): single bounded peek per status, up to this.maxFingerprintScan
     // total rows across PENDING + PROCESSING. The actual cap is the minimum
-    // of MAX_FINGERPRINT_SCAN and whatever the underlying peek() impl
-    // chooses to cap `num` at internally. We rely on MAX_FINGERPRINT_SCAN as
+    // of this.maxFingerprintScan and whatever the underlying peek() impl
+    // chooses to cap `num` at internally. We rely on this.maxFingerprintScan as
     // a hard ceiling and surface a one-shot warning when we exhaust it
     // without finding a match. The wrapped storage is already scoped to a
     // single queue, so any row found here is in "this" queue — the
@@ -276,20 +268,20 @@ class WrappedJobStore<Input, Output> implements IJobStore<Input, Output> {
     // used for filtering.
     let scanned = 0;
     for (const status of ["PENDING", "PROCESSING"] as const) {
-      const remaining = MAX_FINGERPRINT_SCAN - scanned;
+      const remaining = this.maxFingerprintScan - scanned;
       if (remaining <= 0) break;
       const rows = await this.storage.peek(status, remaining);
       for (const r of rows) {
         scanned += 1;
         if (r.fingerprint === fingerprint) return r;
-        if (scanned >= MAX_FINGERPRINT_SCAN) break;
+        if (scanned >= this.maxFingerprintScan) break;
       }
     }
 
-    if (scanned >= MAX_FINGERPRINT_SCAN && !this.fingerprintScanExhaustedWarned) {
+    if (scanned >= this.maxFingerprintScan && !this.fingerprintScanExhaustedWarned) {
       this.fingerprintScanExhaustedWarned = true;
       getLogger().warn(
-        "WrappedJobStore.findActiveByFingerprint: scanned MAX_FINGERPRINT_SCAN rows without a match; dedup may be best-effort under load"
+        `WrappedJobStore.findActiveByFingerprint: scanned ${scanned} rows (max ${this.maxFingerprintScan}) without a match; dedup may be best-effort under load`
       );
     }
     return undefined;
@@ -387,14 +379,20 @@ function applySendOptions<Input, Output>(
   return out;
 }
 
+export interface WrapQueueStorageOptions {
+  /** Overrides {@link DEFAULT_LIMITS.jobQueueMaxFingerprintScan}. */
+  readonly maxFingerprintScan?: number;
+}
+
 export function wrapQueueStorage<Input, Output>(
-  storage: IQueueStorage<Input, Output>
+  storage: IQueueStorage<Input, Output>,
+  options: WrapQueueStorageOptions = {}
 ): {
   messageQueue: IMessageQueue<JobStorageFormat<Input, Output>>;
   jobStore: IJobStore<Input, Output>;
 } {
   return {
     messageQueue: new WrappedMessageQueue(storage),
-    jobStore: new WrappedJobStore(storage),
+    jobStore: new WrappedJobStore(storage, options.maxFingerprintScan),
   };
 }

--- a/packages/storage/src/tabular/Cursor.ts
+++ b/packages/storage/src/tabular/Cursor.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SECURITY_LIMITS } from "@workglow/util";
 import { StorageValidationError } from "./StorageError";
 
 /**
@@ -51,7 +52,7 @@ export const CURSOR_VERSION = 1 as const;
  * can't force the server to base64-decode and JSON-parse arbitrarily
  * large strings, which would be cheap memory/CPU abuse.
  */
-export const MAX_CURSOR_LENGTH = 8 * 1024;
+export const MAX_CURSOR_LENGTH = SECURITY_LIMITS.tabularMaxCursorLength;
 
 /**
  * Encodes a cursor payload as an opaque, URL-safe string.

--- a/packages/storage/src/tabular/SharedInMemoryTabularStorage.ts
+++ b/packages/storage/src/tabular/SharedInMemoryTabularStorage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createServiceToken, getLogger } from "@workglow/util";
+import { createServiceToken, DEFAULT_LIMITS, getLogger } from "@workglow/util";
 import { DataPortSchemaObject, FromSchema, TypedArraySchemaOptions } from "@workglow/util/schema";
 import { safeEmit } from "../events/safeEmit";
 import { type ITabularMigration, type ITabularMigrationApplier } from "../migrations";
@@ -28,7 +28,6 @@ export const SHARED_IN_MEMORY_TABULAR_REPOSITORY = createServiceToken<AnyTabular
 );
 
 const SYNC_TIMEOUT = 1000;
-const MAX_PENDING_MESSAGES = 1000;
 
 type BroadcastMessage =
   | { type: "SYNC_REQUEST" }
@@ -61,6 +60,7 @@ export class SharedInMemoryTabularStorage<
   private isInitialized = false;
   private syncInProgress = false;
   private pendingMessages: BroadcastMessage[] = [];
+  private readonly maxPendingMessages: number;
   /**
    * Resolves when the current `syncFromOtherTabs()` settles, either because a
    * peer tab sent a `SYNC_RESPONSE` (drained, then resolved) or because the
@@ -76,10 +76,12 @@ export class SharedInMemoryTabularStorage<
     primaryKeyNames: PrimaryKeyNames,
     indexes: readonly (keyof NoInfer<Entity> | readonly (keyof NoInfer<Entity>)[])[] = [],
     clientProvidedKeys: ClientProvidedKeysOption = "if-missing",
-    tabularMigrations?: ReadonlyArray<ITabularMigration>
+    tabularMigrations?: ReadonlyArray<ITabularMigration>,
+    maxPendingMessages: number = DEFAULT_LIMITS.storageMaxPendingMessages
   ) {
     super(schema, primaryKeyNames, indexes, clientProvidedKeys, tabularMigrations, channelName);
     this.channelName = channelName;
+    this.maxPendingMessages = maxPendingMessages;
     // Don't pass migrations to the inner repo — migrations are owned by the
     // outer Shared wrapper which delegates them through getMigrationApplier.
     this.inMemoryRepo = new InMemoryTabularStorage<Schema, PrimaryKeyNames, Entity, PrimaryKey>(
@@ -139,7 +141,7 @@ export class SharedInMemoryTabularStorage<
   private async handleBroadcastMessage(message: BroadcastMessage): Promise<void> {
     if (this.syncInProgress && message.type !== "SYNC_RESPONSE") {
       // Queue messages during sync; we'll replay them after SYNC_RESPONSE.
-      if (this.pendingMessages.length < MAX_PENDING_MESSAGES) {
+      if (this.pendingMessages.length < this.maxPendingMessages) {
         this.pendingMessages.push(message);
       }
       return;

--- a/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
+++ b/packages/task-graph/src/task-graph/SubGraphEventBridge.ts
@@ -4,19 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLogger } from "@workglow/util";
+import { DEFAULT_LIMITS, getLogger } from "@workglow/util";
 import type { TaskGraph } from "./TaskGraph";
-
-/**
- * Default maximum bridge nesting depth before re-emit listeners are dropped.
- * Each level installs one listener per event type and re-emits up; without a
- * cap, a pathologically nested compound task (e.g. a MapTask containing a
- * GraphAsTask containing a MapTask…) amplifies a single inner emit into N
- * parent emits before reaching any wire subscriber, and downstream consumers
- * with a bounded event log can evict legitimate events under sustained
- * fan-out.
- */
-const DEFAULT_MAX_BRIDGE_DEPTH = 16;
 
 /**
  * Symbol-keyed marker we attach to each subgraph so nested calls can derive
@@ -43,7 +32,13 @@ const warnedParents = new WeakSet<TaskGraph>();
  *
  * Depth is tracked on the parent graph via a symbol-keyed marker so callers do
  * not need to thread a counter through. Once `depth >= maxDepth` the call
- * degrades to a no-op (with a single warn log) — see {@link DEFAULT_MAX_BRIDGE_DEPTH}.
+ * degrades to a no-op (with a single warn log) — see
+ * {@link DEFAULT_LIMITS.bridgeMaxDepth}. Each level installs one listener per
+ * event type and re-emits up; without a cap, a pathologically nested compound
+ * task (e.g. a MapTask containing a GraphAsTask containing a MapTask…)
+ * amplifies a single inner emit into N parent emits before reaching any wire
+ * subscriber, and downstream consumers with a bounded event log can evict
+ * legitimate events under sustained fan-out.
  *
  * @returns a teardown that unsubscribes every bridged listener. Callers MUST
  *   invoke it in a `finally` so a rejecting/aborted/early-terminated subgraph
@@ -53,7 +48,7 @@ export function bridgeSubGraphTaskEvents(
   subGraph: TaskGraph,
   parentGraph: TaskGraph,
   depth: number = (parentGraph as unknown as Record<symbol, number>)[BRIDGE_DEPTH] ?? 0,
-  maxDepth: number = DEFAULT_MAX_BRIDGE_DEPTH
+  maxDepth: number = DEFAULT_LIMITS.bridgeMaxDepth
 ): () => void {
   // A subgraph bridging to itself would re-emit each event back onto the same
   // graph it just observed, looping forever. This cannot arise from normal

--- a/packages/tasks/src/task/RegexTask.ts
+++ b/packages/tasks/src/task/RegexTask.ts
@@ -13,10 +13,8 @@ import {
   TaskInvalidInputError,
   Workflow,
 } from "@workglow/task-graph";
+import { SECURITY_LIMITS } from "@workglow/util";
 import { DataPortSchema, FromSchema } from "@workglow/util/schema";
-
-/** Maximum number of '[' characters allowed in a regex pattern before rejecting (ReDoS guard). */
-const MAX_BRACKET_COUNT = 100;
 
 /**
  * Detects regex patterns prone to catastrophic backtracking (ReDoS).
@@ -34,7 +32,7 @@ function executeRegex(input: { value: string; pattern: string; flags?: string })
   matches: string[];
 } {
   const bracketCount = (input.pattern.match(/\[/g) ?? []).length;
-  if (bracketCount > MAX_BRACKET_COUNT) {
+  if (bracketCount > SECURITY_LIMITS.regexMaxBracketCount) {
     throw new TaskInvalidInputError(
       "Regex pattern rejected: too many '[' characters (potential ReDoS). " +
         "Simplify the pattern to reduce complexity."

--- a/packages/tasks/src/task/image/imageCodecLimits.ts
+++ b/packages/tasks/src/task/image/imageCodecLimits.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SECURITY_LIMITS } from "@workglow/util";
+
 /**
  * Maximum number of decoded pixels (width * height) accepted by the image raster codec.
  *
@@ -14,7 +16,7 @@
  * Defends against header-declared pixel bombs where a small compressed payload
  * claims billions of pixels to force a downstream OOM.
  */
-export const MAX_DECODED_PIXELS = 100_000_000;
+export const MAX_DECODED_PIXELS = SECURITY_LIMITS.imageMaxDecodedPixels;
 
 /**
  * Maximum raw (base64-decoded) byte size of an incoming data URI on the Node codec.
@@ -23,7 +25,7 @@ export const MAX_DECODED_PIXELS = 100_000_000;
  * additionally enforces {@link MAX_DECODED_PIXELS} via sharp's header-level
  * `limitInputPixels`, so 64 MiB is a comfortable ceiling on the server side.
  */
-export const MAX_INPUT_BYTES_NODE = 64 * 1024 * 1024;
+export const MAX_INPUT_BYTES_NODE = SECURITY_LIMITS.imageMaxInputBytesNode;
 
 /**
  * Maximum raw byte size of an incoming data URI on the browser codec.
@@ -38,7 +40,7 @@ export const MAX_INPUT_BYTES_NODE = 64 * 1024 * 1024;
  * photos sit at 10–20 MiB. Anything larger than this is either an 8K image
  * or a malformed input and should be downscaled before upload.
  */
-export const MAX_INPUT_BYTES_BROWSER = 32 * 1024 * 1024;
+export const MAX_INPUT_BYTES_BROWSER = SECURITY_LIMITS.imageMaxInputBytesBrowser;
 
 /**
  * Mime types rejected at decode time because rasterization would silently lose

--- a/packages/tasks/src/util/SafeFetch.ts
+++ b/packages/tasks/src/util/SafeFetch.ts
@@ -16,6 +16,7 @@
  * `network:private` entitlement (via its dynamic `entitlements()`).
  */
 
+import { SECURITY_LIMITS } from "@workglow/util";
 import { createFetchUrlJobError, FetchUrlErrorCode } from "../task/FetchUrlJobError";
 import { classifyUrl, urlMatchesScope } from "./UrlClassifier";
 
@@ -47,7 +48,7 @@ export interface SafeFetchOptions extends RequestInit {
 
 export type SafeFetchFn = (url: string, options: SafeFetchOptions) => Promise<Response>;
 
-const MAX_REDIRECT_HOPS = 20;
+const MAX_REDIRECT_HOPS = SECURITY_LIMITS.safeFetchMaxRedirectHops;
 
 function assertAllowedUrl(
   url: string,

--- a/packages/test/src/test/ai-provider-api/localOnlyFetch.test.ts
+++ b/packages/test/src/test/ai-provider-api/localOnlyFetch.test.ts
@@ -22,6 +22,7 @@
  */
 
 import { localOnlyFetch } from "@workglow/ai/provider-utils";
+import { DEFAULT_LIMITS } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const originalFetch = globalThis.fetch;
@@ -282,5 +283,24 @@ describe("localOnlyFetch", () => {
       localOnlyFetch("http://127.0.0.1:9000/start", undefined, "TestProvider")
     ).rejects.toThrow(/too many redirects/);
     expect(calls).toHaveLength(6);
+  });
+
+  it("accepts an explicit maxRedirects override tighter than the default", async () => {
+    stubFetch([redirect("http://localhost/a"), redirect("http://localhost/b"), new Response("ok")]);
+    await expect(localOnlyFetch("http://localhost/start", undefined, "test", 1)).rejects.toThrow(
+      /too many redirects/
+    );
+    expect(calls.length).toBe(2);
+  });
+
+  it("still allows more hops than DEFAULT_LIMITS.aiLocalFetchMaxRedirects when maxRedirects is raised", async () => {
+    const hops = DEFAULT_LIMITS.aiLocalFetchMaxRedirects + 2;
+    const responses = Array.from({ length: hops }, (_, i) =>
+      redirect(`http://localhost/hop-${i + 1}`)
+    );
+    responses.push(new Response("ok"));
+    stubFetch(responses);
+    const res = await localOnlyFetch("http://localhost/start", undefined, "test", hops + 1);
+    expect(await res.text()).toBe("ok");
   });
 });

--- a/packages/test/src/test/job-queue/JobErrorDiagnostics.test.ts
+++ b/packages/test/src/test/job-queue/JobErrorDiagnostics.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatErrorChainForDiagnostics } from "@workglow/job-queue";
+import { DEFAULT_LIMITS } from "@workglow/util";
+import { describe, expect, it } from "vitest";
+
+function chainOf(depth: number): Error {
+  let err = new Error("root");
+  for (let i = 1; i < depth; i++) {
+    const next = new Error(`level-${i}`);
+    (next as Error & { cause?: unknown }).cause = err;
+    err = next;
+  }
+  return err;
+}
+
+describe("formatErrorChainForDiagnostics", () => {
+  it("defaults maxChars to DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars", () => {
+    const err = new Error("x".repeat(DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars + 1000));
+    const withDefault = formatErrorChainForDiagnostics(err);
+    const withExplicitSameLimit = formatErrorChainForDiagnostics(
+      err,
+      DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars
+    );
+    // If the default diverged from DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars, these would differ.
+    expect(withDefault).toBe(withExplicitSameLimit);
+  });
+
+  function uniqueLevelCount(formatted: string): number {
+    const matches = formatted.match(/level-\d+/g) ?? [];
+    return new Set(matches).size;
+  }
+
+  it("defaults the cause-chain walk depth to DEFAULT_LIMITS.jobErrorMaxCauseChainDepth", () => {
+    const err = chainOf(20);
+    const formatted = formatErrorChainForDiagnostics(err);
+    expect(uniqueLevelCount(formatted)).toBeLessThanOrEqual(
+      DEFAULT_LIMITS.jobErrorMaxCauseChainDepth
+    );
+  });
+
+  it("accepts an explicit maxCauseChainDepth override", () => {
+    const err = chainOf(20);
+    const formatted = formatErrorChainForDiagnostics(err, undefined, 3);
+    expect(uniqueLevelCount(formatted)).toBeLessThanOrEqual(3);
+  });
+});

--- a/packages/test/src/test/job-queue/JobQueueWorker.test.ts
+++ b/packages/test/src/test/job-queue/JobQueueWorker.test.ts
@@ -18,7 +18,7 @@ import {
   RateLimiter,
   wrapQueueStorage,
 } from "@workglow/job-queue";
-import { setLogger, sleep, uuid4 } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger, sleep, uuid4 } from "@workglow/util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
 
@@ -304,5 +304,54 @@ describe("JobQueueWorker — PR #511 follow-up regressions", () => {
 
     expect(seen.length).toBeGreaterThanOrEqual(1);
     expect(seen[0]!.errorCode).toBe("PermanentJobError");
+  });
+});
+
+describe("JobQueueWorker limit overrides", () => {
+  it("caps the processing-time sample window at the configured maxProcessingTimeSamples", async () => {
+    TJob.executeCalls = 0;
+    const queueName = `limits-test-queue-${uuid4()}`;
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    await storage.migrate();
+    const { messageQueue, jobStore } = wrapQueueStorage(storage);
+    const worker = new JobQueueWorker<TI, TO, TJob>(TJob, {
+      messageQueue,
+      jobStore,
+      queueName,
+      pollIntervalMs: 5,
+      stopTimeoutMs: 0,
+      maxProcessingTimeSamples: 2,
+    });
+    await worker.start();
+    for (let i = 0; i < 3; i++) {
+      await storage.add({
+        input: { taskType: "default", data: `job-${i}` },
+        visible_at: null,
+        completed_at: null,
+        deadline_at: null,
+      } as any);
+    }
+    await waitUntil(() => TJob.executeCalls >= 3, 2000);
+    await sleep(20);
+    // @ts-expect-error accessing protected internal for the assertion
+    expect(worker.processingTimes.length).toBeLessThanOrEqual(2);
+    await worker.stop();
+    await storage.deleteAll();
+  });
+
+  it("uses the DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs value when limiterMaxWakeMs is not set", async () => {
+    const queueName = `limits-test-queue-2-${uuid4()}`;
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    await storage.migrate();
+    const { messageQueue, jobStore } = wrapQueueStorage(storage);
+    const worker = new JobQueueWorker<TI, TO, TJob>(TJob, {
+      messageQueue,
+      jobStore,
+      queueName,
+      stopTimeoutMs: 0,
+    });
+    // @ts-expect-error accessing protected internal for the assertion
+    expect(worker.limiterMaxWakeMs).toBe(DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs);
+    await storage.deleteAll();
   });
 });

--- a/packages/test/src/test/job-queue/WrapQueueStorageFingerprintScanCap.test.ts
+++ b/packages/test/src/test/job-queue/WrapQueueStorageFingerprintScanCap.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InMemoryQueueStorage, wrapQueueStorage } from "@workglow/job-queue";
+import { describe, expect, it } from "vitest";
+
+interface TI {
+  readonly data?: string;
+}
+interface TO {
+  readonly result?: string;
+}
+
+async function seedFiveJobs(storage: InMemoryQueueStorage<TI, TO>): Promise<void> {
+  // Insert 5 PENDING jobs with distinct fingerprints, in order fp-0..fp-4.
+  // InMemoryQueueStorage.peek() sorts by visible_at with a stable sort, so
+  // insertion order is preserved when timestamps tie.
+  for (let i = 0; i < 5; i++) {
+    await storage.add({
+      input: { data: `job-${i}` },
+      fingerprint: `fp-${i}`,
+      visible_at: null,
+      completed_at: null,
+      deadline_at: null,
+    } as any);
+  }
+}
+
+/**
+ * InMemoryQueueStorage implements findActiveByFingerprint natively (an
+ * unbounded Array.find), so WrappedJobStore.findActiveByFingerprint would
+ * delegate straight to it and never exercise the wrapper's bounded-scan
+ * fallback. Shadowing the method with an own-property `undefined` hides the
+ * native implementation from `typeof storage.findActiveByFingerprint ===
+ * "function"`, forcing the wrapper down its peek-and-scan fallback path so
+ * maxFingerprintScan is actually exercised.
+ */
+function disableNativeFingerprintLookup(storage: InMemoryQueueStorage<TI, TO>): void {
+  (storage as { findActiveByFingerprint?: unknown }).findActiveByFingerprint = undefined;
+}
+
+describe("wrapQueueStorage maxFingerprintScan override", () => {
+  it("does not find a fingerprint past the configured maxFingerprintScan", async () => {
+    const queueName = "fp-scan-cap-queue-low";
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    disableNativeFingerprintLookup(storage);
+    const { jobStore } = wrapQueueStorage(storage, { maxFingerprintScan: 2 });
+    await seedFiveJobs(storage);
+
+    // fp-3 is the 4th inserted job; a cap of 2 only scans fp-0 and fp-1.
+    const result = await jobStore.findActiveByFingerprint("fp-3", queueName);
+    expect(result).toBeUndefined();
+  });
+
+  it("finds a fingerprint within the configured maxFingerprintScan", async () => {
+    const queueName = "fp-scan-cap-queue-high";
+    const storage = new InMemoryQueueStorage<TI, TO>(queueName);
+    disableNativeFingerprintLookup(storage);
+    const { jobStore } = wrapQueueStorage(storage, { maxFingerprintScan: 10 });
+    await seedFiveJobs(storage);
+
+    // Same fp-3 target, but the cap is now large enough to reach it — proves
+    // the low-cap case above is actually exercising the cap, not some other
+    // failure mode (e.g. the fallback path being unreachable).
+    const result = await jobStore.findActiveByFingerprint("fp-3", queueName);
+    expect(result?.fingerprint).toBe("fp-3");
+  });
+});

--- a/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/SharedInMemoryTabularStorage.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { SharedInMemoryTabularStorage } from "@workglow/storage";
-import { setLogger, uuid4 } from "@workglow/util";
+import { DEFAULT_LIMITS, setLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 import { describe, expect, it } from "vitest";
 import { getTestingLogger } from "../../binding/TestingLogger";
@@ -52,6 +52,34 @@ describe("SharedInMemoryTabularStorage.queryIndex", () => {
     const ids = rows.map((r) => r.id).sort();
     expect(ids).toEqual(["1", "2"]);
     storage.destroy();
+  });
+});
+
+describe("SharedInMemoryTabularStorage maxPendingMessages override", () => {
+  it("uses the DEFAULT_LIMITS.storageMaxPendingMessages value when not overridden", () => {
+    const store = new SharedInMemoryTabularStorage<typeof SearchSchema, typeof SearchPK>(
+      `pending-default-${uuid4()}`,
+      SearchSchema,
+      SearchPK
+    );
+    // @ts-expect-error accessing private internal for the assertion
+    expect(store.maxPendingMessages).toBe(DEFAULT_LIMITS.storageMaxPendingMessages);
+    store.destroy();
+  });
+
+  it("accepts an explicit maxPendingMessages override", () => {
+    const store = new SharedInMemoryTabularStorage<typeof SearchSchema, typeof SearchPK>(
+      `pending-override-${uuid4()}`,
+      SearchSchema,
+      SearchPK,
+      [],
+      "if-missing",
+      undefined,
+      5
+    );
+    // @ts-expect-error accessing private internal for the assertion
+    expect(store.maxPendingMessages).toBe(5);
+    store.destroy();
   });
 });
 

--- a/packages/test/src/test/util/Limits.test.ts
+++ b/packages/test/src/test/util/Limits.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_LIMITS, SECURITY_LIMITS } from "@workglow/util";
+import { describe, expect, it } from "vitest";
+
+describe("DEFAULT_LIMITS", () => {
+  it("exposes every documented behavioral default with its expected value", () => {
+    expect(DEFAULT_LIMITS.bridgeMaxDepth).toBe(16);
+    expect(DEFAULT_LIMITS.jobMaxAttempts).toBe(10);
+    expect(DEFAULT_LIMITS.jobQueuePollIntervalMs).toBe(100);
+    expect(DEFAULT_LIMITS.jobQueueLeaseFloorMs).toBe(30_000);
+    expect(DEFAULT_LIMITS.jobQueueLimiterMaxWakeMs).toBe(30_000);
+    expect(DEFAULT_LIMITS.jobQueueMaxProcessingTimeSamples).toBe(1_000);
+    expect(DEFAULT_LIMITS.jobQueueMaxFingerprintScan).toBe(10_000);
+    expect(DEFAULT_LIMITS.jobErrorMaxDiagnosticsChars).toBe(48_000);
+    expect(DEFAULT_LIMITS.jobErrorMaxCauseChainDepth).toBe(8);
+    expect(DEFAULT_LIMITS.storageMaxPendingMessages).toBe(1_000);
+    expect(DEFAULT_LIMITS.aiLocalFetchMaxRedirects).toBe(5);
+    expect(DEFAULT_LIMITS.aiChatMaxIterations).toBe(100);
+    expect(DEFAULT_LIMITS.structuredGenMaxRetries).toBe(2);
+    expect(DEFAULT_LIMITS.otpCacheHardTtlMs).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it("is a frozen object shape (const assertion) with only number values", () => {
+    for (const value of Object.values(DEFAULT_LIMITS)) {
+      expect(typeof value).toBe("number");
+    }
+  });
+});
+
+describe("SECURITY_LIMITS", () => {
+  it("exposes every documented security ceiling with its expected value", () => {
+    expect(SECURITY_LIMITS.regexMaxBracketCount).toBe(100);
+    expect(SECURITY_LIMITS.imageMaxDecodedPixels).toBe(100_000_000);
+    expect(SECURITY_LIMITS.imageMaxInputBytesNode).toBe(64 * 1024 * 1024);
+    expect(SECURITY_LIMITS.imageMaxInputBytesBrowser).toBe(32 * 1024 * 1024);
+    expect(SECURITY_LIMITS.safeFetchMaxRedirectHops).toBe(20);
+    expect(SECURITY_LIMITS.tabularMaxCursorLength).toBe(8 * 1024);
+  });
+
+  it("is a frozen object shape (const assertion) with only number values", () => {
+    for (const value of Object.values(SECURITY_LIMITS)) {
+      expect(typeof value).toBe("number");
+    }
+  });
+});

--- a/packages/util/src/common.ts
+++ b/packages/util/src/common.ts
@@ -16,6 +16,7 @@ export * from "./utilities/Misc";
 export * from "./utilities/objectOfArraysAsArrayOfObjects";
 export * from "./utilities/TypeUtilities";
 export * from "./worker/WorkerManager";
+export * from "./limits";
 export * from "./credentials";
 export * from "./crypto/WebCrypto";
 export * from "./crypto/Hmac";

--- a/packages/util/src/credentials/OtpPassphraseCache.ts
+++ b/packages/util/src/credentials/OtpPassphraseCache.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_LIMITS } from "../limits";
+
 /**
  * Options for {@link OtpPassphraseCache}.
  */
@@ -28,7 +30,7 @@ export interface OtpPassphraseCacheOptions {
   readonly onExpiry?: () => void;
 }
 
-const DEFAULT_HARD_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const DEFAULT_HARD_TTL_MS = DEFAULT_LIMITS.otpCacheHardTtlMs;
 
 /**
  * XOR-masks a passphrase with a random one-time pad so the cache does not

--- a/packages/util/src/limits.ts
+++ b/packages/util/src/limits.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single source of truth for default numeric limits used across the
+ * `libs` packages (task-graph, job-queue, storage, ai, tasks). Every one
+ * of these defaults remains overridable at its call site (constructor or
+ * function option); this module only centralizes the fallback value so it
+ * is not duplicated and drifted across packages.
+ *
+ * See {@link SECURITY_LIMITS} for hard ceilings that are NOT caller
+ * overridable because they exist to defend against resource-exhaustion /
+ * injection attacks (ReDoS, decompression bombs, SSRF).
+ */
+export const DEFAULT_LIMITS = {
+  /** Max nesting depth for subgraph task-event re-emission before bridging becomes a no-op. */
+  bridgeMaxDepth: 16,
+  /** Default max attempts before a job is considered permanently failed. */
+  jobMaxAttempts: 10,
+  /** Default interval (ms) between JobQueueWorker poll iterations. */
+  jobQueuePollIntervalMs: 100,
+  /** Floor (ms) applied when deriving a worker's lease duration from its poll interval. */
+  jobQueueLeaseFloorMs: 30_000,
+  /** Upper bound (ms) on how long JobQueueWorker will sleep before re-checking a rate limiter. */
+  jobQueueLimiterMaxWakeMs: 30_000,
+  /** Size of the rolling window of recent job-processing-time samples JobQueueWorker retains. */
+  jobQueueMaxProcessingTimeSamples: 1_000,
+  /** Max rows the in-memory/IndexedDB fingerprint-dedup fallback will scan before giving up. */
+  jobQueueMaxFingerprintScan: 10_000,
+  /** Max characters kept when formatting a job error's `.cause` chain for diagnostics. */
+  jobErrorMaxDiagnosticsChars: 48_000,
+  /** Max levels of `.cause` walked when formatting error diagnostics. */
+  jobErrorMaxCauseChainDepth: 8,
+  /** Max buffered cross-tab change-notification messages before older ones are dropped. */
+  storageMaxPendingMessages: 1_000,
+  /** Max redirect hops followed by the loopback-only AI provider fetch helper. */
+  aiLocalFetchMaxRedirects: 5,
+  /** Max tool-calling turns for AiChatTask / AiChatWithKbTask. */
+  aiChatMaxIterations: 100,
+  /** Max validation-error retries for StructuredGenerationTask. */
+  structuredGenMaxRetries: 2,
+  /** Default absolute TTL (ms) for OtpPassphraseCache. */
+  otpCacheHardTtlMs: 6 * 60 * 60 * 1000,
+} as const satisfies Record<string, number>;
+
+/**
+ * Hard ceilings that defend against resource-exhaustion or injection
+ * attacks (ReDoS, decompression/pixel bombs, SSRF via redirects, cursor
+ * tampering). Unlike {@link DEFAULT_LIMITS}, these are NOT exposed as
+ * caller-overridable options — a caller weakening one of these would
+ * reopen the vulnerability the constant defends against.
+ */
+export const SECURITY_LIMITS = {
+  /** Max '[' characters allowed in a RegexTask pattern before rejecting (ReDoS guard). */
+  regexMaxBracketCount: 100,
+  /** Max decoded pixels (width * height) accepted by the image raster codec. */
+  imageMaxDecodedPixels: 100_000_000,
+  /** Max raw (base64-decoded) byte size of an incoming data URI on the Node image codec. */
+  imageMaxInputBytesNode: 64 * 1024 * 1024,
+  /** Max raw byte size of an incoming data URI on the browser image codec. */
+  imageMaxInputBytesBrowser: 32 * 1024 * 1024,
+  /** Max redirect hops followed by the SSRF-aware `safeFetch` wrapper. */
+  safeFetchMaxRedirectHops: 20,
+  /** Max accepted length (characters) of an encoded tabular storage pagination cursor. */
+  tabularMaxCursorLength: 8 * 1024,
+} as const satisfies Record<string, number>;

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/common.ts", "src/*/**/*"],
+  "include": ["src/common.ts", "src/limits.ts", "src/*/**/*"],
   "files": [
     "./src/node.ts",
     "./src/browser.ts",


### PR DESCRIPTION
## Summary

- Adds `packages/util/src/limits.ts`, exporting `DEFAULT_LIMITS` (14 behavioral defaults) and `SECURITY_LIMITS` (6 hard security ceilings), as the single source of truth for numeric limits across the monorepo.
- Migrates ~13 hardcoded constants across `task-graph`, `job-queue`, `storage`, `ai`, and `tasks` to source their defaults from this shared module, adding a genuinely new override path for 6 constants that previously had none (`JobQueueWorker.limiterMaxWakeMs`/`maxProcessingTimeSamples`, `wrapQueueStorage`'s `maxFingerprintScan`, `formatErrorChainForDiagnostics`'s `maxCauseChainDepth`, `SharedInMemoryTabularStorage`'s `maxPendingMessages`, `localOnlyFetch`'s `maxRedirects`).
- Security-critical ceilings (ReDoS regex guard, image decompression-bomb guards, SSRF redirect-hop caps, tabular cursor-length cap) are intentionally kept non-overridable via `SECURITY_LIMITS`.
- No default numeric values changed — this is a refactor/consolidation, not a behavior change, except for the 6 newly-overridable constants which retain their prior defaults when unspecified.

Design spec: `docs/superpowers/specs/2026-07-02-libs-limits-consolidation-design.md` and implementation plan: `docs/superpowers/plans/2026-07-02-libs-limits-consolidation.md` in the `prd` repo (same branch name).

## Test Plan

- [x] `bun run build:packages` — 71/71 tasks succeeded
- [x] `bun scripts/test.ts graph queue storage util ai provider-api task vitest` — 343/346 files passed (3 pre-existing environment-gated skips), 5097 tests passed
- [x] `bun run build:types` — 36/36 packages succeeded
- [x] Each of the 11 commits independently reviewed for spec compliance and code quality (two-stage review), plus a final holistic review across the full diff

## Known follow-up (not in this PR's scope)

`JobQueueServer` doesn't yet forward the newly-added `limiterMaxWakeMs`/`maxProcessingTimeSamples` options to the `JobQueueWorker` instances it constructs, and still hardcodes its own `pollIntervalMs` default as a bare `100` instead of `DEFAULT_LIMITS.jobQueuePollIntervalMs`. This is a pre-existing gap, not a regression — no behavior change for existing callers — but worth a small follow-up PR to close.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhFTTdwH2BManwtBBdQ3fj)_