### PR TITLE
fix(node-llama-cpp,huggingface-transformers): concurrency + sequence-leak + bounded pipeline cache

### DIFF
--- a/packages/test/src/test/ai-provider-hft/HFT_Pipeline.eviction.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_Pipeline.eviction.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  acquireHftPipelineInUse,
+  hasCachedPipeline,
+  isHftPipelineInUse,
+  MAX_CACHED_PIPELINES,
+  pipelines,
+  releaseHftPipelineInUse,
+  removeCachedPipeline,
+  withHftPipelineInUse,
+} from "@workglow/huggingface-transformers/ai-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A pipeline for cache tests only needs the shape that `removeCachedPipeline`
+ * reaches into — `model.dispose()`. `pipelines.set` accepts `unknown`-shaped
+ * pipelines because the underlying map values are typed by the transformers
+ * SDK's `Awaited<ReturnType<pipeline>>`; we cast at insertion.
+ */
+function makeFakePipeline(): {
+  pipeline: unknown;
+  dispose: ReturnType<typeof vi.fn>;
+} {
+  const dispose = vi.fn(async () => {});
+  const pipeline = { model: { dispose } };
+  return { pipeline, dispose };
+}
+
+function seedPipeline(cacheKey: string): ReturnType<typeof vi.fn> {
+  const { pipeline, dispose } = makeFakePipeline();
+  (pipelines as Map<string, unknown>).set(cacheKey, pipeline);
+  return dispose;
+}
+
+/**
+ * Force LRU eviction by pushing the cache over cap and disposing the LRU
+ * candidate. This mirrors the housekeeping path in `getPipeline` (which
+ * runs `enforcePipelineCacheCap` after storing a fresh pipeline) so the
+ * test suite exercises the public shape without needing to load a real
+ * pipeline.
+ */
+async function evictUntilAtCap(exceptKey: string): Promise<string[]> {
+  const evicted: string[] = [];
+  while (pipelines.size > MAX_CACHED_PIPELINES) {
+    let picked: string | undefined;
+    for (const key of pipelines.keys()) {
+      if (key === exceptKey) continue;
+      if (isHftPipelineInUse(key)) continue;
+      picked = key;
+      break;
+    }
+    if (picked === undefined) return evicted;
+    const removed = await removeCachedPipeline(picked);
+    if (!removed) return evicted;
+    evicted.push(picked);
+  }
+  return evicted;
+}
+
+describe("withHftPipelineInUse", () => {
+  afterEach(() => {
+    pipelines.clear();
+  });
+
+  it("acquires and releases the refcount around the callback", async () => {
+    const key = "test:acquire-release";
+    expect(isHftPipelineInUse(key)).toBe(false);
+
+    let sawInUseDuringCallback = false;
+    await withHftPipelineInUse(key, async () => {
+      sawInUseDuringCallback = isHftPipelineInUse(key);
+    });
+
+    expect(sawInUseDuringCallback).toBe(true);
+    expect(isHftPipelineInUse(key)).toBe(false);
+  });
+
+  it("releases the refcount even when the callback throws", async () => {
+    const key = "test:release-on-throw";
+    await expect(
+      withHftPipelineInUse(key, async () => {
+        expect(isHftPipelineInUse(key)).toBe(true);
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(isHftPipelineInUse(key)).toBe(false);
+  });
+});
+
+describe("removeCachedPipeline in-use safety", () => {
+  afterEach(() => {
+    pipelines.clear();
+  });
+
+  it("skips disposal when the pipeline is in-use", async () => {
+    const key = "test:in-use-skip";
+    const dispose = seedPipeline(key);
+
+    acquireHftPipelineInUse(key);
+    try {
+      const removed = await removeCachedPipeline(key);
+      expect(removed).toBe(false);
+      expect(dispose).not.toHaveBeenCalled();
+      expect(hasCachedPipeline(key)).toBe(true);
+    } finally {
+      releaseHftPipelineInUse(key);
+    }
+
+    // Once released, disposal proceeds normally.
+    const removedAfter = await removeCachedPipeline(key);
+    expect(removedAfter).toBe(true);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(hasCachedPipeline(key)).toBe(false);
+  });
+});
+
+describe("bounded LRU cache", () => {
+  afterEach(() => {
+    pipelines.clear();
+  });
+
+  it("evicts the least-recently-used non-in-use entry when over cap", async () => {
+    // Seed exactly at cap.
+    const disposeFns = new Map<string, ReturnType<typeof vi.fn>>();
+    for (let i = 0; i < MAX_CACHED_PIPELINES; i++) {
+      const key = `test:lru:${i}`;
+      disposeFns.set(key, seedPipeline(key));
+    }
+
+    // Adding one more pushes the cache over cap.
+    const freshKey = "test:lru:fresh";
+    disposeFns.set(freshKey, seedPipeline(freshKey));
+
+    const evicted = await evictUntilAtCap(freshKey);
+
+    // The first-seeded key (insertion-order LRU) should be the sole eviction.
+    const expectedEvictKey = "test:lru:0";
+    expect(evicted).toEqual([expectedEvictKey]);
+    expect(disposeFns.get(expectedEvictKey)!).toHaveBeenCalledTimes(1);
+    expect(hasCachedPipeline(expectedEvictKey)).toBe(false);
+
+    // Freshly loaded pipeline must survive.
+    expect(hasCachedPipeline(freshKey)).toBe(true);
+    expect(disposeFns.get(freshKey)!).not.toHaveBeenCalled();
+
+    expect(pipelines.size).toBe(MAX_CACHED_PIPELINES);
+  });
+
+  it("skips an in-use entry and evicts the next LRU candidate", async () => {
+    // Seed to cap.
+    const disposeFns = new Map<string, ReturnType<typeof vi.fn>>();
+    for (let i = 0; i < MAX_CACHED_PIPELINES; i++) {
+      const key = `test:lru-inuse:${i}`;
+      disposeFns.set(key, seedPipeline(key));
+    }
+
+    // Pin the LRU (first-seeded) key as in-use so eviction must skip it.
+    const pinnedKey = "test:lru-inuse:0";
+    const survivorKey = "test:lru-inuse:1";
+    acquireHftPipelineInUse(pinnedKey);
+
+    try {
+      const freshKey = "test:lru-inuse:fresh";
+      disposeFns.set(freshKey, seedPipeline(freshKey));
+
+      const evicted = await evictUntilAtCap(freshKey);
+
+      // The second-oldest (non-pinned) entry should be evicted instead.
+      expect(evicted).toEqual([survivorKey]);
+      expect(disposeFns.get(survivorKey)!).toHaveBeenCalledTimes(1);
+      expect(hasCachedPipeline(survivorKey)).toBe(false);
+
+      // The pinned in-use entry must survive.
+      expect(hasCachedPipeline(pinnedKey)).toBe(true);
+      expect(disposeFns.get(pinnedKey)!).not.toHaveBeenCalled();
+
+      // Freshly loaded pipeline must survive.
+      expect(hasCachedPipeline(freshKey)).toBe(true);
+    } finally {
+      releaseHftPipelineInUse(pinnedKey);
+    }
+  });
+});

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -6,12 +6,16 @@
 
 import {
   acquireContextSequence,
+  acquireModelInUse,
   getOrCreateEmbeddingContext,
   isVramError,
   llamaCppEmbeddingContexts,
   llamaCppModels,
   llamaCppTextContexts,
   recycleLlamaCppTextContext,
+  releaseModelInUse,
+  withSequence,
+  withVramEviction,
 } from "@workglow/node-llama-cpp/ai-runtime";
 import type {
   LlamaContext,
@@ -21,7 +25,11 @@ import type {
 } from "node-llama-cpp";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-function makeFakeContext(reclaimAfter: number): {
+/**
+ * Fake context whose `sequencesLeft` reports zero for the first `reclaimAfter`
+ * `sequencesLeft` reads, simulating the async reclaim path.
+ */
+function makeReclaimAfterContext(reclaimAfter: number): {
   context: LlamaContext;
   getSequenceCalls: () => number;
 } {
@@ -50,19 +58,105 @@ function makeFakeContext(reclaimAfter: number): {
   return { context, getSequenceCalls: () => calls };
 }
 
+/**
+ * Fake context whose `sequencesLeft` always returns 1 but whose `getSequence`
+ * throws `"No sequences left"` for the first `retriesBeforeSuccess` calls —
+ * exactly the race path {@link acquireContextSequence} was written to tolerate.
+ */
+function makeGetSequenceRetryContext(retriesBeforeSuccess: number): {
+  context: LlamaContext;
+  getSequenceCalls: () => number;
+} {
+  let calls = 0;
+  const context = {
+    get sequencesLeft(): number {
+      return 1;
+    },
+    getSequence(): LlamaContextSequence {
+      calls += 1;
+      if (calls <= retriesBeforeSuccess) throw new Error("No sequences left");
+      return { id: "seq" } as unknown as LlamaContextSequence;
+    },
+  } as unknown as LlamaContext;
+  return { context, getSequenceCalls: () => calls };
+}
+
 describe("acquireContextSequence", () => {
   it("returns immediately when a sequence is already free", async () => {
-    const { context, getSequenceCalls } = makeFakeContext(0);
+    const { context, getSequenceCalls } = makeReclaimAfterContext(0);
     const seq = await acquireContextSequence(context);
     expect(seq).toBeDefined();
     expect(getSequenceCalls()).toBe(1);
   });
 
-  it("waits for a deferred reclaim instead of throwing 'No sequences left'", async () => {
-    const { context, getSequenceCalls } = makeFakeContext(3);
+  it("waits for a deferred reclaim before calling getSequence", async () => {
+    const { context, getSequenceCalls } = makeReclaimAfterContext(3);
     const seq = await acquireContextSequence(context);
     expect(seq).toBeDefined();
     expect(getSequenceCalls()).toBe(1);
+  });
+
+  it("retries when getSequence throws 'No sequences left' while sequencesLeft says slots are free", async () => {
+    const { context, getSequenceCalls } = makeGetSequenceRetryContext(3);
+    const seq = await acquireContextSequence(context);
+    expect(seq).toBeDefined();
+    // 3 failing calls then a fourth that succeeds.
+    expect(getSequenceCalls()).toBe(4);
+  });
+
+  it("rejects immediately when the abort signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const context = {
+      get sequencesLeft(): number {
+        return 1;
+      },
+      getSequence(): LlamaContextSequence {
+        return { id: "seq" } as unknown as LlamaContextSequence;
+      },
+    } as unknown as LlamaContext;
+
+    await expect(acquireContextSequence(context, controller.signal)).rejects.toBeDefined();
+  });
+});
+
+describe("withSequence", () => {
+  it("disposes the sequence exactly once when the body throws", async () => {
+    const seqDispose = vi.fn(async () => {});
+    const stubSequence = { dispose: seqDispose } as unknown as LlamaContextSequence;
+    const context = {
+      get sequencesLeft(): number {
+        return 1;
+      },
+      getSequence(): LlamaContextSequence {
+        return stubSequence;
+      },
+    } as unknown as LlamaContext;
+
+    await expect(
+      withSequence(context, async () => {
+        throw new Error("session ctor failed");
+      })
+    ).rejects.toThrow("session ctor failed");
+
+    expect(seqDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes the sequence after a successful run", async () => {
+    const seqDispose = vi.fn(async () => {});
+    const stubSequence = { dispose: seqDispose } as unknown as LlamaContextSequence;
+    const context = {
+      get sequencesLeft(): number {
+        return 1;
+      },
+      getSequence(): LlamaContextSequence {
+        return stubSequence;
+      },
+    } as unknown as LlamaContext;
+
+    const result = await withSequence(context, async () => "ok");
+    expect(result).toBe("ok");
+    expect(seqDispose).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -138,6 +232,63 @@ describe("recycleLlamaCppTextContext with reloadModel disposes embedding context
     expect(modelDisposeB).not.toHaveBeenCalled();
     expect(textDisposeB).not.toHaveBeenCalled();
     expect(embeddingDisposeB).not.toHaveBeenCalled();
+  });
+});
+
+describe("withVramEviction concurrent-safety", () => {
+  afterEach(() => {
+    llamaCppModels.clear();
+    llamaCppTextContexts.clear();
+    llamaCppEmbeddingContexts.clear();
+  });
+
+  it("skips models marked in-use during LRU eviction", async () => {
+    const modelDisposeA = vi.fn(async () => {});
+    const modelDisposeB = vi.fn(async () => {});
+    const modelA = { dispose: modelDisposeA } as unknown as LlamaModel;
+    const modelB = { dispose: modelDisposeB } as unknown as LlamaModel;
+    llamaCppModels.set("/tmp/A.gguf", modelA);
+    llamaCppModels.set("/tmp/B.gguf", modelB);
+
+    // B is powering a concurrent run and must survive the eviction sweep.
+    acquireModelInUse("/tmp/B.gguf");
+
+    let attempts = 0;
+    const attempt = async (): Promise<string> => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("cuda out of memory");
+      return "ok";
+    };
+
+    try {
+      const result = await withVramEviction("/tmp/C.gguf", attempt);
+
+      expect(result).toBe("ok");
+      expect(modelDisposeA).toHaveBeenCalledTimes(1);
+      expect(modelDisposeB).not.toHaveBeenCalled();
+      expect(llamaCppModels.has("/tmp/A.gguf")).toBe(false);
+      expect(llamaCppModels.get("/tmp/B.gguf")).toBe(modelB);
+    } finally {
+      releaseModelInUse("/tmp/B.gguf");
+    }
+  });
+
+  it("rethrows the original VRAM error when every candidate is in-use", async () => {
+    const modelDisposeA = vi.fn(async () => {});
+    const modelA = { dispose: modelDisposeA } as unknown as LlamaModel;
+    llamaCppModels.set("/tmp/A.gguf", modelA);
+    acquireModelInUse("/tmp/A.gguf");
+
+    const original = new Error("cuda out of memory");
+    const attempt = () => Promise.reject(original);
+
+    try {
+      await expect(withVramEviction("/tmp/B.gguf", attempt)).rejects.toBe(original);
+      expect(modelDisposeA).not.toHaveBeenCalled();
+      expect(llamaCppModels.get("/tmp/A.gguf")).toBe(modelA);
+    } finally {
+      releaseModelInUse("/tmp/A.gguf");
+    }
   });
 });
 

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -7,13 +7,17 @@
 import {
   acquireContextSequence,
   acquireModelInUse,
+  disposeLlamaCppSessionsForModel,
   getOrCreateEmbeddingContext,
   isVramError,
   llamaCppEmbeddingContexts,
   llamaCppModels,
+  llamaCppSessions,
   llamaCppTextContexts,
   recycleLlamaCppTextContext,
   releaseModelInUse,
+  resolvedPaths,
+  setLlamaCppSession,
   withSequence,
   withVramEviction,
 } from "@workglow/node-llama-cpp/ai-runtime";
@@ -289,6 +293,76 @@ describe("withVramEviction concurrent-safety", () => {
     } finally {
       releaseModelInUse("/tmp/A.gguf");
     }
+  });
+});
+
+describe("disposeLlamaCppSessionsForModel key-spelling tolerance", () => {
+  afterEach(() => {
+    llamaCppSessions.clear();
+    resolvedPaths.clear();
+  });
+
+  it("disposes sessions stored under the config key when called with the resolved on-disk path", async () => {
+    // Sessions are stored with `modelKey: getConfigKey(model)` (typically `model_url`),
+    // but `evictLeastRecentlyUsedModel` iterates `llamaCppModels` keys, which are
+    // resolved filesystem paths. The dispose helper must match both spellings.
+    const configKey = "https://huggingface.co/example/model.gguf";
+    const resolvedPath = "/tmp/example/model.gguf";
+    resolvedPaths.set(configKey, resolvedPath);
+
+    const sessionDispose = vi.fn(async () => {});
+    const sequenceDispose = vi.fn(async () => {});
+    setLlamaCppSession("session-1", {
+      session: { dispose: sessionDispose } as unknown as never,
+      sequence: { dispose: sequenceDispose } as unknown as never,
+      modelKey: configKey,
+    } as never);
+
+    await disposeLlamaCppSessionsForModel(resolvedPath);
+
+    expect(sessionDispose).toHaveBeenCalledTimes(1);
+    expect(sequenceDispose).toHaveBeenCalledTimes(1);
+    expect(llamaCppSessions.has("session-1")).toBe(false);
+  });
+
+  it("still disposes sessions when the caller passes the exact stored key", async () => {
+    const configKey = "/tmp/local/model.gguf";
+    const sessionDispose = vi.fn(async () => {});
+    setLlamaCppSession("session-2", {
+      session: { dispose: sessionDispose } as unknown as never,
+      sequence: undefined as unknown as never,
+      modelKey: configKey,
+    } as never);
+
+    await disposeLlamaCppSessionsForModel(configKey);
+
+    expect(sessionDispose).toHaveBeenCalledTimes(1);
+    expect(llamaCppSessions.has("session-2")).toBe(false);
+  });
+
+  it("does not dispose sessions belonging to a different model", async () => {
+    resolvedPaths.set("url-A", "/tmp/A.gguf");
+    resolvedPaths.set("url-B", "/tmp/B.gguf");
+
+    const sessionADispose = vi.fn(async () => {});
+    const sessionBDispose = vi.fn(async () => {});
+    setLlamaCppSession("sess-A", {
+      session: { dispose: sessionADispose } as unknown as never,
+      sequence: undefined as unknown as never,
+      modelKey: "url-A",
+    } as never);
+    setLlamaCppSession("sess-B", {
+      session: { dispose: sessionBDispose } as unknown as never,
+      sequence: undefined as unknown as never,
+      modelKey: "url-B",
+    } as never);
+
+    await disposeLlamaCppSessionsForModel("/tmp/A.gguf");
+
+    expect(sessionADispose).toHaveBeenCalledTimes(1);
+    expect(sessionBDispose).not.toHaveBeenCalled();
+    expect(llamaCppSessions.has("sess-A")).toBe(false);
+    expect(llamaCppSessions.has("sess-B")).toBe(true);
   });
 });
 

--- a/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_BackgroundRemoval.ts
@@ -13,7 +13,7 @@ import type {
 import { dataUriToImageValue, imageValueToBlob } from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 function rawImageToBase64Png(image: RawImage): string {
   const fn = (image as unknown as { toBase64?: () => string }).toBase64;
@@ -31,16 +31,18 @@ export const HFT_BackgroundRemoval: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const remover = (await getPipeline(model!, emit, {}, signal)) as BackgroundRemovalPipeline;
-  const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-  const result = await remover(imageArg);
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
+    const result = await remover(imageArg);
 
-  const resultImage = Array.isArray(result) ? result[0] : result;
-  const dataUri = `data:image/png;base64,${rawImageToBase64Png(resultImage)}`;
+    const resultImage = Array.isArray(result) ? result[0] : result;
+    const dataUri = `data:image/png;base64,${rawImageToBase64Png(resultImage)}`;
 
-  emit({
-    type: "finish",
-    data: {
-      image: await dataUriToImageValue(dataUri),
-    },
+    emit({
+      type: "finish",
+      data: {
+        image: await dataUriToImageValue(dataUri),
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
@@ -8,7 +8,14 @@ import type { AiChatProviderInput, AiChatProviderOutput, AiProviderRunFn } from 
 import type { StreamPhase } from "@workglow/task-graph";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
 import type { HftPrefixRewindSession } from "./HFT_Pipeline";
-import { getHftSession, getPipeline, loadTransformersSDK, setHftSession } from "./HFT_Pipeline";
+import {
+  getHftSession,
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  setHftSession,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer, createTextStreamer } from "./HFT_Streaming";
 import { buildHFTMessages } from "./HFT_ToolCalling";
 
@@ -143,8 +150,13 @@ export const HFT_Chat: AiProviderRunFn<
   AiChatProviderOutput,
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit, _outputSchema, sessionId) => {
-  await generateTurn(input, model!, sessionId, emit, signal, (piece) => {
-    emit({ type: "text-delta", port: "text", textDelta: piece });
+  // Refcount the pipeline for the duration of a single turn — long-lived
+  // conversations are not held across turns; only active inference is
+  // protected from concurrent LRU eviction.
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    await generateTurn(input, model!, sessionId, emit, signal, (piece) => {
+      emit({ type: "text-delta", port: "text", textDelta: piece });
+    });
+    emit({ type: "finish", data: {} as AiChatProviderOutput });
   });
-  emit({ type: "finish", data: {} as AiChatProviderOutput });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ImageClassification.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ImageClassification.ts
@@ -16,7 +16,7 @@ import type {
 import { imageValueToBlob } from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 /**
  * Auto-selects between regular and zero-shot classification based on
@@ -38,38 +38,42 @@ export const HFT_ImageClassification: AiProviderRunFn<
       {},
       signal
     )) as ZeroShotImageClassificationPipeline;
+    await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+      const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
+      const result = await zeroShotClassifier(imageArg, input.categories! as string[], {});
+
+      const results = Array.isArray(result) ? result : [result];
+
+      emit({
+        type: "finish",
+        data: {
+          categories: results.map((r) => ({
+            label: r.label,
+            score: r.score,
+          })),
+        },
+      });
+    });
+    return;
+  }
+
+  const classifier = (await getPipeline(model!, emit, {}, signal)) as ImageClassificationPipeline;
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
     const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-    const result = await zeroShotClassifier(imageArg, input.categories! as string[], {});
+    const result = await classifier(imageArg, {
+      top_k: input.maxCategories,
+    });
 
     const results = Array.isArray(result) ? result : [result];
 
     emit({
       type: "finish",
       data: {
-        categories: results.map((r) => ({
+        categories: results.map((r: any) => ({
           label: r.label,
           score: r.score,
         })),
       },
     });
-    return;
-  }
-
-  const classifier = (await getPipeline(model!, emit, {}, signal)) as ImageClassificationPipeline;
-  const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-  const result = await classifier(imageArg, {
-    top_k: input.maxCategories,
-  });
-
-  const results = Array.isArray(result) ? result : [result];
-
-  emit({
-    type: "finish",
-    data: {
-      categories: results.map((r: any) => ({
-        label: r.label,
-        score: r.score,
-      })),
-    },
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ImageEmbedding.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ImageEmbedding.ts
@@ -13,7 +13,7 @@ import type {
 import { imageValueToBlob } from "@workglow/ai/provider-utils";
 import { getLogger, TypedArray } from "@workglow/util/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_ImageEmbedding: AiProviderRunFn<
   ImageEmbeddingTaskInput,
@@ -30,24 +30,26 @@ export const HFT_ImageEmbedding: AiProviderRunFn<
     model: model?.provider_config.model_path,
   });
 
-  if (Array.isArray(input.image)) {
-    const vectors: TypedArray[] = [];
-    for (const image of input.image) {
-      const imageArg = await imageValueToBlob(image);
-      const result = await embedder(imageArg);
-      vectors.push(result.data as TypedArray);
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    if (Array.isArray(input.image)) {
+      const vectors: TypedArray[] = [];
+      for (const image of input.image) {
+        const imageArg = await imageValueToBlob(image);
+        const result = await embedder(imageArg);
+        vectors.push(result.data as TypedArray);
+      }
+      logger.timeEnd(timerLabel, { count: vectors.length });
+      emit({ type: "finish", data: { vector: vectors } as ImageEmbeddingTaskOutput });
+      return;
     }
-    logger.timeEnd(timerLabel, { count: vectors.length });
-    emit({ type: "finish", data: { vector: vectors } as ImageEmbeddingTaskOutput });
-    return;
-  }
 
-  const imageArg = await imageValueToBlob(input.image);
-  const result = await embedder(imageArg);
+    const imageArg = await imageValueToBlob(input.image);
+    const result = await embedder(imageArg);
 
-  logger.timeEnd(timerLabel, { dimensions: result?.data?.length });
-  emit({
-    type: "finish",
-    data: { vector: result.data as TypedArray } as ImageEmbeddingTaskOutput,
+    logger.timeEnd(timerLabel, { dimensions: result?.data?.length });
+    emit({
+      type: "finish",
+      data: { vector: result.data as TypedArray } as ImageEmbeddingTaskOutput,
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ImageSegmentation.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ImageSegmentation.ts
@@ -14,7 +14,7 @@ import { imageValueToBlob } from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import { imageValueFromBitmap, imageValueFromBuffer } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 async function rawImageToImageValue(image: RawImage): Promise<ImageValue> {
   const raw = image as unknown as {
@@ -65,26 +65,28 @@ export const HFT_ImageSegmentation: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const segmenter = (await getPipeline(model!, emit, {}, signal)) as ImageSegmentationPipeline;
-  const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-  const result = await segmenter(imageArg, {
-    threshold: input.threshold,
-    mask_threshold: input.maskThreshold,
-  });
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
+    const result = await segmenter(imageArg, {
+      threshold: input.threshold,
+      mask_threshold: input.maskThreshold,
+    });
 
-  const masks = Array.isArray(result) ? result : [result];
+    const masks = Array.isArray(result) ? result : [result];
 
-  const processedMasks = await Promise.all(
-    masks.map(async (mask) => ({
-      label: mask.label || "",
-      score: mask.score || 0,
-      mask: await rawImageToImageValue(mask.mask),
-    }))
-  );
+    const processedMasks = await Promise.all(
+      masks.map(async (mask) => ({
+        label: mask.label || "",
+        score: mask.score || 0,
+        mask: await rawImageToImageValue(mask.mask),
+      }))
+    );
 
-  emit({
-    type: "finish",
-    data: {
-      masks: processedMasks,
-    },
+    emit({
+      type: "finish",
+      data: {
+        masks: processedMasks,
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ImageToText.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ImageToText.ts
@@ -9,7 +9,7 @@ import type { AiProviderRunFn, ImageToTextTaskInput, ImageToTextTaskOutput } fro
 import { imageValueToBlob } from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_ImageToText: AiProviderRunFn<
   ImageToTextTaskInput,
@@ -17,17 +17,21 @@ export const HFT_ImageToText: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const captioner = (await getPipeline(model!, emit, {}, signal)) as ImageToTextPipeline;
-  const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-  const result = await captioner(imageArg, {
-    max_new_tokens: input.maxTokens,
-  });
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
+    const result = await captioner(imageArg, {
+      max_new_tokens: input.maxTokens,
+    });
 
-  const text = Array.isArray(result[0]) ? result[0][0]?.generated_text : result[0]?.generated_text;
+    const text = Array.isArray(result[0])
+      ? result[0][0]?.generated_text
+      : result[0]?.generated_text;
 
-  emit({
-    type: "finish",
-    data: {
-      text: text || "",
-    },
+    emit({
+      type: "finish",
+      data: {
+        text: text || "",
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ObjectDetection.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ObjectDetection.ts
@@ -16,7 +16,7 @@ import type {
 import { imageValueToBlob } from "@workglow/ai/provider-utils";
 import type { ImageValue } from "@workglow/util/media";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 /**
  * Auto-selects between regular and zero-shot detection based on
@@ -37,38 +37,42 @@ export const HFT_ObjectDetection: AiProviderRunFn<
       {},
       signal
     )) as ZeroShotObjectDetectionPipeline;
+    await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+      const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
+      const result = await zeroShotDetector(imageArg, Array.from(input.labels!), {
+        threshold: input.threshold,
+      });
+
+      emit({
+        type: "finish",
+        data: {
+          detections: result.map((d: any) => ({
+            label: d.label,
+            score: d.score,
+            box: d.box,
+          })),
+        },
+      });
+    });
+    return;
+  }
+
+  const detector = (await getPipeline(model!, emit, {}, signal)) as ObjectDetectionPipeline;
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
     const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-    const result = await zeroShotDetector(imageArg, Array.from(input.labels!), {
+    const detections = await detector(imageArg, {
       threshold: input.threshold,
     });
 
     emit({
       type: "finish",
       data: {
-        detections: result.map((d: any) => ({
+        detections: detections.map((d) => ({
           label: d.label,
           score: d.score,
           box: d.box,
         })),
-      },
+      } as unknown as ObjectDetectionTaskOutput,
     });
-    return;
-  }
-
-  const detector = (await getPipeline(model!, emit, {}, signal)) as ObjectDetectionPipeline;
-  const imageArg = await imageValueToBlob(input.image as unknown as ImageValue);
-  const detections = await detector(imageArg, {
-    threshold: input.threshold,
-  });
-
-  emit({
-    type: "finish",
-    data: {
-      detections: detections.map((d) => ({
-        label: d.label,
-        score: d.score,
-        box: d.box,
-      })),
-    } as unknown as ObjectDetectionTaskOutput,
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
@@ -184,7 +184,81 @@ function abortableFetch(url: string, options?: RequestInit): Promise<Response> {
   );
 }
 
-const pipelines = new Map<string, Awaited<ReturnType<TransformersSDKModule["pipeline"]>>>();
+/** @internal Cached pipelines keyed by {@link getPipelineCacheKey}. Exported for unit tests. */
+export const pipelines = new Map<string, Awaited<ReturnType<TransformersSDKModule["pipeline"]>>>();
+
+/**
+ * Upper bound on cached pipelines. Each pipeline pins an ONNX session (WASM
+ * heap / WebGPU buffers) that is never reclaimed by V8 GC — only an explicit
+ * `session.release()` frees it. Without a cap, a caller cycling through
+ * embed + classify + generate + rerank keeps every pipeline for the process
+ * lifetime, and browser/WASM contexts have no OOM retry path.
+ *
+ * Overridable via `HFT_MAX_CACHED_PIPELINES`. Guarded for browser contexts
+ * where `process` is undefined.
+ */
+export const MAX_CACHED_PIPELINES: number = (() => {
+  if (typeof process === "undefined" || !process.env) return 6;
+  const raw = process.env.HFT_MAX_CACHED_PIPELINES;
+  if (!raw) return 6;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 6;
+})();
+
+/**
+ * Move `cacheKey` to the most-recently-used end of the `pipelines` iteration
+ * order. Map iteration follows insertion order, so delete-then-set is the
+ * canonical LRU-touch pattern. No-op if the key isn't cached.
+ */
+function touchPipeline(cacheKey: string): void {
+  const pipeline = pipelines.get(cacheKey);
+  if (pipeline === undefined) return;
+  pipelines.delete(cacheKey);
+  pipelines.set(cacheKey, pipeline);
+}
+
+// ============================================================================
+// Refcount: protect in-use pipelines from housekeeping eviction
+// ============================================================================
+
+/**
+ * Reference count of in-flight callers holding each cached pipeline. Prevents
+ * the bounded-LRU sweep in {@link getPipeline} from disposing a pipeline that
+ * is currently powering another run — without this guard, one caller pushing
+ * the cache over cap could release the ONNX session of a concurrent inference.
+ */
+const hftPipelineInUse = new Map<string, number>();
+
+export function acquireHftPipelineInUse(cacheKey: string): void {
+  hftPipelineInUse.set(cacheKey, (hftPipelineInUse.get(cacheKey) ?? 0) + 1);
+}
+
+export function releaseHftPipelineInUse(cacheKey: string): void {
+  const current = hftPipelineInUse.get(cacheKey) ?? 0;
+  if (current <= 1) {
+    hftPipelineInUse.delete(cacheKey);
+  } else {
+    hftPipelineInUse.set(cacheKey, current - 1);
+  }
+}
+
+export function isHftPipelineInUse(cacheKey: string): boolean {
+  return (hftPipelineInUse.get(cacheKey) ?? 0) > 0;
+}
+
+/**
+ * Hold an in-use refcount on `cacheKey` for the lifetime of `fn`, so a
+ * concurrent LRU housekeeping pass on a different task cannot dispose this
+ * task's pipeline mid-inference.
+ */
+export async function withHftPipelineInUse<T>(cacheKey: string, fn: () => Promise<T>): Promise<T> {
+  acquireHftPipelineInUse(cacheKey);
+  try {
+    return await fn();
+  } finally {
+    releaseHftPipelineInUse(cacheKey);
+  }
+}
 
 // ============================================================================
 // Session cache for multi-turn conversations
@@ -319,8 +393,15 @@ export function hasCachedPipeline(cacheKey: string): boolean {
  * (e.g. inside HFT_DownloadRemove's async generator) so the WASM release completes
  * before the next operation. Best-effort: dispose failure does not prevent
  * cache eviction.
+ *
+ * Skips (returns `false`) when the pipeline is currently in-use — releasing
+ * its ONNX session out from under a concurrent inference would crash the
+ * WASM worker. Callers doing housekeeping should pick a different candidate.
  */
 export async function removeCachedPipeline(cacheKey: string): Promise<boolean> {
+  if (isHftPipelineInUse(cacheKey)) {
+    return false;
+  }
   const pipeline = pipelines.get(cacheKey);
   const deleted = pipelines.delete(cacheKey);
   if (pipeline) {
@@ -332,6 +413,47 @@ export async function removeCachedPipeline(cacheKey: string): Promise<boolean> {
     }
   }
   return deleted;
+}
+
+/**
+ * Iterate cached pipelines in LRU order and dispose the first non-in-use
+ * candidate, skipping `exceptKey` (the freshly loaded pipeline the caller
+ * must not evict). Returns the evicted cache key, or `undefined` when every
+ * eligible pipeline is currently in-use (in which case the caller should
+ * leave the cache over cap for this cycle — a housekeeping eviction must
+ * never block active inference).
+ */
+async function evictLeastRecentlyUsedPipeline(
+  exceptKey: string | undefined
+): Promise<string | undefined> {
+  for (const key of pipelines.keys()) {
+    if (key === exceptKey) continue;
+    if (isHftPipelineInUse(key)) continue;
+    const removed = await removeCachedPipeline(key);
+    if (removed) return key;
+  }
+  return undefined;
+}
+
+/**
+ * Bring the pipeline cache back to at most {@link MAX_CACHED_PIPELINES} by
+ * evicting LRU non-in-use entries. `exceptKey` is the freshly loaded pipeline
+ * that must not be evicted. If every other eviction candidate is in-use,
+ * leaves the cache over cap for this cycle — housekeeping never blocks or
+ * waits on active inference.
+ */
+async function enforcePipelineCacheCap(exceptKey: string): Promise<void> {
+  while (pipelines.size > MAX_CACHED_PIPELINES) {
+    const evicted = await evictLeastRecentlyUsedPipeline(exceptKey);
+    if (evicted === undefined) {
+      getLogger().debug(
+        "HFT pipeline cache over cap but every entry is in-use; deferring eviction",
+        { size: pipelines.size, cap: MAX_CACHED_PIPELINES }
+      );
+      return;
+    }
+    getLogger().debug("HFT pipeline cache evicted LRU entry", { evicted });
+  }
 }
 
 /**
@@ -364,6 +486,7 @@ export async function getPipeline(
   const cacheKey = getPipelineCacheKey(model);
   if (pipelines.has(cacheKey)) {
     getLogger().debug("HFT pipeline cache hit", { cacheKey });
+    touchPipeline(cacheKey);
     return pipelines.get(cacheKey);
   }
 
@@ -545,6 +668,7 @@ const doGetPipeline = async (
 
     logger.timeEnd(pipelineTimerLabel, { status: "loaded" });
     pipelines.set(cacheKey, result);
+    await enforcePipelineCacheCap(cacheKey);
     return result;
   } catch (error: any) {
     logger.timeEnd(pipelineTimerLabel, { status: "error", error: String(error) });

--- a/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
@@ -70,9 +70,9 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const prompt = buildStructuredGenerationPrompt(input);
 
     const messages: Message[] = [{ role: "user", content: prompt }];

--- a/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_StructuredGeneration.ts
@@ -12,7 +12,12 @@ import type {
 } from "@workglow/ai";
 import { parsePartialJson } from "@workglow/util/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline, loadTransformersSDK } from "./HFT_Pipeline";
+import {
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 function buildStructuredGenerationPrompt(input: StructuredGenerationTaskInput): string {
@@ -67,80 +72,82 @@ export const HFT_StructuredGeneration: AiProviderRunFn<
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const prompt = buildStructuredGenerationPrompt(input);
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const prompt = buildStructuredGenerationPrompt(input);
 
-  const messages: Message[] = [{ role: "user", content: prompt }];
+    const messages: Message[] = [{ role: "user", content: prompt }];
 
-  const formattedPrompt = generateText.tokenizer.apply_chat_template(messages, {
-    tokenize: false,
-    add_generation_prompt: true,
-  }) as string;
+    const formattedPrompt = generateText.tokenizer.apply_chat_template(messages, {
+      tokenize: false,
+      add_generation_prompt: true,
+    }) as string;
 
-  let fullText = "";
-  // Incrementally maintain cleaned text to avoid O(n²) full-string regex on every token.
-  // Use a simple state machine to skip <think>...</think> blocks and strip special
-  // tokens only from the delta received, not from the entire accumulated string.
-  let cleanedText = "";
-  let inThinkBlock = false;
-  let jsonStart = -1; // index into cleanedText where the first '{' was found
+    let fullText = "";
+    // Incrementally maintain cleaned text to avoid O(n²) full-string regex on every token.
+    // Use a simple state machine to skip <think>...</think> blocks and strip special
+    // tokens only from the delta received, not from the entire accumulated string.
+    let cleanedText = "";
+    let inThinkBlock = false;
+    let jsonStart = -1; // index into cleanedText where the first '{' was found
 
-  const streamer = createStreamingTextStreamer(
-    generateText.tokenizer,
-    (delta) => {
-      fullText += delta;
+    const streamer = createStreamingTextStreamer(
+      generateText.tokenizer,
+      (delta) => {
+        fullText += delta;
 
-      // Process the delta through the state machine to update cleanedText
-      let remaining = delta;
-      while (remaining.length > 0) {
-        if (inThinkBlock) {
-          const closeIdx = remaining.indexOf("</think>");
-          if (closeIdx !== -1) {
-            inThinkBlock = false;
-            remaining = remaining.slice(closeIdx + "</think>".length);
+        // Process the delta through the state machine to update cleanedText
+        let remaining = delta;
+        while (remaining.length > 0) {
+          if (inThinkBlock) {
+            const closeIdx = remaining.indexOf("</think>");
+            if (closeIdx !== -1) {
+              inThinkBlock = false;
+              remaining = remaining.slice(closeIdx + "</think>".length);
+            } else {
+              remaining = ""; // still inside think block; discard rest of delta
+            }
           } else {
-            remaining = ""; // still inside think block; discard rest of delta
-          }
-        } else {
-          const openIdx = remaining.indexOf("<think>");
-          if (openIdx !== -1) {
-            cleanedText += remaining.slice(0, openIdx).replace(/<\|[a-z_]+\|>/g, "");
-            inThinkBlock = true;
-            remaining = remaining.slice(openIdx + "<think>".length);
-          } else {
-            cleanedText += remaining.replace(/<\|[a-z_]+\|>/g, "");
-            remaining = "";
+            const openIdx = remaining.indexOf("<think>");
+            if (openIdx !== -1) {
+              cleanedText += remaining.slice(0, openIdx).replace(/<\|[a-z_]+\|>/g, "");
+              inThinkBlock = true;
+              remaining = remaining.slice(openIdx + "<think>".length);
+            } else {
+              cleanedText += remaining.replace(/<\|[a-z_]+\|>/g, "");
+              remaining = "";
+            }
           }
         }
-      }
 
-      // Locate the start of the JSON object once and reuse that index
-      if (jsonStart === -1) {
-        jsonStart = cleanedText.indexOf("{");
-      }
-      if (jsonStart !== -1) {
-        const partial = parsePartialJson(cleanedText.slice(jsonStart));
-        if (partial !== undefined) {
-          emit({ type: "object-delta", port: "object", objectDelta: partial });
-          return;
+        // Locate the start of the JSON object once and reuse that index
+        if (jsonStart === -1) {
+          jsonStart = cleanedText.indexOf("{");
         }
-      }
-      emit({ type: "text-delta", port: "text", textDelta: delta });
-    },
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+        if (jsonStart !== -1) {
+          const partial = parsePartialJson(cleanedText.slice(jsonStart));
+          if (partial !== undefined) {
+            emit({ type: "object-delta", port: "object", objectDelta: partial });
+            return;
+          }
+        }
+        emit({ type: "text-delta", port: "text", textDelta: delta });
+      },
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  await generateText(formattedPrompt, {
-    max_new_tokens: input.maxTokens ?? 1024,
-    temperature: input.temperature ?? undefined,
-    return_full_text: false,
-    streamer,
-    stopping_criteria: [stopping_criteria],
+    await generateText(formattedPrompt, {
+      max_new_tokens: input.maxTokens ?? 1024,
+      temperature: input.temperature ?? undefined,
+      return_full_text: false,
+      streamer,
+      stopping_criteria: [stopping_criteria],
+    });
+
+    const object = extractJsonFromText(fullText);
+    emit({ type: "finish", data: { object } as StructuredGenerationTaskOutput });
   });
-
-  const object = extractJsonFromText(fullText);
-  emit({ type: "finish", data: { object } as StructuredGenerationTaskOutput });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextClassification.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextClassification.ts
@@ -14,7 +14,7 @@ import type {
   TextClassificationTaskOutput,
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_TextClassification: AiProviderRunFn<
   TextClassificationTaskInput,
@@ -36,16 +36,22 @@ export const HFT_TextClassification: AiProviderRunFn<
       {},
       signal
     )) as ZeroShotClassificationPipeline;
-    const result: any = await zeroShotClassifier(input.text, input.candidateLabels as string[], {});
+    await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+      const result: any = await zeroShotClassifier(
+        input.text,
+        input.candidateLabels as string[],
+        {}
+      );
 
-    emit({
-      type: "finish",
-      data: {
-        categories: result.labels.map((label: string, idx: number) => ({
-          label,
-          score: result.scores[idx],
-        })),
-      },
+      emit({
+        type: "finish",
+        data: {
+          categories: result.labels.map((label: string, idx: number) => ({
+            label,
+            score: result.scores[idx],
+          })),
+        },
+      });
     });
     return;
   }
@@ -56,17 +62,19 @@ export const HFT_TextClassification: AiProviderRunFn<
     {},
     signal
   )) as TextClassificationPipeline;
-  const result = await TextClassification(input.text, {
-    top_k: input.maxCategories || undefined,
-  });
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const result = await TextClassification(input.text, {
+      top_k: input.maxCategories || undefined,
+    });
 
-  emit({
-    type: "finish",
-    data: {
-      categories: result.map((category) => ({
-        label: category.label,
-        score: category.score,
-      })),
-    },
+    emit({
+      type: "finish",
+      data: {
+        categories: result.map((category) => ({
+          label: category.label,
+          score: category.score,
+        })),
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextEmbedding.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextEmbedding.ts
@@ -12,7 +12,7 @@ import type {
 } from "@workglow/ai";
 import { getLogger, TypedArray } from "@workglow/util/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 /**
  * Model download progress (first-call cold start) is forwarded as `phase`
@@ -41,61 +41,63 @@ export const HFT_TextEmbedding: AiProviderRunFn<
     inputLength: Array.isArray(input.text) ? input.text.length : input.text?.length,
   });
 
-  // Generate the embedding
-  const hfVector = await generateEmbedding(input.text, {
-    pooling: model?.provider_config.pooling || "mean",
-    normalize: model?.provider_config.normalize,
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    // Generate the embedding
+    const hfVector = await generateEmbedding(input.text, {
+      pooling: model?.provider_config.pooling || "mean",
+      normalize: model?.provider_config.normalize,
+    });
+
+    const isArrayInput = Array.isArray(input.text);
+    const embeddingDim = model?.provider_config.native_dimensions;
+
+    // If the input is an array, the tensor will have multiple dimensions (e.g., [10, 384])
+    // We need to split it into separate vectors for each input text
+    if (isArrayInput && hfVector.dims.length > 1) {
+      const [numTexts, vectorDim] = hfVector.dims;
+
+      // Validate that the number of texts matches
+      if (numTexts !== input.text.length) {
+        throw new Error(
+          `HuggingFace Embedding tensor batch size does not match input array length: ${numTexts} != ${input.text.length}`
+        );
+      }
+
+      // Validate dimensions
+      if (vectorDim !== embeddingDim) {
+        throw new Error(
+          `HuggingFace Embedding vector dimension does not match model dimensions: ${vectorDim} != ${embeddingDim}`
+        );
+      }
+
+      // Extract each embedding vector using tensor indexing
+      // hfVector[i] returns a sub-tensor for the i-th text
+      // .slice() is required to create independent TypedArrays with their own ArrayBuffers,
+      // because sub-tensor views all share the same backing buffer, which causes DataCloneError
+      // when postMessage tries to transfer the same ArrayBuffer multiple times.
+      const vectors: TypedArray[] = Array.from({ length: numTexts }, (_, i) =>
+        ((hfVector as any)[i].data as TypedArray).slice()
+      );
+
+      logger.timeEnd(timerLabel, { batchSize: numTexts, dimensions: vectorDim });
+      emit({ type: "finish", data: { vector: vectors } });
+      return;
+    }
+
+    // Output[number] text input - validate dimensions
+    if (hfVector.size !== embeddingDim) {
+      logger.timeEnd(timerLabel, { status: "error", reason: "dimension mismatch" });
+      console.warn(
+        `HuggingFace Embedding vector length does not match model dimensions v${hfVector.size} != m${embeddingDim}`,
+        input,
+        hfVector
+      );
+      throw new Error(
+        `HuggingFace Embedding vector length does not match model dimensions v${hfVector.size} != m${embeddingDim}`
+      );
+    }
+
+    logger.timeEnd(timerLabel, { dimensions: hfVector.size });
+    emit({ type: "finish", data: { vector: hfVector.data as TypedArray } });
   });
-
-  const isArrayInput = Array.isArray(input.text);
-  const embeddingDim = model?.provider_config.native_dimensions;
-
-  // If the input is an array, the tensor will have multiple dimensions (e.g., [10, 384])
-  // We need to split it into separate vectors for each input text
-  if (isArrayInput && hfVector.dims.length > 1) {
-    const [numTexts, vectorDim] = hfVector.dims;
-
-    // Validate that the number of texts matches
-    if (numTexts !== input.text.length) {
-      throw new Error(
-        `HuggingFace Embedding tensor batch size does not match input array length: ${numTexts} != ${input.text.length}`
-      );
-    }
-
-    // Validate dimensions
-    if (vectorDim !== embeddingDim) {
-      throw new Error(
-        `HuggingFace Embedding vector dimension does not match model dimensions: ${vectorDim} != ${embeddingDim}`
-      );
-    }
-
-    // Extract each embedding vector using tensor indexing
-    // hfVector[i] returns a sub-tensor for the i-th text
-    // .slice() is required to create independent TypedArrays with their own ArrayBuffers,
-    // because sub-tensor views all share the same backing buffer, which causes DataCloneError
-    // when postMessage tries to transfer the same ArrayBuffer multiple times.
-    const vectors: TypedArray[] = Array.from({ length: numTexts }, (_, i) =>
-      ((hfVector as any)[i].data as TypedArray).slice()
-    );
-
-    logger.timeEnd(timerLabel, { batchSize: numTexts, dimensions: vectorDim });
-    emit({ type: "finish", data: { vector: vectors } });
-    return;
-  }
-
-  // Output[number] text input - validate dimensions
-  if (hfVector.size !== embeddingDim) {
-    logger.timeEnd(timerLabel, { status: "error", reason: "dimension mismatch" });
-    console.warn(
-      `HuggingFace Embedding vector length does not match model dimensions v${hfVector.size} != m${embeddingDim}`,
-      input,
-      hfVector
-    );
-    throw new Error(
-      `HuggingFace Embedding vector length does not match model dimensions v${hfVector.size} != m${embeddingDim}`
-    );
-  }
-
-  logger.timeEnd(timerLabel, { dimensions: hfVector.size });
-  emit({ type: "finish", data: { vector: hfVector.data as TypedArray } });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextFillMask.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextFillMask.ts
@@ -7,7 +7,7 @@
 import type { FillMaskPipeline } from "@huggingface/transformers";
 import type { AiProviderRunFn, TextFillMaskTaskInput, TextFillMaskTaskOutput } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_TextFillMask: AiProviderRunFn<
   TextFillMaskTaskInput,
@@ -15,16 +15,18 @@ export const HFT_TextFillMask: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const unmasker = (await getPipeline(model!, emit, {}, signal)) as FillMaskPipeline;
-  const predictions = await unmasker(input.text);
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const predictions = await unmasker(input.text);
 
-  emit({
-    type: "finish",
-    data: {
-      predictions: predictions.map((prediction) => ({
-        entity: prediction.token_str,
-        score: prediction.score,
-        sequence: prediction.sequence,
-      })),
-    },
+    emit({
+      type: "finish",
+      data: {
+        predictions: predictions.map((prediction) => ({
+          entity: prediction.token_str,
+          score: prediction.score,
+          sequence: prediction.sequence,
+        })),
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
@@ -12,7 +12,14 @@ import type {
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
 import type { HftProgressiveSession } from "./HFT_Pipeline";
-import { getHftSession, getPipeline, loadTransformersSDK, setHftSession } from "./HFT_Pipeline";
+import {
+  getHftSession,
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  setHftSession,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 export const HFT_TextGeneration: AiProviderRunFn<
@@ -23,48 +30,50 @@ export const HFT_TextGeneration: AiProviderRunFn<
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const streamer = createStreamingTextStreamer(
-    generateText.tokenizer,
-    (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const streamer = createStreamingTextStreamer(
+      generateText.tokenizer,
+      (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  // Session cache: progressive caching for text generation (streaming)
-  const modelPath = model!.provider_config.model_path;
-  let session = sessionId ? getHftSession(sessionId) : undefined;
-  let past_key_values: any = undefined;
+    // Session cache: progressive caching for text generation (streaming)
+    const modelPath = model!.provider_config.model_path;
+    let session = sessionId ? getHftSession(sessionId) : undefined;
+    let past_key_values: any = undefined;
 
-  if (sessionId && !session) {
-    const sdk = await loadTransformersSDK();
-    const cache = new sdk.DynamicCache();
-    const newSession: HftProgressiveSession = {
-      mode: "progressive",
-      cache,
-      modelPath,
-    };
-    setHftSession(sessionId, newSession);
-    session = newSession;
-  }
+    if (sessionId && !session) {
+      const sdk = await loadTransformersSDK();
+      const cache = new sdk.DynamicCache();
+      const newSession: HftProgressiveSession = {
+        mode: "progressive",
+        cache,
+        modelPath,
+      };
+      setHftSession(sessionId, newSession);
+      session = newSession;
+    }
 
-  if (session?.mode === "progressive") {
-    past_key_values = session.cache;
-  }
+    if (session?.mode === "progressive") {
+      past_key_values = session.cache;
+    }
 
-  // Use the chat-template format for instruction-tuned models. Passing a raw
-  // prompt string skips the chat template and most instruct models produce no
-  // output.
-  const messages: Message[] = [{ role: "user", content: input.prompt }];
+    // Use the chat-template format for instruction-tuned models. Passing a raw
+    // prompt string skips the chat template and most instruct models produce no
+    // output.
+    const messages: Message[] = [{ role: "user", content: input.prompt }];
 
-  await generateText(messages, {
-    streamer,
-    do_sample: false,
-    max_new_tokens: input.maxTokens ?? 4 * 1024,
-    stopping_criteria: [stopping_criteria],
-    ...(past_key_values ? { past_key_values } : {}),
+    await generateText(messages, {
+      streamer,
+      do_sample: false,
+      max_new_tokens: input.maxTokens ?? 4 * 1024,
+      stopping_criteria: [stopping_criteria],
+      ...(past_key_values ? { past_key_values } : {}),
+    });
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
   });
-  emit({ type: "finish", data: {} as TextGenerationTaskOutput });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
@@ -28,9 +28,9 @@ export const HFT_TextGeneration: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit, _outputSchema, sessionId) => {
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const streamer = createStreamingTextStreamer(
       generateText.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextLanguageDetection.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextLanguageDetection.ts
@@ -11,7 +11,7 @@ import type {
   TextLanguageDetectionTaskOutput,
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_TextLanguageDetection: AiProviderRunFn<
   TextLanguageDetectionTaskInput,
@@ -24,17 +24,19 @@ export const HFT_TextLanguageDetection: AiProviderRunFn<
     {},
     signal
   )) as TextClassificationPipeline;
-  const result = await TextClassification(input.text, {
-    top_k: input.maxLanguages || undefined,
-  });
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const result = await TextClassification(input.text, {
+      top_k: input.maxLanguages || undefined,
+    });
 
-  emit({
-    type: "finish",
-    data: {
-      languages: result.map((category) => ({
-        language: category.label,
-        score: category.score,
-      })),
-    },
+    emit({
+      type: "finish",
+      data: {
+        languages: result.map((category) => ({
+          language: category.label,
+          score: category.score,
+        })),
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextNamedEntityRecognition.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextNamedEntityRecognition.ts
@@ -11,7 +11,7 @@ import type {
   TextNamedEntityRecognitionTaskOutput,
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 export const HFT_TextNamedEntityRecognition: AiProviderRunFn<
   TextNamedEntityRecognitionTaskInput,
@@ -24,18 +24,20 @@ export const HFT_TextNamedEntityRecognition: AiProviderRunFn<
     {},
     signal
   )) as TokenClassificationPipeline;
-  const results = await textNamedEntityRecognition(input.text, {
-    ignore_labels: input.blockList as string[] | undefined,
-  });
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const results = await textNamedEntityRecognition(input.text, {
+      ignore_labels: input.blockList as string[] | undefined,
+    });
 
-  emit({
-    type: "finish",
-    data: {
-      entities: results.map((entity) => ({
-        entity: entity.entity,
-        score: entity.score,
-        word: entity.word,
-      })),
-    },
+    emit({
+      type: "finish",
+      data: {
+        entities: results.map((entity) => ({
+          entity: entity.entity,
+          score: entity.score,
+          word: entity.word,
+        })),
+      },
+    });
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
@@ -28,9 +28,9 @@ export const HFT_TextQuestionAnswer: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const generateAnswer = (await getPipeline(model!, emit, {}, signal)) as QuestionAnsweringPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const streamer = createStreamingTextStreamer(
       generateAnswer.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextQuestionAnswer.ts
@@ -14,7 +14,12 @@ import type {
   TextQuestionAnswerTaskOutput,
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline, loadTransformersSDK } from "./HFT_Pipeline";
+import {
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 export const HFT_TextQuestionAnswer: AiProviderRunFn<
@@ -25,24 +30,26 @@ export const HFT_TextQuestionAnswer: AiProviderRunFn<
   const generateAnswer = (await getPipeline(model!, emit, {}, signal)) as QuestionAnsweringPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const streamer = createStreamingTextStreamer(
-    generateAnswer.tokenizer,
-    (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const streamer = createStreamingTextStreamer(
+      generateAnswer.tokenizer,
+      (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  const pipelineResult = (await generateAnswer(input.question, input.context, {
-    streamer,
-    stopping_criteria: [stopping_criteria],
-  } as any)) as DocumentQuestionAnsweringOutput[number] | DocumentQuestionAnsweringOutput;
+    const pipelineResult = (await generateAnswer(input.question, input.context, {
+      streamer,
+      stopping_criteria: [stopping_criteria],
+    } as any)) as DocumentQuestionAnsweringOutput[number] | DocumentQuestionAnsweringOutput;
 
-  const answerText = Array.isArray(pipelineResult)
-    ? ((pipelineResult[0] as DocumentQuestionAnsweringOutput[number])?.answer ?? "")
-    : ((pipelineResult as DocumentQuestionAnsweringOutput[number])?.answer ?? "");
+    const answerText = Array.isArray(pipelineResult)
+      ? ((pipelineResult[0] as DocumentQuestionAnsweringOutput[number])?.answer ?? "")
+      : ((pipelineResult as DocumentQuestionAnsweringOutput[number])?.answer ?? "");
 
-  emit({ type: "finish", data: { text: answerText } as TextQuestionAnswerTaskOutput });
+    emit({ type: "finish", data: { text: answerText } as TextQuestionAnswerTaskOutput });
+  });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextReranker.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextReranker.ts
@@ -9,7 +9,7 @@ import type { AiProviderRunFn, TextRerankerTaskInput, TextRerankerTaskOutput } f
 import { KbRerankerOutputError } from "@workglow/ai";
 import { getLogger } from "@workglow/util/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline } from "./HFT_Pipeline";
+import { getPipeline, getPipelineCacheKey, withHftPipelineInUse } from "./HFT_Pipeline";
 
 /**
  * Narrow guard: an entry from the text-classification pipeline must be an
@@ -108,32 +108,34 @@ export const HFT_TextReranker: AiProviderRunFn<
 
   const reranker: TextClassificationPipeline = await getPipeline(model!, emit, {}, signal);
 
-  // Transformers.js' text-classification pipeline accepts an array of
-  // { text, text_pair } objects for sentence-pair tasks (which cross-encoder
-  // rerankers are). The pipeline returns one score per input pair (or an
-  // array of scored entries per pair when `top_k > 1`).
-  const pairs = input.documents.map((doc) => ({ text: input.query, text_pair: doc }));
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    // Transformers.js' text-classification pipeline accepts an array of
+    // { text, text_pair } objects for sentence-pair tasks (which cross-encoder
+    // rerankers are). The pipeline returns one score per input pair (or an
+    // array of scored entries per pair when `top_k > 1`).
+    const pairs = input.documents.map((doc) => ({ text: input.query, text_pair: doc }));
 
-  // We cast the *input parameter* shape (transformers.js types the pipeline
-  // very loosely) but keep the return as `Promise<unknown>` so the guard at
-  // `validateAndExtractRerankerScores` is the only path to a typed score.
-  // Casting the return to a typed score shape would erase the safety net and
-  // let a mismatched pipeline silently return garbage.
-  const callable = reranker as unknown as (
-    inputs: ReadonlyArray<{ text: string; text_pair: string }>,
-    options?: Record<string, unknown>
-  ) => Promise<unknown>;
-  const rawResults: unknown = await callable(pairs, { top_k: 1 });
+    // We cast the *input parameter* shape (transformers.js types the pipeline
+    // very loosely) but keep the return as `Promise<unknown>` so the guard at
+    // `validateAndExtractRerankerScores` is the only path to a typed score.
+    // Casting the return to a typed score shape would erase the safety net and
+    // let a mismatched pipeline silently return garbage.
+    const callable = reranker as unknown as (
+      inputs: ReadonlyArray<{ text: string; text_pair: string }>,
+      options?: Record<string, unknown>
+    ) => Promise<unknown>;
+    const rawResults: unknown = await callable(pairs, { top_k: 1 });
 
-  const scores = validateAndExtractRerankerScores(rawResults, modelPath);
+    const scores = validateAndExtractRerankerScores(rawResults, modelPath);
 
-  const indices = scores
-    .map((score, idx) => ({ score, idx }))
-    .sort((a, b) => b.score - a.score)
-    .map((p) => p.idx);
+    const indices = scores
+      .map((score, idx) => ({ score, idx }))
+      .sort((a, b) => b.score - a.score)
+      .map((p) => p.idx);
 
-  const limited = typeof input.topK === "number" ? indices.slice(0, input.topK) : indices;
+    const limited = typeof input.topK === "number" ? indices.slice(0, input.topK) : indices;
 
-  logger.timeEnd(timerLabel, { docs: input.documents.length });
-  emit({ type: "finish", data: { scores, indices: limited } });
+    logger.timeEnd(timerLabel, { docs: input.documents.length });
+    emit({ type: "finish", data: { scores, indices: limited } });
+  });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
@@ -7,7 +7,12 @@
 import type { TextGenerationPipeline } from "@huggingface/transformers";
 import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline, loadTransformersSDK } from "./HFT_Pipeline";
+import {
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 export const HFT_TextRewriter: AiProviderRunFn<
@@ -18,21 +23,23 @@ export const HFT_TextRewriter: AiProviderRunFn<
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const streamer = createStreamingTextStreamer(
-    generateText.tokenizer,
-    (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const streamer = createStreamingTextStreamer(
+      generateText.tokenizer,
+      (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  const promptedText = (input.prompt ? input.prompt + "\n" : "") + input.text;
+    const promptedText = (input.prompt ? input.prompt + "\n" : "") + input.text;
 
-  await generateText(promptedText, {
-    streamer,
-    stopping_criteria: [stopping_criteria],
+    await generateText(promptedText, {
+      streamer,
+      stopping_criteria: [stopping_criteria],
+    });
+    emit({ type: "finish", data: {} as TextRewriterTaskOutput });
   });
-  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextRewriter.ts
@@ -21,9 +21,9 @@ export const HFT_TextRewriter: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const streamer = createStreamingTextStreamer(
       generateText.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
@@ -21,9 +21,9 @@ export const HFT_TextSummary: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const generateSummary = (await getPipeline(model!, emit, {}, signal)) as SummarizationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const streamer = createStreamingTextStreamer(
       generateSummary.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextSummary.ts
@@ -7,7 +7,12 @@
 import type { SummarizationPipeline } from "@huggingface/transformers";
 import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline, loadTransformersSDK } from "./HFT_Pipeline";
+import {
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 export const HFT_TextSummary: AiProviderRunFn<
@@ -18,19 +23,21 @@ export const HFT_TextSummary: AiProviderRunFn<
   const generateSummary = (await getPipeline(model!, emit, {}, signal)) as SummarizationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const streamer = createStreamingTextStreamer(
-    generateSummary.tokenizer,
-    (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const streamer = createStreamingTextStreamer(
+      generateSummary.tokenizer,
+      (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  await generateSummary(input.text, {
-    streamer,
-    stopping_criteria: [stopping_criteria],
-  } as any);
-  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+    await generateSummary(input.text, {
+      streamer,
+      stopping_criteria: [stopping_criteria],
+    } as any);
+    emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+  });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
@@ -25,9 +25,9 @@ export const HFT_TextTranslation: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit) => {
   const translate = (await getPipeline(model!, emit, {}, signal)) as TranslationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const streamer = createStreamingTextStreamer(
       translate.tokenizer,
       (text) => emit({ type: "text-delta", port: "text", textDelta: text }),

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextTranslation.ts
@@ -11,7 +11,12 @@ import type {
   TextTranslationTaskOutput,
 } from "@workglow/ai";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
-import { getPipeline, loadTransformersSDK } from "./HFT_Pipeline";
+import {
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 
 export const HFT_TextTranslation: AiProviderRunFn<
@@ -22,21 +27,23 @@ export const HFT_TextTranslation: AiProviderRunFn<
   const translate = (await getPipeline(model!, emit, {}, signal)) as TranslationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
 
-  const streamer = createStreamingTextStreamer(
-    translate.tokenizer,
-    (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const streamer = createStreamingTextStreamer(
+      translate.tokenizer,
+      (text) => emit({ type: "text-delta", port: "text", textDelta: text }),
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
+    }
 
-  await translate(input.text, {
-    src_lang: input.source_lang,
-    tgt_lang: input.target_lang,
-    streamer,
-    stopping_criteria: [stopping_criteria],
+    await translate(input.text, {
+      src_lang: input.source_lang,
+      tgt_lang: input.target_lang,
+      streamer,
+      stopping_criteria: [stopping_criteria],
+    });
+    emit({ type: "finish", data: { target_lang: input.target_lang } as TextTranslationTaskOutput });
   });
-  emit({ type: "finish", data: { target_lang: input.target_lang } as TextTranslationTaskOutput });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
@@ -26,7 +26,14 @@ import {
 } from "@workglow/ai/worker";
 import type { HfTransformersOnnxModelConfig } from "./HFT_ModelSchema";
 import type { HftPrefixRewindSession } from "./HFT_Pipeline";
-import { getHftSession, getPipeline, loadTransformersSDK, setHftSession } from "./HFT_Pipeline";
+import {
+  getHftSession,
+  getPipeline,
+  getPipelineCacheKey,
+  loadTransformersSDK,
+  setHftSession,
+  withHftPipelineInUse,
+} from "./HFT_Pipeline";
 import { createStreamingTextStreamer } from "./HFT_Streaming";
 import { createToolCallMarkupFilter } from "./HFT_ToolMarkup";
 
@@ -300,101 +307,103 @@ export const HFT_ToolCalling: AiProviderRunFn<
 > = async (input, model, signal, emit, _outputSchema, sessionId) => {
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
   const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
-  const modelFamily = detectModelFamilyFromConfig(model!);
-  const { prompt, responsePrefix } = buildPromptAndPrefix(
-    generateText.tokenizer,
-    input,
-    modelFamily
-  );
+  await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const modelFamily = detectModelFamilyFromConfig(model!);
+    const { prompt, responsePrefix } = buildPromptAndPrefix(
+      generateText.tokenizer,
+      input,
+      modelFamily
+    );
 
-  // Accumulate raw tokens for post-hoc tool-call parsing, and feed each
-  // delta through a markup filter that emits cleaned text-delta events.
-  let fullText = "";
-  const filter = createToolCallMarkupFilter((text) => {
-    emit({ type: "text-delta", port: "text", textDelta: text });
-  });
-
-  const streamer = createStreamingTextStreamer(
-    generateText.tokenizer,
-    (text) => {
-      fullText += text;
-      filter.feed(text);
-    },
-    TextStreamer
-  );
-  const stopping_criteria = new InterruptableStoppingCriteria();
-  if (signal) {
-    signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
-  }
-
-  // Session cache: prefix-rewind for tool calling (streaming)
-  const modelPath = model!.provider_config.model_path;
-  let session = sessionId ? getHftSession(sessionId) : undefined;
-  let past_key_values: any = undefined;
-
-  if (sessionId && !session) {
-    const { DynamicCache } = await loadTransformersSDK();
-    const hfModel = generateText.model;
-    const hfTokenizer = generateText.tokenizer;
-    const cache = new DynamicCache();
-    const tokenized = hfTokenizer(prompt);
-    await hfModel.generate({
-      ...tokenized,
-      max_new_tokens: 0,
-      past_key_values: cache,
+    // Accumulate raw tokens for post-hoc tool-call parsing, and feed each
+    // delta through a markup filter that emits cleaned text-delta events.
+    let fullText = "";
+    const filter = createToolCallMarkupFilter((text) => {
+      emit({ type: "text-delta", port: "text", textDelta: text });
     });
-    // Snapshot the prefix entries so we can create fresh caches on each rewind
-    const baseEntries: Record<string, any> = {};
-    for (const key of Object.keys(cache)) {
-      baseEntries[key] = cache[key];
+
+    const streamer = createStreamingTextStreamer(
+      generateText.tokenizer,
+      (text) => {
+        fullText += text;
+        filter.feed(text);
+      },
+      TextStreamer
+    );
+    const stopping_criteria = new InterruptableStoppingCriteria();
+    if (signal) {
+      signal.addEventListener("abort", () => stopping_criteria.interrupt(), { once: true });
     }
-    const newSession: HftPrefixRewindSession = {
-      mode: "prefix-rewind",
-      baseEntries,
-      baseSeqLength: cache.get_seq_length(),
-      modelPath,
-    };
-    setHftSession(sessionId, newSession);
-    session = newSession;
-  }
 
-  if (session?.mode === "prefix-rewind") {
-    // Create a fresh DynamicCache from the prefix snapshot for this call
-    const { DynamicCache } = await loadTransformersSDK();
-    past_key_values = new DynamicCache(session.baseEntries);
-  }
+    // Session cache: prefix-rewind for tool calling (streaming)
+    const modelPath = model!.provider_config.model_path;
+    let session = sessionId ? getHftSession(sessionId) : undefined;
+    let past_key_values: any = undefined;
 
-  try {
-    await generateText(prompt, {
-      max_new_tokens: input.maxTokens ?? 1024,
-      temperature: input.temperature ?? undefined,
-      return_full_text: false,
-      streamer,
-      stopping_criteria: [stopping_criteria],
-      ...(past_key_values ? { past_key_values } : {}),
+    if (sessionId && !session) {
+      const { DynamicCache } = await loadTransformersSDK();
+      const hfModel = generateText.model;
+      const hfTokenizer = generateText.tokenizer;
+      const cache = new DynamicCache();
+      const tokenized = hfTokenizer(prompt);
+      await hfModel.generate({
+        ...tokenized,
+        max_new_tokens: 0,
+        past_key_values: cache,
+      });
+      // Snapshot the prefix entries so we can create fresh caches on each rewind
+      const baseEntries: Record<string, any> = {};
+      for (const key of Object.keys(cache)) {
+        baseEntries[key] = cache[key];
+      }
+      const newSession: HftPrefixRewindSession = {
+        mode: "prefix-rewind",
+        baseEntries,
+        baseSeqLength: cache.get_seq_length(),
+        modelPath,
+      };
+      setHftSession(sessionId, newSession);
+      session = newSession;
+    }
+
+    if (session?.mode === "prefix-rewind") {
+      // Create a fresh DynamicCache from the prefix snapshot for this call
+      const { DynamicCache } = await loadTransformersSDK();
+      past_key_values = new DynamicCache(session.baseEntries);
+    }
+
+    try {
+      await generateText(prompt, {
+        max_new_tokens: input.maxTokens ?? 1024,
+        temperature: input.temperature ?? undefined,
+        return_full_text: false,
+        streamer,
+        stopping_criteria: [stopping_criteria],
+        ...(past_key_values ? { past_key_values } : {}),
+      });
+    } finally {
+      filter.flush();
+    }
+
+    // Parse the accumulated text for tool calls using the model-family-aware parser.
+    // For models that use a generation prefix, prepend it so the parser sees the
+    // full markup pattern.
+    const parseableFullText = responsePrefix ? `${responsePrefix}${fullText}` : fullText;
+    const { text: cleanedText, toolCalls } = adaptParserResult(
+      parseToolCalls(parseableFullText, { parser: modelFamily })
+    );
+    const validToolCalls = filterValidToolCalls(
+      normalizeParsedToolCalls(input, toolCalls),
+      input.tools
+    );
+
+    if (validToolCalls.length > 0) {
+      emit({ type: "object-delta", port: "toolCalls", objectDelta: [...validToolCalls] });
+    }
+
+    emit({
+      type: "finish",
+      data: { text: cleanedText, toolCalls: validToolCalls } as ToolCallingTaskOutput,
     });
-  } finally {
-    filter.flush();
-  }
-
-  // Parse the accumulated text for tool calls using the model-family-aware parser.
-  // For models that use a generation prefix, prepend it so the parser sees the
-  // full markup pattern.
-  const parseableFullText = responsePrefix ? `${responsePrefix}${fullText}` : fullText;
-  const { text: cleanedText, toolCalls } = adaptParserResult(
-    parseToolCalls(parseableFullText, { parser: modelFamily })
-  );
-  const validToolCalls = filterValidToolCalls(
-    normalizeParsedToolCalls(input, toolCalls),
-    input.tools
-  );
-
-  if (validToolCalls.length > 0) {
-    emit({ type: "object-delta", port: "toolCalls", objectDelta: [...validToolCalls] });
-  }
-
-  emit({
-    type: "finish",
-    data: { text: cleanedText, toolCalls: validToolCalls } as ToolCallingTaskOutput,
   });
 };

--- a/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
@@ -306,8 +306,8 @@ export const HFT_ToolCalling: AiProviderRunFn<
   HfTransformersOnnxModelConfig
 > = async (input, model, signal, emit, _outputSchema, sessionId) => {
   const generateText = (await getPipeline(model!, emit, {}, signal)) as TextGenerationPipeline;
-  const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
   await withHftPipelineInUse(getPipelineCacheKey(model!), async () => {
+    const { TextStreamer, InterruptableStoppingCriteria } = await loadTransformersSDK();
     const modelFamily = detectModelFamilyFromConfig(model!);
     const { prompt, responsePrefix } = buildPromptAndPrefix(
       generateText.tokenizer,

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
@@ -13,6 +13,7 @@ import type {
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
   acquireContextSequence,
+  getActualModelPath,
   getConfigKey,
   getLlamaCppSession,
   getOrCreateTextContext,
@@ -20,12 +21,14 @@ import {
   llamaCppSeedPromptSpread,
   loadSdk,
   setLlamaCppSession,
+  withModelInUse,
 } from "./LlamaCpp_Runtime";
 
 async function getOrCreateChatSession(
   sessionId: string | undefined,
   model: LlamaCppModelConfig,
-  systemPrompt: string | undefined
+  systemPrompt: string | undefined,
+  signal: AbortSignal
 ): Promise<{ session: any; sequence: any }> {
   if (sessionId) {
     const existing = getLlamaCppSession(sessionId);
@@ -38,12 +41,23 @@ async function getOrCreateChatSession(
 
   const { LlamaChatSession } = await loadSdk();
   const context = await getOrCreateTextContext(model);
-  const sequence = await acquireContextSequence(context);
-  const session = new LlamaChatSession({
-    contextSequence: sequence,
-    ...(systemPrompt !== undefined && { systemPrompt }),
-    ...llamaCppChatSessionConstructorSpread(model),
-  });
+  const sequence = await acquireContextSequence(context, signal);
+  // Sequence ownership only transfers to the session once its constructor
+  // returns; a throw before that would strand the sequence and eventually
+  // exhaust the per-context sequence pool, so free it in the failure path.
+  let session: any;
+  try {
+    session = new LlamaChatSession({
+      contextSequence: sequence,
+      ...(systemPrompt !== undefined && { systemPrompt }),
+      ...llamaCppChatSessionConstructorSpread(model),
+    });
+  } catch (err) {
+    try {
+      await sequence.dispose();
+    } catch {}
+    throw err;
+  }
 
   if (sessionId) {
     setLlamaCppSession(sessionId, {
@@ -76,47 +90,56 @@ export const LlamaCpp_Chat_Stream: AiProviderRunFn<
 > = async (input, model, signal, emit, _outputSchema, sessionId) => {
   if (!model) throw new Error("Model config is required for AiChatTask.");
 
-  const { session, sequence } = await getOrCreateChatSession(sessionId, model, input.systemPrompt);
+  const modelPath = getActualModelPath(model);
 
-  const userText = lastUserText(input.messages ?? []);
+  await withModelInUse(modelPath, async () => {
+    const { session, sequence } = await getOrCreateChatSession(
+      sessionId,
+      model,
+      input.systemPrompt,
+      signal
+    );
 
-  const queue: string[] = [];
-  let done = false;
-  let resolver: (() => void) | undefined;
+    const userText = lastUserText(input.messages ?? []);
 
-  const promptPromise = session
-    .prompt(userText, {
-      signal,
-      ...llamaCppSeedPromptSpread(model.provider_config),
-      ...(input.temperature !== undefined && { temperature: input.temperature }),
-      ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
-      onTextChunk: (chunk: string) => {
-        queue.push(chunk);
+    const queue: string[] = [];
+    let done = false;
+    let resolver: (() => void) | undefined;
+
+    const promptPromise = session
+      .prompt(userText, {
+        signal,
+        ...llamaCppSeedPromptSpread(model.provider_config),
+        ...(input.temperature !== undefined && { temperature: input.temperature }),
+        ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
+        onTextChunk: (chunk: string) => {
+          queue.push(chunk);
+          resolver?.();
+        },
+      })
+      .finally(async () => {
+        done = true;
         resolver?.();
-      },
-    })
-    .finally(async () => {
-      done = true;
-      resolver?.();
-      if (!sessionId) {
-        try {
-          await session.dispose({ disposeSequence: false });
-        } catch {}
-        try {
-          await sequence.dispose();
-        } catch {}
-      }
-    });
+        if (!sessionId) {
+          try {
+            await session.dispose({ disposeSequence: false });
+          } catch {}
+          try {
+            await sequence.dispose();
+          } catch {}
+        }
+      });
 
-  while (!done || queue.length > 0) {
-    if (queue.length === 0 && !done) {
-      await new Promise<void>((res) => (resolver = res));
-      resolver = undefined;
+    while (!done || queue.length > 0) {
+      if (queue.length === 0 && !done) {
+        await new Promise<void>((res) => (resolver = res));
+        resolver = undefined;
+      }
+      while (queue.length > 0) {
+        emit({ type: "text-delta", port: "text", textDelta: queue.shift()! });
+      }
     }
-    while (queue.length > 0) {
-      emit({ type: "text-delta", port: "text", textDelta: queue.shift()! });
-    }
-  }
-  await promptPromise;
-  emit({ type: "finish", data: {} as AiChatProviderOutput });
+    await promptPromise;
+    emit({ type: "finish", data: {} as AiChatProviderOutput });
+  });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -220,14 +220,58 @@ function touchModel(modelPath: string): void {
 }
 
 /**
+ * Reference count of in-flight callers using each cached model path. Prevents
+ * {@link evictLeastRecentlyUsedModel} from disposing a model that is currently
+ * powering another run — without this guard, one caller's VRAM OOM can pull
+ * the `LlamaModel` (and its contexts / sessions) out from under a concurrent
+ * task on a different model.
+ */
+const modelInUse = new Map<string, number>();
+
+export function acquireModelInUse(modelPath: string): void {
+  modelInUse.set(modelPath, (modelInUse.get(modelPath) ?? 0) + 1);
+}
+
+export function releaseModelInUse(modelPath: string): void {
+  const current = modelInUse.get(modelPath) ?? 0;
+  if (current <= 1) {
+    modelInUse.delete(modelPath);
+  } else {
+    modelInUse.set(modelPath, current - 1);
+  }
+}
+
+/** @internal exported for unit tests. */
+export function isModelInUse(modelPath: string): boolean {
+  return (modelInUse.get(modelPath) ?? 0) > 0;
+}
+
+/**
+ * Acquire an in-use refcount on `modelPath` for the lifetime of `fn`, so a
+ * concurrent LRU eviction on a different task cannot dispose this task's
+ * model / context / session mid-flight.
+ */
+export async function withModelInUse<T>(modelPath: string, fn: () => Promise<T>): Promise<T> {
+  acquireModelInUse(modelPath);
+  try {
+    return await fn();
+  } finally {
+    releaseModelInUse(modelPath);
+  }
+}
+
+/**
  * Evict the least-recently-used cached model (and its text context) to free
- * VRAM, skipping `exceptPath` (the model currently being loaded). `llamaCppModels`
- * is kept in access order by {@link touchModel}, so the first key is the LRU one.
- * Returns the evicted path, or undefined when nothing else is cached.
+ * VRAM, skipping `exceptPath` (the model currently being loaded) and any model
+ * with a live in-use refcount. `llamaCppModels` is kept in access order by
+ * {@link touchModel}, so the first eligible key is the LRU one. Returns the
+ * evicted path, or undefined when every non-`exceptPath` candidate is in use
+ * (in which case the caller's VRAM error propagates unchanged).
  */
 async function evictLeastRecentlyUsedModel(exceptPath: string): Promise<string | undefined> {
   for (const path of llamaCppModels.keys()) {
     if (path === exceptPath) continue;
+    if (isModelInUse(path)) continue;
     await recycleLlamaCppTextContext(path, { reloadModel: true });
     return path;
   }
@@ -237,11 +281,15 @@ async function evictLeastRecentlyUsedModel(exceptPath: string): Promise<string |
 /**
  * Run `attempt`, and if it fails with a VRAM allocation error, evict the LRU
  * cached model and retry — repeating until it succeeds or there is nothing left
- * to evict (then the original error is rethrown). This lets a large model or a
- * large KV cache load by reclaiming VRAM still held by earlier models the worker
- * cached but no longer needs (e.g. successive candidates in an eval sweep).
+ * to evict (then the original error is rethrown, unchanged). This lets a large
+ * model or a large KV cache load by reclaiming VRAM still held by earlier
+ * models the worker cached but no longer needs (e.g. successive candidates in
+ * an eval sweep). In-use models are skipped by {@link evictLeastRecentlyUsedModel}.
  */
-async function withVramEviction<T>(exceptPath: string, attempt: () => Promise<T>): Promise<T> {
+export async function withVramEviction<T>(
+  exceptPath: string,
+  attempt: () => Promise<T>
+): Promise<T> {
   while (true) {
     try {
       return await attempt();
@@ -360,9 +408,18 @@ const NO_SEQUENCES_LEFT_ERROR_SUBSTRING = "no sequences left";
  * the sequence pool (each extra sequence costs another `contextSize` of KV cells, so
  * a larger pool would regress memory on VRAM-constrained hosts).
  */
-export async function acquireContextSequence(context: LlamaContext): Promise<LlamaContextSequence> {
+export async function acquireContextSequence(
+  context: LlamaContext,
+  signal?: AbortSignal
+): Promise<LlamaContextSequence> {
+  const abortReason = (): Error => {
+    const raw = (signal as { reason?: unknown } | undefined)?.reason;
+    return raw instanceof Error ? raw : new Error("acquireContextSequence aborted");
+  };
+
   const deadline = Date.now() + SEQUENCE_RECLAIM_TIMEOUT_MS;
   while (true) {
+    if (signal?.aborted) throw abortReason();
     if (context.sequencesLeft > 0) {
       try {
         return context.getSequence();
@@ -378,8 +435,45 @@ export async function acquireContextSequence(context: LlamaContext): Promise<Lla
         "Timed out waiting for a llama.cpp context sequence to be reclaimed after dispose."
       );
     }
-    // Yield a macrotask so the lock-guarded reclaim callback can run.
-    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+    // Yield a macrotask so the lock-guarded reclaim callback can run. Short-circuit
+    // the wait on abort so a queued cancellation doesn't have to burn a full poll tick.
+    await new Promise<void>((resolve) => {
+      let onAbort: (() => void) | null = null;
+      const timer = setTimeout(() => {
+        if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, 1);
+      if (signal) {
+        onAbort = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
+  }
+}
+
+/**
+ * Acquire a sequence, run `body`, and always dispose the sequence — even when
+ * `body` throws (e.g. a `LlamaChatSession` / `LlamaChat` constructor throwing
+ * partway through, which would otherwise strand the sequence and eventually
+ * exhaust the per-context sequence pool).
+ */
+export async function withSequence<T>(
+  context: LlamaContext,
+  body: (sequence: LlamaContextSequence) => Promise<T>,
+  options: { readonly signal?: AbortSignal } = {}
+): Promise<T> {
+  const sequence = await acquireContextSequence(context, options.signal);
+  try {
+    return await body(sequence);
+  } finally {
+    try {
+      await sequence.dispose();
+    } catch {
+      // best-effort dispose
+    }
   }
 }
 

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -146,7 +146,13 @@ export async function recycleLlamaCppTextContext(
 
 export async function disposeLlamaCppSessionsForModel(modelKey: string): Promise<void> {
   for (const [id, state] of llamaCppSessions) {
-    if (state.modelKey === modelKey) {
+    // Sessions are stored with `modelKey = getConfigKey(model)` (typically the
+    // caller's `model_url`), but callers may dispose by the resolved on-disk
+    // path (e.g. `evictLeastRecentlyUsedModel` iterates `llamaCppModels` keys,
+    // which are resolved paths). Match on both spellings so eviction actually
+    // clears the session state instead of stranding it against a disposed model.
+    const matches = state.modelKey === modelKey || resolvedPaths.get(state.modelKey) === modelKey;
+    if (matches) {
       try {
         await state.session?.dispose?.({ disposeSequence: false });
       } catch {}

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts
@@ -12,13 +12,15 @@ import type {
 import { parsePartialJson } from "@workglow/util/worker";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
-  acquireContextSequence,
+  getActualModelPath,
   getLlamaCppSdk,
   getLlamaInstance,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
   loadSdk,
+  withModelInUse,
+  withSequence,
 } from "./LlamaCpp_Runtime";
 
 export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
@@ -30,94 +32,100 @@ export const LlamaCpp_StructuredGeneration_Stream: AiProviderRunFn<
 
   await loadSdk();
 
-  const llama = await getLlamaInstance();
-  const context = await getOrCreateTextContext(model);
-  const grammar = await llama.createGrammarForJsonSchema(input.outputSchema as any);
+  const modelPath = getActualModelPath(model);
 
-  const sequence = await acquireContextSequence(context);
-  const { LlamaChatSession } = getLlamaCppSdk();
-  const session = new LlamaChatSession({
-    contextSequence: sequence,
-    ...llamaCppChatSessionConstructorSpread(model),
-  });
+  await withModelInUse(modelPath, async () => {
+    const llama = await getLlamaInstance();
+    const context = await getOrCreateTextContext(model);
+    const grammar = await llama.createGrammarForJsonSchema(input.outputSchema as any);
 
-  const queue: string[] = [];
-  let isComplete = false;
-  let completionError: unknown;
-  let resolveWait: (() => void) | null = null;
+    await withSequence(
+      context,
+      async (sequence) => {
+        const { LlamaChatSession } = getLlamaCppSdk();
+        const session = new LlamaChatSession({
+          contextSequence: sequence,
+          ...llamaCppChatSessionConstructorSpread(model),
+        });
 
-  const notifyWaiter = () => {
-    resolveWait?.();
-    resolveWait = null;
-  };
+        const queue: string[] = [];
+        let isComplete = false;
+        let completionError: unknown;
+        let resolveWait: (() => void) | null = null;
 
-  let accumulatedText = "";
-  const promptPromise = session
-    .prompt(input.prompt as string, {
-      signal,
-      grammar,
-      ...llamaCppSeedPromptSpread(model.provider_config),
-      onTextChunk: (chunk: string) => {
-        queue.push(chunk);
-        notifyWaiter();
-      },
-      ...(input.temperature !== undefined && { temperature: input.temperature }),
-      ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
-    })
-    .then(() => {
-      isComplete = true;
-      notifyWaiter();
-    })
-    .catch((err: unknown) => {
-      completionError = err;
-      isComplete = true;
-      notifyWaiter();
-    });
+        const notifyWaiter = () => {
+          resolveWait?.();
+          resolveWait = null;
+        };
 
-  try {
-    while (true) {
-      while (queue.length > 0) {
-        const chunk = queue.shift()!;
-        accumulatedText += chunk;
-        const partial = parsePartialJson(accumulatedText);
-        if (partial !== undefined) {
-          emit({
-            type: "object-delta",
-            port: "object",
-            objectDelta: partial as Record<string, unknown>,
+        let accumulatedText = "";
+        const promptPromise = session
+          .prompt(input.prompt as string, {
+            signal,
+            grammar,
+            ...llamaCppSeedPromptSpread(model.provider_config),
+            onTextChunk: (chunk: string) => {
+              queue.push(chunk);
+              notifyWaiter();
+            },
+            ...(input.temperature !== undefined && { temperature: input.temperature }),
+            ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
+          })
+          .then(() => {
+            isComplete = true;
+            notifyWaiter();
+          })
+          .catch((err: unknown) => {
+            completionError = err;
+            isComplete = true;
+            notifyWaiter();
           });
+
+        try {
+          while (true) {
+            while (queue.length > 0) {
+              const chunk = queue.shift()!;
+              accumulatedText += chunk;
+              const partial = parsePartialJson(accumulatedText);
+              if (partial !== undefined) {
+                emit({
+                  type: "object-delta",
+                  port: "object",
+                  objectDelta: partial as Record<string, unknown>,
+                });
+              }
+            }
+            if (isComplete) break;
+            await new Promise<void>((r) => {
+              resolveWait = r;
+            });
+          }
+          while (queue.length > 0) {
+            const chunk = queue.shift()!;
+            accumulatedText += chunk;
+          }
+        } finally {
+          await promptPromise.catch(() => {});
+          try {
+            await session.dispose({ disposeSequence: false });
+          } catch {}
         }
-      }
-      if (isComplete) break;
-      await new Promise<void>((r) => {
-        resolveWait = r;
-      });
-    }
-    while (queue.length > 0) {
-      const chunk = queue.shift()!;
-      accumulatedText += chunk;
-    }
-  } finally {
-    await promptPromise.catch(() => {});
-    try {
-      await session.dispose({ disposeSequence: false });
-    } catch {}
-    try {
-      await sequence.dispose();
-    } catch {}
-  }
 
-  if (completionError) {
-    if (signal.aborted) return;
-    throw completionError;
-  }
+        if (completionError) {
+          if (signal.aborted) return;
+          throw completionError;
+        }
 
-  let finalObject: Record<string, unknown>;
-  try {
-    finalObject = JSON.parse(accumulatedText);
-  } catch {
-    finalObject = (parsePartialJson(accumulatedText) as Record<string, unknown>) ?? {};
-  }
+        let finalObject: Record<string, unknown>;
+        try {
+          finalObject = JSON.parse(accumulatedText);
+        } catch {
+          finalObject = (parsePartialJson(accumulatedText) as Record<string, unknown>) ?? {};
+        }
 
-  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+        emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+      },
+      { signal }
+    );
+  });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextEmbedding.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextEmbedding.ts
@@ -10,7 +10,11 @@ import type {
   TextEmbeddingTaskOutput,
 } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
-import { getOrCreateEmbeddingContext } from "./LlamaCpp_Runtime";
+import {
+  getActualModelPath,
+  getOrCreateEmbeddingContext,
+  withModelInUse,
+} from "./LlamaCpp_Runtime";
 
 export const LlamaCpp_TextEmbedding: AiProviderRunFn<
   TextEmbeddingTaskInput,
@@ -19,17 +23,21 @@ export const LlamaCpp_TextEmbedding: AiProviderRunFn<
 > = async (input, model, _signal, emit) => {
   if (!model) throw new Error("Model config is required for TextEmbeddingTask.");
 
-  const context = await getOrCreateEmbeddingContext(model);
+  const modelPath = getActualModelPath(model);
 
-  const texts = Array.isArray(input.text) ? input.text : [input.text];
+  await withModelInUse(modelPath, async () => {
+    const context = await getOrCreateEmbeddingContext(model);
 
-  const embeddings = await Promise.all(
-    texts.map((text) => context.getEmbeddingFor(text).then((e) => new Float32Array(e.vector)))
-  );
+    const texts = Array.isArray(input.text) ? input.text : [input.text];
 
-  if (Array.isArray(input.text)) {
-    emit({ type: "finish", data: { vector: embeddings } });
-    return;
-  }
-  emit({ type: "finish", data: { vector: embeddings[0] } });
+    const embeddings = await Promise.all(
+      texts.map((text) => context.getEmbeddingFor(text).then((e) => new Float32Array(e.vector)))
+    );
+
+    if (Array.isArray(input.text)) {
+      emit({ type: "finish", data: { vector: embeddings } });
+      return;
+    }
+    emit({ type: "finish", data: { vector: embeddings[0] } });
+  });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
@@ -12,6 +12,7 @@ import type {
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
   acquireContextSequence,
+  getActualModelPath,
   getConfigKey,
   getLlamaCppSession,
   getOrCreateTextContext,
@@ -20,6 +21,7 @@ import {
   loadSdk,
   setLlamaCppSession,
   streamFromSession,
+  withModelInUse,
 } from "./LlamaCpp_Runtime";
 
 export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
@@ -30,47 +32,63 @@ export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
   if (!model) throw new Error("Model config is required for TextGenerationTask.");
 
   const { LlamaChatSession } = await loadSdk();
+  const modelPath = getActualModelPath(model);
 
-  const cached = sessionId ? getLlamaCppSession(sessionId) : undefined;
-  const context = cached ? undefined : await getOrCreateTextContext(model);
-  const sequence = cached ? cached.sequence : await acquireContextSequence(context!);
-  const session =
-    cached?.session ??
-    new LlamaChatSession({
-      contextSequence: sequence,
-      ...llamaCppChatSessionConstructorSpread(model),
-    });
+  await withModelInUse(modelPath, async () => {
+    const cached = sessionId ? getLlamaCppSession(sessionId) : undefined;
+    const context = cached ? undefined : await getOrCreateTextContext(model);
+    const sequence = cached ? cached.sequence : await acquireContextSequence(context!, signal);
+    // Sequence ownership only transfers to the session once its constructor
+    // returns; a throw before that would strand the sequence and eventually
+    // exhaust the per-context sequence pool, so free it in the failure path.
+    let session: any;
+    if (cached?.session) {
+      session = cached.session;
+    } else {
+      try {
+        session = new LlamaChatSession({
+          contextSequence: sequence,
+          ...llamaCppChatSessionConstructorSpread(model),
+        });
+      } catch (err) {
+        try {
+          await sequence.dispose();
+        } catch {}
+        throw err;
+      }
+    }
 
-  if (sessionId && !cached) {
-    setLlamaCppSession(sessionId, {
-      mode: "progressive",
-      sequence,
-      session,
-      modelKey: getConfigKey(model),
-    });
-  }
-
-  try {
-    for await (const e of streamFromSession<TextGenerationTaskOutput>((onTextChunk) => {
-      return session.prompt(input.prompt, {
-        signal,
-        onTextChunk,
-        ...llamaCppSeedPromptSpread(model.provider_config),
-        ...(input.temperature !== undefined && { temperature: input.temperature }),
-        ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
-        ...(input.topP !== undefined && { topP: input.topP }),
+    if (sessionId && !cached) {
+      setLlamaCppSession(sessionId, {
+        mode: "progressive",
+        sequence,
+        session,
+        modelKey: getConfigKey(model),
       });
-    }, signal)) {
-      emit(e);
     }
-  } finally {
-    if (!sessionId) {
-      try {
-        await session.dispose({ disposeSequence: false });
-      } catch {}
-      try {
-        await sequence.dispose();
-      } catch {}
+
+    try {
+      for await (const e of streamFromSession<TextGenerationTaskOutput>((onTextChunk) => {
+        return session.prompt(input.prompt, {
+          signal,
+          onTextChunk,
+          ...llamaCppSeedPromptSpread(model.provider_config),
+          ...(input.temperature !== undefined && { temperature: input.temperature }),
+          ...(input.maxTokens !== undefined && { maxTokens: input.maxTokens }),
+          ...(input.topP !== undefined && { topP: input.topP }),
+        });
+      }, signal)) {
+        emit(e);
+      }
+    } finally {
+      if (!sessionId) {
+        try {
+          await session.dispose({ disposeSequence: false });
+        } catch {}
+        try {
+          await sequence.dispose();
+        } catch {}
+      }
     }
-  }
+  });
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextRewriter.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextRewriter.ts
@@ -7,12 +7,14 @@
 import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
-  acquireContextSequence,
+  getActualModelPath,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
   loadSdk,
   streamFromSession,
+  withModelInUse,
+  withSequence,
 } from "./LlamaCpp_Runtime";
 
 export const LlamaCpp_TextRewriter_Stream: AiProviderRunFn<
@@ -23,30 +25,35 @@ export const LlamaCpp_TextRewriter_Stream: AiProviderRunFn<
   if (!model) throw new Error("Model config is required for TextRewriterTask.");
 
   const { LlamaChatSession } = await loadSdk();
+  const modelPath = getActualModelPath(model);
 
-  const context = await getOrCreateTextContext(model);
-  const sequence = await acquireContextSequence(context);
-  const session = new LlamaChatSession({
-    contextSequence: sequence,
-    ...llamaCppChatSessionConstructorSpread(model),
-    systemPrompt: input.prompt,
+  await withModelInUse(modelPath, async () => {
+    const context = await getOrCreateTextContext(model);
+    await withSequence(
+      context,
+      async (sequence) => {
+        const session = new LlamaChatSession({
+          contextSequence: sequence,
+          ...llamaCppChatSessionConstructorSpread(model),
+          systemPrompt: input.prompt,
+        });
+        try {
+          for await (const e of streamFromSession<TextRewriterTaskOutput>((onTextChunk) => {
+            return session.prompt(input.text, {
+              signal,
+              onTextChunk,
+              ...llamaCppSeedPromptSpread(model.provider_config),
+            });
+          }, signal)) {
+            emit(e);
+          }
+        } finally {
+          try {
+            await session.dispose({ disposeSequence: false });
+          } catch {}
+        }
+      },
+      { signal }
+    );
   });
-  try {
-    for await (const e of streamFromSession<TextRewriterTaskOutput>((onTextChunk) => {
-      return session.prompt(input.text, {
-        signal,
-        onTextChunk,
-        ...llamaCppSeedPromptSpread(model.provider_config),
-      });
-    }, signal)) {
-      emit(e);
-    }
-  } finally {
-    try {
-      await session.dispose({ disposeSequence: false });
-    } catch {}
-    try {
-      await sequence.dispose();
-    } catch {}
-  }
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextSummary.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextSummary.ts
@@ -7,12 +7,14 @@
 import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
-  acquireContextSequence,
+  getActualModelPath,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
   loadSdk,
   streamFromSession,
+  withModelInUse,
+  withSequence,
 } from "./LlamaCpp_Runtime";
 
 export const LlamaCpp_TextSummary_Stream: AiProviderRunFn<
@@ -23,30 +25,35 @@ export const LlamaCpp_TextSummary_Stream: AiProviderRunFn<
   if (!model) throw new Error("Model config is required for TextSummaryTask.");
 
   const { LlamaChatSession } = await loadSdk();
+  const modelPath = getActualModelPath(model);
 
-  const context = await getOrCreateTextContext(model);
-  const sequence = await acquireContextSequence(context);
-  const session = new LlamaChatSession({
-    contextSequence: sequence,
-    ...llamaCppChatSessionConstructorSpread(model),
-    systemPrompt: "Summarize the following text concisely, preserving the key points.",
+  await withModelInUse(modelPath, async () => {
+    const context = await getOrCreateTextContext(model);
+    await withSequence(
+      context,
+      async (sequence) => {
+        const session = new LlamaChatSession({
+          contextSequence: sequence,
+          ...llamaCppChatSessionConstructorSpread(model),
+          systemPrompt: "Summarize the following text concisely, preserving the key points.",
+        });
+        try {
+          for await (const e of streamFromSession<TextSummaryTaskOutput>((onTextChunk) => {
+            return session.prompt(input.text, {
+              signal,
+              onTextChunk,
+              ...llamaCppSeedPromptSpread(model.provider_config),
+            });
+          }, signal)) {
+            emit(e);
+          }
+        } finally {
+          try {
+            await session.dispose({ disposeSequence: false });
+          } catch {}
+        }
+      },
+      { signal }
+    );
   });
-  try {
-    for await (const e of streamFromSession<TextSummaryTaskOutput>((onTextChunk) => {
-      return session.prompt(input.text, {
-        signal,
-        onTextChunk,
-        ...llamaCppSeedPromptSpread(model.provider_config),
-      });
-    }, signal)) {
-      emit(e);
-    }
-  } finally {
-    try {
-      await session.dispose({ disposeSequence: false });
-    } catch {}
-    try {
-      await sequence.dispose();
-    } catch {}
-  }
 };

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
@@ -17,12 +17,14 @@ import { filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
 import type { StreamEvent } from "@workglow/task-graph";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
-  acquireContextSequence,
+  getActualModelPath,
   getLlamaCppSdk,
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
   loadSdk,
+  withModelInUse,
+  withSequence,
 } from "./LlamaCpp_Runtime";
 import { extractToolCallsFromText } from "./LlamaCpp_ToolParser";
 
@@ -269,62 +271,68 @@ export const LlamaCpp_ToolCalling_Stream: AiProviderRunFn<
 
   await loadSdk();
 
-  const context = await getOrCreateTextContext(model);
+  const modelPath = getActualModelPath(model);
 
-  const sequence = await acquireContextSequence(context);
-  const { LlamaChat } = getLlamaCppSdk();
-  const systemPrompt = buildSystemPrompt(input);
+  await withModelInUse(modelPath, async () => {
+    const context = await getOrCreateTextContext(model);
 
-  const llamaChat = new LlamaChat({
-    contextSequence: sequence,
-    ...llamaCppChatSessionConstructorSpread(model),
-  });
+    await withSequence(
+      context,
+      async (sequence) => {
+        const { LlamaChat } = getLlamaCppSdk();
+        const systemPrompt = buildSystemPrompt(input);
 
-  const promptText =
-    typeof input.prompt === "string" ? input.prompt : extractMessageText(input.prompt);
-  const chatHistory = convertMessagesToChatHistory(input.messages, promptText, systemPrompt);
-  const functions = buildChatModelFunctions(input.tools);
+        const llamaChat = new LlamaChat({
+          contextSequence: sequence,
+          ...llamaCppChatSessionConstructorSpread(model),
+        });
 
-  const gen = streamTextChunks(
-    (onTextChunk) =>
-      llamaChat.generateResponse(chatHistory, {
-        signal,
-        ...llamaCppChatGenerateOptions(input, model),
-        functions,
-        ...(toolChoiceForcesToolCall(input.toolChoice) && { documentFunctionParams: true }),
-        onTextChunk,
-      }),
-    signal,
-    async () => {
-      try {
-        await llamaChat.dispose({ disposeSequence: false });
-      } catch {}
-      try {
-        await sequence.dispose();
-      } catch {}
-    }
-  );
-  let step = await gen.next();
-  while (!step.done) {
-    emit(step.value);
-    step = await gen.next();
-  }
-  const { text: accumulatedText, result: chatResponse } = step.value;
+        const promptText =
+          typeof input.prompt === "string" ? input.prompt : extractMessageText(input.prompt);
+        const chatHistory = convertMessagesToChatHistory(input.messages, promptText, systemPrompt);
+        const functions = buildChatModelFunctions(input.tools);
 
-  const toolCalls = extractNativeFunctionCalls(chatResponse?.functionCalls);
+        const gen = streamTextChunks(
+          (onTextChunk) =>
+            llamaChat.generateResponse(chatHistory, {
+              signal,
+              ...llamaCppChatGenerateOptions(input, model),
+              functions,
+              ...(toolChoiceForcesToolCall(input.toolChoice) && { documentFunctionParams: true }),
+              onTextChunk,
+            }),
+          signal,
+          async () => {
+            try {
+              await llamaChat.dispose({ disposeSequence: false });
+            } catch {}
+          }
+        );
+        let step = await gen.next();
+        while (!step.done) {
+          emit(step.value);
+          step = await gen.next();
+        }
+        const { text: accumulatedText, result: chatResponse } = step.value;
 
-  // Fallback: parse tool calls from text if native parsing found nothing
-  if (toolCalls.length === 0 && input.tools.length > 0 && input.toolChoice !== "none") {
-    toolCalls.push(...extractToolCallsFromText(accumulatedText, input));
-  }
-  const validToolCalls = filterValidToolCalls(toolCalls, input.tools);
+        const toolCalls = extractNativeFunctionCalls(chatResponse?.functionCalls);
 
-  if (validToolCalls.length > 0) {
-    emit({ type: "object-delta", port: "toolCalls", objectDelta: [...validToolCalls] });
-  }
+        // Fallback: parse tool calls from text if native parsing found nothing
+        if (toolCalls.length === 0 && input.tools.length > 0 && input.toolChoice !== "none") {
+          toolCalls.push(...extractToolCallsFromText(accumulatedText, input));
+        }
+        const validToolCalls = filterValidToolCalls(toolCalls, input.tools);
 
-  emit({
-    type: "finish",
-    data: { text: accumulatedText, toolCalls: validToolCalls } as ToolCallingTaskOutput,
+        if (validToolCalls.length > 0) {
+          emit({ type: "object-delta", port: "toolCalls", objectDelta: [...validToolCalls] });
+        }
+
+        emit({
+          type: "finish",
+          data: { text: accumulatedText, toolCalls: validToolCalls } as ToolCallingTaskOutput,
+        });
+      },
+      { signal }
+    );
   });
 };


### PR DESCRIPTION
## Summary

Follow-up to PR #632. Review of the merged code found two concurrency defects in the llama.cpp runtime that the initial fix left open — this PR closes both.

**Issue 1 — concurrent-model eviction.** `withVramEviction` called `recycleLlamaCppTextContext(path, { reloadModel: true })`, which disposes the LRU model **and** its contexts / sessions. If two run-fns targeted different models and one OOMed, the other run&#39;s `LlamaModel` could be pulled out from under it (only `exceptPath` was protected). Fixed with an in-use refcount (`modelInUse` map, `acquireModelInUse` / `releaseModelInUse`, `withModelInUse` wrapper) that the LRU sweep skips over. If every non-`exceptPath` candidate is in use, the original VRAM error propagates unchanged.

**Issue 2 — sequence leak on session/chat constructor throw.** Six run-fns acquired the sequence *before* entering the `try/finally`, so a throw from `new LlamaChatSession(…)` / `new LlamaChat(…)` stranded the sequence — the exact leak PR #632 was meant to prevent. Introduced a `withSequence(context, body, { signal })` helper (acquire → run body → dispose in finally). The four non-persistent run-fns (`TextRewriter`, `TextSummary`, `StructuredGeneration`, `ToolCalling`) now use it uniformly. The two persistent run-fns (`Chat`, `TextGeneration`) keep an inline `try { new … } catch { sequence.dispose(); throw }` around the session ctor only, since ownership transfers to the cached session on success.

**Also rolled in:**
- `acquireContextSequence` now accepts an optional `AbortSignal` — the abort is checked at the top of each poll tick and short-circuits the 1 ms wait so a queued cancellation isn&#39;t blocked on the poll interval. Threaded through the run-fns.
- `LlamaCpp_Runtime.test.ts` regression test now actually drives the &#34;No sequences left&#34; retry path (previously the fake never let `getSequence()` throw). New tests cover the concurrent-eviction skip, the all-in-use rethrow, the sequence-leak, and signal cancellation.

### Rebase note (2026-07-14)

Rebased onto `main` after PR #632&#39;s follow-up commits landed (`05ae519f` / `09e51265` / `9c0bc266`). Those already deliver the broader `isVramError` matcher, embedding-context eviction, and embedding VRAM-pressure retry, so the previous scope&#39;s `isVramError` narrowing was dropped from this PR (main&#39;s broadened matcher wins). The remaining novel work — the refcount, `withSequence`, the abort signal, and the associated tests — is what this branch now contributes on top of current `main`.

## HFT provider (`d0bf2f2e`..`1252d49e`)

The same protection was extended to `@workglow/huggingface-transformers`, where the `pipelines` cache was previously unbounded. A caller cycling through embed + classify + generate + rerank held every pipeline for the process lifetime — each pipeline pins an ONNX session (WASM heap / WebGPU buffers) that V8 GC never reclaims; only an explicit `session.release()` frees it, and browser/WASM contexts have no OOM retry path (unlike CUDA, where PR #632&#39;s `withVramEviction` reactively evicts).

**Bounded LRU on the `pipelines` cache.** After a fresh pipeline is stored, `enforcePipelineCacheCap` prunes non-in-use entries in insertion order down to `MAX_CACHED_PIPELINES` (`HFT_MAX_CACHED_PIPELINES` env var, default 6, browser-safe `typeof process` guard). Cache-hit path `touch`es the entry (delete-and-re-set) so hot pipelines stay MRU. Existing `pipelineLoadPromises` dedup, `clearPipelineCache`, `disposeHftSessionsForModel`, and `hasCachedPipeline` are unchanged.

**`withHftPipelineInUse` refcount.** Mirrors the node-llama-cpp `withModelInUse` pattern: `acquireHftPipelineInUse` / `releaseHftPipelineInUse` / `isHftPipelineInUse` + a `try/finally` wrapper. `removeCachedPipeline` skips (returns `false`) when the pipeline is in-use — releasing an ONNX session mid-inference would crash the WASM worker. The LRU sweep skips in-use entries; if every candidate is in-use the cache stays over cap for this cycle (proactive housekeeping never blocks or waits on active inference).

**All 15 run-fns that touch `getPipeline` are wrapped** — `HFT_BackgroundRemoval`, `HFT_Chat`, `HFT_ImageClassification`, `HFT_ImageEmbedding`, `HFT_ImageSegmentation`, `HFT_ImageToText`, `HFT_ObjectDetection`, `HFT_StructuredGeneration`, `HFT_TextClassification`, `HFT_TextEmbedding`, `HFT_TextFillMask`, `HFT_TextGeneration`, `HFT_TextLanguageDetection`, `HFT_TextNamedEntityRecognition`, `HFT_TextQuestionAnswer`, `HFT_TextReranker`, `HFT_TextRewriter`, `HFT_TextSummary`, `HFT_TextTranslation`, `HFT_ToolCalling`. The refcount is held around the inference call (not the `getPipeline` load itself — load races are already deduped by `pipelineLoadPromises`). For `HFT_Chat`, the refcount spans a single turn only; multi-turn conversation state remains in the separate `hftSessions` cache.

`HFT_Download` intentionally does *not* wrap — it only triggers a load and never runs inference.

## Files Changed

### node-llama-cpp (PR #632 follow-up)

- `providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts` — `modelInUse` refcount, `withModelInUse`, `withSequence`, `AbortSignal` on `acquireContextSequence`, exported `withVramEviction`.
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts` — `withModelInUse` wrap; inline try/catch around `new LlamaChatSession` (persistent branch).
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts` — same pattern.
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_StructuredGeneration.ts` — `withModelInUse` + `withSequence`.
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_TextRewriter.ts` — `withModelInUse` + `withSequence`.
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_TextSummary.ts` — `withModelInUse` + `withSequence`.
- `providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts` — `withModelInUse` + `withSequence`.
- `packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts` — retry-path fake fixed; new coverage for `withSequence`, concurrent-eviction skip, all-in-use rethrow, abort-signal propagation.

### huggingface-transformers (this follow-up)

- `providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts` — `pipelines` map exported for tests, `MAX_CACHED_PIPELINES`, `touchPipeline`, `hftPipelineInUse` refcount + `withHftPipelineInUse`, `evictLeastRecentlyUsedPipeline`, `enforcePipelineCacheCap`; `removeCachedPipeline` skips in-use; cache-hit path touches.
- `providers/huggingface-transformers/src/ai/common/HFT_{BackgroundRemoval,Chat,ImageClassification,ImageEmbedding,ImageSegmentation,ImageToText,ObjectDetection,StructuredGeneration,TextClassification,TextEmbedding,TextFillMask,TextGeneration,TextLanguageDetection,TextNamedEntityRecognition,TextQuestionAnswer,TextReranker,TextRewriter,TextSummary,TextTranslation,ToolCalling}.ts` — inference bodies wrapped in `withHftPipelineInUse(getPipelineCacheKey(model), …)`.
- `packages/test/src/test/ai-provider-hft/HFT_Pipeline.eviction.test.ts` — new: refcount acquire/release/finally, `removeCachedPipeline` in-use skip, LRU evicts oldest at cap, in-use protection skips pinned entry.

## Test Plan

- [x] `bun run build:types` — all affected packages type-check clean.
- [x] `bunx vitest run packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts` — 23 / 23 pass on the rebased branch.
- [x] `bunx vitest run packages/test/src/test/ai-provider-hft/HFT_Pipeline.eviction.test.ts` — 5 / 5 pass.
- [x] `bun scripts/test.ts provider-nodellama vitest` — same integration failures as `main` (missing `.gguf` fixture files under `/home/user/libs/models/`); no new failures introduced.
- [x] `bun scripts/test.ts provider-hft vitest` — pre-existing `VisionTasks.integration.test.ts` failures are HuggingFace `Forbidden access to file` 403s on the CI host and reproduce on the branch head prior to these changes; no new failures introduced.
- [ ] Manual: verify on a GPU host that two parallel long generations on different models no longer race-evict each other under memory pressure.
- [ ] Manual (HFT): verify on a WASM-backed worker that a caller cycling through embed / classify / generate / rerank stays under `HFT_MAX_CACHED_PIPELINES` sessions (was previously unbounded).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhbEn2ijqUupcwtoSypT8r)_