### PR TITLE
fix(storage): genuine CAS for updateWhere on IndexedDb + HttpTabularProxy

### DIFF
--- a/packages/indexeddb/src/storage/IndexedDbTabularStorage.ts
+++ b/packages/indexeddb/src/storage/IndexedDbTabularStorage.ts
@@ -960,21 +960,76 @@ export class IndexedDbTabularStorage<
   }
 
   /**
-   * Read-modify-write over {@link query}/{@link put}. IndexedDB has no
-   * native conditional-update primitive, so this is not a true atomic CAS
-   * like the SQL backends' `UPDATE ... WHERE ... RETURNING` — concurrent
-   * writers could race between the read and the write. Matches the
-   * unoptimized `query`+`put` fallback used by the other non-SQL backends.
+   * Compare-and-swap `updateWhere`: opens a single `readwrite` transaction
+   * on the object store, walks the first cursor row satisfying `match`,
+   * applies `patch` in place via `cursor.update()`, and resolves on
+   * `tx.oncomplete`. Two concurrent callers with overlapping `match`
+   * criteria therefore serialize on the underlying IDB transaction rather
+   * than racing between a `query()` and a `put()`. Uniqueness is enforced
+   * by IDB's native UNIQUE indexes — a patch that collides with another
+   * row rejects the cursor request with `ConstraintError`, which aborts
+   * the transaction (mirroring how {@link put} propagates the same error).
+   *
+   * The cursor source is picked with the same equality-prefix planner
+   * {@link createIndexedRange} uses for {@link count}: an index scan when
+   * an equality prefix narrows the criteria, otherwise a full store scan.
    */
   async updateWhere(
     match: SearchCriteria<Entity>,
     patch: Partial<Entity>
   ): Promise<Entity | undefined> {
     this.assertPatchKeepsPrimaryKey(patch);
-    const matches = (await this.query(match)) ?? [];
-    if (matches.length === 0) return undefined;
-    const updated = { ...matches[0], ...patch } as Entity;
-    return this.put(updated as never);
+    this.validateQueryParams(match);
+    const db = await this.getDb();
+
+    return new Promise<Entity | undefined>((resolve, reject) => {
+      let tx: IDBTransaction;
+      try {
+        tx = db.transaction(this.table, "readwrite");
+      } catch (err) {
+        reject(err);
+        return;
+      }
+      const store = tx.objectStore(this.table);
+      const plan = this.createIndexedRange(store, match);
+      const source = plan?.source ?? store;
+      const range = plan?.range;
+
+      let updated: Entity | undefined;
+
+      tx.oncomplete = () => {
+        if (updated !== undefined) {
+          safeEmit(this.events, "put", updated);
+          this.hybridManager?.notifyLocalChange();
+        }
+        resolve(updated);
+      };
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error ?? new Error("updateWhere transaction aborted"));
+
+      const request = source.openCursor(range);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) return;
+
+        const record = cursor.value as Entity;
+        if (!this.matchesCriteria(record, match)) {
+          cursor.continue();
+          return;
+        }
+
+        const candidate = { ...record, ...patch } as Entity;
+        const updateRequest = cursor.update(candidate);
+        updateRequest.onsuccess = () => {
+          updated = candidate;
+        };
+        updateRequest.onerror = () => {
+          // Let the ConstraintError (unique-index collision) abort the
+          // transaction; tx.onabort surfaces it to the caller.
+        };
+      };
+    });
   }
 
   private getEqualityCriterionValue(

--- a/packages/storage/src/tabular/HttpTabularProxyStorage.ts
+++ b/packages/storage/src/tabular/HttpTabularProxyStorage.ts
@@ -200,9 +200,13 @@ export class HttpTabularProxyStorage<
     patch: Partial<Entity>
   ): Promise<Entity | undefined> {
     this.assertPatchKeepsPrimaryKey(patch);
-    const matches = (await this.query(match)) ?? [];
-    if (matches.length === 0) return undefined;
-    return this.put({ ...matches[0], ...patch } as never);
+    const { entity } = await this.call<{ entity: Entity | null }>("updateWhere", {
+      match,
+      patch,
+    });
+    const result = entity ?? undefined;
+    if (result) safeEmit(this.events, "put", result);
+    return result;
   }
 
   async getOffsetPage(offset: number, limit: number): Promise<Entity[] | undefined> {

--- a/packages/test/src/test/storage-tabular/HttpTabularProxyStorage.test.ts
+++ b/packages/test/src/test/storage-tabular/HttpTabularProxyStorage.test.ts
@@ -88,6 +88,10 @@ function makeFakeServer(
           await storage.deleteSearch(body.criteria);
           return new Response(JSON.stringify({ ok: true }), { status: 200 });
         }
+        case "updateWhere": {
+          const entity = await storage.updateWhere(body.match, body.patch);
+          return new Response(JSON.stringify({ entity: entity ?? null }), { status: 200 });
+        }
         case "getOffsetPage": {
           const entities = await storage.getOffsetPage(body.offset, body.limit);
           return new Response(JSON.stringify({ entities: entities ?? null }), { status: 200 });

--- a/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
+++ b/packages/test/src/test/storage-tabular/genericTabularStorageTests.ts
@@ -969,6 +969,32 @@ export function runGenericTabularStorageTests(
         expect(await repository.get({ id: "pk1" } as never)).toBeDefined();
         expect(await repository.get({ id: "pk2" } as never)).toBeUndefined();
       });
+
+      it("is CAS under a raced update on the same match", async () => {
+        // Two updateWhere calls with the same before-value predicate race for a
+        // single row. A genuine CAS implementation must let exactly one win —
+        // an unlocked read-modify-write would let both "succeed" and the last
+        // writer would silently clobber the first.
+        const ts = new Date().toISOString();
+        await repository.put({
+          id: "cas1",
+          category: "a",
+          subcategory: "s",
+          value: 0,
+          createdAt: ts,
+          updatedAt: ts,
+        } as never);
+
+        const [a, b] = await Promise.all([
+          repository.updateWhere({ id: "cas1", value: 0 } as never, { value: 1 } as never),
+          repository.updateWhere({ id: "cas1", value: 0 } as never, { value: 2 } as never),
+        ]);
+        const winners = [a, b].filter(Boolean) as Array<{ value: number }>;
+        expect(winners).toHaveLength(1);
+        const row = (await repository.get({ id: "cas1" } as never)) as
+          { value: number } | undefined;
+        expect(row?.value).toBe(winners[0]!.value);
+      });
     });
 
     describe(`query tests`, () => {


### PR DESCRIPTION
## Summary

Two HIGH-severity bugs in `updateWhere` — both a client-side read-modify-write over `query()` + `put()` that races between the read and the write — are replaced with genuine CAS.

### Bug 1: `IndexedDbTabularStorage.updateWhere`

**File:** `packages/indexeddb/src/storage/IndexedDbTabularStorage.ts`

Before: `this.query(match)` followed by `this.put(updated)` — two separate IDB transactions. Two concurrent callers with overlapping `match` criteria both read the same pre-state and only one write survives. The existing JSDoc even self-acknowledged the race.

After: a single `readwrite` transaction that opens a cursor on the object store (narrowed via the same equality-prefix planner `count()` uses), walks to the first row satisfying `match`, applies `patch` in place via `cursor.update()`, and resolves the returned `Entity | undefined` on `tx.oncomplete`. `safeEmit("put", ...)` and `hybridManager?.notifyLocalChange()` fire only after the commit succeeds — matching the invariants `put()` already upholds. UNIQUE-index enforcement is delegated to IDB's native `ConstraintError` (same shape as `put()`).

Overlapping `updateWhere` calls now serialize on the IDB readwrite lock rather than racing.

### Bug 2: `HttpTabularProxyStorage.updateWhere`

**File:** `packages/storage/src/tabular/HttpTabularProxyStorage.ts`

Before: the proxy issued a `query` wire call, a local merge, and a `put` wire call — so two concurrent proxy calls race on the server the same way. Even if the server had SQLite's atomic `UPDATE ... RETURNING`, the proxy couldn't use it.

After: a single `updateWhere` wire op forwards `{ match, patch }` to the server, which resolves it atomically against whatever tabular backend the server uses (SQL `UPDATE ... WHERE ... RETURNING` on the SQL backends; on IndexedDb, the same single-txn CAS above). The proxy just returns `entity ?? undefined` and re-emits a local `put` event for downstream subscribers.

> Server-side wiring: `HttpTabularProxy`'s server implementation lives in `builder/packages/api/src/routes/storage.ts`. A companion PR in `builder` adds the `updateWhere` route case there.

### Test

**File:** `packages/test/src/test/storage-tabular/genericTabularStorageTests.ts`

Extended the existing `describe("updateWhere tests", …)` block with a CAS race case: seed a row with `value: 0`, kick off two overlapping `updateWhere({ id, value: 0 }, { value: N })` calls via `Promise.all`, and assert exactly one winner (the other must resolve `undefined`) and that the persisted row reflects the winner's value. The pre-fix `IndexedDb` and `HttpTabularProxy` paths would have reported two winners or silently clobbered one write.

**File:** `packages/test/src/test/storage-tabular/HttpTabularProxyStorage.test.ts`

Added an `updateWhere` case to the fake server's switch so the generic contract round-trips over the mocked wire.

## Test plan

- [x] `bun scripts/test.ts storage vitest` — all 1531 tests pass
- [x] `bunx turbo run build-js --filter=@workglow/storage --filter=@workglow/indexeddb`
- [x] `bun run build:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U172SSv5Tai5yJhhzwjaex

---
_Generated by [Claude Code](https://claude.ai/code/session_01U172SSv5Tai5yJhhzwjaex)_