### PR TITLE
Migrate Gemini provider to @google/genai SDK and add thinking model support

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -62,7 +62,7 @@
     "node-llama-cpp": "catalog:",
     "@huggingface/inference": "catalog:",
     "@anthropic-ai/sdk": "catalog:",
-    "@google/generative-ai": "catalog:",
+    "@google/genai": "catalog:",
     "@napi-rs/keyring": "^1.3.0",
     "@inkjs/ui": "^2.0.0",
     "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@mediapipe/tasks-genai": "^0.10.29",
     "@anthropic-ai/sdk": "^0.110.0",
     "electron": "^42.5.0",
-    "@google/generative-ai": "^0.24.1",
+    "@google/genai": "^2.10.0",
     "node-llama-cpp": "^3.19.0",
     "needle-rs": "^0.1.0",
     "@huggingface/inference": "^4.13.23",

--- a/packages/ai/src/task/AiChatTask.ts
+++ b/packages/ai/src/task/AiChatTask.ts
@@ -168,14 +168,26 @@ export type AiChatTaskInput = Omit<
       | (
           | { type: "text"; text: string }
           | { type: "image"; mimeType: string; data: string }
-          | { type: "tool_use"; id: string; name: string; input: { [x: string]: unknown } }
+          | {
+              type: "tool_use";
+              id: string;
+              name: string;
+              input: { [x: string]: unknown };
+              providerSignature?: string | undefined;
+            }
           | {
               is_error?: boolean | undefined;
               type: "tool_result";
               content: (
                 | { type: "text"; text: string }
                 | { type: "image"; mimeType: string; data: string }
-                | { type: "tool_use"; id: string; name: string; input: { [x: string]: unknown } }
+                | {
+                    type: "tool_use";
+                    id: string;
+                    name: string;
+                    input: { [x: string]: unknown };
+                    providerSignature?: string | undefined;
+                  }
               )[];
               tool_use_id: string;
             }

--- a/packages/ai/src/task/AiChatWithKbTask.ts
+++ b/packages/ai/src/task/AiChatWithKbTask.ts
@@ -272,14 +272,26 @@ export type AiChatWithKbTaskInput = Omit<
       | (
           | { type: "text"; text: string }
           | { type: "image"; mimeType: string; data: string }
-          | { type: "tool_use"; id: string; name: string; input: { [x: string]: unknown } }
+          | {
+              type: "tool_use";
+              id: string;
+              name: string;
+              input: { [x: string]: unknown };
+              providerSignature?: string | undefined;
+            }
           | {
               is_error?: boolean | undefined;
               type: "tool_result";
               content: (
                 | { type: "text"; text: string }
                 | { type: "image"; mimeType: string; data: string }
-                | { type: "tool_use"; id: string; name: string; input: { [x: string]: unknown } }
+                | {
+                    type: "tool_use";
+                    id: string;
+                    name: string;
+                    input: { [x: string]: unknown };
+                    providerSignature?: string | undefined;
+                  }
               )[];
               tool_use_id: string;
             }

--- a/packages/ai/src/task/ChatMessage.ts
+++ b/packages/ai/src/task/ChatMessage.ts
@@ -22,6 +22,14 @@ export type ContentBlockToolUse = {
   readonly id: string;
   readonly name: string;
   readonly input: Record<string, unknown>;
+  /**
+   * Opaque, provider-scoped signature that some models attach to a tool call
+   * and require to be echoed back verbatim on the corresponding request part in
+   * later turns. Gemini "thinking" models (2.5+/3.x) return a `thoughtSignature`
+   * here; replaying it is mandatory or the API rejects the multi-turn request.
+   * Providers that have no such concept leave it undefined.
+   */
+  readonly providerSignature?: string;
 };
 
 /**
@@ -79,6 +87,7 @@ const ContentBlockToolUseSchema = {
     id: { type: "string" },
     name: { type: "string" },
     input: { type: "object", additionalProperties: true },
+    providerSignature: { type: "string" },
   },
   required: ["type", "id", "name", "input"],
   additionalProperties: false,

--- a/packages/ai/src/task/ToolCallingTask.ts
+++ b/packages/ai/src/task/ToolCallingTask.ts
@@ -280,7 +280,12 @@ export type ToolCallingTaskInput = Omit<
 
 export type ToolCallingTaskOutput = {
   text: string;
-  toolCalls: { id: string; name: string; input: { [x: string]: unknown } }[];
+  toolCalls: {
+    id: string;
+    name: string;
+    input: { [x: string]: unknown };
+    providerSignature?: string;
+  }[];
 };
 export type ToolCallingTaskConfig = TaskConfig<ToolCallingTaskInput>;
 

--- a/packages/ai/src/task/ToolCallingTask.ts
+++ b/packages/ai/src/task/ToolCallingTask.ts
@@ -125,6 +125,12 @@ const ToolCallSchema = {
       description: "The input arguments for the tool call",
       additionalProperties: true,
     },
+    providerSignature: {
+      type: "string",
+      title: "Provider Signature",
+      description:
+        "Opaque provider-scoped signature (e.g. Gemini's thoughtSignature) to replay on later turns",
+    },
   },
   required: ["id", "name", "input"],
   additionalProperties: false,

--- a/packages/ai/src/task/ToolCallingUtils.ts
+++ b/packages/ai/src/task/ToolCallingUtils.ts
@@ -53,6 +53,12 @@ export interface ToolCall {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  /**
+   * Opaque, provider-scoped signature the model attached to this call that must
+   * be echoed back verbatim when the call is replayed in a later turn (e.g.
+   * Gemini's `thoughtSignature`). Undefined for providers without the concept.
+   */
+  providerSignature?: string;
 }
 
 export type ToolCalls = Array<ToolCall>;

--- a/packages/test/src/contract/ai-provider/assertions/toolCallMultiTurn.ts
+++ b/packages/test/src/contract/ai-provider/assertions/toolCallMultiTurn.ts
@@ -52,7 +52,16 @@ export function toolCallMultiTurnBlock(
               role: "assistant",
               content: [
                 { type: "text", text: r1.text || fixture.multiTurnTranscript[1].text },
-                { type: "tool_use", id: call.id, name: call.name, input: call.input },
+                {
+                  type: "tool_use",
+                  id: call.id,
+                  name: call.name,
+                  input: call.input,
+                  // Round-trip the opaque provider signature (e.g. Gemini's
+                  // thoughtSignature) — thinking models reject a replayed tool
+                  // call whose signature was dropped.
+                  providerSignature: call.providerSignature,
+                },
               ],
             },
             {

--- a/packages/test/src/test/ai-provider-api/Gemini_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider-api/Gemini_Generic.integration.test.ts
@@ -18,16 +18,15 @@ import { getTestingLogger } from "../../binding/TestingLogger";
 import { runAiProviderConformance } from "../../contract/ai-provider/runAiProviderConformance";
 
 const RUN = !!process.env.GOOGLE_API_KEY || !!process.env.GEMINI_API_KEY;
-// Google retired `gemini-2.5-flash` (the live API now returns 404 "no longer
-// available"), which fails this conformance suite. Temporarily disabled until
-// the model id is refreshed; flip to false to re-enable.
-const MODEL_RETIRED: boolean = true;
-const MODEL_ID = "gemini:gemini-2.5-flash";
+// gemini-2.5-flash was retired from the v1beta API. Exercise a current
+// "thinking" model so the thought-signature and structured-generation paths
+// are covered live.
+const MODEL_ID = "gemini:gemini-3.5-flash";
 const EMBED_MODEL_ID = "gemini:gemini-embedding-001";
 
 runAiProviderConformance({
   name: "Google Gemini",
-  skip: !RUN || MODEL_RETIRED,
+  skip: !RUN,
   timeout: 30_000,
   factory: async () => ({
     register: async () => {
@@ -38,11 +37,11 @@ runAiProviderConformance({
       await registerGeminiInline();
       await getGlobalModelRepository().addModel({
         model_id: MODEL_ID,
-        title: "Gemini 2.5 Flash",
-        description: "Google Gemini 2.5 Flash",
+        title: "Gemini 3.5 Flash",
+        description: "Google Gemini 3.5 Flash",
         capabilities: ["text.generation", "text.rewriter", "text.summary", "tool-use", "json-mode"],
         provider: GOOGLE_GEMINI as typeof GOOGLE_GEMINI,
-        provider_config: { model_name: "gemini-2.5-flash" },
+        provider_config: { model_name: "gemini-3.5-flash" },
         metadata: {},
       });
       await getGlobalModelRepository().addModel({

--- a/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ModelRecord } from "@workglow/ai";
+import type { ChatMessage, ModelRecord } from "@workglow/ai";
 import { GEMINI_FALLBACK_MODELS, _testOnly } from "@workglow/google-gemini/ai";
 import { describe, expect, it } from "vitest";
 
@@ -191,5 +191,106 @@ describe("GEMINI_RUN_FNS shape", () => {
   it("tiebreaks `text.generation` to the smallest serves entry (plain text-gen)", () => {
     const candidates = GEMINI_RUN_FNS.filter((r) => r.serves.includes("text.generation"));
     expect(candidates.some((r) => r.serves.length === 1)).toBe(true);
+  });
+});
+
+describe("buildGeminiContents multi-turn", () => {
+  const { buildGeminiContents } = _testOnly;
+
+  // Helper: pull every functionResponse name out of the built contents, in order.
+  function functionResponseNames(contents: any[]): string[] {
+    const names: string[] = [];
+    for (const c of contents) {
+      for (const part of c.parts ?? []) {
+        if (part.functionResponse) names.push(part.functionResponse.name);
+      }
+    }
+    return names;
+  }
+
+  it("resolves each tool_result to the tool_use it answers even when ids collide across turns", () => {
+    // The provider assigns tool-call ids per run starting at `call_0`, so two
+    // separate turns can each carry a tool_use with id `call_0`. Each turn's
+    // functionResponse must still get its own turn's function name.
+    const messages: ChatMessage[] = [
+      { role: "user", content: [{ type: "text", text: "weather?" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_0", name: "get_weather", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_0",
+            content: [{ type: "text", text: '{"temp":22}' }],
+            is_error: undefined,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "and the time?" },
+          { type: "tool_use", id: "call_0", name: "get_time", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call_0",
+            content: [{ type: "text", text: '{"time":"noon"}' }],
+            is_error: undefined,
+          },
+        ],
+      },
+    ];
+
+    const contents = buildGeminiContents(messages, "");
+    // Turn 1's response must map to get_weather, turn 2's to get_time — a global
+    // last-write-wins map would mislabel the first as get_time.
+    expect(functionResponseNames(contents)).toEqual(["get_weather", "get_time"]);
+  });
+
+  it("replays the tool_use providerSignature as thoughtSignature on the functionCall part", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [{ type: "text", text: "weather?" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_0",
+            name: "get_weather",
+            input: { city: "Tokyo" },
+            providerSignature: "sig-abc",
+          },
+        ],
+      },
+    ];
+
+    const contents = buildGeminiContents(messages, "");
+    const modelTurn = contents.find((c) => c.role === "model");
+    const fnPart = modelTurn.parts.find((p: any) => p.functionCall);
+    expect(fnPart.functionCall.name).toBe("get_weather");
+    expect(fnPart.thoughtSignature).toBe("sig-abc");
+  });
+
+  it("omits thoughtSignature when the tool_use has no providerSignature", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: [{ type: "text", text: "weather?" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_0", name: "get_weather", input: {} }],
+      },
+    ];
+
+    const contents = buildGeminiContents(messages, "");
+    const modelTurn = contents.find((c) => c.role === "model");
+    const fnPart = modelTurn.parts.find((p: any) => p.functionCall);
+    expect("thoughtSignature" in fnPart).toBe(false);
   });
 });

--- a/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/GoogleGeminiProvider.test.ts
@@ -79,7 +79,7 @@ describe("GoogleGeminiQueuedProvider.inferCapabilities", () => {
   });
 
   it("infers image.generation + image.editing for gemini-*-image-* models", () => {
-    const caps = provider.inferCapabilities(model("gemini-3.1-flash-image-preview"));
+    const caps = provider.inferCapabilities(model("gemini-3.1-flash-image"));
     expect(caps).toContain("image.generation");
     expect(caps).toContain("image.editing");
     expect(caps).not.toContain("text.generation");

--- a/packages/test/src/test/ai-provider/provider-model-search.test.ts
+++ b/packages/test/src/test/ai-provider/provider-model-search.test.ts
@@ -73,8 +73,8 @@ describe("provider model search samples", () => {
       modelIdsForSearch(Gemini_ModelSearch, "gemini-3.1-pro-preview")
     ).resolves.toContain("gemini-3.1-pro-preview");
     await expect(
-      modelIdsForSearch(Gemini_ModelSearch, "gemini-3.1-flash-image-preview")
-    ).resolves.toContain("gemini-3.1-flash-image-preview");
+      modelIdsForSearch(Gemini_ModelSearch, "gemini-3.1-flash-image")
+    ).resolves.toContain("gemini-3.1-flash-image");
     await expect(modelIdsForSearch(Gemini_ModelSearch, "gemini-embedding-2")).resolves.toContain(
       "gemini-embedding-2"
     );

--- a/providers/google-gemini/package.json
+++ b/providers/google-gemini/package.json
@@ -35,7 +35,7 @@
     }
   },
   "dependencies": {
-    "@google/generative-ai": "catalog:"
+    "@google/genai": "catalog:"
   },
   "peerDependencies": {
     "@workglow/ai": "workspace:*",

--- a/providers/google-gemini/src/ai/common/Gemini_Capabilities.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Capabilities.ts
@@ -63,10 +63,11 @@ export function inferGeminiCapabilities(model: CapabilityHints): readonly Capabi
     return ["image.generation", "model.info", "model.search"];
   }
 
-  // Gemini image-output model variants — e.g. gemini-3.1-flash-image-preview,
-  // gemini-3-pro-image-preview. These come from the fallback list with explicit
-  // capabilities and also need to be covered by inference.
-  if (/^gemini-.*-image-/i.test(id)) {
+  // Gemini image-output model variants — e.g. gemini-3.1-flash-image,
+  // gemini-3-pro-image (and their older -image-preview forms). These come from
+  // the fallback list with explicit capabilities and also need to be covered by
+  // inference. Match `-image` at the end or followed by a suffix (`-preview`).
+  if (/^gemini-.*-image(?:-|$)/i.test(id)) {
     return ["image.generation", "image.editing", "model.info", "model.search"];
   }
 

--- a/providers/google-gemini/src/ai/common/Gemini_Client.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Client.ts
@@ -26,24 +26,30 @@ export async function loadGeminiSDK(): Promise<GoogleGenAIConstructor> {
   return _loadPromise;
 }
 
-const _clientByKey = new Map<string, GoogleGenAI>();
+const _clientByKey = new Map<string, Promise<GoogleGenAI>>();
 
 /**
  * Load the SDK and return a client bound to the resolved API key. The
  * `@google/genai` `GoogleGenAI` facade stands up auth wiring and several
  * sub-service objects, so it is memoized per API key rather than rebuilt on
- * every run-fn invocation.
+ * every run-fn invocation. The in-flight promise is cached (set synchronously
+ * before the first await) so concurrent calls for the same key share one client
+ * instead of racing to construct duplicates; a failed load evicts the entry so
+ * the next call can retry.
  */
-export async function createGeminiClient(
-  model: GeminiModelConfig | undefined
-): Promise<GoogleGenAI> {
+export function createGeminiClient(model: GeminiModelConfig | undefined): Promise<GoogleGenAI> {
   const apiKey = getApiKey(model);
-  const cached = _clientByKey.get(apiKey);
-  if (cached) return cached;
-  const GoogleGenAICtor = await loadGeminiSDK();
-  const client = new GoogleGenAICtor({ apiKey });
-  _clientByKey.set(apiKey, client);
-  return client;
+  let clientPromise = _clientByKey.get(apiKey);
+  if (!clientPromise) {
+    clientPromise = loadGeminiSDK()
+      .then((GoogleGenAICtor) => new GoogleGenAICtor({ apiKey }))
+      .catch((err) => {
+        _clientByKey.delete(apiKey);
+        throw err;
+      });
+    _clientByKey.set(apiKey, clientPromise);
+  }
+  return clientPromise;
 }
 
 interface ResolvedProviderConfig {

--- a/providers/google-gemini/src/ai/common/Gemini_Client.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Client.ts
@@ -26,12 +26,24 @@ export async function loadGeminiSDK(): Promise<GoogleGenAIConstructor> {
   return _loadPromise;
 }
 
-/** Load the SDK and construct a client bound to the resolved API key. */
+const _clientByKey = new Map<string, GoogleGenAI>();
+
+/**
+ * Load the SDK and return a client bound to the resolved API key. The
+ * `@google/genai` `GoogleGenAI` facade stands up auth wiring and several
+ * sub-service objects, so it is memoized per API key rather than rebuilt on
+ * every run-fn invocation.
+ */
 export async function createGeminiClient(
   model: GeminiModelConfig | undefined
 ): Promise<GoogleGenAI> {
+  const apiKey = getApiKey(model);
+  const cached = _clientByKey.get(apiKey);
+  if (cached) return cached;
   const GoogleGenAICtor = await loadGeminiSDK();
-  return new GoogleGenAICtor({ apiKey: getApiKey(model) });
+  const client = new GoogleGenAICtor({ apiKey });
+  _clientByKey.set(apiKey, client);
+  return client;
 }
 
 interface ResolvedProviderConfig {
@@ -66,4 +78,30 @@ export function getModelName(model: GeminiModelConfig | undefined): string {
 export function getThinkingBudget(model: GeminiModelConfig | undefined): number | undefined {
   const budget = model?.provider_config?.thinking_budget;
   return typeof budget === "number" ? budget : undefined;
+}
+
+/**
+ * Resolves the thinking-related request fields consistently across run-fns.
+ * Gemini counts thinking tokens against `maxOutputTokens`, so a positive budget
+ * is added on top of the caller's cap to leave room for the visible answer.
+ *
+ * @param defaultBudget applied when the model has no configured budget. Pass a
+ *   value for tasks that always need bounded reasoning (structured generation);
+ *   omit it for tasks that should inherit the model's own default thinking
+ *   (plain generation, tool calling) and only opt in when explicitly configured.
+ */
+export function resolveThinkingConfig(
+  model: GeminiModelConfig | undefined,
+  maxTokens: number | undefined,
+  defaultBudget?: number
+): {
+  thinkingConfig: { thinkingBudget: number } | undefined;
+  maxOutputTokens: number | undefined;
+} {
+  const budget = getThinkingBudget(model) ?? defaultBudget;
+  if (budget === undefined) {
+    return { thinkingConfig: undefined, maxOutputTokens: maxTokens };
+  }
+  const maxOutputTokens = maxTokens !== undefined && budget > 0 ? maxTokens + budget : maxTokens;
+  return { thinkingConfig: { thinkingBudget: budget }, maxOutputTokens };
 }

--- a/providers/google-gemini/src/ai/common/Gemini_Client.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Client.ts
@@ -4,25 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { GoogleGenAI } from "@google/genai";
 import { resolveApiKey } from "@workglow/ai/provider-utils";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
-type GeminiSDKModule = typeof import("@google/generative-ai");
-type GoogleGenerativeAIConstructor = GeminiSDKModule["GoogleGenerativeAI"];
+type GeminiSDKModule = typeof import("@google/genai");
+type GoogleGenAIConstructor = GeminiSDKModule["GoogleGenAI"];
 
-let _loadPromise: Promise<GoogleGenerativeAIConstructor> | undefined;
+let _loadPromise: Promise<GoogleGenAIConstructor> | undefined;
 
 // NOTE: we do not want to de-dup this in the provider-utils, vite wants direct import with string literals.
-export async function loadGeminiSDK(): Promise<GoogleGenerativeAIConstructor> {
-  _loadPromise ??= import("@google/generative-ai")
-    .then((mod) => mod.GoogleGenerativeAI)
+export async function loadGeminiSDK(): Promise<GoogleGenAIConstructor> {
+  _loadPromise ??= import("@google/genai")
+    .then((mod) => mod.GoogleGenAI)
     .catch(() => {
       _loadPromise = undefined;
       throw new Error(
-        "@google/generative-ai is required for Gemini tasks. Install it with: bun add @google/generative-ai"
+        "@google/genai is required for Gemini tasks. Install it with: bun add @google/genai"
       );
     });
   return _loadPromise;
+}
+
+/** Load the SDK and construct a client bound to the resolved API key. */
+export async function createGeminiClient(
+  model: GeminiModelConfig | undefined
+): Promise<GoogleGenAI> {
+  const GoogleGenAICtor = await loadGeminiSDK();
+  return new GoogleGenAICtor({ apiKey: getApiKey(model) });
 }
 
 interface ResolvedProviderConfig {
@@ -47,4 +56,14 @@ export function getModelName(model: GeminiModelConfig | undefined): string {
     throw new Error("Missing model name in provider_config.model_name.");
   }
   return name;
+}
+
+/**
+ * Reasoning-token budget for thinking models, sourced from the model's
+ * `provider_config.thinking_budget`. Returns `undefined` when unset so callers
+ * can decide whether to apply a task-specific default.
+ */
+export function getThinkingBudget(model: GeminiModelConfig | undefined): number | undefined {
+  const budget = model?.provider_config?.thinking_budget;
+  return typeof budget === "number" ? budget : undefined;
 }

--- a/providers/google-gemini/src/ai/common/Gemini_CountTokens.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_CountTokens.ts
@@ -10,19 +10,20 @@ import type {
   CountTokensTaskInput,
   CountTokensTaskOutput,
 } from "@workglow/ai";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 export const Gemini_CountTokens_Stream: AiProviderRunFn<
   CountTokensTaskInput,
   CountTokensTaskOutput,
   GeminiModelConfig
-> = async (input, model, signal, emit) => {
-  const GoogleGenerativeAI = await loadGeminiSDK();
-  const genAI = new GoogleGenerativeAI(getApiKey(model));
-  const genModel = genAI.getGenerativeModel({ model: getModelName(model) });
-  const result = await genModel.countTokens(input.text);
-  emit({ type: "finish", data: { count: result.totalTokens } });
+> = async (input, model, _signal, emit) => {
+  const ai = await createGeminiClient(model);
+  const result = await ai.models.countTokens({
+    model: getModelName(model),
+    contents: input.text,
+  });
+  emit({ type: "finish", data: { count: result.totalTokens ?? 0 } });
 };
 
 export const Gemini_CountTokens_Preview: AiProviderPreviewRunFn<

--- a/providers/google-gemini/src/ai/common/Gemini_ImageEdit.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ImageEdit.ts
@@ -14,7 +14,7 @@ import {
   imageValueToPngBytes,
   modelIdForError,
 } from "@workglow/ai/provider-utils";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 /** Decode a base64 inline image part into an ImageValue. */
@@ -64,10 +64,8 @@ export const Gemini_ImageEdit_Stream: AiProviderRunFn<
   const timer = `gemini:ImageEdit:${modelIdForError(model, "gemini")}`;
   logger.time(timer, { model: modelIdForError(model, "gemini") });
   try {
-    const GoogleGenerativeAI = await loadGeminiSDK();
-    const genAI = new GoogleGenerativeAI(getApiKey(model));
+    const ai = await createGeminiClient(model);
     const modelName = getModelName(model);
-    const genModel = genAI.getGenerativeModel({ model: modelName });
 
     // image/additionalImages may be data URI strings if the input crossed
     // an earlier worker boundary in legacy form; otherwise they are ImageValue
@@ -86,11 +84,11 @@ export const Gemini_ImageEdit_Stream: AiProviderRunFn<
     const parts: Array<any> = [{ text: input.prompt }, primaryPart, ...additionalParts];
 
     try {
-      const result = await genModel.generateContent({ contents: [{ role: "user", parts }] }, {
-        signal,
-      } as any);
-
-      const response = result.response;
+      const response = await ai.models.generateContent({
+        model: modelName,
+        contents: [{ role: "user", parts }],
+        config: { abortSignal: signal ?? undefined },
+      });
 
       if (
         !response.candidates ||

--- a/providers/google-gemini/src/ai/common/Gemini_ImageGenerate.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ImageGenerate.ts
@@ -14,7 +14,7 @@ import type { ImageValue } from "@workglow/util/media";
 import { getLogger } from "@workglow/util/worker";
 
 import { dataUriToImageValue, modelIdForError } from "@workglow/ai/provider-utils";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 /** Decode a base64 string with an explicit mime type into an ImageValue. */
@@ -36,19 +36,17 @@ export const Gemini_ImageGenerate_Stream: AiProviderRunFn<
   const timer = `gemini:ImageGenerate:${modelIdForError(model, "gemini")}`;
   logger.time(timer, { model: modelIdForError(model, "gemini") });
   try {
-    const GoogleGenerativeAI = await loadGeminiSDK();
-    const genAI = new GoogleGenerativeAI(getApiKey(model));
+    const ai = await createGeminiClient(model);
     const modelName = getModelName(model);
-    const genModel = genAI.getGenerativeModel({ model: modelName });
 
     const parts: Array<{ text: string }> = [{ text: input.prompt }];
 
     try {
-      const result = await genModel.generateContent({ contents: [{ role: "user", parts }] }, {
-        signal,
-      } as any);
-
-      const response = result.response;
+      const response = await ai.models.generateContent({
+        model: modelName,
+        contents: [{ role: "user", parts }],
+        config: { abortSignal: signal ?? undefined },
+      });
 
       if (
         !response.candidates ||

--- a/providers/google-gemini/src/ai/common/Gemini_ModelSchema.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ModelSchema.ts
@@ -50,9 +50,10 @@ export const GeminiModelSchema = {
         thinking_budget: {
           type: "number",
           description:
-            "Reasoning token allowance for thinking models (2.5+/3.x), separate from " +
-            "maxOutputTokens. 0 disables thinking; -1 lets the model choose. When unset, " +
-            "the provider applies a sensible default for structured generation.",
+            "Reasoning token allowance for thinking models (2.5+/3.x). Gemini counts " +
+            "thinking tokens against maxOutputTokens, so the provider pads the output cap " +
+            "by this budget to leave room for the answer. 0 disables thinking; -1 lets the " +
+            "model choose. When unset, structured generation applies a sensible default.",
         },
       },
       required: ["model_name"],

--- a/providers/google-gemini/src/ai/common/Gemini_ModelSchema.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ModelSchema.ts
@@ -47,6 +47,13 @@ export const GeminiModelSchema = {
           description: "Task type hint for embedding models.",
           default: null,
         },
+        thinking_budget: {
+          type: "number",
+          description:
+            "Reasoning token allowance for thinking models (2.5+/3.x), separate from " +
+            "maxOutputTokens. 0 disables thinking; -1 lets the model choose. When unset, " +
+            "the provider applies a sensible default for structured generation.",
+        },
       },
       required: ["model_name"],
       additionalProperties: false,

--- a/providers/google-gemini/src/ai/common/Gemini_ModelSearch.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ModelSearch.ts
@@ -20,31 +20,24 @@ interface GeminiModelEntry {
 }
 
 export const GEMINI_FALLBACK_MODELS: readonly GeminiModelEntry[] = [
+  { label: "gemini-3.5-flash", value: "gemini-3.5-flash" },
   { label: "gemini-3.1-pro-preview", value: "gemini-3.1-pro-preview" },
-  { label: "gemini-3-flash-preview", value: "gemini-3-flash-preview" },
-  { label: "gemini-3.1-flash-lite-preview", value: "gemini-3.1-flash-lite-preview" },
-  { label: "gemini-2.5-flash", value: "gemini-2.5-flash" },
-  { label: "gemini-2.5-pro", value: "gemini-2.5-pro" },
+  { label: "gemini-3.1-flash-lite", value: "gemini-3.1-flash-lite" },
   // Embedding models
   {
     label: "gemini-embedding-2",
     value: "gemini-embedding-2",
     capabilities: ["text.embedding"],
   },
-  {
-    label: "gemini-embedding-001",
-    value: "gemini-embedding-001",
-    capabilities: ["text.embedding"],
-  },
   // Image-output models
   {
-    label: "gemini-3.1-flash-image-preview",
-    value: "gemini-3.1-flash-image-preview",
+    label: "gemini-3.1-flash-image",
+    value: "gemini-3.1-flash-image",
     capabilities: ["image.generation", "image.editing"],
   },
   {
-    label: "gemini-3-pro-image-preview",
-    value: "gemini-3-pro-image-preview",
+    label: "gemini-3-pro-image",
+    value: "gemini-3-pro-image",
     capabilities: ["image.generation", "image.editing"],
   },
   {

--- a/providers/google-gemini/src/ai/common/Gemini_Schema.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_Schema.ts
@@ -6,17 +6,26 @@
 
 /**
  * Recursively strip JSON Schema properties that the Gemini API does not support
- * (e.g. `additionalProperties`). Returns a shallow-cloned schema without mutating the original.
+ * (e.g. `additionalProperties`). Returns a cloned schema without mutating the
+ * original. Recurses into both nested objects and array elements (e.g. the
+ * subschemas of `anyOf`/`oneOf`/`allOf`/`prefixItems`) so stripped keys cannot
+ * survive inside a union or tuple and reach `responseSchema` / `parameters`.
  */
 export function sanitizeSchemaForGemini(schema: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
     if (key === "additionalProperties") continue;
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      result[key] = sanitizeSchemaForGemini(value as Record<string, unknown>);
-    } else {
-      result[key] = value;
-    }
+    result[key] = sanitizeSchemaValue(value);
   }
   return result;
+}
+
+function sanitizeSchemaValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeSchemaValue);
+  }
+  if (value && typeof value === "object") {
+    return sanitizeSchemaForGemini(value as Record<string, unknown>);
+  }
+  return value;
 }

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -10,9 +10,20 @@ import type {
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
 import { parsePartialJson } from "@workglow/util/worker";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { sanitizeSchemaForGemini } from "./Gemini_Schema";
+
+/**
+ * Default reasoning allowance (in tokens) for the model's internal "thinking"
+ * pass on a structured-generation request when `provider_config.thinking_budget`
+ * is unset. Thinking models (Gemini 2.5+/3.x) reason before emitting the answer;
+ * the thinking budget is separate from `maxOutputTokens`, so a small output cap
+ * (the caller's `maxTokens`) still leaves room for the JSON. Without an explicit
+ * budget a thinking model could consume the whole allotment reasoning and return
+ * an empty object.
+ */
+const DEFAULT_STRUCTURED_THINKING_BUDGET = 2048;
 
 /**
  * Streaming run-fn for `["text.generation", "json-mode"]`. Gemini uses
@@ -20,37 +31,49 @@ import { sanitizeSchemaForGemini } from "./Gemini_Schema";
  * structured output. Per the streaming convention exception for json-mode,
  * the `finish` event MUST include the parsed `object` so that
  * `StructuredGenerationTask` can read it without a JSON streaming parser.
+ *
+ * With `responseMimeType: "application/json"` the response payload is JSON only —
+ * reasoning stays internal and never appears in the emitted parts — so the
+ * streamed text can be accumulated directly.
  */
 export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
   GeminiModelConfig
 > = async (input, model, signal, emit, outputSchema) => {
-  const GoogleGenerativeAI = await loadGeminiSDK();
-  const genAI = new GoogleGenerativeAI(getApiKey(model));
+  const ai = await createGeminiClient(model);
 
   const schema = input.outputSchema ?? outputSchema;
-
   const sanitizedSchema = sanitizeSchemaForGemini(schema as Record<string, unknown>);
 
-  const genModel = genAI.getGenerativeModel({
+  const thinkingBudget = getThinkingBudget(model) ?? DEFAULT_STRUCTURED_THINKING_BUDGET;
+
+  // Gemini counts thinking tokens against `maxOutputTokens`, so a caller's small
+  // output cap (e.g. 100) would be entirely consumed by reasoning and truncate
+  // the JSON to nothing. Give the answer the caller's full budget by adding the
+  // thinking allowance on top of it; the emitted JSON still respects maxTokens.
+  const maxOutputTokens =
+    input.maxTokens !== undefined && thinkingBudget > 0
+      ? input.maxTokens + thinkingBudget
+      : input.maxTokens;
+
+  const result = await ai.models.generateContentStream({
     model: getModelName(model),
-    generationConfig: {
+    contents: [{ role: "user", parts: [{ text: input.prompt as string }] }],
+    config: {
+      abortSignal: signal ?? undefined,
       responseMimeType: "application/json",
       responseSchema: sanitizedSchema as any,
-      maxOutputTokens: input.maxTokens,
+      maxOutputTokens,
       temperature: input.temperature,
+      thinkingConfig: { thinkingBudget },
     },
   });
 
-  const result = await genModel.generateContentStream(
-    { contents: [{ role: "user", parts: [{ text: input.prompt as string }] }] },
-    { signal }
-  );
-
   let accumulatedJson = "";
-  for await (const chunk of result.stream) {
-    const text = chunk.text();
+  for await (const chunk of result) {
+    // `chunk.text` concatenates the answer text (thought parts are excluded).
+    const text = chunk.text;
     if (text) {
       accumulatedJson += text;
       const partial = parsePartialJson(accumulatedJson);

--- a/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_StructuredGeneration.ts
@@ -10,7 +10,7 @@ import type {
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
 import { parsePartialJson } from "@workglow/util/worker";
-import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
+import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { sanitizeSchemaForGemini } from "./Gemini_Schema";
 
@@ -46,16 +46,15 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
   const schema = input.outputSchema ?? outputSchema;
   const sanitizedSchema = sanitizeSchemaForGemini(schema as Record<string, unknown>);
 
-  const thinkingBudget = getThinkingBudget(model) ?? DEFAULT_STRUCTURED_THINKING_BUDGET;
-
   // Gemini counts thinking tokens against `maxOutputTokens`, so a caller's small
-  // output cap (e.g. 100) would be entirely consumed by reasoning and truncate
-  // the JSON to nothing. Give the answer the caller's full budget by adding the
-  // thinking allowance on top of it; the emitted JSON still respects maxTokens.
-  const maxOutputTokens =
-    input.maxTokens !== undefined && thinkingBudget > 0
-      ? input.maxTokens + thinkingBudget
-      : input.maxTokens;
+  // output cap (e.g. 100) would otherwise be consumed by reasoning and truncate
+  // the JSON to nothing. resolveThinkingConfig adds the thinking allowance on top
+  // of the caller's cap; the emitted JSON still respects maxTokens.
+  const { thinkingConfig, maxOutputTokens } = resolveThinkingConfig(
+    model,
+    input.maxTokens,
+    DEFAULT_STRUCTURED_THINKING_BUDGET
+  );
 
   const result = await ai.models.generateContentStream({
     model: getModelName(model),
@@ -66,7 +65,7 @@ export const Gemini_StructuredGeneration_Stream: AiProviderRunFn<
       responseSchema: sanitizedSchema as any,
       maxOutputTokens,
       temperature: input.temperature,
-      thinkingConfig: { thinkingBudget },
+      thinkingConfig,
     },
   });
 

--- a/providers/google-gemini/src/ai/common/Gemini_TextEmbedding.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextEmbedding.ts
@@ -4,59 +4,51 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TaskType } from "@google/generative-ai";
 import type {
   AiProviderRunFn,
   TextEmbeddingTaskInput,
   TextEmbeddingTaskOutput,
 } from "@workglow/ai";
 import { getLogger } from "@workglow/util/worker";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 export const Gemini_TextEmbedding_Stream: AiProviderRunFn<
   TextEmbeddingTaskInput,
   TextEmbeddingTaskOutput,
   GeminiModelConfig
-> = async (input, model, _signal, emit) => {
+> = async (input, model, signal, emit) => {
   const logger = getLogger();
   const timerLabel = `gemini:TextEmbedding:${model?.provider_config?.model_name}`;
   logger.time(timerLabel, { model: model?.provider_config?.model_name });
   try {
-    const GoogleGenerativeAI = await loadGeminiSDK();
-    const genAI = new GoogleGenerativeAI(getApiKey(model));
-    const embeddingModel = genAI.getGenerativeModel({
-      model: getModelName(model),
-    });
-
-    const taskType =
-      (model?.provider_config?.embedding_task_type as TaskType) ||
-      ("RETRIEVAL_DOCUMENT" as TaskType);
+    const ai = await createGeminiClient(model);
+    const taskType = model?.provider_config?.embedding_task_type || "RETRIEVAL_DOCUMENT";
 
     if (Array.isArray(input.text)) {
-      const result = await embeddingModel.batchEmbedContents({
-        requests: input.text.map((t) => ({
-          content: { role: "user", parts: [{ text: t }] },
-          taskType,
-        })),
+      const result = await ai.models.embedContent({
+        model: getModelName(model),
+        contents: input.text,
+        config: { taskType, abortSignal: signal ?? undefined },
       });
       emit({
         type: "finish",
         data: {
-          vector: result.embeddings.map((e) => new Float32Array(e.values)),
+          vector: (result.embeddings ?? []).map((e) => new Float32Array(e.values ?? [])),
         },
       });
       return;
     }
 
-    const result = await embeddingModel.embedContent({
-      content: { role: "user", parts: [{ text: input.text as string }] },
-      taskType,
+    const result = await ai.models.embedContent({
+      model: getModelName(model),
+      contents: input.text as string,
+      config: { taskType, abortSignal: signal ?? undefined },
     });
 
     emit({
       type: "finish",
-      data: { vector: new Float32Array(result.embedding.values) },
+      data: { vector: new Float32Array(result.embeddings?.[0]?.values ?? []) },
     });
   } finally {
     logger.timeEnd(timerLabel, { model: model?.provider_config?.model_name });

--- a/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
@@ -10,7 +10,7 @@ import type {
   TextGenerationTaskOutput,
 } from "@workglow/ai";
 import { getLogger } from "@workglow/util/worker";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { buildGeminiContents } from "./Gemini_ToolCalling";
 
@@ -73,47 +73,34 @@ export const Gemini_TextGeneration_Stream: AiProviderRunFn<
     const unified = input as UnifiedTextGenerationInput;
     const hasMessages = Array.isArray(unified.messages) && unified.messages.length > 0;
 
-    const GoogleGenerativeAI = await loadGeminiSDK();
-    const genAI = new GoogleGenerativeAI(getApiKey(model));
+    const ai = await createGeminiClient(model);
 
-    if (hasMessages) {
-      // Chat path — use buildGeminiContents to map the messages array.
-      const genModel = genAI.getGenerativeModel({
-        model: getModelName(model),
-        systemInstruction: unified.systemPrompt || undefined,
-        generationConfig: buildGenerationConfig(input),
-      });
+    const contents = hasMessages
+      ? buildGeminiContents(
+          unified.messages as Parameters<typeof buildGeminiContents>[0],
+          unified.prompt ?? ""
+        )
+      : [{ role: "user", parts: [{ text: input.prompt }] }];
 
-      const contents = buildGeminiContents(
-        unified.messages as Parameters<typeof buildGeminiContents>[0],
-        unified.prompt ?? ""
-      );
+    const thinkingBudget = getThinkingBudget(model);
 
-      const result = await genModel.generateContentStream({ contents }, { signal });
+    const result = await ai.models.generateContentStream({
+      model: getModelName(model),
+      contents,
+      config: {
+        abortSignal: signal ?? undefined,
+        // Only the chat path carries a system prompt; the prompt path has none.
+        systemInstruction: hasMessages ? unified.systemPrompt || undefined : undefined,
+        ...buildGenerationConfig(input),
+        ...(thinkingBudget !== undefined ? { thinkingConfig: { thinkingBudget } } : {}),
+      },
+    });
 
-      for await (const chunk of result.stream) {
-        const text = chunk.text();
-        if (text) {
-          emit({ type: "text-delta", port: "text", textDelta: text });
-        }
-      }
-    } else {
-      // Prompt path — simple single-user-message generation.
-      const genModel = genAI.getGenerativeModel({
-        model: getModelName(model),
-        generationConfig: buildGenerationConfig(input),
-      });
-
-      const result = await genModel.generateContentStream(
-        { contents: [{ role: "user", parts: [{ text: input.prompt }] }] },
-        { signal }
-      );
-
-      for await (const chunk of result.stream) {
-        const text = chunk.text();
-        if (text) {
-          emit({ type: "text-delta", port: "text", textDelta: text });
-        }
+    for await (const chunk of result) {
+      // `chunk.text` concatenates answer text and already skips thought parts.
+      const text = chunk.text;
+      if (text) {
+        emit({ type: "text-delta", port: "text", textDelta: text });
       }
     }
 

--- a/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
@@ -10,7 +10,7 @@ import type {
   TextGenerationTaskOutput,
 } from "@workglow/ai";
 import { getLogger } from "@workglow/util/worker";
-import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
+import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { buildGeminiContents } from "./Gemini_ToolCalling";
 
@@ -82,7 +82,9 @@ export const Gemini_TextGeneration_Stream: AiProviderRunFn<
         )
       : [{ role: "user", parts: [{ text: input.prompt }] }];
 
-    const thinkingBudget = getThinkingBudget(model);
+    // Thinking is opt-in here (no default budget); when a budget is configured,
+    // the output cap is padded so reasoning can't starve the visible answer.
+    const { thinkingConfig, maxOutputTokens } = resolveThinkingConfig(model, input.maxTokens);
 
     const result = await ai.models.generateContentStream({
       model: getModelName(model),
@@ -92,7 +94,9 @@ export const Gemini_TextGeneration_Stream: AiProviderRunFn<
         // Only the chat path carries a system prompt; the prompt path has none.
         systemInstruction: hasMessages ? unified.systemPrompt || undefined : undefined,
         ...buildGenerationConfig(input),
-        ...(thinkingBudget !== undefined ? { thinkingConfig: { thinkingBudget } } : {}),
+        // Override maxOutputTokens from buildGenerationConfig with the thinking-aware value.
+        maxOutputTokens,
+        thinkingConfig,
       },
     });
 

--- a/providers/google-gemini/src/ai/common/Gemini_TextRewriter.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextRewriter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 export const Gemini_TextRewriter_Stream: AiProviderRunFn<
@@ -13,20 +13,19 @@ export const Gemini_TextRewriter_Stream: AiProviderRunFn<
   TextRewriterTaskOutput,
   GeminiModelConfig
 > = async (input, model, signal, emit) => {
-  const GoogleGenerativeAI = await loadGeminiSDK();
-  const genAI = new GoogleGenerativeAI(getApiKey(model));
-  const genModel = genAI.getGenerativeModel({
+  const ai = await createGeminiClient(model);
+
+  const result = await ai.models.generateContentStream({
     model: getModelName(model),
-    systemInstruction: input.prompt,
+    contents: [{ role: "user", parts: [{ text: input.text }] }],
+    config: {
+      abortSignal: signal ?? undefined,
+      systemInstruction: input.prompt,
+    },
   });
 
-  const result = await genModel.generateContentStream(
-    { contents: [{ role: "user", parts: [{ text: input.text }] }] },
-    { signal }
-  );
-
-  for await (const chunk of result.stream) {
-    const text = chunk.text();
+  for await (const chunk of result) {
+    const text = chunk.text;
     if (text) {
       emit({ type: "text-delta", port: "text", textDelta: text });
     }

--- a/providers/google-gemini/src/ai/common/Gemini_TextSummary.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextSummary.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 
 export const Gemini_TextSummary_Stream: AiProviderRunFn<
@@ -13,20 +13,19 @@ export const Gemini_TextSummary_Stream: AiProviderRunFn<
   TextSummaryTaskOutput,
   GeminiModelConfig
 > = async (input, model, signal, emit) => {
-  const GoogleGenerativeAI = await loadGeminiSDK();
-  const genAI = new GoogleGenerativeAI(getApiKey(model));
-  const genModel = genAI.getGenerativeModel({
+  const ai = await createGeminiClient(model);
+
+  const result = await ai.models.generateContentStream({
     model: getModelName(model),
-    systemInstruction: "Summarize the following text concisely.",
+    contents: [{ role: "user", parts: [{ text: input.text }] }],
+    config: {
+      abortSignal: signal ?? undefined,
+      systemInstruction: "Summarize the following text concisely.",
+    },
   });
 
-  const result = await genModel.generateContentStream(
-    { contents: [{ role: "user", parts: [{ text: input.text }] }] },
-    { signal }
-  );
-
-  for await (const chunk of result.stream) {
-    const text = chunk.text();
+  for await (const chunk of result) {
+    const text = chunk.text;
     if (text) {
       emit({ type: "text-delta", port: "text", textDelta: text });
     }

--- a/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
@@ -13,7 +13,7 @@ import type {
   ToolDefinition,
 } from "@workglow/ai";
 import { buildToolDescription, filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
-import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
+import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { sanitizeSchemaForGemini } from "./Gemini_Schema";
 
@@ -131,7 +131,10 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
 
   const contents = buildGeminiContents(input.messages, input.prompt);
 
-  const thinkingBudget = getThinkingBudget(model);
+  // Thinking is opt-in here (no default budget): the model uses its own default
+  // reasoning unless `provider_config.thinking_budget` is set, in which case the
+  // output cap is padded so reasoning can't starve the tool call / answer.
+  const { thinkingConfig, maxOutputTokens } = resolveThinkingConfig(model, input.maxTokens);
 
   const result = await ai.models.generateContentStream({
     model: getModelName(model),
@@ -139,11 +142,11 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
     config: {
       abortSignal: signal ?? undefined,
       systemInstruction: input.systemPrompt || undefined,
-      maxOutputTokens: input.maxTokens,
+      maxOutputTokens,
       temperature: input.temperature,
       tools: [{ functionDeclarations }],
       toolConfig: toolConfig as any,
-      ...(thinkingBudget !== undefined ? { thinkingConfig: { thinkingBudget } } : {}),
+      thinkingConfig,
     },
   });
 

--- a/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FunctionCallingMode } from "@google/generative-ai";
+import { FunctionCallingConfigMode } from "@google/genai";
 import type {
   AiProviderRunFn,
   ChatMessage,
@@ -13,7 +13,7 @@ import type {
   ToolDefinition,
 } from "@workglow/ai";
 import { buildToolDescription, filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
-import { getApiKey, getModelName, loadGeminiSDK } from "./Gemini_Client";
+import { createGeminiClient, getModelName, getThinkingBudget } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { sanitizeSchemaForGemini } from "./Gemini_Schema";
 
@@ -55,7 +55,17 @@ export function buildGeminiContents(
         if (block.type === "text" && block.text) {
           parts.push({ text: block.text });
         } else if (block.type === "tool_use") {
-          parts.push({ functionCall: { name: block.name, args: block.input } });
+          // Thinking models (Gemini 2.5+/3.x) return an opaque `thoughtSignature`
+          // alongside each functionCall part. It MUST be echoed back verbatim on
+          // the same part in later turns or the API rejects the request with
+          // "Function call is missing a thought_signature".
+          const part: Record<string, unknown> = {
+            functionCall: { name: block.name, args: block.input },
+          };
+          if (block.providerSignature) {
+            part.thoughtSignature = block.providerSignature;
+          }
+          parts.push(part);
         }
       }
       if (parts.length > 0) contents.push({ role: "model", parts });
@@ -85,20 +95,20 @@ export function buildGeminiContents(
 function mapGeminiToolConfig(
   toolChoice: string | undefined
 ):
-  | { functionCallingConfig: { mode: FunctionCallingMode; allowedFunctionNames?: string[] } }
+  | { functionCallingConfig: { mode: FunctionCallingConfigMode; allowedFunctionNames?: string[] } }
   | undefined {
   if (!toolChoice || toolChoice === "auto") {
-    return { functionCallingConfig: { mode: "AUTO" as FunctionCallingMode } };
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO } };
   }
   if (toolChoice === "none") {
-    return { functionCallingConfig: { mode: "NONE" as FunctionCallingMode } };
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.NONE } };
   }
   if (toolChoice === "required") {
-    return { functionCallingConfig: { mode: "ANY" as FunctionCallingMode } };
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.ANY } };
   }
   return {
     functionCallingConfig: {
-      mode: "ANY" as FunctionCallingMode,
+      mode: FunctionCallingConfigMode.ANY,
       allowedFunctionNames: [toolChoice],
     },
   };
@@ -109,8 +119,7 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
   ToolCallingTaskOutput,
   GeminiModelConfig
 > = async (input, model, signal, emit) => {
-  const GoogleGenerativeAI = await loadGeminiSDK();
-  const genAI = new GoogleGenerativeAI(getApiKey(model));
+  const ai = await createGeminiClient(model);
 
   const functionDeclarations = input.tools.map((t: ToolDefinition) => ({
     name: t.name,
@@ -120,30 +129,33 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
 
   const toolConfig = mapGeminiToolConfig(input.toolChoice);
 
-  const genModel = genAI.getGenerativeModel({
+  const contents = buildGeminiContents(input.messages, input.prompt);
+
+  const thinkingBudget = getThinkingBudget(model);
+
+  const result = await ai.models.generateContentStream({
     model: getModelName(model),
-    tools: [{ functionDeclarations }],
-    toolConfig: toolConfig as any,
-    systemInstruction: input.systemPrompt || undefined,
-    generationConfig: {
+    contents,
+    config: {
+      abortSignal: signal ?? undefined,
+      systemInstruction: input.systemPrompt || undefined,
       maxOutputTokens: input.maxTokens,
       temperature: input.temperature,
+      tools: [{ functionDeclarations }],
+      toolConfig: toolConfig as any,
+      ...(thinkingBudget !== undefined ? { thinkingConfig: { thinkingBudget } } : {}),
     },
   });
 
-  const contents = buildGeminiContents(input.messages, input.prompt);
-
-  const result = await genModel.generateContentStream({ contents }, { signal });
-
   let callIndex = 0;
 
-  for await (const chunk of result.stream) {
+  for await (const chunk of result) {
     const parts = chunk.candidates?.[0]?.content?.parts ?? [];
     for (const part of parts) {
-      if ("text" in part && part.text) {
+      if (part.text && !part.thought) {
         emit({ type: "text-delta", port: "text", textDelta: part.text });
       }
-      if ("functionCall" in part && part.functionCall) {
+      if (part.functionCall) {
         const id = `call_${callIndex++}`;
         // Defence-in-depth: drop tool calls whose name isn't in the
         // declared tool set before emitting. Gemini's tool API respects
@@ -153,10 +165,13 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
           [
             {
               id,
-              name: part.functionCall.name,
+              name: part.functionCall.name ?? "",
               input: sanitizeToolArgs(
                 (part.functionCall.args as Record<string, unknown>) ?? {}
               ) as Record<string, unknown>,
+              // Carry the opaque thinking-model signature so the consumer can
+              // replay it on the next turn (see buildGeminiContents).
+              ...(part.thoughtSignature ? { providerSignature: part.thoughtSignature } : {}),
             },
           ],
           input.tools

--- a/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
@@ -25,17 +25,14 @@ export function buildGeminiContents(
     return [{ role: "user", parts: [{ text: prompt }] }];
   }
 
-  // Index tool_use ids → names from any prior assistant turn (Gemini wants
-  // the function name on the functionResponse, not just the id).
+  // Resolve tool_use id → name for the functionResponse (Gemini wants the
+  // function name there, not just the id). Built during the single ordered pass
+  // rather than up front: the provider assigns ids per run starting at `call_0`,
+  // so ids collide across turns. Updating the map as each assistant turn is
+  // processed makes every tool_result resolve against the most-recent preceding
+  // tool_use with that id — the call it actually answers — instead of a global
+  // last-write-wins that would mislabel earlier turns.
   const toolUseNames = new Map<string, string>();
-  for (const msg of messages) {
-    if (msg.role !== "assistant") continue;
-    for (const block of msg.content) {
-      if (block.type === "tool_use") {
-        toolUseNames.set(block.id, block.name);
-      }
-    }
-  }
 
   const contents: any[] = [];
   for (const msg of messages) {
@@ -55,6 +52,7 @@ export function buildGeminiContents(
         if (block.type === "text" && block.text) {
           parts.push({ text: block.text });
         } else if (block.type === "tool_use") {
+          toolUseNames.set(block.id, block.name);
           // Thinking models (Gemini 2.5+/3.x) return an opaque `thoughtSignature`
           // alongside each functionCall part. It MUST be echoed back verbatim on
           // the same part in later turns or the API rejects the request with

--- a/providers/google-gemini/src/ai/index.ts
+++ b/providers/google-gemini/src/ai/index.ts
@@ -14,6 +14,7 @@ export * from "./registerGemini";
 
 import { GEMINI_RUN_FN_SPECS } from "./common/Gemini_Capabilities";
 import { GEMINI_RUN_FNS } from "./common/Gemini_JobRunFns";
+import { buildGeminiContents } from "./common/Gemini_ToolCalling";
 import { GoogleGeminiQueuedProvider } from "./GoogleGeminiQueuedProvider";
 
 /**
@@ -23,4 +24,5 @@ export const _testOnly = {
   GoogleGeminiQueuedProvider,
   GEMINI_RUN_FN_SPECS,
   GEMINI_RUN_FNS,
+  buildGeminiContents,
 } as const;


### PR DESCRIPTION
## Summary

Migrates the Google Gemini provider from the deprecated `@google/generative-ai` SDK to the new `@google/genai` SDK, and adds support for Gemini's "thinking" models (2.5+/3.x) which use extended reasoning before generating responses.

## Key Changes

### SDK Migration
- Replace `@google/generative-ai` with `@google/genai` across all Gemini run-fns
- Update API surface: `getGenerativeModel()` → `ai.models.generateContentStream()`, `chunk.text()` → `chunk.text`
- Migrate `FunctionCallingMode` string literals to `FunctionCallingConfigMode` enum
- Update all streaming patterns to iterate directly over result (not `result.stream`)

### Thinking Model Support
- Add `thinking_budget` configuration field to `GeminiModelSchema` for reasoning token allocation
- Implement `resolveThinkingConfig()` helper to compute `thinkingConfig` and pad `maxOutputTokens` (thinking tokens count against output cap)
- Apply thinking support to text generation, structured generation, and tool calling tasks
- Structured generation defaults to 2048 reasoning tokens when budget is unset; other tasks are opt-in

### Multi-Turn Tool Calling Fixes
- Fix tool_use id collision handling: build `toolUseNames` map during ordered message pass instead of pre-computing, so each turn's `tool_result` resolves to the correct preceding `tool_use` even when ids repeat across turns
- Add `providerSignature` field to `ContentBlockToolUse` to capture and replay Gemini's opaque `thoughtSignature` on functionCall parts in later turns (required by thinking models)
- Update `buildGeminiContents()` to attach `thoughtSignature` to functionCall parts when present

### Client Lifecycle
- Introduce `createGeminiClient()` to memoize `GoogleGenAI` instances per API key (avoids rebuilding auth wiring on every run-fn call)
- Consolidate SDK loading and client creation in `Gemini_Client.ts`

### Schema Improvements
- Enhance `sanitizeSchemaForGemini()` to recursively strip `additionalProperties` from nested objects and array elements (e.g., inside `anyOf`/`oneOf`/`allOf`/`prefixItems`)

### Model List Updates
- Update fallback models to current Gemini lineup: `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`
- Remove deprecated models and consolidate image-output model names

### Test Coverage
- Add comprehensive multi-turn tests for `buildGeminiContents()` covering id collision resolution and `thoughtSignature` round-tripping
- Update integration test to use `gemini-3.5-flash` (current thinking model) instead of retired `gemini-2.5-flash`

## Notable Implementation Details

- Thinking tokens are opt-in for generation/tool-calling (no default budget) but default to 2048 for structured generation (JSON mode needs reasoning headroom with small output caps)
- The `thoughtSignature` is opaque and provider-specific; only Gemini thinking models currently use it, but the field is available on `ContentBlockToolUse` for future providers
- Streaming chunks from `@google/genai` automatically exclude thought parts from `chunk.text`, so no filtering is needed in run-fns

https://claude.ai/code/session_018t7DGA7NRNVWnzFDCRHSnQ