### PR TITLE
fix(util): make objectOfArraysAsArrayOfObjects work with native array methods

### DIFF
--- a/packages/test/src/test/util/arrayAsObjectProxy.test.ts
+++ b/packages/test/src/test/util/arrayAsObjectProxy.test.ts
@@ -106,4 +106,41 @@ describe("Object of arrays to array of objects proxy", () => {
     }
     expect(data.name).toEqual(["Alice Updated", "Bob Updated", "Charlie Updated"]);
   });
+
+  it("slice returns dense rows, not sparse holes", () => {
+    // Regression: without a `has` trap, native Array.prototype.slice sees every
+    // index as an absent hole and returns a sparse array whose spread becomes
+    // [undefined, undefined].
+    const data = { a: [1, 2, 3, 4], b: ["w", "x", "y", "z"] };
+    const proxy = objectOfArraysAsArrayOfObjects(data);
+    const head = proxy.slice(0, 2);
+    expect(head.length).toBe(2);
+    expect([...head]).toEqual([
+      { a: 1, b: "w" },
+      { a: 2, b: "x" },
+    ]);
+    expect(head.some((r) => r === undefined)).toBe(false);
+    expect(head.map((r) => r.a)).toEqual([1, 2]);
+    expect(proxy.slice(2).map((r) => r.a)).toEqual([3, 4]);
+    expect(proxy.slice(-1).map((r) => r.a)).toEqual([4]);
+  });
+
+  it("reports in-range indices as present via the `in` operator", () => {
+    const data = { a: [1, 2, 3, 4], b: ["w", "x", "y", "z"] };
+    const proxy = objectOfArraysAsArrayOfObjects(data);
+    expect(0 in proxy).toBe(true);
+    expect(3 in proxy).toBe(true);
+    expect(4 in proxy).toBe(false);
+    expect("length" in proxy).toBe(true);
+  });
+
+  it("supports native methods that probe presence (at, concat)", () => {
+    const data = { a: [1, 2, 3, 4], b: ["w", "x", "y", "z"] };
+    const proxy = objectOfArraysAsArrayOfObjects(data);
+    expect((proxy.at?.(1) as { b: string } | undefined)?.b).toBe("x");
+    const combined = ([] as { a: number; b: string }[]).concat(
+      proxy as unknown as { a: number; b: string }[]
+    );
+    expect(combined.map((r) => r.a)).toEqual([1, 2, 3, 4]);
+  });
 });

--- a/packages/util/src/utilities/objectOfArraysAsArrayOfObjects.ts
+++ b/packages/util/src/utilities/objectOfArraysAsArrayOfObjects.ts
@@ -312,6 +312,16 @@ export function objectOfArraysAsArrayOfObjects<T extends Record<string, any>>(da
           return [...receiver].some(callback, thisArg);
         };
       }
+      if (prop === "slice") {
+        // Native `Array.prototype.slice` copies an index only when
+        // `HasProperty` reports it present. The `has` trap below now answers
+        // truthfully for in-range indices, but implement `slice` explicitly
+        // too — it mirrors the other materializing methods and keeps the
+        // common case correct regardless of how a host walks the receiver.
+        return function (start?: number, end?: number) {
+          return [...receiver].slice(start, end);
+        };
+      }
 
       if (typeof prop === "string" && !isNaN(Number(prop))) {
         const index = Number(prop);
@@ -330,6 +340,21 @@ export function objectOfArraysAsArrayOfObjects<T extends Record<string, any>>(da
       }
 
       return Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      // Without this trap, `HasProperty` for a numeric index falls through to
+      // the empty backing array and reports `false`, so native array methods
+      // that probe presence (`slice`, `concat`, `at`, `flat`, …) treat every
+      // row as an absent hole and silently drop the data. Report in-range
+      // indices — and `length` — as present so those methods see real rows.
+      if (typeof prop === "string" && !isNaN(Number(prop))) {
+        const index = Number(prop);
+        return index >= 0 && index < data[keys[0]].length;
+      }
+      if (prop === "length") {
+        return true;
+      }
+      return Reflect.has(target, prop);
     },
     set(target, prop, value, receiver) {
       if (typeof prop === "string" && !isNaN(Number(prop))) {


### PR DESCRIPTION
## Problem
The `objectOfArraysAsArrayOfObjects` proxy backs onto an empty `[]`, so `HasProperty` for a numeric index returned `false`. Native array methods that probe presence (`slice`, `concat`, `at`, `flat`, …) therefore treated every row as an absent hole and silently dropped the data:

```js
const p = objectOfArraysAsArrayOfObjects({ a: [1,2,3,4], b: ["w","x","y","z"] });
p.slice(0, 2)        // -> [ 2 x empty items ]  (sparse!)
[...p.slice(0, 2)]   // -> [ undefined, undefined ]
p.map(r => r.a)      // -> [1,2,3,4]  (map is explicitly implemented, so it worked)
```

This surfaced downstream in `@workglow/sec`, where `StoreSubmissionFilingsTask` sliced the proxy to batch filings and then spread the result into a bulk insert — every filing became an `undefined` row and the insert crashed, storing zero filings. (That caller has its own fix; this is the root cause.)

## Fix
- Add a `has` trap that reports in-range numeric indices (and `length`) as present, so native methods that rely on `HasProperty` see real rows.
- Implement `slice` explicitly, mirroring the file's other materializing methods (`map`/`filter`/`forEach`/…) and guarding the exact method that regressed.

## Test
Regression cases (slice returns dense rows, the `in` operator, `at`/`concat`) added to the existing proxy suite in the dedicated `@workglow/test` package (`packages/test/src/test/util/arrayAsObjectProxy.test.ts`) — 14 pass against a freshly built `@workglow/util`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNNJyBunCkJhiUhdM9ys7V