### PR TITLE
fix(huggingface-inference): guard chunk.choices[0] in streaming run-fns

### DIFF
--- a/packages/test/src/test/ai-provider-api/HFI_StreamChunkSafety.test.ts
+++ b/packages/test/src/test/ai-provider-api/HFI_StreamChunkSafety.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/huggingface-inference/ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const { HFI_RUN_FNS, _setHfInferenceSDKForTesting } = _testOnly;
+
+let chunkQueue: unknown[] = [];
+
+async function* asyncIterOf<T>(items: readonly T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+class FakeInferenceClient {
+  chatCompletionStream() {
+    return asyncIterOf(chunkQueue);
+  }
+}
+
+function findRunFn(servesKey: string) {
+  const reg = HFI_RUN_FNS.find((r) => [...r.serves].sort().join(",") === servesKey);
+  if (!reg) throw new Error(`no HFI run-fn registered for ${servesKey}`);
+  return reg.runFn;
+}
+
+const textGenerationFn = findRunFn("text.generation");
+const textRewriterFn = findRunFn("text.rewriter");
+const textSummaryFn = findRunFn("text.summary");
+
+const model = {
+  model_id: "hfi-x",
+  provider_config: {
+    model_name: "meta-llama/Meta-Llama-3-8B-Instruct",
+    api_key: "test-key",
+  },
+} as any;
+
+// The three unsafe SDK chunk shapes we replaced with `chunk.choices?.[0]?.…`:
+//   - `choices` field absent (SSE keepalive / multiplexed upstream frame)
+//   - `choices` is an empty array
+//   - `choices[0]` exists but has no `delta` (initial role frame)
+const unsafeShapes = [
+  { label: "choices field absent", pre: [{}] },
+  { label: "empty choices array", pre: [{ choices: [] }] },
+  { label: "choices[0] with no delta", pre: [{ choices: [{}] }] },
+];
+
+describe("HFI streaming run-fns tolerate SDK chunks without choices/delta", () => {
+  beforeEach(() => {
+    chunkQueue = [];
+    _setHfInferenceSDKForTesting({ InferenceClient: FakeInferenceClient } as any);
+  });
+
+  afterEach(() => {
+    _setHfInferenceSDKForTesting(undefined);
+  });
+
+  describe("HFI_TextGeneration_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        chunkQueue = [...pre, { choices: [{ delta: { content: "hello" } }] }];
+
+        const events: any[] = [];
+        await expect(
+          textGenerationFn({ prompt: "hi" } as any, model, new AbortController().signal, (e) =>
+            events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe("hello");
+        expect(events.at(-1)?.type).toBe("finish");
+      });
+    }
+  });
+
+  describe("HFI_TextRewriter_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        chunkQueue = [...pre, { choices: [{ delta: { content: "rewritten" } }] }];
+
+        const events: any[] = [];
+        await expect(
+          textRewriterFn(
+            { prompt: "rewrite", text: "input" } as any,
+            model,
+            new AbortController().signal,
+            (e) => events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe("rewritten");
+        expect(events.at(-1)?.type).toBe("finish");
+      });
+    }
+  });
+
+  describe("HFI_TextSummary_Stream", () => {
+    for (const { label, pre } of unsafeShapes) {
+      it(`skips ${label} and emits the text-delta from later chunks`, async () => {
+        chunkQueue = [...pre, { choices: [{ delta: { content: "summary" } }] }];
+
+        const events: any[] = [];
+        await expect(
+          textSummaryFn({ text: "input" } as any, model, new AbortController().signal, (e) =>
+            events.push(e)
+          )
+        ).resolves.toBeUndefined();
+
+        const textDeltas = events.filter((e) => e.type === "text-delta");
+        expect(textDeltas.map((d) => d.textDelta).join("")).toBe("summary");
+        expect(events.at(-1)?.type).toBe("finish");
+      });
+    }
+  });
+});

--- a/providers/huggingface-inference/src/ai/common/HFI_Client.ts
+++ b/providers/huggingface-inference/src/ai/common/HFI_Client.ts
@@ -10,9 +10,11 @@ import type { HfInferenceModelConfig } from "./HFI_ModelSchema";
 type HfInferenceSDKModule = typeof import("@huggingface/inference");
 
 let _loadPromise: Promise<HfInferenceSDKModule> | undefined;
+let _sdkOverride: HfInferenceSDKModule | undefined;
 
 // NOTE: we do not want to de-dup this in the provider-utils, vite wants direct import with string literals.
 export async function loadHfInferenceSDK(): Promise<HfInferenceSDKModule> {
+  if (_sdkOverride) return _sdkOverride;
   _loadPromise ??= import(/* @vite-ignore */ "@huggingface/inference")
     .then((mod) => mod as HfInferenceSDKModule)
     .catch(() => {
@@ -22,6 +24,16 @@ export async function loadHfInferenceSDK(): Promise<HfInferenceSDKModule> {
       );
     });
   return _loadPromise;
+}
+
+/**
+ * @internal Test-only injection point. The dynamic `import()` in
+ * {@link loadHfInferenceSDK} carries a `@vite-ignore` directive, so `vi.mock`
+ * cannot intercept it; tests set a fake SDK module here instead.
+ */
+export function _setHfInferenceSDKForTesting(sdk: HfInferenceSDKModule | undefined): void {
+  _sdkOverride = sdk;
+  _loadPromise = undefined;
 }
 
 interface ResolvedProviderConfig {

--- a/providers/huggingface-inference/src/ai/common/HFI_TextGeneration.ts
+++ b/providers/huggingface-inference/src/ai/common/HFI_TextGeneration.ts
@@ -66,7 +66,7 @@ export const HFI_TextGeneration_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }

--- a/providers/huggingface-inference/src/ai/common/HFI_TextRewriter.ts
+++ b/providers/huggingface-inference/src/ai/common/HFI_TextRewriter.ts
@@ -30,7 +30,7 @@ export const HFI_TextRewriter_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }

--- a/providers/huggingface-inference/src/ai/common/HFI_TextSummary.ts
+++ b/providers/huggingface-inference/src/ai/common/HFI_TextSummary.ts
@@ -30,7 +30,7 @@ export const HFI_TextSummary_Stream: AiProviderRunFn<
   );
 
   for await (const chunk of stream) {
-    const delta = chunk.choices[0]?.delta?.content ?? "";
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
     if (delta) {
       emit({ type: "text-delta", port: "text", textDelta: delta });
     }

--- a/providers/huggingface-inference/src/ai/index.ts
+++ b/providers/huggingface-inference/src/ai/index.ts
@@ -14,6 +14,7 @@ export * from "./common/HFI_ModelSearch";
 export * from "./registerHfInference";
 
 import { HFI_RUN_FN_SPECS } from "./common/HFI_Capabilities";
+import { _setHfInferenceSDKForTesting } from "./common/HFI_Client";
 import { HFI_RUN_FNS } from "./common/HFI_JobRunFns";
 import { HfInferenceQueuedProvider } from "./HfInferenceQueuedProvider";
 
@@ -24,4 +25,5 @@ export const _testOnly = {
   HfInferenceQueuedProvider,
   HFI_RUN_FN_SPECS,
   HFI_RUN_FNS,
+  _setHfInferenceSDKForTesting,
 } as const;


### PR DESCRIPTION
## Summary

HIGH — same class of bug PR #630 fixed for xAI + OpenRouter, still present in the HuggingFace Inference provider's three non-tool-calling streaming run-fns:

- `providers/huggingface-inference/src/ai/common/HFI_TextGeneration.ts`
- `providers/huggingface-inference/src/ai/common/HFI_TextRewriter.ts`
- `providers/huggingface-inference/src/ai/common/HFI_TextSummary.ts`

Each accessed `chunk.choices[0]?.delta?.content` on every SDK chunk. Guarded to `chunk.choices?.[0]?.delta?.content`, matching the idiom `Xai_TextGeneration` and the shared `accumulateOpenAIChatStream` helper already use, and now also `Xai_TextRewriter` / `Xai_TextSummary` / `Xai_StructuredGeneration` / their OpenRouter twins after PR #630.

## Failure scenario

`@huggingface/inference`'s `chatCompletionStream` yields OpenAI-compatible SSE frames. Not every frame carries a `choices` array:

- SSE keepalives arrive as `{}`.
- Some upstream router providers occasionally emit `{choices: []}` before / after the content stream.
- The initial role frame comes through as `{choices: [{}]}` (no `delta`).

On any of these, `chunk.choices[0]` throws `TypeError: Cannot read properties of undefined (reading '0')`, the `for await` aborts, and the stream tears down with no `finish` event — the caller sees the whole generation fail even after partial content has already been emitted.

## Tests

Adds `packages/test/src/test/ai-provider-api/HFI_StreamChunkSafety.test.ts` (mirrors PR #630's `Xai_StreamChunkSafety.test.ts`): for each of the three run-fns (`text.generation`, `text.rewriter`, `text.summary`), feeds each of the three unsafe SDK chunk shapes (`{}`, `{choices: []}`, `{choices: [{}]}`) followed by a good content chunk, and asserts the stream completes with the trailing `text-delta` emitted and a final `finish` event.

Because `HFI_Client.loadHfInferenceSDK` uses `import(/* @vite-ignore */ "@huggingface/inference")`, `vi.mock` cannot intercept the dynamic import. The test uses a new `_setHfInferenceSDKForTesting` injection point exposed on the existing `_testOnly` namespace to swap in a fake `InferenceClient`; the override is cleared in `afterEach`.

## Verification

- [x] `bunx vitest run packages/test/src/test/ai-provider-api/HFI_StreamChunkSafety.test.ts` — 9/9 passed.
- [x] `git grep -n 'chunk\.choices\[0\]' providers/ packages/` — 0 hits.
- [x] `bun run build:types` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XS3k9pekkPuaGURpvbNSPa)_