### PR TITLE
fix(xai,openrouter): guard chunk.choices access and honor strict-schema downshift

### DIFF
--- a/packages/ai/src/provider-utils.ts
+++ b/packages/ai/src/provider-utils.ts
@@ -24,6 +24,7 @@ export * from "./provider-utils/BaseCloudProvider";
 export * from "./provider-utils/CloudProviderClient";
 export * from "./provider-utils/OpenAIShapedChat";
 export * from "./provider-utils/OpenAIShapedResponses";
+export * from "./provider-utils/OpenAIShapedJsonSchema";
 export * from "./provider-utils/RefusalHelpers";
 export * from "./provider-utils/IBackendsTransport";
 export * from "./provider-utils/localUrl";

--- a/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Whether a JSON schema satisfies the OpenAI-shape `strict` subset — every
+ * object has `additionalProperties: false` and lists all of its properties in
+ * `required`, recursively. Combinators (`anyOf`/`oneOf`/`allOf`) and `$ref`
+ * are treated conservatively as non-strict. When false, callers should send
+ * `strict: false` so the request isn't rejected with a 400; the
+ * `StructuredGenerationTask` consumer still re-validates (and retries) the
+ * output against the original schema.
+ *
+ * Shared across every provider that speaks the OpenAI `json_schema`
+ * `response_format` (chat completions) or `text.format` (Responses) — OpenAI,
+ * xAI, OpenRouter, and any future OpenAI-compatible provider.
+ */
+export function isStrictCompatibleSchema(schema: unknown): boolean {
+  if (schema === null || typeof schema !== "object") return true;
+  const s = schema as Record<string, unknown>;
+  if (s.$ref !== undefined) return false;
+  if (Array.isArray(s.anyOf) || Array.isArray(s.oneOf) || Array.isArray(s.allOf)) return false;
+
+  const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);
+  if (isObject) {
+    if (s.additionalProperties !== false) return false;
+    const props = (s.properties as Record<string, unknown> | undefined) ?? {};
+    const required = Array.isArray(s.required) ? (s.required as string[]) : [];
+    for (const key of Object.keys(props)) {
+      if (!required.includes(key)) return false;
+      if (!isStrictCompatibleSchema(props[key])) return false;
+    }
+    return true;
+  }
+
+  const isArray = s.type === "array" || s.items !== undefined;
+  if (isArray) {
+    if (Array.isArray(s.items)) return s.items.every(isStrictCompatibleSchema);
+    return isStrictCompatibleSchema(s.items);
+  }
+  return true;
+}

--- a/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouterProvider.test.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ModelRecord } from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import {
   _testOnly,
   deriveCapabilitiesFromMeta,
@@ -121,5 +122,28 @@ describe("OpenRouter capability-set parity", () => {
   it("tiebreaks text.generation to the smallest serves entry", () => {
     const candidates = OPENROUTER_RUN_FNS.filter((r) => r.serves.includes("text.generation"));
     expect(candidates.some((r) => r.serves.length === 1)).toBe(true);
+  });
+});
+
+describe("isStrictCompatibleSchema wiring", () => {
+  it("resolves the shared helper from @workglow/ai/provider-utils (parity with OpenAI)", () => {
+    expect(typeof isStrictCompatibleSchema).toBe("function");
+  });
+
+  it("returns false for combinator schemas (anyOf/oneOf/allOf)", () => {
+    expect(isStrictCompatibleSchema({ anyOf: [{ type: "string" }, { type: "number" }] })).toBe(
+      false
+    );
+  });
+
+  it("returns true for an object with additionalProperties:false and all-required properties", () => {
+    expect(
+      isStrictCompatibleSchema({
+        type: "object",
+        additionalProperties: false,
+        required: ["a"],
+        properties: { a: { type: "string" } },
+      })
+    ).toBe(true);
   });
 });

--- a/packages/test/src/test/ai-provider-api/OpenRouter_StreamChunkSafety.test.ts
+++ b/packages/test/src/test/ai-provider-api/OpenRouter_StreamChunkSafety.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/openrouter/ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { OPENROUTER_RUN_FNS } = _testOnly;
+
+function findRunFn(servesKey: string) {
+  const reg = OPENROUTER_RUN_FNS.find((r) => [...r.serves].sort().join(",") === servesKey);
+  if (!reg) throw new Error(`no OpenRouter run-fn registered for ${servesKey}`);
+  return reg.runFn;
+}
+
+const structuredGenFn = findRunFn("json-mode,text.generation");
+const textRewriterFn = findRunFn("text.rewriter");
+const textSummaryFn = findRunFn("text.summary");
+
+/**
+ * SSE-encoded fake upstream: one `data: {json}` line per chunk, blank-line
+ * separated, `[DONE]` terminator — the wire format the openai SDK's stream
+ * parser expects. Passes the chunk objects verbatim so we can inject the
+ * unguarded shapes (`{}`, `{choices: []}`, `{choices: [{}]}`) alongside
+ * content frames.
+ */
+function sseResponse(chunks: readonly unknown[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(c)}\n\n`));
+      }
+      controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const model = {
+  model_id: "openrouter-x",
+  provider_config: { model_name: "anthropic/claude-sonnet-4", api_key: "test-key" },
+} as any;
+
+const strictObjectSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["a"],
+  properties: { a: { type: "number" } },
+} as const;
+
+// OpenRouter multiplexes upstream provider frames; keepalives and provider
+// switchovers routinely arrive without a `choices` field. Each case exercises
+// one of the unsafe access shapes we replaced with `chunk.choices?.[0]?.…`.
+const unsafeShapes = [
+  { label: "choices field absent", pre: [{}] },
+  { label: "empty choices array", pre: [{ choices: [] }] },
+  { label: "choices[0] with no delta", pre: [{ choices: [{}] }] },
+];
+
+describe("OpenRouter streaming run-fns tolerate SDK chunks without choices/delta", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe("OpenRouter_StructuredGeneration_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and completes with the assembled object`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([
+            ...pre,
+            { choices: [{ delta: { content: '{"a":' } }] },
+            { choices: [{ delta: { content: "1}" } }] },
+          ])
+        );
+
+        const events: any[] = [];
+        await expect(
+          structuredGenFn(
+            { prompt: "hi", outputSchema: strictObjectSchema } as any,
+            model,
+            new AbortController().signal,
+            (e) => events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const finish = events.at(-1);
+        expect(finish?.type).toBe("finish");
+        expect(finish?.data?.object).toEqual({ a: 1 });
+      });
+    }
+  });
+
+  describe("OpenRouter_TextRewriter_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([...pre, { choices: [{ delta: { content: "hello" } }] }])
+        );
+
+        const events: any[] = [];
+        await expect(
+          textRewriterFn(
+            { prompt: "rewrite", text: "input" } as any,
+            model,
+            new AbortController().signal,
+            (e) => events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe("hello");
+      });
+    }
+  });
+
+  describe("OpenRouter_TextSummary_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([...pre, { choices: [{ delta: { content: " world" } }] }])
+        );
+
+        const events: any[] = [];
+        await expect(
+          textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+            events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe(" world");
+      });
+    }
+  });
+});

--- a/packages/test/src/test/ai-provider-api/XaiProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/XaiProvider.test.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ModelRecord } from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { _testOnly } from "@workglow/xai/ai";
 import { describe, expect, it } from "vitest";
 
@@ -111,5 +112,28 @@ describe("XAI_RUN_FNS shape", () => {
   it("tiebreaks `text.generation` to the smallest serves entry (plain text-gen)", () => {
     const candidates = XAI_RUN_FNS.filter((r) => r.serves.includes("text.generation"));
     expect(candidates.some((r) => r.serves.length === 1)).toBe(true);
+  });
+});
+
+describe("isStrictCompatibleSchema wiring", () => {
+  it("resolves the shared helper from @workglow/ai/provider-utils (parity with OpenAI)", () => {
+    expect(typeof isStrictCompatibleSchema).toBe("function");
+  });
+
+  it("returns false for combinator schemas (anyOf/oneOf/allOf)", () => {
+    expect(isStrictCompatibleSchema({ anyOf: [{ type: "string" }, { type: "number" }] })).toBe(
+      false
+    );
+  });
+
+  it("returns true for an object with additionalProperties:false and all-required properties", () => {
+    expect(
+      isStrictCompatibleSchema({
+        type: "object",
+        additionalProperties: false,
+        required: ["a"],
+        properties: { a: { type: "string" } },
+      })
+    ).toBe(true);
   });
 });

--- a/packages/test/src/test/ai-provider-api/Xai_StreamChunkSafety.test.ts
+++ b/packages/test/src/test/ai-provider-api/Xai_StreamChunkSafety.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/xai/ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { XAI_RUN_FNS } = _testOnly;
+
+function findRunFn(servesKey: string) {
+  const reg = XAI_RUN_FNS.find((r) => [...r.serves].sort().join(",") === servesKey);
+  if (!reg) throw new Error(`no xAI run-fn registered for ${servesKey}`);
+  return reg.runFn;
+}
+
+const structuredGenFn = findRunFn("json-mode,text.generation");
+const textRewriterFn = findRunFn("text.rewriter");
+const textSummaryFn = findRunFn("text.summary");
+
+/**
+ * Encode a list of streaming chunk objects into the OpenAI-compatible SSE wire
+ * format that the openai SDK's stream parser consumes: one `data: {json}` per
+ * event, blank line separator, `data: [DONE]` terminator. The chunks array is
+ * passed verbatim so we can inject the unguarded shapes (`{}`, `{choices: []}`,
+ * `{choices: [{}]}`) alongside real content frames.
+ */
+function sseResponse(chunks: readonly unknown[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(c)}\n\n`));
+      }
+      controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+const model = {
+  model_id: "grok-x",
+  provider_config: { model_name: "grok-3-mini", api_key: "test-key" },
+} as any;
+
+const strictObjectSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["a"],
+  properties: { a: { type: "number" } },
+} as const;
+
+// The three unsafe SDK chunk shapes we replaced with `chunk.choices?.[0]?.…`:
+//   - `choices` field absent (SSE keepalive / multiplexed upstream frame)
+//   - `choices` is an empty array
+//   - `choices[0]` exists but has no `delta` (initial role frame)
+const unsafeShapes = [
+  { label: "choices field absent", pre: [{}] },
+  { label: "empty choices array", pre: [{ choices: [] }] },
+  { label: "choices[0] with no delta", pre: [{ choices: [{}] }] },
+];
+
+describe("xAI streaming run-fns tolerate SDK chunks without choices/delta", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe("Xai_StructuredGeneration_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and completes with the assembled object`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([
+            ...pre,
+            { choices: [{ delta: { content: '{"a":' } }] },
+            { choices: [{ delta: { content: "1}" } }] },
+          ])
+        );
+
+        const events: any[] = [];
+        await expect(
+          structuredGenFn(
+            { prompt: "hi", outputSchema: strictObjectSchema } as any,
+            model,
+            new AbortController().signal,
+            (e) => events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const finish = events.at(-1);
+        expect(finish?.type).toBe("finish");
+        expect(finish?.data?.object).toEqual({ a: 1 });
+      });
+    }
+  });
+
+  describe("Xai_TextRewriter_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([...pre, { choices: [{ delta: { content: "hello" } }] }])
+        );
+
+        const events: any[] = [];
+        await expect(
+          textRewriterFn(
+            { prompt: "rewrite", text: "input" } as any,
+            model,
+            new AbortController().signal,
+            (e) => events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe("hello");
+      });
+    }
+  });
+
+  describe("Xai_TextSummary_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        fetchSpy.mockResolvedValueOnce(
+          sseResponse([...pre, { choices: [{ delta: { content: " world" } }] }])
+        );
+
+        const events: any[] = [];
+        await expect(
+          textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+            events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe(" world");
+      });
+    }
+  });
+});

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -9,43 +9,12 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { finalizeResponsesRequest, getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
 
-/**
- * Whether a JSON schema satisfies the Responses `strict` subset — every object
- * has `additionalProperties: false` and lists all of its properties in
- * `required`, recursively. Combinators (`anyOf`/`oneOf`/`allOf`) and `$ref` are
- * treated conservatively as non-strict. When false we send `strict: false` so
- * the request isn't rejected with a 400; the `StructuredGenerationTask` consumer
- * still re-validates (and retries) the output against the original schema.
- */
-export function isStrictCompatibleSchema(schema: unknown): boolean {
-  if (schema === null || typeof schema !== "object") return true;
-  const s = schema as Record<string, unknown>;
-  if (s.$ref !== undefined) return false;
-  if (Array.isArray(s.anyOf) || Array.isArray(s.oneOf) || Array.isArray(s.allOf)) return false;
-
-  const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);
-  if (isObject) {
-    if (s.additionalProperties !== false) return false;
-    const props = (s.properties as Record<string, unknown> | undefined) ?? {};
-    const required = Array.isArray(s.required) ? (s.required as string[]) : [];
-    for (const key of Object.keys(props)) {
-      if (!required.includes(key)) return false;
-      if (!isStrictCompatibleSchema(props[key])) return false;
-    }
-    return true;
-  }
-
-  const isArray = s.type === "array" || s.items !== undefined;
-  if (isArray) {
-    if (Array.isArray(s.items)) return s.items.every(isStrictCompatibleSchema);
-    return isStrictCompatibleSchema(s.items);
-  }
-  return true;
-}
+export { isStrictCompatibleSchema };
 
 /**
  * Streaming run-fn for `["text.generation", "json-mode"]`. Emits

--- a/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_StructuredGeneration.ts
@@ -9,6 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getModelName } from "./OpenRouter_Client";
 import type { OpenRouterModelConfig } from "./OpenRouter_ModelSchema";
@@ -34,7 +35,11 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
   const responseFormat = schema
     ? {
         type: "json_schema" as never,
-        json_schema: { name: "structured_output", schema: schema, strict: true },
+        json_schema: {
+          name: "structured_output",
+          schema: schema,
+          strict: isStrictCompatibleSchema(schema),
+        },
       }
     : { type: "json_object" as never };
 
@@ -54,7 +59,7 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
   let accumulatedJson = "";
   let refusal = "";
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       accumulatedJson += delta;
       const partial = parsePartialJson(accumulatedJson);
@@ -62,7 +67,7 @@ export const OpenRouter_StructuredGeneration_Stream: AiProviderRunFn<
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
     }
-    refusal += chunk.choices[0]?.delta?.refusal ?? "";
+    refusal += chunk.choices?.[0]?.delta?.refusal ?? "";
   }
 
   if (refusal) {

--- a/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextRewriter.ts
@@ -32,11 +32,11 @@ export const OpenRouter_TextRewriter_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }
-    const refusalDelta = chunk.choices[0]?.delta?.refusal ?? "";
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
     if (refusalDelta) {
       emit({ type: "refusal", refusal: refusalDelta });
     }

--- a/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
+++ b/providers/openrouter/src/ai/common/OpenRouter_TextSummary.ts
@@ -32,11 +32,11 @@ export const OpenRouter_TextSummary_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }
-    const refusalDelta = chunk.choices[0]?.delta?.refusal ?? "";
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
     if (refusalDelta) {
       emit({ type: "refusal", refusal: refusalDelta });
     }

--- a/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
+++ b/providers/xai/src/ai/common/Xai_StructuredGeneration.ts
@@ -9,6 +9,7 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getModelName } from "./Xai_Client";
 import type { XaiModelConfig } from "./Xai_ModelSchema";
@@ -38,7 +39,7 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
         json_schema: {
           name: "structured_output",
           schema: schema,
-          strict: true,
+          strict: isStrictCompatibleSchema(schema),
         },
       } as never,
       max_completion_tokens: input.maxTokens,
@@ -51,7 +52,7 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
   let accumulatedJson = "";
   let refusal = "";
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       accumulatedJson += delta;
       const partial = parsePartialJson(accumulatedJson);
@@ -59,7 +60,7 @@ export const Xai_StructuredGeneration_Stream: AiProviderRunFn<
         emit({ type: "object-delta", port: "object", objectDelta: partial });
       }
     }
-    refusal += chunk.choices[0]?.delta?.refusal ?? "";
+    refusal += chunk.choices?.[0]?.delta?.refusal ?? "";
   }
 
   if (refusal) {

--- a/providers/xai/src/ai/common/Xai_TextRewriter.ts
+++ b/providers/xai/src/ai/common/Xai_TextRewriter.ts
@@ -33,11 +33,11 @@ export const Xai_TextRewriter_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }
-    const refusalDelta = chunk.choices[0]?.delta?.refusal ?? "";
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
     if (refusalDelta) {
       emit({ type: "refusal", refusal: refusalDelta });
     }

--- a/providers/xai/src/ai/common/Xai_TextSummary.ts
+++ b/providers/xai/src/ai/common/Xai_TextSummary.ts
@@ -33,11 +33,11 @@ export const Xai_TextSummary_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }
-    const refusalDelta = chunk.choices[0]?.delta?.refusal ?? "";
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
     if (refusalDelta) {
       emit({ type: "refusal", refusal: refusalDelta });
     }


### PR DESCRIPTION
## Summary
Two HIGH findings from a review of libs main's 2026-07-10 pushes:

- **HIGH-1** — xAI + OpenRouter non-tool streaming run-fns crashed on any SDK chunk without a `choices` field (OpenRouter multiplexed-upstream keepalives, rare frames). Guarded access to `chunk.choices?.[0]?.delta?.X` — the idiom already used by `Xai_TextGeneration` and the shared `accumulateOpenAIChatStream` helper.
- **HIGH-2** — xAI + OpenRouter structured generation hardcoded `strict: true` on the `json_schema` response format. Any schema with `anyOf` / `oneOf` / `$ref` (or an object without `additionalProperties:false` + all-required) got HTTP 400 from the provider. Lifted `isStrictCompatibleSchema` from `providers/openai` into `@workglow/ai/provider-utils` and applied it to all three providers.

## Test plan
- [x] `bun run build:types` clean.
- [x] `bun scripts/test.ts provider-api vitest` — 432 passed, 55 skipped (integration; no keys), 0 failed. New `Xai_StreamChunkSafety` / `OpenRouter_StreamChunkSafety` cover the three unsafe chunk shapes across all three run-fns; parity tests confirm the shared helper is wired.
- [ ] Live conformance (run manually when a key is available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rbaaec32Y6y2vNhKF2KyYE)_