### PR TITLE
fix(ai): key OpenAIShapedResponses tool-call accumulator on stable item id

### DIFF
--- a/packages/ai/src/provider-utils/OpenAIShapedResponses.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedResponses.ts
@@ -238,9 +238,12 @@ export async function accumulateOpenAIResponsesStream<Output = Record<string, an
   stream: AsyncIterable<any>,
   emit: (event: StreamEvent<Output>) => void
 ): Promise<void> {
-  // Keyed by `output_index`: Responses assigns each output item (message,
-  // function_call, reasoning) a stable index within the response.
-  const toolCalls = new Map<number, ResponsesToolCallEntry>();
+  // Keyed by the output item's stable id (`item.id` on `output_item.{added,done}`,
+  // `item_id` on `function_call_arguments.delta`). Falls back to `output_index`
+  // only for gateways that omit both — keying purely on `output_index` collapses
+  // concurrent function calls that share (or lack) the index onto one slot,
+  // silently dropping every call but the last.
+  const toolCalls = new Map<string, ResponsesToolCallEntry>();
 
   const emitToolCall = (entry: ResponsesToolCallEntry): void => {
     const parsed = parseToolArgs(entry.arguments);
@@ -272,9 +275,9 @@ export async function accumulateOpenAIResponsesStream<Output = Record<string, an
       case "response.output_item.added": {
         const item = event.item;
         if (item?.type === "function_call") {
-          const index: number = event.output_index ?? 0;
-          toolCalls.set(index, {
-            id: (item.call_id as string) || (item.id as string) || `call_${index}`,
+          const key = String(event.item?.id ?? event.item_id ?? event.output_index ?? 0);
+          toolCalls.set(key, {
+            id: (item.call_id as string) || (item.id as string) || `call_${key}`,
             name: (item.name as string) ?? "",
             arguments: (item.arguments as string) ?? "",
           });
@@ -283,31 +286,57 @@ export async function accumulateOpenAIResponsesStream<Output = Record<string, an
       }
 
       case "response.function_call_arguments.delta": {
-        const index: number = event.output_index ?? 0;
-        let entry = toolCalls.get(index);
-        if (!entry) {
+        // Delta events carry `item_id` (not `item.id`); prefer it. Fall back to
+        // `output_index` when no entry is registered under the id — the added
+        // event may have registered under the index alone for legacy shapes.
+        const idKey = event.item_id ?? event.item?.id;
+        const indexKey = event.output_index;
+        let key: string;
+        let entry: ResponsesToolCallEntry | undefined;
+        if (idKey !== undefined && toolCalls.has(String(idKey))) {
+          key = String(idKey);
+          entry = toolCalls.get(key);
+        } else if (indexKey !== undefined && toolCalls.has(String(indexKey))) {
+          key = String(indexKey);
+          entry = toolCalls.get(key);
+        } else {
           // Defensive: a delta arrived before we saw `output_item.added`.
-          entry = { id: (event.item_id as string) || `call_${index}`, name: "", arguments: "" };
-          toolCalls.set(index, entry);
+          key = String(idKey ?? indexKey ?? 0);
+          entry = { id: (event.item_id as string) || `call_${key}`, name: "", arguments: "" };
+          toolCalls.set(key, entry);
         }
-        entry.arguments += event.delta ?? "";
-        emitToolCall(entry);
+        entry!.arguments += event.delta ?? "";
+        emitToolCall(entry!);
         break;
       }
 
       case "response.output_item.done": {
         const item = event.item;
         if (item?.type === "function_call") {
-          const index: number = event.output_index ?? 0;
-          const entry = toolCalls.get(index) ?? {
-            id: (item.call_id as string) || (item.id as string) || `call_${index}`,
-            name: (item.name as string) ?? "",
-            arguments: "",
-          };
+          // Same lookup order as delta: id first, then output_index, so an entry
+          // registered under either shape by `added` is found.
+          const idKey = event.item?.id ?? event.item_id;
+          const indexKey = event.output_index;
+          let key: string;
+          let entry: ResponsesToolCallEntry | undefined;
+          if (idKey !== undefined && toolCalls.has(String(idKey))) {
+            key = String(idKey);
+            entry = toolCalls.get(key);
+          } else if (indexKey !== undefined && toolCalls.has(String(indexKey))) {
+            key = String(indexKey);
+            entry = toolCalls.get(key);
+          } else {
+            key = String(idKey ?? indexKey ?? 0);
+            entry = {
+              id: (item.call_id as string) || (item.id as string) || `call_${key}`,
+              name: (item.name as string) ?? "",
+              arguments: "",
+            };
+          }
           // The `done` item carries the authoritative full arguments string.
-          if (typeof item.arguments === "string") entry.arguments = item.arguments;
-          if (item.name) entry.name = item.name;
-          emitToolCall(entry);
+          if (typeof item.arguments === "string") entry!.arguments = item.arguments;
+          if (item.name) entry!.name = item.name;
+          emitToolCall(entry!);
         }
         break;
       }

--- a/packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts
@@ -178,6 +178,131 @@ describe("accumulateOpenAIResponsesStream", () => {
     ]);
     expect(out).toEqual([{ type: "text-delta", port: "text", textDelta: "hi" }]);
   });
+
+  it("keeps concurrent tool calls separate by item id when output_index is absent", async () => {
+    const out = await collect([
+      {
+        type: "response.output_item.added",
+        item: {
+          type: "function_call",
+          id: "fc_a",
+          call_id: "call_a",
+          name: "alpha",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.output_item.added",
+        item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "beta", arguments: "" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_a",
+        delta: '{"a":1}',
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_b",
+        delta: '{"b":2}',
+      },
+      {
+        type: "response.output_item.done",
+        item: {
+          type: "function_call",
+          id: "fc_a",
+          call_id: "call_a",
+          name: "alpha",
+          arguments: '{"a":1}',
+        },
+      },
+      {
+        type: "response.output_item.done",
+        item: {
+          type: "function_call",
+          id: "fc_b",
+          call_id: "call_b",
+          name: "beta",
+          arguments: '{"b":2}',
+        },
+      },
+      { type: "response.completed" },
+    ]);
+
+    const a = out.find((e) => e.objectDelta[0].id === "call_a");
+    const b = out.find((e) => e.objectDelta[0].id === "call_b");
+    expect(a.objectDelta[0]).toMatchObject({ name: "alpha", input: { a: 1 } });
+    expect(b.objectDelta[0]).toMatchObject({ name: "beta", input: { b: 2 } });
+  });
+
+  it("falls back to output_index when neither item.id nor item_id is provided", async () => {
+    const out = await collect([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "function_call", call_id: "call_a", name: "alpha", arguments: "" },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { type: "function_call", call_id: "call_b", name: "beta", arguments: "" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        delta: '{"a":1}',
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 1,
+        delta: '{"b":2}',
+      },
+      { type: "response.completed" },
+    ]);
+
+    const a = out.find((e) => e.objectDelta[0].id === "call_a");
+    const b = out.find((e) => e.objectDelta[0].id === "call_b");
+    expect(a.objectDelta[0]).toMatchObject({ name: "alpha", input: { a: 1 } });
+    expect(b.objectDelta[0]).toMatchObject({ name: "beta", input: { b: 2 } });
+  });
+
+  it("prefers item id over a colliding output_index", async () => {
+    const out = await collect([
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_x",
+          call_id: "call_x",
+          name: "alpha",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "function_call", id: "fc_y", call_id: "call_y", name: "beta", arguments: "" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_x",
+        delta: '{"a":1}',
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_y",
+        delta: '{"b":2}',
+      },
+      { type: "response.completed" },
+    ]);
+
+    const x = out.find((e) => e.objectDelta[0].id === "call_x");
+    const y = out.find((e) => e.objectDelta[0].id === "call_y");
+    expect(x.objectDelta[0]).toMatchObject({ name: "alpha", input: { a: 1 } });
+    expect(y.objectDelta[0]).toMatchObject({ name: "beta", input: { b: 2 } });
+  });
 });
 
 const TOOL: ToolDefinition = {


### PR DESCRIPTION
## Summary
HIGH finding from a review of libs main's recent OpenAI Responses migration:
`accumulateOpenAIResponsesStream` keyed its internal tool-call map on
`event.output_index ?? 0`. When a Responses stream omitted `output_index`
on concurrent `function_call` items, every call collapsed onto key `0`
and the first call was silently dropped.

Switched keying to the stable item id (`event.item?.id` on
`output_item.{added,done}`, `event.item_id` on `function_call_arguments.delta`),
falling back to `output_index` only when no id is available. Public API,
emitted event shape, and downstream StreamProcessor `call_id` flow are unchanged.

## Changes
- `packages/ai/src/provider-utils/OpenAIShapedResponses.ts` — map key is `string`; each of the three lifecycle branches computes `key` from the stable id with `output_index` fallback. On `delta` and `done` the lookup tries the id first, then `output_index`, so an entry `added` registered under either shape is still found (keeps the existing "output_index only on `added`, `item_id` only on `delta`" test unchanged).
- `packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts` — three new cases (regression: distinct `item.id`, no `output_index`; legacy fallback: `output_index` only; id wins over colliding `output_index`).

## Test plan
- [x] `bun run build:types` clean.
- [x] `bun test packages/test/src/test/ai-provider/OpenAIShapedResponses.test.ts` — 21/21 pass (18 existing + 3 new).
- [ ] `bun scripts/test.ts provider vitest` (run if reviewer wants).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeJoTKKLkPD7Zks5qQTM9N)_