### PR TITLE
fix(tasks): route SafeFetch.server redirect ceiling through SECURITY_LIMITS

### DIFF
--- a/packages/tasks/src/util/SafeFetch.server.ts
+++ b/packages/tasks/src/util/SafeFetch.server.ts
@@ -18,6 +18,7 @@
  * `packages/tasks/src/bun.ts` via `registerSafeFetch`.
  */
 
+import { SECURITY_LIMITS } from "@workglow/util";
 import { lookup as dnsLookup } from "node:dns/promises";
 import { Agent, fetch as undiciFetch } from "undici";
 import {
@@ -28,7 +29,7 @@ import {
 import { registerSafeFetch, type SafeFetchFn, type SafeFetchOptions } from "./SafeFetch";
 import { classifyIpLiteral, classifyUrl, urlMatchesScope } from "./UrlClassifier";
 
-const MAX_REDIRECT_HOPS = 20;
+const MAX_REDIRECT_HOPS = SECURITY_LIMITS.safeFetchMaxRedirectHops;
 
 /**
  * Close an undici {@link Agent} if it exposes a `close` method.


### PR DESCRIPTION
## Summary

Route the server-side `SafeFetch` (Node/Bun) redirect ceiling through
`SECURITY_LIMITS.safeFetchMaxRedirectHops` instead of a local hardcoded `20`,
matching what the browser sibling (`SafeFetch.ts`) already does.

## Failure scenario

The consolidation into `SECURITY_LIMITS` in `packages/util/src/limits.ts`
covered the browser `SafeFetch.ts` but missed `SafeFetch.server.ts` — the
Node/Bun path that additionally does DNS pre-resolution and undici-Agent
connection pinning to defeat DNS rebinding. As a result the two entrypoints
could drift on their SSRF redirect-hop cap: raising or lowering the ceiling
in `limits.ts` would only affect the browser path, and the server would
silently keep the stale value. That is exactly the drift risk the
`SECURITY_LIMITS` constant was introduced to prevent.

## Fix

- Import `SECURITY_LIMITS` from `@workglow/util` (already a peer dependency
  of `@workglow/tasks`).
- Replace `const MAX_REDIRECT_HOPS = 20;` with
  `const MAX_REDIRECT_HOPS = SECURITY_LIMITS.safeFetchMaxRedirectHops;`.

Two-line change; the constant name and its call site in the redirect loop
are unchanged, and `SECURITY_LIMITS.safeFetchMaxRedirectHops` is `20`, so
this is behavior-preserving.

## Test plan

- [x] `bun run build:types` — passes across all 36 packages.
- [x] Diff review: identical value (20), identical const name, import
      placement matches the browser sibling.
- [ ] Manual smoke: server-side redirect chains beyond the ceiling still
      throw `TOO_MANY_REDIRECTS`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0144REafnz73SXwzutnm8sTP)_