### PR TITLE
fix(node-llama-cpp): close sequence-reclaim race and auto-evict on VRAM pressure

### DIFF
--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -4,18 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "bun:test";
+import { acquireContextSequence } from "@workglow/node-llama-cpp/ai-runtime";
 import type { LlamaContext, LlamaContextSequence } from "node-llama-cpp";
-import { acquireContextSequence } from "./LlamaCpp_Runtime";
+import { describe, expect, it } from "vitest";
 
-/**
- * A minimal stand-in for `LlamaContext` that models node-llama-cpp's
- * **asynchronous** sequence reclamation: `sequencesLeft` reports 0 while a
- * previously disposed sequence's id is still being pushed back into the pool
- * under the context lock, then flips positive after `reclaimAfter` macrotasks.
- * `getSequence()` throws "No sequences left" whenever it is called while the
- * pool is empty — exactly as the real context does.
- */
 function makeFakeContext(reclaimAfter: number): {
   context: LlamaContext;
   getSequenceCalls: () => number;
@@ -25,9 +17,6 @@ function makeFakeContext(reclaimAfter: number): {
   const tick = (): void => {
     ticks += 1;
   };
-  // Advance a macrotask counter on every event-loop turn so `sequencesLeft`
-  // becomes positive only after `reclaimAfter` yields, mimicking the deferred
-  // lock-guarded reclaim.
   const pump = (): void => {
     if (ticks < reclaimAfter) setTimeout(pump, 0);
   };
@@ -53,17 +42,13 @@ describe("acquireContextSequence", () => {
     const { context, getSequenceCalls } = makeFakeContext(0);
     const seq = await acquireContextSequence(context);
     expect(seq).toBeDefined();
-    // No waiting, and getSequence called exactly once.
     expect(getSequenceCalls()).toBe(1);
   });
 
   it("waits for a deferred reclaim instead of throwing 'No sequences left'", async () => {
-    // Pool is empty for the first few event-loop turns, then reclaimed — the
-    // exact race that made the raw `context.getSequence()` throw on slow models.
     const { context, getSequenceCalls } = makeFakeContext(3);
     const seq = await acquireContextSequence(context);
     expect(seq).toBeDefined();
-    // getSequence is only invoked once the pool is non-empty, so it never throws.
     expect(getSequenceCalls()).toBe(1);
   });
 });

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -4,9 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { acquireContextSequence } from "@workglow/node-llama-cpp/ai-runtime";
-import type { LlamaContext, LlamaContextSequence } from "node-llama-cpp";
-import { describe, expect, it } from "vitest";
+import {
+  acquireContextSequence,
+  getOrCreateEmbeddingContext,
+  isVramError,
+  llamaCppEmbeddingContexts,
+  llamaCppModels,
+  llamaCppTextContexts,
+  recycleLlamaCppTextContext,
+} from "@workglow/node-llama-cpp/ai-runtime";
+import type {
+  LlamaContext,
+  LlamaContextSequence,
+  LlamaEmbeddingContext,
+  LlamaModel,
+} from "node-llama-cpp";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 function makeFakeContext(reclaimAfter: number): {
   context: LlamaContext;
@@ -50,5 +63,126 @@ describe("acquireContextSequence", () => {
     const seq = await acquireContextSequence(context);
     expect(seq).toBeDefined();
     expect(getSequenceCalls()).toBe(1);
+  });
+});
+
+describe("isVramError classification", () => {
+  const cases: readonly { readonly msg: string; readonly expected: boolean }[] = [
+    { msg: "CUDA error: out of memory", expected: true },
+    {
+      msg: "ggml_backend_cuda_buffer_type_alloc_buffer: allocating 8192.00 MiB on device 0: cudaMalloc failed",
+      expected: true,
+    },
+    { msg: "MTLBuffer allocation failed", expected: true },
+    { msg: "hipMalloc failed", expected: true },
+    { msg: "HIP out of memory", expected: true },
+    { msg: "VK_ERROR_OUT_OF_DEVICE_MEMORY", expected: true },
+    { msg: "Not enough VRAM to load model", expected: true },
+    { msg: "failed to allocate buffer", expected: true },
+    { msg: "too large for the available VRAM", expected: true },
+    { msg: "ENOENT: no such file or directory", expected: false },
+    { msg: "invalid model file", expected: false },
+    { msg: "No sequences left", expected: false },
+    { msg: "", expected: false },
+  ];
+
+  it.each(cases)("classifies $msg as $expected", ({ msg, expected }) => {
+    expect(isVramError(new Error(msg))).toBe(expected);
+    expect(isVramError(msg)).toBe(expected);
+  });
+});
+
+describe("recycleLlamaCppTextContext with reloadModel disposes embedding context", () => {
+  afterEach(() => {
+    llamaCppModels.clear();
+    llamaCppTextContexts.clear();
+    llamaCppEmbeddingContexts.clear();
+  });
+
+  it("disposes the model, text context, and embedding context for the target key", async () => {
+    const modelDisposeA = vi.fn(async () => {});
+    const textDisposeA = vi.fn(async () => {});
+    const embeddingDisposeA = vi.fn(async () => {});
+    const modelDisposeB = vi.fn(async () => {});
+    const textDisposeB = vi.fn(async () => {});
+    const embeddingDisposeB = vi.fn(async () => {});
+
+    const modelA = { dispose: modelDisposeA } as unknown as LlamaModel;
+    const textA = { dispose: textDisposeA } as unknown as LlamaContext;
+    const embeddingA = { dispose: embeddingDisposeA } as unknown as LlamaEmbeddingContext;
+    const modelB = { dispose: modelDisposeB } as unknown as LlamaModel;
+    const textB = { dispose: textDisposeB } as unknown as LlamaContext;
+    const embeddingB = { dispose: embeddingDisposeB } as unknown as LlamaEmbeddingContext;
+
+    llamaCppModels.set("/tmp/a.gguf", modelA);
+    llamaCppTextContexts.set("/tmp/a.gguf", textA);
+    llamaCppEmbeddingContexts.set("/tmp/a.gguf", embeddingA);
+    llamaCppModels.set("/tmp/b.gguf", modelB);
+    llamaCppTextContexts.set("/tmp/b.gguf", textB);
+    llamaCppEmbeddingContexts.set("/tmp/b.gguf", embeddingB);
+
+    await recycleLlamaCppTextContext("/tmp/a.gguf", { reloadModel: true });
+
+    expect(llamaCppModels.has("/tmp/a.gguf")).toBe(false);
+    expect(llamaCppTextContexts.has("/tmp/a.gguf")).toBe(false);
+    expect(llamaCppEmbeddingContexts.has("/tmp/a.gguf")).toBe(false);
+
+    expect(llamaCppModels.get("/tmp/b.gguf")).toBe(modelB);
+    expect(llamaCppTextContexts.get("/tmp/b.gguf")).toBe(textB);
+    expect(llamaCppEmbeddingContexts.get("/tmp/b.gguf")).toBe(embeddingB);
+
+    expect(modelDisposeA).toHaveBeenCalledTimes(1);
+    expect(textDisposeA).toHaveBeenCalledTimes(1);
+    expect(embeddingDisposeA).toHaveBeenCalledTimes(1);
+
+    expect(modelDisposeB).not.toHaveBeenCalled();
+    expect(textDisposeB).not.toHaveBeenCalled();
+    expect(embeddingDisposeB).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOrCreateEmbeddingContext under VRAM pressure", () => {
+  afterEach(() => {
+    llamaCppModels.clear();
+    llamaCppTextContexts.clear();
+    llamaCppEmbeddingContexts.clear();
+  });
+
+  it("evicts the LRU cached model and retries after createEmbeddingContext throws a VRAM error", async () => {
+    const stubEmbeddingContext = {
+      dispose: vi.fn(async () => {}),
+    } as unknown as LlamaEmbeddingContext;
+
+    const createEmbeddingContext = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("CUDA error: out of memory"))
+      .mockResolvedValueOnce(stubEmbeddingContext);
+
+    const stubModel = {
+      createEmbeddingContext,
+      dispose: vi.fn(async () => {}),
+    } as unknown as LlamaModel;
+
+    const stubLRUModel = {
+      dispose: vi.fn(async () => {}),
+    } as unknown as LlamaModel;
+    const stubLRUCtx = {
+      dispose: vi.fn(async () => {}),
+    } as unknown as LlamaContext;
+
+    llamaCppModels.set("/tmp/lru.gguf", stubLRUModel);
+    llamaCppTextContexts.set("/tmp/lru.gguf", stubLRUCtx);
+    llamaCppModels.set("/tmp/target.gguf", stubModel);
+
+    const result = await getOrCreateEmbeddingContext({
+      model_id: "t",
+      provider_config: { model_path: "/tmp/target.gguf" },
+    } as any);
+
+    expect(result).toBe(stubEmbeddingContext);
+    expect(createEmbeddingContext).toHaveBeenCalledTimes(2);
+    expect(llamaCppModels.has("/tmp/lru.gguf")).toBe(false);
+    expect(llamaCppTextContexts.has("/tmp/lru.gguf")).toBe(false);
+    expect(llamaCppEmbeddingContexts.get("/tmp/target.gguf")).toBe(stubEmbeddingContext);
   });
 });

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
@@ -12,6 +12,7 @@ import type {
 } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getConfigKey,
   getLlamaCppSession,
   getOrCreateTextContext,
@@ -37,7 +38,7 @@ async function getOrCreateChatSession(
 
   const { LlamaChatSession } = await loadSdk();
   const context = await getOrCreateTextContext(model);
-  const sequence = context.getSequence();
+  const sequence = await acquireContextSequence(context);
   const session = new LlamaChatSession({
     contextSequence: sequence,
     ...(systemPrompt !== undefined && { systemPrompt }),

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.test.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { LlamaContext, LlamaContextSequence } from "node-llama-cpp";
+import { acquireContextSequence } from "./LlamaCpp_Runtime";
+
+/**
+ * A minimal stand-in for `LlamaContext` that models node-llama-cpp's
+ * **asynchronous** sequence reclamation: `sequencesLeft` reports 0 while a
+ * previously disposed sequence's id is still being pushed back into the pool
+ * under the context lock, then flips positive after `reclaimAfter` macrotasks.
+ * `getSequence()` throws "No sequences left" whenever it is called while the
+ * pool is empty — exactly as the real context does.
+ */
+function makeFakeContext(reclaimAfter: number): {
+  context: LlamaContext;
+  getSequenceCalls: () => number;
+} {
+  let ticks = 0;
+  let calls = 0;
+  const tick = (): void => {
+    ticks += 1;
+  };
+  // Advance a macrotask counter on every event-loop turn so `sequencesLeft`
+  // becomes positive only after `reclaimAfter` yields, mimicking the deferred
+  // lock-guarded reclaim.
+  const pump = (): void => {
+    if (ticks < reclaimAfter) setTimeout(pump, 0);
+  };
+  setTimeout(pump, 0);
+
+  const context = {
+    get sequencesLeft(): number {
+      tick();
+      return ticks >= reclaimAfter ? 1 : 0;
+    },
+    getSequence(): LlamaContextSequence {
+      calls += 1;
+      if (ticks < reclaimAfter) throw new Error("No sequences left");
+      return { id: "seq" } as unknown as LlamaContextSequence;
+    },
+  } as unknown as LlamaContext;
+
+  return { context, getSequenceCalls: () => calls };
+}
+
+describe("acquireContextSequence", () => {
+  it("returns immediately when a sequence is already free", async () => {
+    const { context, getSequenceCalls } = makeFakeContext(0);
+    const seq = await acquireContextSequence(context);
+    expect(seq).toBeDefined();
+    // No waiting, and getSequence called exactly once.
+    expect(getSequenceCalls()).toBe(1);
+  });
+
+  it("waits for a deferred reclaim instead of throwing 'No sequences left'", async () => {
+    // Pool is empty for the first few event-loop turns, then reclaimed — the
+    // exact race that made the raw `context.getSequence()` throw on slow models.
+    const { context, getSequenceCalls } = makeFakeContext(3);
+    const seq = await acquireContextSequence(context);
+    expect(seq).toBeDefined();
+    // getSequence is only invoked once the pool is non-empty, so it never throws.
+    expect(getSequenceCalls()).toBe(1);
+  });
+});

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -108,10 +108,9 @@ export async function releaseLlamaCppTransientSessions(): Promise<void> {
  * resolved on-disk path; both spellings are tried so callers don't have to
  * know which form ended up in the context cache.
  *
- * If `reloadModel` is true the cached `LlamaModel` is disposed as well, so the
- * next request reloads weights from disk. Use this when prior runs may have
- * leaked sequence-pool slots at the C level — disposing the context alone may
- * not be sufficient to reclaim them inside the same model lifetime.
+ * If `reloadModel` is true the cached `LlamaModel` and any cached embedding
+ * context for the same key are disposed as well, so the next request reloads
+ * weights from disk.
  */
 export async function recycleLlamaCppTextContext(
   modelKey: string,
@@ -129,6 +128,13 @@ export async function recycleLlamaCppTextContext(
   }
   if (options.reloadModel) {
     for (const key of candidates) {
+      const embeddingContext = llamaCppEmbeddingContexts.get(key);
+      if (embeddingContext) {
+        llamaCppEmbeddingContexts.delete(key);
+        await (embeddingContext as unknown as { dispose?: () => Promise<void> })
+          .dispose?.()
+          .catch(() => {});
+      }
       const loadedModel = llamaCppModels.get(key);
       if (loadedModel) {
         llamaCppModels.delete(key);
@@ -170,21 +176,38 @@ export function getActualModelPath(model: LlamaCppModelConfig): string {
   return resolved ?? model.provider_config.model_path;
 }
 
-/** Substrings (lower-cased) for allocation failures after confirming a VRAM/GPU/CUDA signal in the message. */
-const ALLOCATION_ERROR_PATTERNS: readonly string[] = [
+/**
+ * Substrings (lower-cased) that identify a device-memory allocation failure
+ * across ggml backends (CUDA, Metal, ROCm/HIP, Vulkan, generic ggml). Any
+ * single match on the lowercased error message is enough — a flat OR beats
+ * the previous two-gate design, which missed messages that spelled the
+ * backend without one of the "vram|cuda|gpu" tokens (Metal / ROCm / Vulkan)
+ * or that used allocation phrases outside the previous whitelist.
+ */
+const VRAM_ERROR_PATTERNS: readonly string[] = [
   "not enough vram",
   "too large for the available vram",
   "out of memory",
   "failed to allocate",
   "cuda out of memory",
+  "cudamalloc",
+  "ggml_backend_cuda",
+  "ggml_cuda",
+  "cublas",
+  "allocating buffer",
+  "allocation failed",
+  "mtlbuffer",
+  "metal allocation",
+  "hipmalloc",
+  "hip out of memory",
+  "vkdevicememory",
+  "vk_error_out_of_device_memory",
 ];
 
-function isVramError(err: unknown): boolean {
+/** @internal exported for unit tests. */
+export function isVramError(err: unknown): boolean {
   const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
-  if (!msg.includes("vram") && !msg.includes("cuda") && !msg.includes("gpu")) {
-    return false;
-  }
-  return ALLOCATION_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
+  return VRAM_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
 }
 
 /** Move a cached model to the most-recently-used end of the insertion-ordered cache. */
@@ -372,7 +395,7 @@ export async function getOrCreateEmbeddingContext(
 
   const loadedModel = await getOrLoadModel(model);
 
-  const context = await loadedModel.createEmbeddingContext();
+  const context = await withVramEviction(modelPath, () => loadedModel.createEmbeddingContext());
 
   llamaCppEmbeddingContexts.set(modelPath, context);
   return context;

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -7,6 +7,7 @@
 import type { StreamEvent } from "@workglow/task-graph";
 import type {
   LlamaContext,
+  LlamaContextSequence,
   LlamaEmbeddingContext,
   Llama as LlamaInstance,
   LlamaModel,
@@ -169,18 +170,81 @@ export function getActualModelPath(model: LlamaCppModelConfig): string {
   return resolved ?? model.provider_config.model_path;
 }
 
+/** Substrings (lower-cased) that identify a llama.cpp allocation failure we can retry after freeing VRAM. */
+const VRAM_ERROR_PATTERNS: readonly string[] = [
+  "not enough vram",
+  "too large for the available vram",
+  "insufficient",
+  "out of memory",
+  "failed to allocate",
+  "failed to create",
+];
+
+function isVramError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return VRAM_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
+}
+
+/** Move a cached model to the most-recently-used end of the insertion-ordered cache. */
+function touchModel(modelPath: string): void {
+  const cached = llamaCppModels.get(modelPath);
+  if (cached) {
+    llamaCppModels.delete(modelPath);
+    llamaCppModels.set(modelPath, cached);
+  }
+}
+
+/**
+ * Evict the least-recently-used cached model (and its text context) to free
+ * VRAM, skipping `exceptPath` (the model currently being loaded). `llamaCppModels`
+ * is kept in access order by {@link touchModel}, so the first key is the LRU one.
+ * Returns the evicted path, or undefined when nothing else is cached.
+ */
+async function evictLeastRecentlyUsedModel(exceptPath: string): Promise<string | undefined> {
+  for (const path of llamaCppModels.keys()) {
+    if (path === exceptPath) continue;
+    await recycleLlamaCppTextContext(path, { reloadModel: true });
+    return path;
+  }
+  return undefined;
+}
+
+/**
+ * Run `attempt`, and if it fails with a VRAM allocation error, evict the LRU
+ * cached model and retry — repeating until it succeeds or there is nothing left
+ * to evict (then the original error is rethrown). This lets a large model or a
+ * large KV cache load by reclaiming VRAM still held by earlier models the worker
+ * cached but no longer needs (e.g. successive candidates in an eval sweep).
+ */
+async function withVramEviction<T>(exceptPath: string, attempt: () => Promise<T>): Promise<T> {
+  while (true) {
+    try {
+      return await attempt();
+    } catch (err) {
+      if (!isVramError(err)) throw err;
+      const evicted = await evictLeastRecentlyUsedModel(exceptPath);
+      if (evicted === undefined) throw err;
+    }
+  }
+}
+
 export async function getOrLoadModel(model: LlamaCppModelConfig): Promise<LlamaModel> {
   const modelPath = getActualModelPath(model);
   const cached = llamaCppModels.get(modelPath);
-  if (cached) return cached;
+  if (cached) {
+    touchModel(modelPath);
+    return cached;
+  }
 
   const llama = await getLlamaInstance();
   const config = model.provider_config;
 
-  const loadedModel = await llama.loadModel({
-    modelPath,
-    ...(config.gpu_layers !== undefined && { gpuLayers: config.gpu_layers }),
-  });
+  const loadedModel = await withVramEviction(modelPath, () =>
+    llama.loadModel({
+      modelPath,
+      ...(config.gpu_layers !== undefined && { gpuLayers: config.gpu_layers }),
+    })
+  );
 
   llamaCppModels.set(modelPath, loadedModel);
   return loadedModel;
@@ -233,13 +297,52 @@ export async function getOrCreateTextContext(model: LlamaCppModelConfig): Promis
   const loadedModel = await getOrLoadModel(model);
   const config = model.provider_config;
 
-  const context = await loadedModel.createContext({
-    ...(config.context_size && { contextSize: config.context_size }),
-    ...(config.flash_attention !== undefined && { flashAttention: config.flash_attention }),
-  });
+  // Evict other cached models on a VRAM error so the KV cache can fit; keep this
+  // model (modelPath) resident since we are building its context.
+  const context = await withVramEviction(modelPath, () =>
+    loadedModel.createContext({
+      ...(config.context_size && { contextSize: config.context_size }),
+      ...(config.flash_attention !== undefined && { flashAttention: config.flash_attention }),
+    })
+  );
 
   llamaCppTextContexts.set(modelPath, context);
   return context;
+}
+
+/** How long {@link acquireContextSequence} waits for a disposed sequence to be reclaimed. */
+const SEQUENCE_RECLAIM_TIMEOUT_MS = 30_000;
+
+/**
+ * Acquire a sequence from a (typically cached, single-sequence) context, tolerating
+ * node-llama-cpp's **asynchronous** sequence reclamation.
+ *
+ * `LlamaContextSequence.dispose()` returns synchronously, but it frees the sequence
+ * id via `_reclaimUnusedSequenceId`, which pushes the id back into the context's pool
+ * inside a `withLock([context])` async callback — so the slot is not actually free
+ * when `dispose()` returns. On a cached single-sequence context, a fast serial
+ * re-acquire (the next task reusing the same context) can therefore observe
+ * `sequencesLeft === 0` and make `getSequence()` throw `"No sequences left"`, even
+ * though the previous sequence was disposed. It is a race, not a leak — which is why
+ * it surfaces on slow models (large sections, MoE) but not on fast ones.
+ *
+ * Waiting for `sequencesLeft > 0` before allocating closes the race without growing
+ * the sequence pool (each extra sequence costs another `contextSize` of KV cells, so
+ * a larger pool would regress memory on VRAM-constrained hosts).
+ */
+export async function acquireContextSequence(context: LlamaContext): Promise<LlamaContextSequence> {
+  if (context.sequencesLeft > 0) return context.getSequence();
+  const deadline = Date.now() + SEQUENCE_RECLAIM_TIMEOUT_MS;
+  while (context.sequencesLeft <= 0) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        "Timed out waiting for a llama.cpp context sequence to be reclaimed after dispose."
+      );
+    }
+    // Yield a macrotask so the lock-guarded reclaim callback can run.
+    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+  }
+  return context.getSequence();
 }
 
 export async function getOrCreateEmbeddingContext(

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -174,14 +174,16 @@ export function getActualModelPath(model: LlamaCppModelConfig): string {
 const VRAM_ERROR_PATTERNS: readonly string[] = [
   "not enough vram",
   "too large for the available vram",
-  "insufficient",
   "out of memory",
   "failed to allocate",
-  "failed to create",
+  "cuda out of memory",
 ];
 
 function isVramError(err: unknown): boolean {
   const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  if (!msg.includes("vram") && !msg.includes("cuda") && !msg.includes("gpu")) {
+    return false;
+  }
   return VRAM_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
 }
 
@@ -292,7 +294,10 @@ export function llamaCppChatSessionConstructorSpread(model: LlamaCppModelConfig)
 export async function getOrCreateTextContext(model: LlamaCppModelConfig): Promise<LlamaContext> {
   const modelPath = getActualModelPath(model);
   const cached = llamaCppTextContexts.get(modelPath);
-  if (cached) return cached;
+  if (cached) {
+    touchModel(modelPath);
+    return cached;
+  }
 
   const loadedModel = await getOrLoadModel(model);
   const config = model.provider_config;
@@ -331,9 +336,18 @@ const SEQUENCE_RECLAIM_TIMEOUT_MS = 30_000;
  * a larger pool would regress memory on VRAM-constrained hosts).
  */
 export async function acquireContextSequence(context: LlamaContext): Promise<LlamaContextSequence> {
-  if (context.sequencesLeft > 0) return context.getSequence();
   const deadline = Date.now() + SEQUENCE_RECLAIM_TIMEOUT_MS;
-  while (context.sequencesLeft <= 0) {
+  while (true) {
+    if (context.sequencesLeft > 0) {
+      try {
+        return context.getSequence();
+      } catch (err) {
+        const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+        if (!msg.includes("no sequences left")) {
+          throw err;
+        }
+      }
+    }
     if (Date.now() > deadline) {
       throw new Error(
         "Timed out waiting for a llama.cpp context sequence to be reclaimed after dispose."
@@ -342,7 +356,6 @@ export async function acquireContextSequence(context: LlamaContext): Promise<Lla
     // Yield a macrotask so the lock-guarded reclaim callback can run.
     await new Promise<void>((resolve) => setTimeout(resolve, 1));
   }
-  return context.getSequence();
 }
 
 export async function getOrCreateEmbeddingContext(
@@ -350,7 +363,10 @@ export async function getOrCreateEmbeddingContext(
 ): Promise<LlamaEmbeddingContext> {
   const modelPath = getActualModelPath(model);
   const cached = llamaCppEmbeddingContexts.get(modelPath);
-  if (cached) return cached;
+  if (cached) {
+    touchModel(modelPath);
+    return cached;
+  }
 
   const loadedModel = await getOrLoadModel(model);
 

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -170,8 +170,8 @@ export function getActualModelPath(model: LlamaCppModelConfig): string {
   return resolved ?? model.provider_config.model_path;
 }
 
-/** Substrings (lower-cased) that identify a llama.cpp allocation failure we can retry after freeing VRAM. */
-const VRAM_ERROR_PATTERNS: readonly string[] = [
+/** Substrings (lower-cased) for allocation failures after confirming a VRAM/GPU/CUDA signal in the message. */
+const ALLOCATION_ERROR_PATTERNS: readonly string[] = [
   "not enough vram",
   "too large for the available vram",
   "out of memory",
@@ -184,7 +184,7 @@ function isVramError(err: unknown): boolean {
   if (!msg.includes("vram") && !msg.includes("cuda") && !msg.includes("gpu")) {
     return false;
   }
-  return VRAM_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
+  return ALLOCATION_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
 }
 
 /** Move a cached model to the most-recently-used end of the insertion-ordered cache. */
@@ -317,6 +317,8 @@ export async function getOrCreateTextContext(model: LlamaCppModelConfig): Promis
 
 /** How long {@link acquireContextSequence} waits for a disposed sequence to be reclaimed. */
 const SEQUENCE_RECLAIM_TIMEOUT_MS = 30_000;
+/** node-llama-cpp currently throws this message from `getSequence()` when no slots are available. */
+const NO_SEQUENCES_LEFT_ERROR_SUBSTRING = "no sequences left";
 
 /**
  * Acquire a sequence from a (typically cached, single-sequence) context, tolerating
@@ -343,7 +345,7 @@ export async function acquireContextSequence(context: LlamaContext): Promise<Lla
         return context.getSequence();
       } catch (err) {
         const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
-        if (!msg.includes("no sequences left")) {
+        if (!msg.includes(NO_SEQUENCES_LEFT_ERROR_SUBSTRING)) {
           throw err;
         }
       }

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
@@ -12,6 +12,7 @@ import type {
 import { parsePartialJson } from "@workglow/util/worker";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getLlamaCppSdk,
   getLlamaInstance,
   getOrCreateTextContext,
@@ -33,7 +34,7 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
   const context = await getOrCreateTextContext(model);
   const grammar = await llama.createGrammarForJsonSchema(input.outputSchema as any);
 
-  const sequence = context.getSequence();
+  const sequence = await acquireContextSequence(context);
   const { LlamaChatSession } = getLlamaCppSdk();
   const session = new LlamaChatSession({
     contextSequence: sequence,

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
@@ -11,6 +11,7 @@ import type {
 } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getConfigKey,
   getLlamaCppSession,
   getOrCreateTextContext,
@@ -32,7 +33,7 @@ export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
 
   const cached = sessionId ? getLlamaCppSession(sessionId) : undefined;
   const context = cached ? undefined : await getOrCreateTextContext(model);
-  const sequence = cached ? cached.sequence : context!.getSequence();
+  const sequence = cached ? cached.sequence : await acquireContextSequence(context!);
   const session =
     cached?.session ??
     new LlamaChatSession({

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextRewriter.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextRewriter.ts
@@ -7,6 +7,7 @@
 import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
@@ -24,7 +25,7 @@ export const LlamaCpp_TextRewriter_Stream: AiProviderRunFn<
   const { LlamaChatSession } = await loadSdk();
 
   const context = await getOrCreateTextContext(model);
-  const sequence = context.getSequence();
+  const sequence = await acquireContextSequence(context);
   const session = new LlamaChatSession({
     contextSequence: sequence,
     ...llamaCppChatSessionConstructorSpread(model),

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextSummary.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextSummary.ts
@@ -7,6 +7,7 @@
 import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
@@ -24,7 +25,7 @@ export const LlamaCpp_TextSummary_Stream: AiProviderRunFn<
   const { LlamaChatSession } = await loadSdk();
 
   const context = await getOrCreateTextContext(model);
-  const sequence = context.getSequence();
+  const sequence = await acquireContextSequence(context);
   const session = new LlamaChatSession({
     contextSequence: sequence,
     ...llamaCppChatSessionConstructorSpread(model),

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
@@ -17,6 +17,7 @@ import { filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
 import type { StreamEvent } from "@workglow/task-graph";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
+  acquireContextSequence,
   getLlamaCppSdk,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
@@ -270,7 +271,7 @@ export const LlamaCpp_ToolCalling_Stream: AiProviderRunFn<
 
   const context = await getOrCreateTextContext(model);
 
-  const sequence = context.getSequence();
+  const sequence = await acquireContextSequence(context);
   const { LlamaChat } = getLlamaCppSdk();
   const systemPrompt = buildSystemPrompt(input);
 


### PR DESCRIPTION
Two robustness fixes for the local GGUF provider, surfaced while running multi-model extraction sweeps:

- "No sequences left": LlamaContextSequence.dispose() reclaims its sequence id asynchronously (under the context lock), so a fast serial re-acquire on a cached single-sequence context could observe an empty pool and throw even though the prior sequence was disposed. It surfaced on slow models but not fast ones -- a race, not a leak. Add acquireContextSequence(), which waits for sequencesLeft > 0 before getSequence(), and route all six run functions through it. Waiting (rather than growing the pool) avoids extra per-sequence KV memory cost on VRAM-constrained hosts.

- VRAM exhaustion across models: the worker caches every loaded model/context without eviction, so sweeping several models in one process runs out of VRAM (each loads fine in isolation). Wrap model load and context creation in withVramEviction(), which on an allocation error evicts the least-recently- used cached model (tracked via touchModel) and retries until it fits or there is nothing left to free.

Adds a regression test that reproduces the reclaim race.