### PR TITLE
fix(task-graph): route RunPrivateCacheRepo by-ref through *ForRun to prevent cross-run leak (follow-up to #611)

### DIFF
--- a/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
+++ b/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
@@ -72,22 +72,27 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
           metadata
         );
     }
-    // By-ref reads/deletes take an opaque `CacheRef` (the runId is already baked
-    // into the `$ref` the backing minted), so they forward straight through.
+    // By-ref reads/deletes MUST route through the backing's `*ForRun` variants,
+    // threading this wrapper's `runId`. A foreign ref (another run's blob, a
+    // malformed `$ref`, an unscoped deterministic write) then resolves to
+    // `undefined` / no-ops at the backing — the wrapper never resolves another
+    // run's bytes. The unscoped `backing.getOutputByRef` / `.getOutputStreamByRef`
+    // / `.deleteOutputByRef` are deliberately NOT forwarded here: their runId-
+    // agnostic surface is the leak this wrapper exists to close.
+    //
     // Gate them on the backing being a run-scoped STREAM backing: a ref can
     // only exist here if it was written through one of the stream writers above,
-    // so a backing that can stream-read but not stream-write-for-run (e.g. a
-    // deterministic-only streaming repo) exposes no readable refs through this
-    // wrapper and must report no read capability.
+    // so a backing that can stream-read but not stream-write-for-run exposes no
+    // readable refs through this wrapper and reports no read capability.
     if (canStreamForRun || canStreamPortForRun) {
-      if (typeof backing.getOutputByRef === "function") {
-        this.getOutputByRef = (ref) => backing.getOutputByRef!(ref);
+      if (typeof backing.getOutputByRefForRun === "function") {
+        this.getOutputByRef = (ref) => backing.getOutputByRefForRun!(ref, this.runId);
       }
-      if (typeof backing.getOutputStreamByRef === "function") {
-        this.getOutputStreamByRef = (ref) => backing.getOutputStreamByRef!(ref);
+      if (typeof backing.getOutputStreamByRefForRun === "function") {
+        this.getOutputStreamByRef = (ref) => backing.getOutputStreamByRefForRun!(ref, this.runId);
       }
-      if (typeof backing.deleteOutputByRef === "function") {
-        this.deleteOutputByRef = (ref) => backing.deleteOutputByRef!(ref);
+      if (typeof backing.deleteOutputByRefForRun === "function") {
+        this.deleteOutputByRef = (ref) => backing.deleteOutputByRefForRun!(ref, this.runId);
       }
     }
   }

--- a/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
@@ -287,8 +287,35 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     return match ? join(this.blobsDir, match[1]) : undefined;
   }
 
+  /**
+   * Return the blob path for `ref` only when its blob name lies within
+   * `runId`'s sanitized run-scope namespace. Foreign refs (malformed,
+   * wrong-runId, or unscoped deterministic writes) yield `undefined` — the
+   * caller then reports a cache miss / no-op instead of touching another run's
+   * blobs. Blob names lead with `sanitize(taskType)`, so a run's sanitized
+   * `runScopePrefix` is the shared prefix of every sidecar it wrote.
+   */
+  private blobPathInRunScope(ref: CacheRef, runId: string): string | undefined {
+    const match = REF_PATTERN.exec(ref.$ref);
+    if (match === null) return undefined;
+    const expectedPrefix = sanitize(runScopePrefix(runId));
+    if (!match[1].startsWith(expectedPrefix)) return undefined;
+    return join(this.blobsDir, match[1]);
+  }
+
   override async getOutputByRef(ref: CacheRef): Promise<Blob | undefined> {
     const path = this.blobPath(ref);
+    if (path === undefined) return undefined;
+    try {
+      return new Blob([await readFile(path)]);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw err;
+    }
+  }
+
+  override async getOutputByRefForRun(ref: CacheRef, runId: string): Promise<Blob | undefined> {
+    const path = this.blobPathInRunScope(ref, runId);
     if (path === undefined) return undefined;
     try {
       return new Blob([await readFile(path)]);
@@ -319,8 +346,30 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     return createReadStream(path, { fd, autoClose: true }) as unknown as AsyncIterable<Uint8Array>;
   }
 
+  override getOutputStreamByRefForRun(
+    ref: CacheRef,
+    runId: string
+  ): AsyncIterable<Uint8Array> | undefined {
+    const path = this.blobPathInRunScope(ref, runId);
+    if (path === undefined) return undefined;
+    let fd: number;
+    try {
+      fd = openSync(path, "r");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw err;
+    }
+    return createReadStream(path, { fd, autoClose: true }) as unknown as AsyncIterable<Uint8Array>;
+  }
+
   override async deleteOutputByRef(ref: CacheRef): Promise<void> {
     const path = this.blobPath(ref);
+    if (path === undefined) return;
+    await rm(path, { force: true });
+  }
+
+  override async deleteOutputByRefForRun(ref: CacheRef, runId: string): Promise<void> {
+    const path = this.blobPathInRunScope(ref, runId);
     if (path === undefined) return;
     await rm(path, { force: true });
   }

--- a/packages/task-graph/src/storage/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputRepository.ts
@@ -294,4 +294,34 @@ export abstract class TaskOutputRepository {
     chunks: AsyncIterable<Uint8Array>,
     metadata: Record<string, unknown>
   ): Promise<CacheRef>;
+
+  /**
+   * OPTIONAL run-scoped reader counterpart of {@link getOutputByRef}. A `ref`
+   * that was NOT produced by a `*ForRun` writer for the given `runId` MUST
+   * resolve to `undefined` — foreign refs are treated as cache misses, never
+   * as errors, to match {@link getOutputByRef}'s idempotency contract.
+   * {@link RunPrivateCacheRepo} routes its by-ref reads through this method
+   * so a wrapper never resolves another run's blob.
+   */
+  getOutputByRefForRun?(ref: CacheRef, runId: string): Promise<Blob | undefined>;
+
+  /**
+   * OPTIONAL run-scoped streaming reader counterpart of
+   * {@link getOutputStreamByRef}. A `ref` that was NOT produced by a `*ForRun`
+   * writer for the given `runId` MUST resolve to `undefined`; foreign refs
+   * never throw. Same synchronous / Promise-returning shape as the unscoped
+   * variant so async backings can probe existence before returning an iterable.
+   */
+  getOutputStreamByRefForRun?(
+    ref: CacheRef,
+    runId: string
+  ): AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+
+  /**
+   * OPTIONAL run-scoped counterpart of {@link deleteOutputByRef}. A `ref` that
+   * was NOT produced by a `*ForRun` writer for the given `runId` MUST be a
+   * no-op — foreign refs never touch disk / storage, matching the base
+   * contract's best-effort idempotency (no throw on missing entry).
+   */
+  deleteOutputByRefForRun?(ref: CacheRef, runId: string): Promise<void>;
 }

--- a/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
@@ -16,7 +16,12 @@
  */
 
 import type { StreamEvent } from "@workglow/task-graph";
-import { getStreamPortCodec, isCacheRef, RunPrivateCacheRepo } from "@workglow/task-graph";
+import {
+  getStreamPortCodec,
+  isCacheRef,
+  makeCacheRef,
+  RunPrivateCacheRepo,
+} from "@workglow/task-graph";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -133,5 +138,108 @@ describe("run-private streaming over an FsFolder backing", () => {
     expect(await repoB.getOutput("T", { p: 1 })).toEqual({ ok: "B" });
     expect(await repoB.size()).toBe(1);
     expect(blobNames(folder)).toHaveLength(1);
+    // clearRun also invalidates run-A's ref for run-B's readers: a ref that
+    // came from run-A must never resolve against run-B, even after the blob
+    // (and its run-A rows) are gone.
+    expect(await repoB.getOutputStreamByRef!(refA)).toBeUndefined();
+  });
+
+  describe("run-scope enforcement", () => {
+    it("does not resolve a ref written by another run", async () => {
+      const codec = getStreamPortCodec("append");
+      const mk = (t: string): AsyncIterable<Uint8Array> =>
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: t }]), "text");
+
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+      const wrapperB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+
+      const refB = await wrapperB.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        mk("B"),
+        {}
+      );
+
+      expect(await wrapperA.getOutputStreamByRef!(refB)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(refB)).toBeUndefined();
+    });
+
+    it("does not delete a blob written by another run", async () => {
+      const codec = getStreamPortCodec("append");
+      const mk = (t: string): AsyncIterable<Uint8Array> =>
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: t }]), "text");
+
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+      const wrapperB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+
+      const refB = await wrapperB.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        mk("B"),
+        {}
+      );
+      const blobsBefore = blobNames(folder).length;
+
+      // Silent no-op: matches the base contract's best-effort idempotency for
+      // by-ref delete (missing entries never throw). Foreign-ref alarms belong
+      // in operator observability, not on the security-invariant path — a
+      // throw here would let a hostile ref crash a legitimate wrapper.
+      await expect(wrapperA.deleteOutputByRef!(refB)).resolves.toBeUndefined();
+
+      const back = await wrapperB.getOutputStreamByRef!(refB);
+      expect(back).toBeDefined();
+      expect(await codec.materialize(back!, "text")).toBe("B");
+      expect(blobNames(folder).length).toBe(blobsBefore);
+    });
+
+    it("still resolves and deletes refs written by the same run", async () => {
+      const codec = getStreamPortCodec("append");
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+
+      const refA = await wrapperA.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: "A" }]), "text"),
+        {}
+      );
+      const before = blobNames(folder).length;
+
+      const stream = await wrapperA.getOutputStreamByRef!(refA);
+      expect(stream).toBeDefined();
+      expect(await codec.materialize(stream!, "text")).toBe("A");
+      const blob = await wrapperA.getOutputByRef!(refA);
+      expect(blob).toBeDefined();
+
+      await wrapperA.deleteOutputByRef!(refA);
+
+      expect(await wrapperA.getOutputStreamByRef!(refA)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(refA)).toBeUndefined();
+      expect(blobNames(folder).length).toBe(before - 1);
+    });
+
+    it("uniformly rejects malformed and foreign-scheme refs", async () => {
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+
+      // Well-formed fsfolder URI but with no run-scope prefix in the blob name:
+      // could only exist as a deterministic-tier write; the wrapper must not
+      // resolve it against run-A.
+      const unscoped = makeCacheRef({ $ref: "fsfolder://blobs/foreign.bin" });
+      // Foreign URI scheme entirely — never a fsfolder blob.
+      const foreign = makeCacheRef({ $ref: "other://something" });
+
+      expect(await wrapperA.getOutputStreamByRef!(unscoped)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(unscoped)).toBeUndefined();
+      await expect(wrapperA.deleteOutputByRef!(unscoped)).resolves.toBeUndefined();
+
+      expect(await wrapperA.getOutputStreamByRef!(foreign)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(foreign)).toBeUndefined();
+      await expect(wrapperA.deleteOutputByRef!(foreign)).resolves.toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

`RunPrivateCacheRepo` wraps a `TaskOutputRepository` so entries are namespaced by `runId`, but its by-ref forwarders passed `CacheRef`s straight to the backing's runId-agnostic `getOutputByRef` / `getOutputStreamByRef` / `deleteOutputByRef`. Any wrapper on the same backing could therefore resolve — and delete — another run's blob just by receiving its `CacheRef`. The private tier's whole point is per-run isolation; this made runs observable and mutable across the boundary.

The fix pushes enforcement into the backing: three optional `*ForRun` by-ref methods on the base interface, and an `FsFolder` implementation that rejects any ref whose blob name does not start with the sanitized `runScopePrefix(runId)`. The wrapper now routes exclusively through those variants, threading its own `runId`; the unscoped surface is never called from the wrapper again.

## Failure scenario

Two `RunPrivateCacheRepo` wrappers (`run-A`, `run-B`) share one `FsFolderTaskOutputRepository`. `run-B` writes a streamed port and gets `refB`. Before this change, `wrapperA.getOutputStreamByRef(refB)` returned `run-B`'s bytes, `wrapperA.getOutputByRef(refB)` returned `run-B`'s blob, and `wrapperA.deleteOutputByRef(refB)` unlinked it — a cross-run read/write channel via any leaked ref.

## Approach

- Add three optional `*ForRun` by-ref methods to `TaskOutputRepository`: `getOutputByRefForRun`, `getOutputStreamByRefForRun`, `deleteOutputByRefForRun`. Each carries a JSDoc contract that a foreign ref MUST resolve to `undefined` (readers) or be a no-op (delete), matching the base by-ref idempotency contract.
- Implement them on `FsFolderTaskOutputRepository`. A shared `blobPathInRunScope(ref, runId)` helper parses the ref through the existing `REF_PATTERN` and requires the captured blob name to start with `sanitize(runScopePrefix(runId))`. On a mismatch the readers return `undefined` and delete never touches disk.
- Rewire `RunPrivateCacheRepo`'s constructor by-ref forwarders to route only through the `*ForRun` variants, gated on the existing `canStreamForRun || canStreamPortForRun` capability. **Delete the forwards to `backing.getOutputByRef` / `.getOutputStreamByRef` / `.deleteOutputByRef` entirely.** Backings without the `*ForRun` ref methods leave the wrapper's method `undefined` (private tier degrades gracefully to accumulation for reads).

## Test coverage

New `describe("run-scope enforcement", ...)` block in `RunPrivateFsFolderStream.test.ts`:

1. **Negative — cross-run stream/blob read.** `wrapperA.getOutputStreamByRef(refB)` and `wrapperA.getOutputByRef(refB)` both resolve to `undefined`.
2. **Negative — cross-run delete.** `wrapperA.deleteOutputByRef(refB)` resolves without throwing; `wrapperB` can still read the blob and the blob count is unchanged. Case carries a comment justifying the silent no-op: matches the base contract's best-effort idempotency; alarms belong in operator observability, not the security-invariant path.
3. **Positive regression.** `wrapperA` reads and deletes its own `refA` through all three methods; delete prunes exactly one blob.
4. **Edge — malformed / foreign-scheme refs.** `makeCacheRef({ $ref: "fsfolder://blobs/foreign.bin" })` (missing run-scope prefix) and `makeCacheRef({ $ref: "other://something" })` are both uniformly rejected: readers `undefined`, delete silent no-op.

Strengthened `clearRun()` assertion: after `repoA.clearRun()`, `repoB.getOutputStreamByRef(refA)` also resolves to `undefined`.

## Sequencing

Three commits, in order:

1. **`feat(task-graph): add optional *ForRun ref methods to TaskOutputRepository`** — interface-only. No behavior change; every existing implementer compiles unchanged.
2. **`feat(task-graph): implement runId-scoped ref readers on FsFolder`** — the three `*ForRun` methods with the sanitized-prefix check. Existing tests still pass; wrapper still uses the unscoped path so the fix is not yet observable.
3. **`fix(task-graph): route RunPrivateCacheRepo by-ref through *ForRun to prevent cross-run leak`** — wrapper rewire + drop the unscoped forwarders + four new tests + strengthened `clearRun` assertion. The vulnerability closes here.

## Verification

- `bun run build:types` — clean.
- `bun scripts/test.ts graph vitest` — **1033 passed / 1033 total** (up from 1029 pre-change; four new tests added, no existing test weakened).
- `grep -rn 'fsfolder://' packages --include='*.ts'` — the only hand-constructed `fsfolder://` refs outside the sanctioned writer paths in `FsFolderTaskOutputRepository.ts` are in test files (pre-existing edge-case tests plus the new negative-edge test added here).

Base is PR #611's head (`claude/task-graph-streaming-phase3-yg5msj`), not `main`, because #611 is not yet merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_019nPCEAuvb2Np5zqB6JLRna)_