### PR TITLE
fix(task-graph): close prefix-boundary + tier-share leaks in RunPrivateCacheRepo (follow-up to #612)

### DIFF
--- a/packages/task-graph/src/cache/CacheRegistry.ts
+++ b/packages/task-graph/src/cache/CacheRegistry.ts
@@ -19,6 +19,21 @@ import type { TaskOutputRepository } from "../storage/TaskOutputRepository";
  *
  * Both slots are optional. When a slot is unset, caching for matching tasks is
  * a silent no-op — the task still runs correctly, just uncached.
+ *
+ * The two slots MUST NOT share a backing repository instance. `private` scopes
+ * every read/delete by `runId` (via `RunPrivateCacheRepo`'s `*ForRun` routing)
+ * specifically so one run cannot see another's rows or blobs; `deterministic`
+ * has no such scoping by design. If both slots resolve to the same backing,
+ * `TaskRunner.hydrateInputRefs`'s fallback loop — which tries `private` first
+ * and falls through to `deterministic` on a miss — lets a foreign-run ref that
+ * `private` correctly rejects still resolve via the unscoped `deterministic`
+ * reader, silently reopening the cross-run leak the scoping exists to close.
+ * `TaskRunner` throws a `TaskConfigurationError` at run-start when it detects
+ * this (`private instanceof RunPrivateCacheRepo && private.backing ===
+ * deterministic`). Note this only catches the *same-instance* case: two
+ * separate `FsFolderTaskOutputRepository` instances pointed at the same folder
+ * path are a residual, currently-undetected variant of the same
+ * misconfiguration — deferred.
  */
 export interface CacheRegistry {
   deterministic?: TaskOutputRepository;

--- a/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
+++ b/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
@@ -38,13 +38,13 @@ export interface RunPrivateCacheRepoOptions {
 export class RunPrivateCacheRepo extends TaskOutputRepository {
   private static fallbackWarned = false;
 
-  private readonly backing: TaskOutputRepository;
+  private readonly _backing: TaskOutputRepository;
   private readonly runId: string;
   private observedFallback: boolean = false;
 
   constructor({ backing, runId }: RunPrivateCacheRepoOptions) {
     super({ outputCompression: backing.outputCompression });
-    this.backing = backing;
+    this._backing = backing;
     this.runId = runId;
 
     // Streaming is a per-backing capability: only backings with a sidecar
@@ -124,14 +124,14 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
     output: TaskOutput,
     createdAt?: Date
   ): Promise<void> {
-    await this.backing.saveOutputForRun(this.runId, cacheIdentity, inputs, output, createdAt);
+    await this._backing.saveOutputForRun(this.runId, cacheIdentity, inputs, output, createdAt);
   }
 
   public async getOutput(
     cacheIdentity: string,
     inputs: TaskInput
   ): Promise<TaskOutput | undefined> {
-    return this.backing.getOutputForRun(this.runId, cacheIdentity, inputs);
+    return this._backing.getOutputForRun(this.runId, cacheIdentity, inputs);
   }
 
   /**
@@ -149,7 +149,7 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
    * on the backing's runId-leading primary key — not a table scan.
    */
   public async clearRun(): Promise<void> {
-    await this.backing.deleteRun(this.runId);
+    await this._backing.deleteRun(this.runId);
   }
 
   /**
@@ -157,7 +157,7 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
    * `saveOutput`/`getOutput`/`clear()` being run-scoped.
    */
   public async size(): Promise<number> {
-    return this.backing.sizeForRun(this.runId);
+    return this._backing.sizeForRun(this.runId);
   }
 
   /**
@@ -166,10 +166,21 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
    * private rows. An indexed `deleteSearch({ runId, createdAt: { "<" } })`.
    */
   public async clearOlderThan(olderThanInMs: number): Promise<void> {
-    await this.backing.deleteRunOlderThan(this.runId, olderThanInMs);
+    await this._backing.deleteRunOlderThan(this.runId, olderThanInMs);
   }
 
   public isDurable(): boolean {
-    return this.backing.isDurable();
+    return this._backing.isDurable();
+  }
+
+  /**
+   * The backing repository this wrapper scopes by `runId`. Exposed so callers
+   * (e.g. {@link TaskRunner}'s cache-registry validation) can detect a
+   * misconfiguration where the private and deterministic tiers share the same
+   * backing instance — see the guard in `TaskRunner` for why that combination
+   * must be rejected rather than silently accepted.
+   */
+  public get backing(): TaskOutputRepository {
+    return this._backing;
   }
 }

--- a/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
+++ b/packages/task-graph/src/cache/RunPrivateCacheRepo.ts
@@ -72,22 +72,27 @@ export class RunPrivateCacheRepo extends TaskOutputRepository {
           metadata
         );
     }
-    // By-ref reads/deletes take an opaque `CacheRef` (the runId is already baked
-    // into the `$ref` the backing minted), so they forward straight through.
+    // By-ref reads/deletes MUST route through the backing's `*ForRun` variants,
+    // threading this wrapper's `runId`. A foreign ref (another run's blob, a
+    // malformed `$ref`, an unscoped deterministic write) then resolves to
+    // `undefined` / no-ops at the backing — the wrapper never resolves another
+    // run's bytes. The unscoped `backing.getOutputByRef` / `.getOutputStreamByRef`
+    // / `.deleteOutputByRef` are deliberately NOT forwarded here: their runId-
+    // agnostic surface is the leak this wrapper exists to close.
+    //
     // Gate them on the backing being a run-scoped STREAM backing: a ref can
     // only exist here if it was written through one of the stream writers above,
-    // so a backing that can stream-read but not stream-write-for-run (e.g. a
-    // deterministic-only streaming repo) exposes no readable refs through this
-    // wrapper and must report no read capability.
+    // so a backing that can stream-read but not stream-write-for-run exposes no
+    // readable refs through this wrapper and reports no read capability.
     if (canStreamForRun || canStreamPortForRun) {
-      if (typeof backing.getOutputByRef === "function") {
-        this.getOutputByRef = (ref) => backing.getOutputByRef!(ref);
+      if (typeof backing.getOutputByRefForRun === "function") {
+        this.getOutputByRef = (ref) => backing.getOutputByRefForRun!(ref, this.runId);
       }
-      if (typeof backing.getOutputStreamByRef === "function") {
-        this.getOutputStreamByRef = (ref) => backing.getOutputStreamByRef!(ref);
+      if (typeof backing.getOutputStreamByRefForRun === "function") {
+        this.getOutputStreamByRef = (ref) => backing.getOutputStreamByRefForRun!(ref, this.runId);
       }
-      if (typeof backing.deleteOutputByRef === "function") {
-        this.deleteOutputByRef = (ref) => backing.deleteOutputByRef!(ref);
+      if (typeof backing.deleteOutputByRefForRun === "function") {
+        this.deleteOutputByRef = (ref) => backing.deleteOutputByRefForRun!(ref, this.runId);
       }
     }
   }

--- a/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
@@ -35,17 +35,29 @@ function sanitize(s: string): string {
 /**
  * Fold a `runId` into the `taskType` axis. FsFolder has no runId column — rows
  * are keyed `(taskType, key)` and blob names lead with `sanitize(taskType)` —
- * so scoping a private run means prefixing its taskType. The `::` terminator
- * keeps one runId's namespace from being a prefix of another's (e.g. `a` vs
- * `ab`), so a run's rows and sidecar blobs are prefix-selectable for cleanup.
+ * so scoping a private run means prefixing its taskType.
+ *
+ * The prefix is netstring-encoded (`__run:<len>:<runId>::`), where `<len>` is
+ * `runId.length`. A trailing `::` terminator alone is *not* sufficient: every
+ * prefix comparison here runs through {@link sanitize}, which collapses `:`
+ * (and every other non-word, non-`.`/`-` character) to `-`. That maps `::` to
+ * `--`, which a crafted runId can also produce or extend — e.g.
+ * `sanitize(runScopePrefix("session1"))` is a strict prefix of
+ * `sanitize(runScopePrefix("session1-"))`, so `session1`'s wrapper would
+ * accept and could delete `session1-`'s blobs. The length digits sanitize to
+ * themselves (`\d` is a word character), so encoding `runId.length` ahead of
+ * `runId` guarantees any two distinct runIds diverge at their length field
+ * before either one's content is compared — the standard netstring property
+ * that makes the boundary between "length" and "payload" unambiguous no
+ * matter what characters the payload contains.
  */
 function runScopedType(runId: string, taskType: string): string {
-  return `__run:${runId}::${taskType}`;
+  return `${runScopePrefix(runId)}${taskType}`;
 }
 
 /** The taskType-namespace prefix for a run (see {@link runScopedType}). */
 function runScopePrefix(runId: string): string {
-  return `__run:${runId}::`;
+  return `__run:${runId.length}:${runId}::`;
 }
 
 /**

--- a/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/FsFolderTaskOutputRepository.ts
@@ -287,8 +287,35 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     return match ? join(this.blobsDir, match[1]) : undefined;
   }
 
+  /**
+   * Return the blob path for `ref` only when its blob name lies within
+   * `runId`'s sanitized run-scope namespace. Foreign refs (malformed,
+   * wrong-runId, or unscoped deterministic writes) yield `undefined` — the
+   * caller then reports a cache miss / no-op instead of touching another run's
+   * blobs. Blob names lead with `sanitize(taskType)`, so a run's sanitized
+   * `runScopePrefix` is the shared prefix of every sidecar it wrote.
+   */
+  private blobPathInRunScope(ref: CacheRef, runId: string): string | undefined {
+    const match = REF_PATTERN.exec(ref.$ref);
+    if (match === null) return undefined;
+    const expectedPrefix = sanitize(runScopePrefix(runId));
+    if (!match[1].startsWith(expectedPrefix)) return undefined;
+    return join(this.blobsDir, match[1]);
+  }
+
   override async getOutputByRef(ref: CacheRef): Promise<Blob | undefined> {
     const path = this.blobPath(ref);
+    if (path === undefined) return undefined;
+    try {
+      return new Blob([await readFile(path)]);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw err;
+    }
+  }
+
+  override async getOutputByRefForRun(ref: CacheRef, runId: string): Promise<Blob | undefined> {
+    const path = this.blobPathInRunScope(ref, runId);
     if (path === undefined) return undefined;
     try {
       return new Blob([await readFile(path)]);
@@ -319,8 +346,30 @@ export class FsFolderTaskOutputRepository extends TaskOutputTabularRepository {
     return createReadStream(path, { fd, autoClose: true }) as unknown as AsyncIterable<Uint8Array>;
   }
 
+  override getOutputStreamByRefForRun(
+    ref: CacheRef,
+    runId: string
+  ): AsyncIterable<Uint8Array> | undefined {
+    const path = this.blobPathInRunScope(ref, runId);
+    if (path === undefined) return undefined;
+    let fd: number;
+    try {
+      fd = openSync(path, "r");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw err;
+    }
+    return createReadStream(path, { fd, autoClose: true }) as unknown as AsyncIterable<Uint8Array>;
+  }
+
   override async deleteOutputByRef(ref: CacheRef): Promise<void> {
     const path = this.blobPath(ref);
+    if (path === undefined) return;
+    await rm(path, { force: true });
+  }
+
+  override async deleteOutputByRefForRun(ref: CacheRef, runId: string): Promise<void> {
+    const path = this.blobPathInRunScope(ref, runId);
     if (path === undefined) return;
     await rm(path, { force: true });
   }

--- a/packages/task-graph/src/storage/TaskOutputRepository.ts
+++ b/packages/task-graph/src/storage/TaskOutputRepository.ts
@@ -294,4 +294,34 @@ export abstract class TaskOutputRepository {
     chunks: AsyncIterable<Uint8Array>,
     metadata: Record<string, unknown>
   ): Promise<CacheRef>;
+
+  /**
+   * OPTIONAL run-scoped reader counterpart of {@link getOutputByRef}. A `ref`
+   * that was NOT produced by a `*ForRun` writer for the given `runId` MUST
+   * resolve to `undefined` — foreign refs are treated as cache misses, never
+   * as errors, to match {@link getOutputByRef}'s idempotency contract.
+   * {@link RunPrivateCacheRepo} routes its by-ref reads through this method
+   * so a wrapper never resolves another run's blob.
+   */
+  getOutputByRefForRun?(ref: CacheRef, runId: string): Promise<Blob | undefined>;
+
+  /**
+   * OPTIONAL run-scoped streaming reader counterpart of
+   * {@link getOutputStreamByRef}. A `ref` that was NOT produced by a `*ForRun`
+   * writer for the given `runId` MUST resolve to `undefined`; foreign refs
+   * never throw. Same synchronous / Promise-returning shape as the unscoped
+   * variant so async backings can probe existence before returning an iterable.
+   */
+  getOutputStreamByRefForRun?(
+    ref: CacheRef,
+    runId: string
+  ): AsyncIterable<Uint8Array> | undefined | Promise<AsyncIterable<Uint8Array> | undefined>;
+
+  /**
+   * OPTIONAL run-scoped counterpart of {@link deleteOutputByRef}. A `ref` that
+   * was NOT produced by a `*ForRun` writer for the given `runId` MUST be a
+   * no-op — foreign refs never touch disk / storage, matching the base
+   * contract's best-effort idempotency (no throw on missing entry).
+   */
+  deleteOutputByRefForRun?(ref: CacheRef, runId: string): Promise<void>;
 }

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -884,6 +884,26 @@ export class TaskRunner<
         : undefined;
     }
 
+    // Fail fast when the private and deterministic slots share a backing.
+    // `hydrateInputRefs` tries `private` first and falls through to
+    // `deterministic` on a miss; if both slots resolve to the same instance,
+    // a foreign-run ref that `private`'s RunPrivateCacheRepo correctly rejects
+    // would still resolve through the unscoped `deterministic` reader,
+    // silently reopening the cross-run leak. Checked here (before any input
+    // hydration runs for this run) rather than only where the policy is
+    // consulted, so the misconfiguration is caught before it can be exploited.
+    if (
+      this.cacheRegistry?.private instanceof RunPrivateCacheRepo &&
+      this.cacheRegistry.deterministic !== undefined &&
+      this.cacheRegistry.private.backing === this.cacheRegistry.deterministic
+    ) {
+      throw new TaskConfigurationError(
+        `TaskRunner: CacheRegistry's "private" and "deterministic" slots resolve to the same ` +
+          `backing repository. The private tier's runId scoping only holds if the deterministic ` +
+          `tier cannot be used to bypass it — point the two slots at distinct backing instances.`
+      );
+    }
+
     // shouldAccumulate defaults to true (backward-compatible for standalone runs)
     ctx.shouldAccumulate = config.shouldAccumulate !== false;
 

--- a/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
@@ -16,7 +16,12 @@
  */
 
 import type { StreamEvent } from "@workglow/task-graph";
-import { getStreamPortCodec, isCacheRef, RunPrivateCacheRepo } from "@workglow/task-graph";
+import {
+  getStreamPortCodec,
+  isCacheRef,
+  makeCacheRef,
+  RunPrivateCacheRepo,
+} from "@workglow/task-graph";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -133,5 +138,108 @@ describe("run-private streaming over an FsFolder backing", () => {
     expect(await repoB.getOutput("T", { p: 1 })).toEqual({ ok: "B" });
     expect(await repoB.size()).toBe(1);
     expect(blobNames(folder)).toHaveLength(1);
+    // clearRun also invalidates run-A's ref for run-B's readers: a ref that
+    // came from run-A must never resolve against run-B, even after the blob
+    // (and its run-A rows) are gone.
+    expect(await repoB.getOutputStreamByRef!(refA)).toBeUndefined();
+  });
+
+  describe("run-scope enforcement", () => {
+    it("does not resolve a ref written by another run", async () => {
+      const codec = getStreamPortCodec("append");
+      const mk = (t: string): AsyncIterable<Uint8Array> =>
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: t }]), "text");
+
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+      const wrapperB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+
+      const refB = await wrapperB.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        mk("B"),
+        {}
+      );
+
+      expect(await wrapperA.getOutputStreamByRef!(refB)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(refB)).toBeUndefined();
+    });
+
+    it("does not delete a blob written by another run", async () => {
+      const codec = getStreamPortCodec("append");
+      const mk = (t: string): AsyncIterable<Uint8Array> =>
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: t }]), "text");
+
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+      const wrapperB = new RunPrivateCacheRepo({ backing, runId: "run-B" });
+
+      const refB = await wrapperB.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        mk("B"),
+        {}
+      );
+      const blobsBefore = blobNames(folder).length;
+
+      // Silent no-op: matches the base contract's best-effort idempotency for
+      // by-ref delete (missing entries never throw). Foreign-ref alarms belong
+      // in operator observability, not on the security-invariant path — a
+      // throw here would let a hostile ref crash a legitimate wrapper.
+      await expect(wrapperA.deleteOutputByRef!(refB)).resolves.toBeUndefined();
+
+      const back = await wrapperB.getOutputStreamByRef!(refB);
+      expect(back).toBeDefined();
+      expect(await codec.materialize(back!, "text")).toBe("B");
+      expect(blobNames(folder).length).toBe(blobsBefore);
+    });
+
+    it("still resolves and deletes refs written by the same run", async () => {
+      const codec = getStreamPortCodec("append");
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+
+      const refA = await wrapperA.saveOutputStreamPort!(
+        "T",
+        { p: 1 },
+        "text",
+        "append",
+        codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: "A" }]), "text"),
+        {}
+      );
+      const before = blobNames(folder).length;
+
+      const stream = await wrapperA.getOutputStreamByRef!(refA);
+      expect(stream).toBeDefined();
+      expect(await codec.materialize(stream!, "text")).toBe("A");
+      const blob = await wrapperA.getOutputByRef!(refA);
+      expect(blob).toBeDefined();
+
+      await wrapperA.deleteOutputByRef!(refA);
+
+      expect(await wrapperA.getOutputStreamByRef!(refA)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(refA)).toBeUndefined();
+      expect(blobNames(folder).length).toBe(before - 1);
+    });
+
+    it("uniformly rejects malformed and foreign-scheme refs", async () => {
+      const wrapperA = new RunPrivateCacheRepo({ backing, runId: "run-A" });
+
+      // Well-formed fsfolder URI but with no run-scope prefix in the blob name:
+      // could only exist as a deterministic-tier write; the wrapper must not
+      // resolve it against run-A.
+      const unscoped = makeCacheRef({ $ref: "fsfolder://blobs/foreign.bin" });
+      // Foreign URI scheme entirely — never a fsfolder blob.
+      const foreign = makeCacheRef({ $ref: "other://something" });
+
+      expect(await wrapperA.getOutputStreamByRef!(unscoped)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(unscoped)).toBeUndefined();
+      await expect(wrapperA.deleteOutputByRef!(unscoped)).resolves.toBeUndefined();
+
+      expect(await wrapperA.getOutputStreamByRef!(foreign)).toBeUndefined();
+      expect(await wrapperA.getOutputByRef!(foreign)).toBeUndefined();
+      await expect(wrapperA.deleteOutputByRef!(foreign)).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
+++ b/packages/test/src/test/task-graph-cache/RunPrivateFsFolderStream.test.ts
@@ -242,4 +242,57 @@ describe("run-private streaming over an FsFolder backing", () => {
       await expect(wrapperA.deleteOutputByRef!(foreign)).resolves.toBeUndefined();
     });
   });
+
+  describe("prefix-boundary collision", () => {
+    // Before the netstring-length fix, sanitize() collapsed the "::" run-scope
+    // terminator to "--", so sanitize(runScopePrefix(victim)) could be a strict
+    // prefix of sanitize(runScopePrefix(attacker)) whenever `attacker` extended
+    // `victim` with dash-mappable characters. That let the victim's wrapper
+    // accept — and delete — blobs it never wrote. Each pair below reproduces a
+    // distinct flavor of that collision (a trailing dash, a literal colon, and
+    // a dash immediately after the terminator).
+    it.each([
+      ["session1", "session1-"],
+      ["run-1", "run-1:x"],
+      ["x", "x-y"],
+    ])(
+      "does not let victim %j read or delete a blob written by attacker %j",
+      async (victimRunId, attackerRunId) => {
+        const codec = getStreamPortCodec("append");
+        const mk = (t: string): AsyncIterable<Uint8Array> =>
+          codec.encode(fromArray([{ type: "text-delta", port: "text", textDelta: t }]), "text");
+
+        const wrapperVictim = new RunPrivateCacheRepo({ backing, runId: victimRunId });
+        const wrapperAttacker = new RunPrivateCacheRepo({ backing, runId: attackerRunId });
+
+        const refAttacker = await wrapperAttacker.saveOutputStreamPort!(
+          "T",
+          { p: 1 },
+          "text",
+          "append",
+          mk("attacker-payload"),
+          {}
+        );
+        const blobsBefore = blobNames(folder).length;
+
+        // Read rejection: the victim's wrapper must not resolve the attacker's ref.
+        expect(await wrapperVictim.getOutputStreamByRef!(refAttacker)).toBeUndefined();
+        expect(await wrapperVictim.getOutputByRef!(refAttacker)).toBeUndefined();
+
+        // Delete rejection: a silent no-op (matching the base by-ref delete
+        // contract), and the attacker's blob must survive.
+        await expect(wrapperVictim.deleteOutputByRef!(refAttacker)).resolves.toBeUndefined();
+        expect(blobNames(folder).length).toBe(blobsBefore);
+
+        // Positive control: the attacker can still round-trip its own ref.
+        const back = await wrapperAttacker.getOutputStreamByRef!(refAttacker);
+        expect(back).toBeDefined();
+        expect(await codec.materialize(back!, "text")).toBe("attacker-payload");
+
+        await wrapperAttacker.deleteOutputByRef!(refAttacker);
+        expect(await wrapperAttacker.getOutputStreamByRef!(refAttacker)).toBeUndefined();
+        expect(blobNames(folder).length).toBe(blobsBefore - 1);
+      }
+    );
+  });
 });


### PR DESCRIPTION
## Summary

PR #612 added run-scoped by-ref readers to close a cross-run leak in the FsFolder task-output cache, but left two related gaps. First, `runScopePrefix`'s `"::"` terminator is not actually unambiguous once it passes through `sanitize()` (which collapses `:` to `-`), so one runId's sanitized scope prefix can be a strict prefix of another's — a `RunPrivateCacheRepo` wrapper for one run can then read or delete blobs belonging to a different run. Second, even with that fixed, if an operator points the `CacheRegistry`'s `private` and `deterministic` slots at the same backing instance, `TaskRunner.hydrateInputRefs`'s private-then-deterministic fallback lets a foreign-run ref that the private wrapper correctly rejects still resolve through the unscoped deterministic reader — reopening the same class of leak at a different layer.

Both are closed here: an unambiguous (netstring-style) length-prefixed encoding for `runScopePrefix`, and a config-time guard in `TaskRunner` that throws when the two cache-registry slots share a backing.

## Failure scenario

Before this fix:
- `sanitize(runScopePrefix("session1"))` === `"__run-session1--"`
- `sanitize(runScopePrefix("session1-"))` === `"__run-session1---"`

The first is a strict prefix of the second, so a `RunPrivateCacheRepo` wrapper scoped to `run=session1` accepts blob names that actually belong to `run=session1-`, and can delete them via `deleteOutputByRef`.

## Approach

- **Netstring-length encoding**: `runScopePrefix(runId)` is now `` `__run:${runId.length}:${runId}::` ``. Any two distinct runIds diverge at their length digits (which sanitize to themselves) before either one's content is compared, so no runId's sanitized prefix can ever be a strict prefix of another's. This is a minimal, localized change — no schema or ref-format migration, and since PR #612's branch is unmerged, there's no back-compat burden.
- **Config-time guard**: rather than tagging every `CacheRef` with its owning tier (a larger, riskier change touching the ref schema and every reader), `TaskRunner.handleStart` now rejects a `CacheRegistry` where `private instanceof RunPrivateCacheRepo` and `private.backing === deterministic`, before any input hydration for the run. This catches the misconfiguration at its source instead of trying to make every consumer of the two slots re-derive tier ownership from ref shape.
- The **same-folder-path-but-different-instance** variant (two separate `FsFolderTaskOutputRepository`s pointed at the same directory) is a residual, currently-undetected case of the same underlying problem; documented as deferred on `CacheRegistry`.

## Test coverage

Added a `describe("prefix-boundary collision", ...)` suite in `RunPrivateFsFolderStream.test.ts` covering 3 (victim, attacker) runId pairs that reproduce distinct flavors of the pre-fix collision:
- `session1` / `session1-`
- `run-1` / `run-1:x`
- `x` / `x-y`

For each pair: the victim's wrapper cannot read (`getOutputStreamByRef` / `getOutputByRef` → `undefined`) or delete (`deleteOutputByRef` resolves as a no-op, blob count unchanged) a blob written by the attacker's wrapper, plus a positive control that the attacker can still round-trip and delete its own ref.

## Verification

```
bun scripts/test.ts graph vitest
```
1036 tests passed / 114 files passed (up from 1033 before this branch's test additions — net +3 for the new prefix-boundary suite).

```
bunx turbo run build-types --filter=@workglow/task-graph
bunx turbo run build-types --filter=@workglow/test
```
Both succeed (task-graph + its full dependency chain, and the test package).

```
grep -rn "sanitize(runScopePrefix\|sanitize(nsPrefix" packages/task-graph/src
grep -rn "runScopePrefix" packages/task-graph/src
```
Confirms every sanitized-prefix comparison routes through the single `runScopePrefix` function in `FsFolderTaskOutputRepository.ts` — no duplicated/inlined prefix logic elsewhere.

## Sequencing

1. `fix(task-graph): use netstring-length prefix in runScopePrefix to prevent collision`
2. `test(task-graph): pin cross-run prefix-boundary rejection`
3. `fix(task-graph): fail fast when private and deterministic tiers share a backing`

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4LhPHFo9KQdKaEAuABcYd)_