### PR TITLE
Upgrade Cloudflare Workers types to v5 and tslog to v5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -303,7 +303,7 @@
       "version": "0.3.25",
       "devDependencies": {
         "@aws-sdk/client-sqs": "^3.1084.0",
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260715.1",
         "@duckdb/node-api": "catalog:",
         "@electric-sql/pglite": "catalog:",
         "@electric-sql/pglite-pgvector": "catalog:",
@@ -395,7 +395,7 @@
         "@workglow/tf-mediapipe": "workspace:*",
         "@workglow/util": "workspace:*",
         "@workglow/xai": "workspace:*",
-        "tslog": "^4.11.0",
+        "tslog": "^5.0.0",
       },
     },
     "providers/anthropic": {
@@ -490,12 +490,12 @@
       "name": "@workglow/cloudflare",
       "version": "0.3.25",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260715.1",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260715.1",
         "@workglow/job-queue": "workspace:*",
         "@workglow/util": "workspace:*",
       },
@@ -979,7 +979,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260715.1", "", {}, "sha512-saxo/nMqQJ1dKDUXp1a2y/+IjKENFVD9+QRefHg5EjJZY20OG3xcEge4PGljbqZiF3AiU4o5ZLS3Vm7cayQIxg=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
@@ -2773,7 +2773,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tslog": ["tslog@4.11.0", "", {}, "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ=="],
+    "tslog": ["tslog@5.0.0", "", { "bin": { "tslog": "esm/subpaths/cli.js" } }, "sha512-ro4kpyeDWxInGB0CK0+hS3USFu/Z/E5QDY99v5wOUqztecDj0rVOQdXUOBBiT0bQk1pw+kpduk4BwPBF5xkQ5g=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-sqs": "^3.1084.0",
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260715.1",
     "@duckdb/node-api": "catalog:",
     "@electric-sql/pglite": "catalog:",
     "@electric-sql/pglite-pgvector": "catalog:",

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -252,6 +252,6 @@
     "@workglow/mcp": "workspace:*",
     "@workglow/tasks": "workspace:*",
     "@workglow/util": "workspace:*",
-    "tslog": "^4.11.0"
+    "tslog": "^5.0.0"
   }
 }

--- a/providers/cloudflare/package.json
+++ b/providers/cloudflare/package.json
@@ -34,7 +34,7 @@
     }
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260715.1",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },
@@ -47,7 +47,7 @@
     }
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260715.1",
     "@workglow/job-queue": "workspace:*",
     "@workglow/util": "workspace:*"
   },


### PR DESCRIPTION
## Summary

Updates peer and dev dependencies for Cloudflare Workers type definitions to v5 (latest), and upgrades the tslog logging library to v5 in the main workglow package.

## Changes

- **Cloudflare Workers types**: Updated `@cloudflare/workers-types` from `^4.20260702.1` to `^5.20260715.1` across:
  - `providers/cloudflare/package.json` (peer and dev dependencies)
  - `packages/test/package.json` (dev dependencies)
  
- **tslog**: Upgraded `tslog` from `^4.11.0` to `^5.0.0` in `packages/workglow/package.json` dev dependencies

These are routine dependency updates to keep the project aligned with the latest stable versions of these libraries.

https://claude.ai/code/session_012APg27ZnCDTENjGJWXjXxK