### PR TITLE
Add node-llama-cpp provider integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -309,6 +309,7 @@
         "@workglow/node-llama-cpp": "workspace:*",
         "@workglow/ollama": "workspace:*",
         "@workglow/openai": "workspace:*",
+        "@workglow/openrouter": "workspace:*",
         "@workglow/playwright": "workspace:*",
         "@workglow/postgres": "workspace:*",
         "@workglow/sqlite": "workspace:*",
@@ -355,8 +356,10 @@
         "@workglow/job-queue": "workspace:*",
         "@workglow/knowledge-base": "workspace:*",
         "@workglow/mcp": "workspace:*",
+        "@workglow/node-llama-cpp": "workspace:*",
         "@workglow/ollama": "workspace:*",
         "@workglow/openai": "workspace:*",
+        "@workglow/openrouter": "workspace:*",
         "@workglow/postgres": "workspace:*",
         "@workglow/sqlite": "workspace:*",
         "@workglow/storage": "workspace:*",
@@ -627,6 +630,27 @@
         "js-tiktoken": "catalog:",
         "openai": "catalog:",
         "tiktoken": "catalog:",
+      },
+      "devDependencies": {
+        "@workglow/ai": "workspace:*",
+        "@workglow/job-queue": "workspace:*",
+        "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
+        "@workglow/util": "workspace:*",
+      },
+      "peerDependencies": {
+        "@workglow/ai": "workspace:*",
+        "@workglow/job-queue": "workspace:*",
+        "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
+        "@workglow/util": "workspace:*",
+      },
+    },
+    "providers/openrouter": {
+      "name": "@workglow/openrouter",
+      "version": "0.0.1",
+      "dependencies": {
+        "openai": "catalog:",
       },
       "devDependencies": {
         "@workglow/ai": "workspace:*",
@@ -1489,6 +1513,8 @@
     "@workglow/ollama": ["@workglow/ollama@workspace:providers/ollama"],
 
     "@workglow/openai": ["@workglow/openai@workspace:providers/openai"],
+
+    "@workglow/openrouter": ["@workglow/openrouter@workspace:providers/openrouter"],
 
     "@workglow/playwright": ["@workglow/playwright@workspace:providers/playwright"],
 

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -168,6 +168,14 @@
       "types": "./dist/xai-runtime.d.ts",
       "import": "./dist/xai-runtime.js"
     },
+    "./node-llama": {
+      "types": "./dist/node-llama.d.ts",
+      "import": "./dist/node-llama.js"
+    },
+    "./node-llama/runtime": {
+      "types": "./dist/node-llama-runtime.d.ts",
+      "import": "./dist/node-llama-runtime.js"
+    },
     "./tf-mediapipe": {
       "types": "./dist/tf-mediapipe.d.ts",
       "import": "./dist/tf-mediapipe.js"
@@ -229,6 +237,7 @@
     "@workglow/ollama": "workspace:*",
     "@workglow/huggingface-transformers": "workspace:*",
     "@workglow/huggingface-inference": "workspace:*",
+    "@workglow/node-llama-cpp": "workspace:*",
     "@workglow/tf-mediapipe": "workspace:*",
     "@workglow/chrome-ai": "workspace:*",
     "@workglow/knowledge-base": "workspace:*",

--- a/packages/workglow/src/node-llama-runtime.ts
+++ b/packages/workglow/src/node-llama-runtime.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/node-llama-cpp/ai-runtime";

--- a/packages/workglow/src/node-llama.ts
+++ b/packages/workglow/src/node-llama.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/node-llama-cpp/ai";

--- a/packages/workglow/tsconfig.json
+++ b/packages/workglow/tsconfig.json
@@ -25,6 +25,7 @@
     { "path": "../../providers/google-gemini" },
     { "path": "../../providers/huggingface-inference" },
     { "path": "../../providers/huggingface-transformers" },
+    { "path": "../../providers/node-llama-cpp" },
     { "path": "../../providers/ollama" },
     { "path": "../../providers/openai" },
     { "path": "../../providers/openrouter" },


### PR DESCRIPTION
Adds support for the `node-llama-cpp` provider to the workglow monorepo, following the established pattern for vendor provider packages.

## Changes

- **Export paths**: Added `./node-llama` and `./node-llama/runtime` conditional exports in `package.json`, mirroring the pattern used by other AI providers (anthropic, openai, etc.)
- **New modules**: Created `src/node-llama.ts` and `src/node-llama-runtime.ts` that re-export from `@workglow/node-llama-cpp/ai` and `@workglow/node-llama-cpp/ai-runtime` respectively
- **Workspace dependency**: Added `@workglow/node-llama-cpp` to the workglow package dependencies
- **TypeScript config**: Registered the `node-llama-cpp` provider path in `tsconfig.json` for proper monorepo resolution

This follows the vendor provider pattern established in the codebase (e.g., anthropic, openai, google-gemini) where each provider exposes `./ai` and `./ai-runtime` sub-paths through the main workglow meta-package.

https://claude.ai/code/session_013kpj2QQrsPAtUQBxL3aEYx