### PR TITLE
Add OpenRouter provider for @workglow/ai

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -58,6 +58,7 @@
     "@workglow/node-llama-cpp": "workspace:*",
     "@workglow/ollama": "workspace:*",
     "@workglow/openai": "workspace:*",
+    "@workglow/openrouter": "workspace:*",
     "@workglow/playwright": "workspace:*",
     "@workglow/postgres": "workspace:*",
     "@workglow/sqlite": "workspace:*",

--- a/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
@@ -5,8 +5,14 @@
  */
 
 import type { ModelRecord } from "@workglow/ai";
-import { deriveCapabilitiesFromMeta, inferOpenRouterCapabilities } from "@workglow/openrouter/ai";
+import {
+  _testOnly,
+  deriveCapabilitiesFromMeta,
+  inferOpenRouterCapabilities,
+} from "@workglow/openrouter/ai";
 import { describe, expect, it } from "vitest";
+
+const { OpenRouterQueuedProvider, OPENROUTER_RUN_FN_SPECS, OPENROUTER_RUN_FNS } = _testOnly;
 
 function model(
   model_id: string,
@@ -79,5 +85,41 @@ describe("inferOpenRouterCapabilities", () => {
     const caps = inferOpenRouterCapabilities(model("some/model", {}, []));
     expect(caps).toContain("text.generation");
     expect(caps).toContain("model.search");
+  });
+});
+
+describe("OpenRouterQueuedProvider.inferCapabilities", () => {
+  const provider = new OpenRouterQueuedProvider(OPENROUTER_RUN_FNS);
+
+  it("infers a full chat+vision set for a multimodal tool model", () => {
+    const caps = provider.inferCapabilities({
+      model_id: "anthropic/claude-sonnet-4",
+      title: "",
+      description: "",
+      provider: "OPENROUTER",
+      provider_config: { model_name: "anthropic/claude-sonnet-4" },
+      capabilities: [],
+      metadata: {
+        architecture: { input_modalities: ["text", "image"] },
+        supported_parameters: ["tools", "response_format"],
+      },
+    } as never);
+    expect(caps).toContain("text.generation");
+    expect(caps).toContain("tool-use");
+    expect(caps).toContain("json-mode");
+    expect(caps).toContain("vision-input");
+  });
+});
+
+describe("OpenRouter capability-set parity", () => {
+  it("OPENROUTER_RUN_FN_SPECS matches OPENROUTER_RUN_FNS serves shapes", () => {
+    const fnsServes = OPENROUTER_RUN_FNS.map((r) => [...r.serves].sort().join(","));
+    const specsServes = OPENROUTER_RUN_FN_SPECS.map((s) => [...s.serves].sort().join(","));
+    expect(specsServes).toEqual(fnsServes);
+  });
+
+  it("tiebreaks text.generation to the smallest serves entry", () => {
+    const candidates = OPENROUTER_RUN_FNS.filter((r) => r.serves.includes("text.generation"));
+    expect(candidates.some((r) => r.serves.length === 1)).toBe(true);
   });
 });

--- a/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelRecord } from "@workglow/ai";
+import { deriveCapabilitiesFromMeta, inferOpenRouterCapabilities } from "@workglow/openrouter/ai";
+import { describe, expect, it } from "vitest";
+
+function model(
+  model_id: string,
+  metadata: Record<string, unknown> = {},
+  capabilities: readonly string[] = []
+): ModelRecord {
+  return {
+    model_id,
+    title: model_id,
+    description: "",
+    provider: "OPENROUTER",
+    provider_config: { model_name: model_id },
+    capabilities: [...capabilities],
+    metadata,
+  } as ModelRecord;
+}
+
+describe("deriveCapabilitiesFromMeta", () => {
+  it("adds vision-input when image is an input modality", () => {
+    const caps = deriveCapabilitiesFromMeta({
+      architecture: { input_modalities: ["text", "image"] },
+      supported_parameters: [],
+    });
+    expect(caps).toContain("vision-input");
+    expect(caps).toContain("text.generation");
+  });
+
+  it("adds tool-use and json-mode from supported_parameters", () => {
+    const caps = deriveCapabilitiesFromMeta({
+      architecture: { input_modalities: ["text"] },
+      supported_parameters: ["tools", "response_format", "structured_outputs"],
+    });
+    expect(caps).toContain("tool-use");
+    expect(caps).toContain("json-mode");
+    expect(caps).not.toContain("vision-input");
+  });
+
+  it("returns the baseline chat set when metadata is bare", () => {
+    const caps = deriveCapabilitiesFromMeta({});
+    expect(caps).toContain("text.generation");
+    expect(caps).toContain("text.rewriter");
+    expect(caps).toContain("text.summary");
+    expect(caps).toContain("model.count-tokens");
+    expect(caps).toContain("model.info");
+    expect(caps).toContain("model.search");
+    expect(caps).not.toContain("tool-use");
+  });
+});
+
+describe("inferOpenRouterCapabilities", () => {
+  it("derives from record metadata when present", () => {
+    const caps = inferOpenRouterCapabilities(
+      model("anthropic/claude-sonnet-4", {
+        architecture: { input_modalities: ["text", "image"] },
+        supported_parameters: ["tools", "response_format"],
+      })
+    );
+    expect(caps).toContain("text.generation");
+    expect(caps).toContain("tool-use");
+    expect(caps).toContain("json-mode");
+    expect(caps).toContain("vision-input");
+  });
+
+  it("falls back to declared capabilities when metadata is absent", () => {
+    const caps = inferOpenRouterCapabilities(model("some/model", {}, ["text.classification"]));
+    expect(caps).toEqual(["text.classification"]);
+  });
+
+  it("falls back to the baseline chat set when nothing is declared", () => {
+    const caps = inferOpenRouterCapabilities(model("some/model", {}, []));
+    expect(caps).toContain("text.generation");
+    expect(caps).toContain("model.search");
+  });
+});

--- a/packages/test/src/test/ai-provider-api/OpenRouter_ModelSearch.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_ModelSearch.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/openrouter/ai";
+import { describe, expect, it } from "vitest";
+
+const { mapOpenRouterModels } = _testOnly;
+
+describe("mapOpenRouterModels", () => {
+  it("maps /models entries to result items with data-driven capabilities", () => {
+    const items = mapOpenRouterModels([
+      {
+        id: "anthropic/claude-sonnet-4",
+        name: "Anthropic: Claude Sonnet 4",
+        description: "desc",
+        context_length: 200000,
+        pricing: { prompt: "0.000003", completion: "0.000015" },
+        architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] },
+        supported_parameters: ["tools", "response_format"],
+      },
+    ]);
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.id).toBe("anthropic/claude-sonnet-4");
+    expect(item.record.provider).toBe("OPENROUTER");
+    expect(item.record.provider_config).toEqual({ model_name: "anthropic/claude-sonnet-4" });
+    expect(item.record.capabilities).toContain("tool-use");
+    expect(item.record.capabilities).toContain("json-mode");
+    expect(item.record.capabilities).toContain("vision-input");
+    expect((item.record.metadata as Record<string, unknown>).context_length).toBe(200000);
+  });
+});

--- a/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_RequestParams.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/openrouter/ai";
+import { describe, expect, it } from "vitest";
+
+const { buildChatParams, buildOpenRouterExtras } = _testOnly;
+
+function cfg(provider_config: Record<string, unknown>) {
+  return { provider: "OPENROUTER", provider_config } as never;
+}
+
+describe("buildChatParams", () => {
+  it("wraps a prompt as a single user message and maps sampling params", () => {
+    const params = buildChatParams(
+      { prompt: "hi", maxTokens: 100, temperature: 0.5 } as never,
+      cfg({ model_name: "openai/gpt-5" })
+    );
+    expect(params.model).toBe("openai/gpt-5");
+    expect(params.messages).toEqual([{ role: "user", content: "hi" }]);
+    expect(params.max_completion_tokens).toBe(100);
+    expect(params.temperature).toBe(0.5);
+  });
+});
+
+describe("buildOpenRouterExtras", () => {
+  it("serializes routing, reasoning, and web search", () => {
+    const extras = buildOpenRouterExtras(
+      cfg({
+        model_name: "openai/gpt-5",
+        provider_routing: { sort: "price", allow_fallbacks: true },
+        reasoning: { effort: "high" },
+        web_search: true,
+      })
+    );
+    expect(extras.provider).toEqual({ sort: "price", allow_fallbacks: true });
+    expect(extras.reasoning).toEqual({ effort: "high" });
+    expect(extras.plugins).toEqual([{ id: "web" }]);
+  });
+
+  it("passes web_search object options through", () => {
+    const extras = buildOpenRouterExtras(
+      cfg({ model_name: "openai/gpt-5", web_search: { max_results: 3 } })
+    );
+    expect(extras.plugins).toEqual([{ id: "web", max_results: 3 }]);
+  });
+
+  it("returns an empty object when no native controls are set", () => {
+    const extras = buildOpenRouterExtras(cfg({ model_name: "openai/gpt-5" }));
+    expect(extras).toEqual({});
+  });
+});

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -136,6 +136,22 @@
       "types": "./dist/openai-runtime.d.ts",
       "import": "./dist/openai-runtime.js"
     },
+    "./openrouter": {
+      "browser": {
+        "types": "./dist/openrouter.d.ts",
+        "import": "./dist/openrouter.browser.js"
+      },
+      "bun": {
+        "types": "./dist/openrouter.d.ts",
+        "import": "./dist/openrouter.bun.js"
+      },
+      "types": "./dist/openrouter.d.ts",
+      "import": "./dist/openrouter.js"
+    },
+    "./openrouter/runtime": {
+      "types": "./dist/openrouter-runtime.d.ts",
+      "import": "./dist/openrouter-runtime.js"
+    },
     "./tf-mediapipe": {
       "types": "./dist/tf-mediapipe.d.ts",
       "import": "./dist/tf-mediapipe.js"
@@ -191,6 +207,7 @@
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
     "@workglow/openai": "workspace:*",
+    "@workglow/openrouter": "workspace:*",
     "@workglow/google-gemini": "workspace:*",
     "@workglow/ollama": "workspace:*",
     "@workglow/huggingface-transformers": "workspace:*",

--- a/packages/workglow/src/openrouter-runtime.ts
+++ b/packages/workglow/src/openrouter-runtime.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/openrouter/ai-runtime";

--- a/packages/workglow/src/openrouter.browser.ts
+++ b/packages/workglow/src/openrouter.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/openrouter/ai";

--- a/packages/workglow/src/openrouter.bun.ts
+++ b/packages/workglow/src/openrouter.bun.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/openrouter/ai";

--- a/packages/workglow/src/openrouter.ts
+++ b/packages/workglow/src/openrouter.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/openrouter/ai";

--- a/packages/workglow/tsconfig.json
+++ b/packages/workglow/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../../providers/huggingface-transformers" },
     { "path": "../../providers/ollama" },
     { "path": "../../providers/openai" },
+    { "path": "../../providers/openrouter" },
     { "path": "../../providers/postgres" },
     { "path": "../../providers/sqlite" },
     { "path": "../../providers/tf-mediapipe" }

--- a/providers/openrouter/README.md
+++ b/providers/openrouter/README.md
@@ -1,0 +1,9 @@
+# @workglow/openrouter
+
+OpenRouter provider for `@workglow/ai`. OpenRouter is a unified gateway to many
+model vendors behind an OpenAI-compatible chat API.
+
+Exposes `./ai` (main-thread shell) and `./ai-runtime` (worker / inline runtime),
+matching the other cloud providers. Supports the full chat capability set plus
+OpenRouter-native controls (provider routing, reasoning, web search, and app
+attribution) configured on the model record's `provider_config`.

--- a/providers/openrouter/package.json
+++ b/providers/openrouter/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@workglow/openrouter",
+  "type": "module",
+  "sideEffects": false,
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/workglow-dev/libs.git",
+    "directory": "providers/openrouter"
+  },
+  "bugs": {
+    "url": "https://github.com/workglow-dev/libs/issues"
+  },
+  "description": "OpenRouter provider for @workglow/ai.",
+  "homepage": "https://workglow.dev",
+  "scripts": {
+    "watch": "concurrently -c 'auto' 'bun:watch-*'",
+    "watch-code": "bun build --watch --no-clear-screen --sourcemap=external --packages=external --root ./src --outdir ./dist ./src/ai.ts ./src/ai-runtime.ts",
+    "watch-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/ai.browser.ts ./src/ai-runtime.browser.ts",
+    "watch-types": "tsc --watch --preserveWatchOutput",
+    "build-package": "concurrently -c 'auto' -n 'code,browser,types' 'bun run build-code' 'bun run build-browser' 'bun run build-types'",
+    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'code,browser' 'bun run build-code' 'bun run build-browser'",
+    "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
+    "build-code": "bun build --sourcemap=external --packages=external --root ./src --outdir ./dist ./src/ai.ts ./src/ai-runtime.ts",
+    "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/ai.browser.ts ./src/ai-runtime.browser.ts",
+    "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "exports": {
+    "./ai": {
+      "browser": {
+        "types": "./dist/ai.d.ts",
+        "import": "./dist/ai.browser.js"
+      },
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    },
+    "./ai-runtime": {
+      "browser": {
+        "types": "./dist/ai-runtime.d.ts",
+        "import": "./dist/ai-runtime.browser.js"
+      },
+      "types": "./dist/ai-runtime.d.ts",
+      "import": "./dist/ai-runtime.js"
+    }
+  },
+  "dependencies": {
+    "openai": "catalog:"
+  },
+  "peerDependencies": {
+    "@workglow/ai": "workspace:*",
+    "@workglow/job-queue": "workspace:*",
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@workglow/ai": { "optional": false },
+    "@workglow/job-queue": { "optional": false },
+    "@workglow/storage": { "optional": false },
+    "@workglow/task-graph": { "optional": false },
+    "@workglow/util": { "optional": false }
+  },
+  "devDependencies": {
+    "@workglow/ai": "workspace:*",
+    "@workglow/job-queue": "workspace:*",
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "files": ["dist", "src/**/*.md"],
+  "publishConfig": { "access": "public" }
+}

--- a/providers/openrouter/src/ai-runtime.browser.ts
+++ b/providers/openrouter/src/ai-runtime.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/runtime.browser";

--- a/providers/openrouter/src/ai-runtime.ts
+++ b/providers/openrouter/src/ai-runtime.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/runtime";

--- a/providers/openrouter/src/ai.browser.ts
+++ b/providers/openrouter/src/ai.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/index.browser";

--- a/providers/openrouter/src/ai.ts
+++ b/providers/openrouter/src/ai.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/index";

--- a/providers/openrouter/src/ai/OpenRouterProvider.ts
+++ b/providers/openrouter/src/ai/OpenRouterProvider.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createCloudProviderClass } from "@workglow/ai/provider-utils";
+import type { Capability, ModelRecord } from "@workglow/ai/worker";
+import { AiProvider } from "@workglow/ai/worker";
+import {
+  inferOpenRouterCapabilities,
+  openRouterWorkerRunFnSpecs,
+} from "./common/OpenRouter_Capabilities";
+import { OPENROUTER } from "./common/OpenRouter_Constants";
+import type { OpenRouterModelConfig } from "./common/OpenRouter_ModelSchema";
+
+/** Worker-server registration class for OpenRouter cloud models. */
+export class OpenRouterProvider extends createCloudProviderClass<OpenRouterModelConfig>(
+  AiProvider,
+  { name: OPENROUTER, displayName: "OpenRouter" }
+) {
+  override inferCapabilities(model: ModelRecord): readonly Capability[] {
+    return inferOpenRouterCapabilities(model);
+  }
+
+  protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {
+    return openRouterWorkerRunFnSpecs();
+  }
+}

--- a/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
+++ b/providers/openrouter/src/ai/OpenRouterQueuedProvider.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability, ModelRecord } from "@workglow/ai";
+import { AiProvider } from "@workglow/ai";
+import { createCloudProviderClass } from "@workglow/ai/provider-utils";
+import {
+  inferOpenRouterCapabilities,
+  openRouterWorkerRunFnSpecs,
+} from "./common/OpenRouter_Capabilities";
+import { OPENROUTER } from "./common/OpenRouter_Constants";
+import type { OpenRouterModelConfig } from "./common/OpenRouter_ModelSchema";
+
+/** Main-thread registration shell for OpenRouter (inline + worker-proxy). */
+export class OpenRouterQueuedProvider extends createCloudProviderClass<OpenRouterModelConfig>(
+  AiProvider,
+  { name: OPENROUTER, displayName: "OpenRouter" }
+) {
+  override inferCapabilities(model: ModelRecord): readonly Capability[] {
+    return inferOpenRouterCapabilities(model);
+  }
+
+  protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {
+    return openRouterWorkerRunFnSpecs();
+  }
+}

--- a/providers/openrouter/src/ai/common/OpenRouter_Capabilities.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_Capabilities.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability, ModelRecord } from "@workglow/ai/worker";
+import { OPENROUTER_CAPABILITY_SETS } from "./OpenRouter_CapabilitySets";
+
+export const OPENROUTER_RUN_FN_SPECS = OPENROUTER_CAPABILITY_SETS.map((serves) => ({ serves }));
+
+export function openRouterWorkerRunFnSpecs(): readonly {
+  readonly serves: readonly Capability[];
+}[] {
+  return OPENROUTER_RUN_FN_SPECS;
+}
+
+/** Baseline capabilities every OpenRouter chat model exposes. */
+const BASELINE_CHAT: readonly Capability[] = [
+  "text.generation",
+  "text.rewriter",
+  "text.summary",
+  "model.count-tokens",
+  "model.info",
+  "model.search",
+];
+
+interface OpenRouterModelMeta {
+  readonly architecture?: {
+    readonly input_modalities?: readonly string[];
+    readonly modality?: string;
+  };
+  readonly supported_parameters?: readonly string[];
+}
+
+/**
+ * Derive the capability set from OpenRouter `/models` metadata: image input
+ * modality → `vision-input`; `tools`/`tool_choice` → `tool-use`;
+ * `response_format`/`structured_outputs` → `json-mode`. Always includes the
+ * baseline chat set.
+ */
+export function deriveCapabilitiesFromMeta(
+  meta: OpenRouterModelMeta | undefined
+): readonly Capability[] {
+  const caps = new Set<Capability>(BASELINE_CHAT);
+  const modalities = meta?.architecture?.input_modalities ?? [];
+  if (modalities.includes("image")) caps.add("vision-input");
+  const params = meta?.supported_parameters ?? [];
+  if (params.includes("tools") || params.includes("tool_choice")) caps.add("tool-use");
+  if (params.includes("response_format") || params.includes("structured_outputs")) {
+    caps.add("json-mode");
+  }
+  return [...caps];
+}
+
+/**
+ * Capability inference for an OpenRouter {@link ModelRecord}. Prefers the
+ * record's stored metadata (populated at model-search time); falls back to the
+ * record's declared `capabilities`, then to the baseline chat set.
+ */
+export function inferOpenRouterCapabilities(model: ModelRecord): readonly Capability[] {
+  const meta = model.metadata as OpenRouterModelMeta | undefined;
+  const hasMeta =
+    (meta?.architecture?.input_modalities?.length ?? 0) > 0 ||
+    (meta?.supported_parameters?.length ?? 0) > 0;
+  if (hasMeta) return deriveCapabilitiesFromMeta(meta);
+
+  const declared = (model.capabilities as readonly Capability[] | undefined) ?? [];
+  if (declared.length > 0) return declared;
+  return BASELINE_CHAT;
+}

--- a/providers/openrouter/src/ai/common/OpenRouter_CapabilitySets.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_CapabilitySets.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability } from "@workglow/ai/worker";
+
+export const OPENROUTER_TEXT_GENERATION = ["text.generation"] as const satisfies Capability[];
+export const OPENROUTER_TOOL_USE = ["text.generation", "tool-use"] as const satisfies Capability[];
+export const OPENROUTER_JSON_MODE = [
+  "text.generation",
+  "json-mode",
+] as const satisfies Capability[];
+export const OPENROUTER_TEXT_REWRITER = ["text.rewriter"] as const satisfies Capability[];
+export const OPENROUTER_TEXT_SUMMARY = ["text.summary"] as const satisfies Capability[];
+export const OPENROUTER_COUNT_TOKENS = ["model.count-tokens"] as const satisfies Capability[];
+export const OPENROUTER_MODEL_SEARCH = ["model.search"] as const satisfies Capability[];
+export const OPENROUTER_MODEL_INFO = ["model.info"] as const satisfies Capability[];
+
+/** Aggregated list — order MUST match `OPENROUTER_RUN_FNS`. */
+export const OPENROUTER_CAPABILITY_SETS = [
+  OPENROUTER_TEXT_GENERATION,
+  OPENROUTER_TOOL_USE,
+  OPENROUTER_JSON_MODE,
+  OPENROUTER_TEXT_REWRITER,
+  OPENROUTER_TEXT_SUMMARY,
+  OPENROUTER_COUNT_TOKENS,
+  OPENROUTER_MODEL_SEARCH,
+  OPENROUTER_MODEL_INFO,
+] as const;

--- a/providers/openrouter/src/ai/common/OpenRouter_Client.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_Client.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+
+/** Hostnames accepted for the OpenRouter `base_url` without `trustedBaseUrl`. */
+export const OPENROUTER_ALLOWED_HOSTS: readonly string[] = ["openrouter.ai"];
+
+type OpenAIClientClass = new (config: any) => any;
+
+let _loadPromise: Promise<OpenAIClientClass> | undefined;
+
+// NOTE: we do not want to de-dup this in the provider-utils, vite wants direct import with string literals.
+export async function loadOpenAISDK(): Promise<OpenAIClientClass> {
+  _loadPromise ??= import(/* @vite-ignore */ "openai")
+
+    .then((mod) => mod.default as OpenAIClientClass)
+    .catch(() => {
+      _loadPromise = undefined;
+      throw new Error("openai is required for OpenRouter tasks. Install it with: bun add openai");
+    });
+  return _loadPromise;
+}
+
+/** Resolved shape of `provider_config` consumed by the client and request builder. */
+export interface OpenRouterProviderConfig {
+  readonly credential_key?: string;
+  readonly api_key?: string;
+  readonly model_name?: string;
+  readonly base_url?: string;
+  readonly trustedBaseUrl?: boolean;
+  readonly provider_routing?: Record<string, unknown>;
+  readonly reasoning?: Record<string, unknown>;
+  readonly web_search?: boolean | Record<string, unknown>;
+  readonly app_referer?: string;
+  readonly app_title?: string;
+}
+
+export async function getClient(model: OpenRouterModelConfig | undefined) {
+  const OpenAI = await loadOpenAISDK();
+  const config = model?.provider_config as OpenRouterProviderConfig | undefined;
+  const apiKey = resolveApiKey({
+    config,
+    envVar: "OPENROUTER_API_KEY",
+    providerLabel: "OpenRouter",
+  });
+  // Validate before SDK construction so the API key is never attached to a
+  // rejected host.
+  const baseURL =
+    validateProviderBaseUrl(config?.base_url, {
+      vendor: "openai",
+      allowHosts: OPENROUTER_ALLOWED_HOSTS,
+      trustedBaseUrl: config?.trustedBaseUrl,
+      providerLabel: "OpenRouter",
+    }) ?? "https://openrouter.ai/api/v1";
+
+  const defaultHeaders: Record<string, string> = {};
+  if (config?.app_referer) defaultHeaders["HTTP-Referer"] = config.app_referer;
+  if (config?.app_title) defaultHeaders["X-Title"] = config.app_title;
+
+  try {
+    return new OpenAI({
+      apiKey,
+      baseURL,
+      defaultHeaders,
+      dangerouslyAllowBrowser: isBrowserLike(),
+    });
+  } catch (err) {
+    throw new Error(
+      `Failed to create OpenRouter client: ${err instanceof Error ? err.message : "unknown error"}`
+    );
+  }
+}
+
+export function getModelName(model: OpenRouterModelConfig | undefined): string {
+  const name = model?.provider_config?.model_name;
+  if (!name) {
+    throw new Error("Missing model name in provider_config.model_name.");
+  }
+  return name;
+}

--- a/providers/openrouter/src/ai/common/OpenRouter_Constants.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_Constants.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const OPENROUTER = "OPENROUTER";

--- a/providers/openrouter/src/ai/common/OpenRouter_CountTokens.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_CountTokens.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderPreviewRunFn,
+  AiProviderRunFn,
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+} from "@workglow/ai";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+
+/**
+ * Heuristic token estimate. OpenRouter fans out to many vendor tokenizers and
+ * exposes no dedicated count endpoint, so we approximate ~4 characters/token —
+ * enough for UI budgeting without bundling a tokenizer.
+ */
+function estimateTokens(input: CountTokensTaskInput): CountTokensTaskOutput {
+  const text = input.text ?? "";
+  return { count: Math.ceil(text.length / 4) };
+}
+
+/** One-shot run-fn for `["model.count-tokens"]`. */
+export const OpenRouter_CountTokens_Stream: AiProviderRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  OpenRouterModelConfig
+> = async (input, _model, _signal, emit) => {
+  emit({ type: "finish", data: estimateTokens(input) });
+};
+
+/** Lightweight preview path used by `AiTask.executePreview()`. */
+export const OpenRouter_CountTokens_Preview: AiProviderPreviewRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  OpenRouterModelConfig
+> = async (input) => {
+  return estimateTokens(input);
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_JobRunFns.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_JobRunFns.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderPreviewRunFn, AiProviderRunFnRegistration } from "@workglow/ai";
+import {
+  OPENROUTER_COUNT_TOKENS,
+  OPENROUTER_JSON_MODE,
+  OPENROUTER_MODEL_INFO,
+  OPENROUTER_MODEL_SEARCH,
+  OPENROUTER_TEXT_GENERATION,
+  OPENROUTER_TEXT_REWRITER,
+  OPENROUTER_TEXT_SUMMARY,
+  OPENROUTER_TOOL_USE,
+} from "./OpenRouter_CapabilitySets";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+
+export { getClient, getModelName } from "./OpenRouter_Client";
+
+import {
+  OpenRouter_CountTokens_Preview,
+  OpenRouter_CountTokens_Stream,
+} from "./OpenRouter_CountTokens";
+import { OpenRouter_ModelInfo_Stream } from "./OpenRouter_ModelInfo";
+import { OpenRouter_ModelSearch_Stream } from "./OpenRouter_ModelSearch";
+import { OpenRouter_StructuredGeneration_Stream } from "./OpenRouter_StructuredGeneration";
+import { OpenRouter_TextGeneration_Stream } from "./OpenRouter_TextGeneration";
+import { OpenRouter_TextRewriter_Stream } from "./OpenRouter_TextRewriter";
+import { OpenRouter_TextSummary_Stream } from "./OpenRouter_TextSummary";
+import { OpenRouter_ToolCalling_Stream } from "./OpenRouter_ToolCalling";
+
+/**
+ * Capability-set run-fn registrations. Order matters only as a tiebreaker —
+ * the dispatcher prefers the smallest `serves` superset, so bare
+ * `["text.generation"]` wins for plain text-gen / chat while the tool-use and
+ * json-mode entries win for their tasks.
+ */
+export const OPENROUTER_RUN_FNS: readonly AiProviderRunFnRegistration<
+  any,
+  any,
+  OpenRouterModelConfig
+>[] = [
+  { serves: OPENROUTER_TEXT_GENERATION, runFn: OpenRouter_TextGeneration_Stream },
+  { serves: OPENROUTER_TOOL_USE, runFn: OpenRouter_ToolCalling_Stream },
+  { serves: OPENROUTER_JSON_MODE, runFn: OpenRouter_StructuredGeneration_Stream },
+  { serves: OPENROUTER_TEXT_REWRITER, runFn: OpenRouter_TextRewriter_Stream },
+  { serves: OPENROUTER_TEXT_SUMMARY, runFn: OpenRouter_TextSummary_Stream },
+  { serves: OPENROUTER_COUNT_TOKENS, runFn: OpenRouter_CountTokens_Stream },
+  { serves: OPENROUTER_MODEL_SEARCH, runFn: OpenRouter_ModelSearch_Stream },
+  { serves: OPENROUTER_MODEL_INFO, runFn: OpenRouter_ModelInfo_Stream },
+];
+
+export const OPENROUTER_PREVIEW_TASKS: Record<
+  string,
+  AiProviderPreviewRunFn<any, any, OpenRouterModelConfig>
+> = {
+  CountTokensTask: OpenRouter_CountTokens_Preview,
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_ModelInfo.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ModelInfo.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, ModelInfoTaskInput, ModelInfoTaskOutput } from "@workglow/ai";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+
+/**
+ * One-shot run-fn for `["model.info"]`. OpenRouter chat models are always
+ * remote and cloud-hosted; emit a single `finish` with the standard remote
+ * info record.
+ */
+export const OpenRouter_ModelInfo_Stream: AiProviderRunFn<
+  ModelInfoTaskInput,
+  ModelInfoTaskOutput,
+  OpenRouterModelConfig
+> = async (input, _model, _signal, emit) => {
+  emit({
+    type: "finish",
+    data: {
+      model: input.model,
+      is_local: false,
+      is_remote: true,
+      supports_browser: true,
+      supports_node: true,
+      is_cached: false,
+      is_loaded: false,
+      file_sizes: null,
+    },
+  });
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_ModelSchema.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ModelSchema.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ModelConfigSchema, ModelRecordSchema } from "@workglow/ai/worker";
+import { DataPortSchemaObject, FromSchema } from "@workglow/util/worker";
+import { OPENROUTER } from "./OpenRouter_Constants";
+
+export const OpenRouterModelSchema = {
+  type: "object",
+  properties: {
+    provider: {
+      const: OPENROUTER,
+      description: "Discriminator: OpenRouter cloud gateway.",
+    },
+    provider_config: {
+      type: "object",
+      description: "OpenRouter-specific configuration.",
+      properties: {
+        model_name: {
+          type: "string",
+          description:
+            "The OpenRouter model id, e.g. 'anthropic/claude-sonnet-4' or 'openai/gpt-5'.",
+        },
+        credential_key: {
+          type: "string",
+          format: "credential",
+          description: "Key to look up in the credential store for the API key.",
+          "x-ui-hidden": true,
+        },
+        base_url: {
+          type: "string",
+          description: "Base URL for the OpenRouter API.",
+          default: "https://openrouter.ai/api/v1",
+        },
+        trustedBaseUrl: {
+          type: "boolean",
+          description:
+            "When true, accept a base_url whose hostname is not in the built-in allow-list. Use only for known-good custom gateways.",
+          default: false,
+          "x-ui-hidden": true,
+        },
+        provider_routing: {
+          type: "object",
+          description:
+            "OpenRouter provider routing preferences (serialized to the request 'provider' field).",
+          properties: {
+            order: { type: "array", items: { type: "string" } },
+            allow_fallbacks: { type: "boolean" },
+            only: { type: "array", items: { type: "string" } },
+            ignore: { type: "array", items: { type: "string" } },
+            sort: { type: "string", enum: ["price", "throughput", "latency"] },
+          },
+          additionalProperties: true,
+          "x-ui-hidden": true,
+        },
+        reasoning: {
+          type: "object",
+          description: "Reasoning configuration (serialized to the request 'reasoning' field).",
+          properties: {
+            effort: { type: "string", enum: ["low", "medium", "high"] },
+            max_tokens: { type: "number" },
+            exclude: { type: "boolean" },
+          },
+          additionalProperties: true,
+          "x-ui-hidden": true,
+        },
+        web_search: {
+          description:
+            "Enable the OpenRouter web-search plugin. `true` enables defaults; an object customizes it.",
+          "x-ui-hidden": true,
+        },
+        app_referer: {
+          type: "string",
+          description: "Value sent as the HTTP-Referer header for OpenRouter app attribution.",
+          "x-ui-hidden": true,
+        },
+        app_title: {
+          type: "string",
+          description: "Value sent as the X-Title header for OpenRouter app attribution.",
+          "x-ui-hidden": true,
+        },
+      },
+      required: ["model_name"],
+      additionalProperties: false,
+    },
+  },
+  required: ["provider", "provider_config"],
+  additionalProperties: true,
+} as const satisfies DataPortSchemaObject;
+
+export const OpenRouterModelRecordSchema = {
+  type: "object",
+  properties: {
+    ...ModelRecordSchema.properties,
+    ...OpenRouterModelSchema.properties,
+  },
+  required: [...ModelRecordSchema.required, ...OpenRouterModelSchema.required],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+export type OpenRouterModelRecord = FromSchema<typeof OpenRouterModelRecordSchema>;
+
+export const OpenRouterModelConfigSchema = {
+  type: "object",
+  properties: {
+    ...ModelConfigSchema.properties,
+    ...OpenRouterModelSchema.properties,
+  },
+  required: [...ModelConfigSchema.required, ...OpenRouterModelSchema.required],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+export type OpenRouterModelConfig = FromSchema<typeof OpenRouterModelConfigSchema>;

--- a/providers/openrouter/src/ai/common/OpenRouter_ModelSchema.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ModelSchema.ts
@@ -70,6 +70,17 @@ export const OpenRouterModelSchema = {
         web_search: {
           description:
             "Enable the OpenRouter web-search plugin. `true` enables defaults; an object customizes it.",
+          oneOf: [
+            { type: "boolean" },
+            {
+              type: "object",
+              properties: {
+                max_results: { type: "number" },
+                engine: { type: "string" },
+              },
+              additionalProperties: true,
+            },
+          ],
           "x-ui-hidden": true,
         },
         app_referer: {

--- a/providers/openrouter/src/ai/common/OpenRouter_ModelSearch.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ModelSearch.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  ModelSearchResultItem,
+  ModelSearchTaskInput,
+  ModelSearchTaskOutput,
+} from "@workglow/ai";
+import { filterLabeledModelsByQuery } from "@workglow/ai/provider-utils";
+import { deriveCapabilitiesFromMeta } from "./OpenRouter_Capabilities";
+import { OPENROUTER } from "./OpenRouter_Constants";
+
+export interface OpenRouterRawModel {
+  readonly id: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly context_length?: number;
+  readonly pricing?: Record<string, unknown>;
+  readonly architecture?: {
+    readonly input_modalities?: readonly string[];
+    readonly output_modalities?: readonly string[];
+    readonly modality?: string;
+  };
+  readonly supported_parameters?: readonly string[];
+}
+
+/** Minimal curated fallback used when the public /models fetch fails. */
+export const OPENROUTER_FALLBACK_MODELS: OpenRouterRawModel[] = [
+  {
+    id: "openai/gpt-5",
+    name: "OpenAI: GPT-5",
+    architecture: { input_modalities: ["text", "image"] },
+    supported_parameters: ["tools", "response_format"],
+  },
+  {
+    id: "anthropic/claude-sonnet-4",
+    name: "Anthropic: Claude Sonnet 4",
+    architecture: { input_modalities: ["text", "image"] },
+    supported_parameters: ["tools", "response_format"],
+  },
+  {
+    id: "google/gemini-2.5-pro",
+    name: "Google: Gemini 2.5 Pro",
+    architecture: { input_modalities: ["text", "image"] },
+    supported_parameters: ["tools", "response_format"],
+  },
+];
+
+export async function fetchOpenRouterModels(
+  baseUrl = "https://openrouter.ai/api/v1"
+): Promise<OpenRouterRawModel[]> {
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/models`);
+    if (!res.ok) return OPENROUTER_FALLBACK_MODELS;
+    const body = (await res.json()) as { data?: OpenRouterRawModel[] };
+    return Array.isArray(body.data) && body.data.length > 0
+      ? body.data
+      : OPENROUTER_FALLBACK_MODELS;
+  } catch {
+    return OPENROUTER_FALLBACK_MODELS;
+  }
+}
+
+export function mapOpenRouterModels(raw: readonly OpenRouterRawModel[]): ModelSearchResultItem[] {
+  return raw.map((m) => {
+    const capabilities = deriveCapabilitiesFromMeta({
+      architecture: m.architecture,
+      supported_parameters: m.supported_parameters,
+    });
+    return {
+      id: m.id,
+      label: m.name ?? m.id,
+      description: m.description ?? "",
+      record: {
+        model_id: m.id,
+        provider: OPENROUTER,
+        title: m.name ?? m.id,
+        description: m.description ?? "",
+        capabilities: [...capabilities],
+        provider_config: { model_name: m.id },
+        metadata: {
+          context_length: m.context_length,
+          pricing: m.pricing,
+          architecture: m.architecture,
+          supported_parameters: m.supported_parameters,
+        },
+      },
+      raw: m,
+    };
+  });
+}
+
+/**
+ * One-shot run-fn for `["model.search"]`. Fetches OpenRouter's public /models
+ * endpoint (no key required), maps entries to result records with data-driven
+ * capabilities, and filters by query. Degrades to a curated list on failure.
+ */
+export const OpenRouter_ModelSearch_Stream: AiProviderRunFn<
+  ModelSearchTaskInput,
+  ModelSearchTaskOutput
+> = async (input, _model, _signal, emit) => {
+  const raw = await fetchOpenRouterModels();
+  const labeled = raw.map((m) => ({ label: m.name ?? m.id, value: m.id, raw: m }));
+  const filtered = filterLabeledModelsByQuery(labeled, input.query);
+  const results = mapOpenRouterModels(filtered.map((f) => f.raw));
+  emit({ type: "finish", data: { results } });
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_ModelSearch.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ModelSearch.ts
@@ -51,16 +51,20 @@ export const OPENROUTER_FALLBACK_MODELS: OpenRouterRawModel[] = [
 ];
 
 export async function fetchOpenRouterModels(
-  baseUrl = "https://openrouter.ai/api/v1"
+  baseUrl = "https://openrouter.ai/api/v1",
+  signal?: AbortSignal
 ): Promise<OpenRouterRawModel[]> {
   try {
-    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/models`);
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/models`, { signal });
     if (!res.ok) return OPENROUTER_FALLBACK_MODELS;
     const body = (await res.json()) as { data?: OpenRouterRawModel[] };
     return Array.isArray(body.data) && body.data.length > 0
       ? body.data
       : OPENROUTER_FALLBACK_MODELS;
-  } catch {
+  } catch (err) {
+    // Propagate a genuine cancellation instead of masking it as a fallback
+    // result; only degrade to the curated list on network/parse failures.
+    if (signal?.aborted) throw err;
     return OPENROUTER_FALLBACK_MODELS;
   }
 }
@@ -102,8 +106,8 @@ export function mapOpenRouterModels(raw: readonly OpenRouterRawModel[]): ModelSe
 export const OpenRouter_ModelSearch_Stream: AiProviderRunFn<
   ModelSearchTaskInput,
   ModelSearchTaskOutput
-> = async (input, _model, _signal, emit) => {
-  const raw = await fetchOpenRouterModels();
+> = async (input, _model, signal, emit) => {
+  const raw = await fetchOpenRouterModels(undefined, signal);
   const labeled = raw.map((m) => ({ label: m.name ?? m.id, value: m.id, raw: m }));
   const filtered = filterLabeledModelsByQuery(labeled, input.query);
   const results = mapOpenRouterModels(filtered.map((f) => f.raw));

--- a/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_RequestParams.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TextGenerationTaskInput } from "@workglow/ai";
+import { toOpenAIMessages } from "@workglow/ai/worker";
+import type { OpenRouterProviderConfig } from "./OpenRouter_Client";
+import { getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+
+interface UnifiedTextGenerationInput extends TextGenerationTaskInput {
+  readonly messages?: readonly unknown[];
+  readonly systemPrompt?: string;
+}
+
+/**
+ * Assemble the base OpenAI-shaped chat params — preferring a populated
+ * `messages` array (AiChatTask), falling back to wrapping `prompt` as a single
+ * user message (TextGenerationTask).
+ */
+export function buildChatParams(
+  input: UnifiedTextGenerationInput,
+  model: OpenRouterModelConfig | undefined
+): Record<string, unknown> {
+  const hasMessages = Array.isArray(input.messages) && input.messages.length > 0;
+  const messages = hasMessages
+    ? toOpenAIMessages({
+        messages: input.messages,
+        systemPrompt: input.systemPrompt,
+        prompt: "",
+        tools: [],
+      } as never)
+    : [{ role: "user" as const, content: input.prompt }];
+
+  const params: Record<string, unknown> = {
+    model: getModelName(model),
+    messages,
+  };
+  if (input.maxTokens !== undefined) params.max_completion_tokens = input.maxTokens;
+  if (input.temperature !== undefined) params.temperature = input.temperature;
+  if ((input as { topP?: number }).topP !== undefined)
+    params.top_p = (input as { topP?: number }).topP;
+  if ((input as { frequencyPenalty?: number }).frequencyPenalty !== undefined)
+    params.frequency_penalty = (input as { frequencyPenalty?: number }).frequencyPenalty;
+  if ((input as { presencePenalty?: number }).presencePenalty !== undefined)
+    params.presence_penalty = (input as { presencePenalty?: number }).presencePenalty;
+  return params;
+}
+
+/**
+ * Assemble OpenRouter-native request extras from `provider_config`: routing
+ * preferences (`provider`), `reasoning`, and the web-search `plugins` entry.
+ */
+export function buildOpenRouterExtras(
+  model: OpenRouterModelConfig | undefined
+): Record<string, unknown> {
+  const pc = model?.provider_config as OpenRouterProviderConfig | undefined;
+  const extras: Record<string, unknown> = {};
+  if (pc?.provider_routing) extras.provider = pc.provider_routing;
+  if (pc?.reasoning) extras.reasoning = pc.reasoning;
+  if (pc?.web_search) {
+    extras.plugins = [pc.web_search === true ? { id: "web" } : { id: "web", ...pc.web_search }];
+  }
+  return extras;
+}

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+} from "@workglow/ai";
+import { parsePartialJson } from "@workglow/util/worker";
+import { getClient, getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+
+/**
+ * Streaming run-fn for `["text.generation", "json-mode"]`. Emits `object-delta`
+ * partial-JSON snapshots on the `object` port and a `finish` carrying the parsed
+ * final object.
+ */
+export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+  OpenRouterModelConfig
+> = async (input, model, signal, emit, outputSchema) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+  const schema = input.outputSchema ?? outputSchema;
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [{ role: "user", content: input.prompt }],
+      response_format: {
+        type: "json_schema" as never,
+        json_schema: { name: "structured_output", schema: schema, strict: true },
+      } as never,
+      max_completion_tokens: input.maxTokens,
+      temperature: input.temperature,
+      stream: true,
+      ...buildOpenRouterExtras(model),
+    },
+    { signal }
+  );
+
+  let accumulatedJson = "";
+  for await (const chunk of stream) {
+    const delta = chunk.choices[0]?.delta?.content ?? "";
+    if (delta) {
+      accumulatedJson += delta;
+      const partial = parsePartialJson(accumulatedJson);
+      if (partial !== undefined) {
+        emit({ type: "object-delta", port: "object", objectDelta: partial });
+      }
+    }
+  }
+
+  let finalObject: Record<string, unknown>;
+  try {
+    finalObject = JSON.parse(accumulatedJson);
+  } catch {
+    finalObject = parsePartialJson(accumulatedJson) ?? {};
+  }
+  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -28,14 +28,21 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
   const modelName = getModelName(model);
   const schema = input.outputSchema ?? outputSchema;
 
+  // With a schema, request strict json_schema mode; without one, fall back to
+  // json_object so the request never carries an undefined schema (which the API
+  // rejects).
+  const responseFormat = schema
+    ? {
+        type: "json_schema" as never,
+        json_schema: { name: "structured_output", schema: schema, strict: true },
+      }
+    : { type: "json_object" as never };
+
   const stream = await client.chat.completions.create(
     {
       model: modelName,
       messages: [{ role: "user", content: input.prompt }],
-      response_format: {
-        type: "json_schema" as never,
-        json_schema: { name: "structured_output", schema: schema, strict: true },
-      } as never,
+      response_format: responseFormat as never,
       max_completion_tokens: input.maxTokens,
       temperature: input.temperature,
       stream: true,

--- a/providers/openrouter/src/ai/common/OpenRouter_TextGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextGeneration.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  TextGenerationTaskInput,
+  TextGenerationTaskOutput,
+} from "@workglow/ai";
+import { getLogger } from "@workglow/util/worker";
+import { getClient, getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+import { buildChatParams, buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+
+/**
+ * Streaming run-fn for `["text.generation"]`. Serves both TextGenerationTask
+ * (prompt) and AiChatTask (messages). Emits `text-delta` events and a final
+ * empty `finish` per the streaming convention.
+ */
+export const OpenRouter_TextGeneration_Stream: AiProviderRunFn<
+  TextGenerationTaskInput,
+  TextGenerationTaskOutput,
+  OpenRouterModelConfig
+> = async (input, model, signal, emit) => {
+  const logger = getLogger();
+  const timerLabel = `openrouter:TextGeneration:${getModelName(model)}`;
+  logger.time(timerLabel, { model: getModelName(model) });
+  try {
+    const client = await getClient(model);
+    const params = { ...buildChatParams(input, model), ...buildOpenRouterExtras(model) };
+
+    const stream = await client.chat.completions.create(
+      { ...params, stream: true } as Parameters<typeof client.chat.completions.create>[0],
+      { signal }
+    );
+
+    for await (const chunk of stream as AsyncIterable<{
+      choices?: Array<{ delta?: { content?: string | null } }>;
+    }>) {
+      const delta = chunk.choices?.[0]?.delta?.content ?? "";
+      if (delta) {
+        emit({ type: "text-delta", port: "text", textDelta: delta });
+      }
+    }
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+  } finally {
+    logger.timeEnd(timerLabel, { model: getModelName(model) });
+  }
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import { getClient, getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+
+/** Streaming run-fn for `["text.rewriter"]`. */
+export const OpenRouter_TextRewriter_Stream: AiProviderRunFn<
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  OpenRouterModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [
+        { role: "system", content: input.prompt },
+        { role: "user", content: input.text },
+      ],
+      stream: true,
+      ...buildOpenRouterExtras(model),
+    },
+    { signal }
+  );
+
+  for await (const chunk of stream) {
+    const delta = chunk.choices[0]?.delta?.content ?? "";
+    if (delta) {
+      emit({ type: "text-delta", port: "text", textDelta: delta });
+    }
+  }
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import { getClient, getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+
+/** Streaming run-fn for `["text.summary"]`. */
+export const OpenRouter_TextSummary_Stream: AiProviderRunFn<
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  OpenRouterModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [
+        { role: "system", content: "Summarize the following text concisely." },
+        { role: "user", content: input.text },
+      ],
+      stream: true,
+      ...buildOpenRouterExtras(model),
+    },
+    { signal }
+  );
+
+  for await (const chunk of stream) {
+    const delta = chunk.choices[0]?.delta?.content ?? "";
+    if (delta) {
+      emit({ type: "text-delta", port: "text", textDelta: delta });
+    }
+  }
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+};

--- a/providers/openrouter/src/ai/common/OpenRouter_ToolCalling.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_ToolCalling.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  ToolCallingTaskInput,
+  ToolCallingTaskOutput,
+  ToolCalls,
+} from "@workglow/ai";
+import {
+  accumulateOpenAIStream,
+  buildOpenAITools,
+  mapOpenAIToolChoice,
+} from "@workglow/ai/provider-utils";
+import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
+import { getClient, getModelName } from "./OpenRouter_Client";
+import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
+import { buildOpenRouterExtras } from "./OpenRouter_RequestParams";
+
+/**
+ * Streaming run-fn for `["text.generation", "tool-use"]`. Forwards deltas via
+ * {@link accumulateOpenAIStream}; each tool-call delta is filtered against
+ * `input.tools` so a hallucinated function name never reaches the consumer.
+ */
+export const OpenRouter_ToolCalling_Stream: AiProviderRunFn<
+  ToolCallingTaskInput,
+  ToolCallingTaskOutput,
+  OpenRouterModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const tools = buildOpenAITools(input.tools);
+  const messages = toOpenAIMessages(input);
+  const toolChoice = mapOpenAIToolChoice(input.toolChoice, true);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages,
+      max_completion_tokens: input.maxTokens,
+      temperature: input.temperature,
+      stream: true,
+      tools,
+      tool_choice: toolChoice,
+      ...buildOpenRouterExtras(model),
+    },
+    { signal }
+  );
+
+  await accumulateOpenAIStream(stream, (event) => {
+    if (event.type === "object-delta" && event.port === "toolCalls") {
+      const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
+      if (validated.length > 0) {
+        emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+      }
+      return;
+    }
+    emit(event);
+  });
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+};

--- a/providers/openrouter/src/ai/index.browser.ts
+++ b/providers/openrouter/src/ai/index.browser.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export { OPENROUTER_ALLOWED_HOSTS } from "./common/OpenRouter_Client";
+export * from "./common/OpenRouter_Constants";
+export * from "./common/OpenRouter_ModelSchema";
+export * from "./registerOpenRouter";

--- a/providers/openrouter/src/ai/index.ts
+++ b/providers/openrouter/src/ai/index.ts
@@ -6,14 +6,27 @@
 
 // organize-imports-ignore
 
+export { OPENROUTER_ALLOWED_HOSTS } from "./common/OpenRouter_Client";
 export * from "./common/OpenRouter_Constants";
 export * from "./common/OpenRouter_Capabilities";
+export * from "./common/OpenRouter_ModelSchema";
+export * from "./common/OpenRouter_ModelSearch";
+export * from "./registerOpenRouter";
 
-import { buildChatParams, buildOpenRouterExtras } from "./common/OpenRouter_RequestParams";
+import { OPENROUTER_RUN_FN_SPECS } from "./common/OpenRouter_Capabilities";
+import { OPENROUTER_RUN_FNS } from "./common/OpenRouter_JobRunFns";
 import { mapOpenRouterModels } from "./common/OpenRouter_ModelSearch";
+import { buildChatParams, buildOpenRouterExtras } from "./common/OpenRouter_RequestParams";
+import { OpenRouterQueuedProvider } from "./OpenRouterQueuedProvider";
 
-/** @internal Symbols exported only for `@workglow/test`. Not a stable API. */
+/**
+ * @internal Symbols exported only for use by `@workglow/test`. Not part of the
+ * stable public API.
+ */
 export const _testOnly = {
+  OpenRouterQueuedProvider,
+  OPENROUTER_RUN_FN_SPECS,
+  OPENROUTER_RUN_FNS,
   buildChatParams,
   buildOpenRouterExtras,
   mapOpenRouterModels,

--- a/providers/openrouter/src/ai/index.ts
+++ b/providers/openrouter/src/ai/index.ts
@@ -10,9 +10,11 @@ export * from "./common/OpenRouter_Constants";
 export * from "./common/OpenRouter_Capabilities";
 
 import { buildChatParams, buildOpenRouterExtras } from "./common/OpenRouter_RequestParams";
+import { mapOpenRouterModels } from "./common/OpenRouter_ModelSearch";
 
 /** @internal Symbols exported only for `@workglow/test`. Not a stable API. */
 export const _testOnly = {
   buildChatParams,
   buildOpenRouterExtras,
+  mapOpenRouterModels,
 } as const;

--- a/providers/openrouter/src/ai/index.ts
+++ b/providers/openrouter/src/ai/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./common/OpenRouter_Constants";
+export * from "./common/OpenRouter_Capabilities";

--- a/providers/openrouter/src/ai/index.ts
+++ b/providers/openrouter/src/ai/index.ts
@@ -8,3 +8,11 @@
 
 export * from "./common/OpenRouter_Constants";
 export * from "./common/OpenRouter_Capabilities";
+
+import { buildChatParams, buildOpenRouterExtras } from "./common/OpenRouter_RequestParams";
+
+/** @internal Symbols exported only for `@workglow/test`. Not a stable API. */
+export const _testOnly = {
+  buildChatParams,
+  buildOpenRouterExtras,
+} as const;

--- a/providers/openrouter/src/ai/registerOpenRouter.ts
+++ b/providers/openrouter/src/ai/registerOpenRouter.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRegisterOptions } from "@workglow/ai";
+import { registerProviderWithWorker } from "@workglow/ai/provider-utils";
+import { OpenRouterQueuedProvider } from "./OpenRouterQueuedProvider";
+
+export async function registerOpenRouter(
+  options: AiProviderRegisterOptions & { worker: Worker | (() => Worker) }
+): Promise<void> {
+  await registerProviderWithWorker(new OpenRouterQueuedProvider(), "OpenRouter", options);
+}

--- a/providers/openrouter/src/ai/registerOpenRouterInline.ts
+++ b/providers/openrouter/src/ai/registerOpenRouterInline.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRegisterOptions } from "@workglow/ai";
+import { registerProviderInline } from "@workglow/ai/provider-utils";
+import { OPENROUTER_PREVIEW_TASKS, OPENROUTER_RUN_FNS } from "./common/OpenRouter_JobRunFns";
+import { OpenRouterQueuedProvider } from "./OpenRouterQueuedProvider";
+
+export async function registerOpenRouterInline(options?: AiProviderRegisterOptions): Promise<void> {
+  await registerProviderInline(
+    new OpenRouterQueuedProvider(OPENROUTER_RUN_FNS, OPENROUTER_PREVIEW_TASKS),
+    "OpenRouter",
+    options
+  );
+}

--- a/providers/openrouter/src/ai/registerOpenRouterWorker.ts
+++ b/providers/openrouter/src/ai/registerOpenRouterWorker.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerProviderWorker } from "@workglow/ai/provider-utils";
+import { OPENROUTER_PREVIEW_TASKS, OPENROUTER_RUN_FNS } from "./common/OpenRouter_JobRunFns";
+import { OpenRouterProvider } from "./OpenRouterProvider";
+
+export async function registerOpenRouterWorker(): Promise<void> {
+  await registerProviderWorker(
+    (ws) =>
+      new OpenRouterProvider(OPENROUTER_RUN_FNS, OPENROUTER_PREVIEW_TASKS).registerOnWorkerServer(
+        ws
+      ),
+    "OpenRouter"
+  );
+}

--- a/providers/openrouter/src/ai/runtime.browser.ts
+++ b/providers/openrouter/src/ai/runtime.browser.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./common/OpenRouter_Client";
+export * from "./registerOpenRouterInline";
+export * from "./registerOpenRouterWorker";

--- a/providers/openrouter/src/ai/runtime.ts
+++ b/providers/openrouter/src/ai/runtime.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./common/OpenRouter_Client";
+export * from "./registerOpenRouterInline";
+export * from "./registerOpenRouterWorker";

--- a/providers/openrouter/tsconfig.json
+++ b/providers/openrouter/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../../packages/util" },
+    { "path": "../../packages/task-graph" },
+    { "path": "../../packages/storage" },
+    { "path": "../../packages/job-queue" },
+    { "path": "../../packages/ai" }
+  ]
+}


### PR DESCRIPTION
Introduces a new OpenRouter provider package (`@workglow/openrouter`) that integrates OpenRouter's unified gateway API with the Workglow AI task system. OpenRouter provides access to multiple model vendors (OpenAI, Anthropic, Google, etc.) through a single OpenAI-compatible chat API.

## Key Changes

- **New provider package** (`providers/openrouter/`) with full AI task support:
  - Text generation, tool calling, structured JSON output, text rewriting, and summarization
  - Model search with data-driven capability inference from OpenRouter's `/models` endpoint
  - Token counting (heuristic-based), model info, and capability detection
  
- **Capability inference system**:
  - `deriveCapabilitiesFromMeta()` — maps OpenRouter model metadata (input modalities, supported parameters) to Workglow capabilities
  - `inferOpenRouterCapabilities()` — prefers stored metadata, falls back to declared capabilities or baseline chat set
  - Automatic detection of vision input, tool use, and JSON mode support

- **Model search & discovery**:
  - Fetches OpenRouter's public `/models` endpoint (no API key required)
  - Maps raw model entries to searchable result items with capabilities
  - Graceful fallback to curated model list on network failure

- **Request building & client management**:
  - Unified chat parameter assembly supporting both `TextGenerationTask` (prompt) and `AiChatTask` (messages)
  - OpenRouter-native extras: provider routing preferences, reasoning configuration, web search plugin
  - Secure API key resolution and base URL validation with allow-list

- **Provider registration**:
  - `OpenRouterProvider` (worker-server) and `OpenRouterQueuedProvider` (main-thread shell)
  - Both support inline and worker-proxy execution modes
  - Comprehensive test suite validating capability derivation, request building, and model search

- **Integration**:
  - Exported via `@workglow/openrouter/ai` and `@workglow/openrouter/ai-runtime`
  - Re-exported in meta-package `@workglow/workglow` with conditional exports for browser/node/bun
  - Added to test package dependencies

## Implementation Details

- Uses OpenAI SDK for API communication (OpenRouter is OpenAI-compatible)
- Streaming support for all text-based tasks with delta emission
- Partial JSON parsing for structured generation with fallback to heuristic token counting
- Tool call validation filters hallucinated function names before emission
- Metadata-driven capability detection enables accurate task routing without manual configuration

https://claude.ai/code/session_01TP8G1bWJrhhiqsyvUGajMb