### PR TITLE
fix(huggingface-transformers,openai): 2 HIGH scheduled-review findings — HFT session sweep + OpenAI Responses warnings

### DIFF
--- a/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
@@ -42,3 +42,47 @@ export function isStrictCompatibleSchema(schema: unknown): boolean {
   }
   return true;
 }
+
+/**
+ * When {@link isStrictCompatibleSchema} would return `false`, describe the first
+ * reason it found — the concrete keyword or shape that made the schema
+ * non-strict. Returns `undefined` when the schema is strict-compatible.
+ *
+ * Used to make a strict → non-strict downshift observable in warn logs (the
+ * request still succeeds; only the strict guarantee is dropped).
+ */
+export function firstNonStrictReason(schema: unknown): string | undefined {
+  if (schema === null || typeof schema !== "object") return undefined;
+  const s = schema as Record<string, unknown>;
+  if (s.$ref !== undefined) return "$ref";
+  if (Array.isArray(s.anyOf)) return "anyOf";
+  if (Array.isArray(s.oneOf)) return "oneOf";
+  if (Array.isArray(s.allOf)) return "allOf";
+
+  const isObject = s.type === "object" || (s.type === undefined && s.properties !== undefined);
+  if (isObject) {
+    if (s.additionalProperties !== false) return "missing additionalProperties:false";
+    const props = (s.properties as Record<string, unknown> | undefined) ?? {};
+    const required = Array.isArray(s.required) ? (s.required as string[]) : [];
+    for (const key of Object.keys(props)) {
+      if (!required.includes(key)) return `unlisted required key: ${key}`;
+      const nested = firstNonStrictReason(props[key]);
+      if (nested !== undefined) return `${key}.${nested}`;
+    }
+    return undefined;
+  }
+
+  const isArray = s.type === "array" || s.items !== undefined;
+  if (isArray) {
+    if (Array.isArray(s.items)) {
+      for (let i = 0; i < s.items.length; i++) {
+        const nested = firstNonStrictReason(s.items[i]);
+        if (nested !== undefined) return `items[${i}].${nested}`;
+      }
+      return undefined;
+    }
+    const nested = firstNonStrictReason(s.items);
+    return nested === undefined ? undefined : `items.${nested}`;
+  }
+  return undefined;
+}

--- a/packages/test/src/test/ai-provider-hft/HFT_Pipeline.race.test.ts
+++ b/packages/test/src/test/ai-provider-hft/HFT_Pipeline.race.test.ts
@@ -5,11 +5,15 @@
  */
 
 import {
+  clearPipelineCache,
+  getHftSession,
   hasCachedPipeline,
+  type HftPrefixRewindSession,
   isHftPipelineInUse,
   MAX_CACHED_PIPELINES,
   pipelines,
   removeCachedPipeline,
+  setHftSession,
   withHftPipelineInUse,
 } from "@workglow/huggingface-transformers/ai-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -143,5 +147,91 @@ describe("H1: refcount before pipeline lookup", () => {
     for (const inUse of inUseKeys) {
       expect(disposeFns.get(inUse)!).not.toHaveBeenCalled();
     }
+  });
+});
+
+/**
+ * Fake session tensor: `disposeSessionResources` only calls `dispose()` on
+ * `HftPrefixRewindSession.baseEntries` values whose `location === "gpu-buffer"`.
+ * A vi.fn() dispose lets the assertion check the sweep actually ran.
+ */
+function makeFakeSessionTensor(): {
+  tensor: { location: "gpu-buffer"; dispose: ReturnType<typeof vi.fn> };
+  dispose: ReturnType<typeof vi.fn>;
+} {
+  const dispose = vi.fn();
+  const tensor = { location: "gpu-buffer" as const, dispose };
+  return { tensor, dispose };
+}
+
+function seedPrefixRewindSession(
+  sessionId: string,
+  modelPath: string,
+  cacheKey: string
+): ReturnType<typeof vi.fn> {
+  const { tensor, dispose } = makeFakeSessionTensor();
+  const session: HftPrefixRewindSession = {
+    mode: "prefix-rewind",
+    baseEntries: { "layer.0": tensor },
+    baseSeqLength: 0,
+    modelPath,
+    cacheKey,
+  };
+  setHftSession(sessionId, session);
+  return dispose;
+}
+
+describe("H1: LRU pipeline eviction sweeps hftSessions", () => {
+  afterEach(async () => {
+    await clearPipelineCache();
+  });
+
+  it("evicting a pipeline sweeps sessions tied to its cacheKey but not sibling variants", async () => {
+    const evictedKey = "A:pipeline:q4:webgpu:main";
+    const survivorKey = "A:pipeline:fp32:wasm:main";
+
+    const evictedPipelineDispose = seedPipeline(evictedKey);
+    seedPipeline(survivorKey);
+    // Filler entries so the cache mirrors real conditions when eviction
+    // fires — the sweep must not depend on any particular cache size.
+    for (let i = 0; i < 2; i++) seedPipeline(`filler:${i}`);
+
+    const evictedSessionId = "convo:1";
+    const survivorSessionId = "convo:2";
+    const evictedSessionDispose = seedPrefixRewindSession(evictedSessionId, "A/model", evictedKey);
+    const survivorSessionDispose = seedPrefixRewindSession(
+      survivorSessionId,
+      "A/model",
+      survivorKey
+    );
+
+    const removed = await removeCachedPipeline(evictedKey);
+
+    expect(removed).toBe(true);
+    expect(evictedPipelineDispose).toHaveBeenCalledTimes(1);
+
+    // Evicted session gone with its tensors disposed.
+    expect(getHftSession(evictedSessionId)).toBeUndefined();
+    expect(evictedSessionDispose).toHaveBeenCalledTimes(1);
+
+    // Sibling variant untouched: same model_path, different cacheKey.
+    expect(getHftSession(survivorSessionId)).toBeDefined();
+    expect(survivorSessionDispose).not.toHaveBeenCalled();
+    expect(hasCachedPipeline(survivorKey)).toBe(true);
+  });
+
+  it("clearPipelineCache disposes every session", async () => {
+    seedPipeline("K1");
+    seedPipeline("K2");
+    const sess1 = seedPrefixRewindSession("s1", "A/model", "K1");
+    const sess2 = seedPrefixRewindSession("s2", "B/model", "K2");
+
+    await clearPipelineCache();
+
+    expect(sess1).toHaveBeenCalledTimes(1);
+    expect(sess2).toHaveBeenCalledTimes(1);
+    expect(getHftSession("s1")).toBeUndefined();
+    expect(getHftSession("s2")).toBeUndefined();
+    expect(pipelines.size).toBe(0);
   });
 });

--- a/packages/test/src/test/ai-provider/OpenAI_TextGeneration.warnings.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAI_TextGeneration.warnings.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { firstNonStrictReason, isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import { _testOnly } from "@workglow/openai/ai";
+import type { ILogger } from "@workglow/util";
+import { setLogger } from "@workglow/util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { _resetOpenAIResponsesWarnings, warnPenaltyDroppedOnce, warnStrictDowngradedOnce } =
+  _testOnly;
+
+/**
+ * Minimal ILogger that records `warn` calls; other methods are no-ops so the
+ * NullLogger-style baseline still applies for anything a subsystem might emit
+ * during import.
+ */
+function makeRecordingLogger(): { logger: ILogger; warn: ReturnType<typeof vi.fn> } {
+  const warn = vi.fn();
+  const logger: ILogger = {
+    debug: () => {},
+    info: () => {},
+    warn,
+    error: () => {},
+    fatal: () => {},
+    child: () => logger,
+    time: () => {},
+    timeEnd: () => {},
+    group: () => {},
+    groupEnd: () => {},
+  };
+  return { logger, warn };
+}
+
+describe("firstNonStrictReason", () => {
+  it("returns undefined for a strict-compatible object schema", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    };
+    expect(isStrictCompatibleSchema(schema)).toBe(true);
+    expect(firstNonStrictReason(schema)).toBeUndefined();
+  });
+
+  it("flags $ref", () => {
+    const schema = { $ref: "#/defs/User" };
+    expect(isStrictCompatibleSchema(schema)).toBe(false);
+    expect(firstNonStrictReason(schema)).toBe("$ref");
+  });
+
+  it("flags anyOf", () => {
+    const schema = { anyOf: [{ type: "string" }, { type: "number" }] };
+    expect(firstNonStrictReason(schema)).toBe("anyOf");
+  });
+
+  it("flags oneOf", () => {
+    const schema = { oneOf: [{ type: "string" }, { type: "number" }] };
+    expect(firstNonStrictReason(schema)).toBe("oneOf");
+  });
+
+  it("flags allOf", () => {
+    const schema = { allOf: [{ type: "object" }] };
+    expect(firstNonStrictReason(schema)).toBe("allOf");
+  });
+
+  it("flags missing additionalProperties:false on an object", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
+    expect(firstNonStrictReason(schema)).toBe("missing additionalProperties:false");
+  });
+
+  it("flags an unlisted required key", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      required: ["a"],
+    };
+    expect(firstNonStrictReason(schema)).toBe("unlisted required key: b");
+  });
+
+  it("recurses into a non-strict child property", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        inner: { anyOf: [{ type: "string" }] },
+      },
+      required: ["inner"],
+    };
+    expect(firstNonStrictReason(schema)).toBe("inner.anyOf");
+  });
+
+  it("recurses into a non-strict array item", () => {
+    const schema = {
+      type: "array",
+      items: { anyOf: [{ type: "string" }] },
+    };
+    expect(firstNonStrictReason(schema)).toBe("items.anyOf");
+  });
+
+  it("recurses into a tuple-shaped array items list", () => {
+    const schema = {
+      type: "array",
+      items: [{ type: "string" }, { anyOf: [{ type: "number" }] }],
+    };
+    expect(firstNonStrictReason(schema)).toBe("items[1].anyOf");
+  });
+});
+
+describe("warnPenaltyDroppedOnce dedupe", () => {
+  let warn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetOpenAIResponsesWarnings();
+    const rec = makeRecordingLogger();
+    warn = rec.warn;
+    setLogger(rec.logger);
+  });
+
+  afterEach(() => {
+    _resetOpenAIResponsesWarnings();
+  });
+
+  it("warns once for frequencyPenalty on the first call and stays silent on repeats", () => {
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("frequencyPenalty");
+    expect(warn.mock.calls[0][0]).toContain("gpt-5.5");
+  });
+
+  it("re-warns when the model changes", () => {
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    warnPenaltyDroppedOnce("gpt-5.5-mini", "frequencyPenalty");
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("frequencyPenalty and presencePenalty dedupe independently", () => {
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    warnPenaltyDroppedOnce("gpt-5.5", "presencePenalty");
+    warnPenaltyDroppedOnce("gpt-5.5", "frequencyPenalty");
+    warnPenaltyDroppedOnce("gpt-5.5", "presencePenalty");
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays silent when neither penalty is warned", () => {
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("warnStrictDowngradedOnce dedupe", () => {
+  let warn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetOpenAIResponsesWarnings();
+    const rec = makeRecordingLogger();
+    warn = rec.warn;
+    setLogger(rec.logger);
+  });
+
+  afterEach(() => {
+    _resetOpenAIResponsesWarnings();
+  });
+
+  it("warns once for a schema with anyOf and dedupes on the same model", () => {
+    const schema = { anyOf: [{ type: "string" }, { type: "number" }] };
+    const reason = firstNonStrictReason(schema)!;
+    warnStrictDowngradedOnce("gpt-5.5", reason);
+    warnStrictDowngradedOnce("gpt-5.5", reason);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("anyOf");
+  });
+
+  it("warns once for an object missing additionalProperties:false", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
+    const reason = firstNonStrictReason(schema)!;
+    expect(reason).toBe("missing additionalProperties:false");
+    warnStrictDowngradedOnce("gpt-5.5", reason);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("missing additionalProperties:false");
+  });
+
+  it("does not warn when the schema is strict-compatible (caller-side gate)", () => {
+    // The run-fn only calls the helper when isStrictCompatibleSchema is false,
+    // so a strict-compatible schema results in zero warn calls.
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: { a: { type: "string" } },
+      required: ["a"],
+    };
+    if (!isStrictCompatibleSchema(schema)) {
+      warnStrictDowngradedOnce("gpt-5.5", firstNonStrictReason(schema) ?? "");
+    }
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("re-warns when the model changes", () => {
+    warnStrictDowngradedOnce("gpt-5.5", "anyOf");
+    warnStrictDowngradedOnce("gpt-5.5-mini", "anyOf");
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Chat.ts
@@ -67,6 +67,7 @@ async function generateTurn(
 
   // Session cache: prefix-rewind growing with the conversation.
   const modelPath = model.provider_config.model_path;
+  const cacheKey = getPipelineCacheKey(model);
   let session = sessionId ? getHftSession(sessionId) : undefined;
   let past_key_values: any = undefined;
 
@@ -137,6 +138,7 @@ async function generateTurn(
         baseEntries,
         baseSeqLength: outputCache.get_seq_length ? outputCache.get_seq_length() : 0,
         modelPath,
+        cacheKey,
       };
       setHftSession(sessionId, newSession);
     }

--- a/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_Pipeline.ts
@@ -316,6 +316,15 @@ export async function withHftPipelineInUse<T>(cacheKey: string, fn: () => Promis
 
 interface HftSessionBase {
   readonly modelPath: string;
+  /**
+   * The pipeline cache key ({@link getPipelineCacheKey}) whose ONNX session
+   * backs this KV-cache snapshot. When that pipeline is evicted the cached
+   * tensors here are freed underneath us; the session must be swept in the
+   * same step. Distinct dtype/device variants of the same `model_path`
+   * (`q4:webgpu` vs `fp32:wasm`) produce different cache keys, so sweeping
+   * by cache key never touches a live sibling variant's sessions.
+   */
+  readonly cacheKey: string;
 }
 
 export interface HftPrefixRewindSession extends HftSessionBase {
@@ -377,6 +386,27 @@ export function disposeHftSessionsForModel(modelPath: string): void {
   }
 }
 
+/**
+ * Sweep every session whose {@link HftSessionBase.cacheKey} matches
+ * `cacheKey`, disposing resources and deleting the entry. Called from
+ * {@link removeCachedPipeline} after the pipeline's ONNX session has been
+ * disposed: the session's cached `baseEntries`/`cache` are tensors backed
+ * by that ONNX session, so leaving them in `hftSessions` would let a later
+ * `generateTurn` rebuild a `DynamicCache` from freed GPU buffers (WebGPU
+ * UAF) or a corrupted WASM heap.
+ *
+ * Per-cacheKey (not per-modelPath) so a distinct dtype/device variant of
+ * the same model that is still cached and in-use is not affected.
+ */
+export function disposeHftSessionsForCacheKey(cacheKey: string): void {
+  for (const [id, state] of hftSessions) {
+    if (state.cacheKey === cacheKey) {
+      disposeSessionResources(state);
+      hftSessions.delete(id);
+    }
+  }
+}
+
 /** In-flight pipeline loads by cache key. Ensures only one load per model at a time to avoid corrupt ONNX files (Protobuf parsing failed). */
 const pipelineLoadPromises = new Map<string, Promise<any>>();
 
@@ -415,6 +445,12 @@ export const HFT_NULL_PROCESSOR_PREFIX = "HFT_NULL_PROCESSOR:";
 export async function clearPipelineCache(): Promise<void> {
   const snapshot = Array.from(pipelines.values());
   pipelines.clear();
+  // Sessions cache tensors backed by these ONNX sessions; leaving them behind
+  // would surface stale entries whose underlying buffers are freed.
+  for (const session of hftSessions.values()) {
+    disposeSessionResources(session);
+  }
+  hftSessions.clear();
   await Promise.allSettled(
     snapshot.map(async (pipeline) => {
       try {
@@ -461,6 +497,12 @@ export async function removeCachedPipeline(cacheKey: string): Promise<boolean> {
     } catch {
       // Best-effort: dispose failure must not propagate.
     }
+  }
+  if (deleted) {
+    // Any KV-cache session stamped with this cacheKey now points at freed
+    // ONNX-session tensors; sweep it before a later turn tries to rebuild
+    // a DynamicCache from those tensors.
+    disposeHftSessionsForCacheKey(cacheKey);
   }
   return deleted;
 }

--- a/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_TextGeneration.ts
@@ -42,6 +42,7 @@ export const HFT_TextGeneration: AiProviderRunFn<
 
     // Session cache: progressive caching for text generation (streaming)
     const modelPath = model!.provider_config.model_path;
+    const cacheKey = getPipelineCacheKey(model!);
     let session = sessionId ? getHftSession(sessionId) : undefined;
     let past_key_values: any = undefined;
 
@@ -52,6 +53,7 @@ export const HFT_TextGeneration: AiProviderRunFn<
         mode: "progressive",
         cache,
         modelPath,
+        cacheKey,
       };
       setHftSession(sessionId, newSession);
       session = newSession;

--- a/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
+++ b/providers/huggingface-transformers/src/ai/common/HFT_ToolCalling.ts
@@ -337,6 +337,7 @@ export const HFT_ToolCalling: AiProviderRunFn<
 
     // Session cache: prefix-rewind for tool calling (streaming)
     const modelPath = model!.provider_config.model_path;
+    const cacheKey = getPipelineCacheKey(model!);
     let session = sessionId ? getHftSession(sessionId) : undefined;
     let past_key_values: any = undefined;
 
@@ -361,6 +362,7 @@ export const HFT_ToolCalling: AiProviderRunFn<
         baseEntries,
         baseSeqLength: cache.get_seq_length(),
         modelPath,
+        cacheKey,
       };
       setHftSession(sessionId, newSession);
       session = newSession;

--- a/providers/openai/CHANGELOG.md
+++ b/providers/openai/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.3.27
+
+### Bug Fixes
+
+Surface two silent Responses-API regressions from 0.3.26:
+
+- `frequencyPenalty` and `presencePenalty` are dropped: the OpenAI Responses
+  API does not accept them. `OpenAI_TextGeneration_Stream` now emits a
+  `warn`-level log once per `(model, param)` per process when either is set.
+- Structured generation `strict:true` downshifts to
+  `isStrictCompatibleSchema(schema)`. Schemas that used to error out on the
+  strict incompatibilities the Responses API rejects (`anyOf`, `$ref`, missing
+  `additionalProperties:false`, unlisted required keys, etc.) now silently
+  return non-conforming JSON — the `StructuredGenerationTask` consumer
+  re-validates and may retry, but the provider-side strict guarantee is off.
+  `OpenAI_StructuredGeneration_Stream` now emits a `warn`-level log once per
+  model per process when the downshift fires, with the first non-strict reason.
+
+Behavior is unchanged; only visibility. Callers that need the pre-0.3.26
+behavior should pin `@workglow/openai@0.3.25` or route to a non-OpenAI
+provider.
+
 ## 0.3.26
 
 ### Bug Fixes

--- a/providers/openai/src/ai/common/OpenAI_ResponsesWarnings.ts
+++ b/providers/openai/src/ai/common/OpenAI_ResponsesWarnings.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util/worker";
+
+/**
+ * Per-(model, param) dedupe key set for penalty-drop warnings. The Responses
+ * API silently ignores `frequency_penalty` / `presence_penalty`; a caller who
+ * used them pre-0.3.26 needs to see it once per model per process, not on
+ * every request.
+ */
+const warnedPenaltyDrops = new Set<string>();
+
+export function warnPenaltyDroppedOnce(
+  model: string,
+  param: "frequencyPenalty" | "presencePenalty"
+): void {
+  const key = `${model}::${param}`;
+  if (warnedPenaltyDrops.has(key)) return;
+  warnedPenaltyDrops.add(key);
+  getLogger().warn(
+    `OpenAI Responses API does not accept ${param}; the value has been dropped ` +
+      `for model "${model}". To use ${param}, pin @workglow/openai@0.3.25 or ` +
+      `route the request to a non-OpenAI provider.`
+  );
+}
+
+/**
+ * Per-model dedupe key set for strict-downshift warnings. Structured generation
+ * requests fall back from `strict: true` to `isStrictCompatibleSchema(schema)`
+ * when the schema uses shapes strict rejects (anyOf, $ref, missing
+ * additionalProperties:false, etc.); callers who relied on strict need to see
+ * the downshift once per model per process.
+ */
+const warnedStrictDownshifts = new Set<string>();
+
+export function warnStrictDowngradedOnce(model: string, reason: string): void {
+  if (warnedStrictDownshifts.has(model)) return;
+  warnedStrictDownshifts.add(model);
+  getLogger().warn(
+    `OpenAI structured generation for model "${model}" downshifted from ` +
+      `strict:true to strict:false because the schema is not strict-compatible ` +
+      `(${reason}). The response is validated by the consumer, but the ` +
+      `provider-side strict guarantee is not applied. To keep strict, ` +
+      `restructure the schema; to pin the previous behavior, use ` +
+      `@workglow/openai@0.3.25.`
+  );
+}
+
+/** @internal test helper — clear both dedupe sets. */
+export function _resetOpenAIResponsesWarnings(): void {
+  warnedPenaltyDrops.clear();
+  warnedStrictDownshifts.clear();
+}

--- a/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_StructuredGeneration.ts
@@ -9,10 +9,11 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import { firstNonStrictReason, isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { finalizeResponsesRequest, getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
+import { warnStrictDowngradedOnce } from "./OpenAI_ResponsesWarnings";
 
 export { isStrictCompatibleSchema };
 
@@ -32,6 +33,14 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
 
   const schema = input.outputSchema ?? outputSchema;
 
+  const strict = isStrictCompatibleSchema(schema);
+  if (!strict) {
+    // Downshifted to strict:false; the request still succeeds but the
+    // provider-side strict guarantee is off. Consumer re-validates.
+    const reason = firstNonStrictReason(schema) ?? "unknown reason";
+    warnStrictDowngradedOnce(modelName, reason);
+  }
+
   const params: Record<string, unknown> = {
     model: modelName,
     input: input.prompt,
@@ -40,7 +49,7 @@ export const OpenAI_StructuredGeneration_Stream: AiProviderRunFn<
         type: "json_schema",
         name: "structured_output",
         schema: schema,
-        strict: isStrictCompatibleSchema(schema),
+        strict,
       },
     },
   };

--- a/providers/openai/src/ai/common/OpenAI_TextGeneration.ts
+++ b/providers/openai/src/ai/common/OpenAI_TextGeneration.ts
@@ -14,6 +14,7 @@ import { toOpenAIMessages } from "@workglow/ai/worker";
 import { getLogger } from "@workglow/util/worker";
 import { finalizeResponsesRequest, getClient, getModelName } from "./OpenAI_Client";
 import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
+import { warnPenaltyDroppedOnce } from "./OpenAI_ResponsesWarnings";
 
 /**
  * Inputs that the unified `["text.generation"]` runFn handles. Both
@@ -25,6 +26,8 @@ import type { OpenAiModelConfig } from "./OpenAI_ModelSchema";
 interface UnifiedTextGenerationInput extends TextGenerationTaskInput {
   readonly messages?: readonly unknown[];
   readonly systemPrompt?: string;
+  readonly frequencyPenalty?: number;
+  readonly presencePenalty?: number;
 }
 
 /**
@@ -62,6 +65,18 @@ function buildResponsesParams(
   if (input.temperature !== undefined) params.temperature = input.temperature;
   if ((input as { topP?: number }).topP !== undefined)
     params.top_p = (input as { topP?: number }).topP;
+
+  // frequency_penalty / presence_penalty are silently dropped by the Responses
+  // API. Warn once per (model, param) so callers who set them notice the
+  // regression from the pre-Responses pipeline (which passed them through).
+  const modelName = getModelName(model);
+  if (input.frequencyPenalty !== undefined) {
+    warnPenaltyDroppedOnce(modelName, "frequencyPenalty");
+  }
+  if (input.presencePenalty !== undefined) {
+    warnPenaltyDroppedOnce(modelName, "presencePenalty");
+  }
+
   return params;
 }
 

--- a/providers/openai/src/ai/index.ts
+++ b/providers/openai/src/ai/index.ts
@@ -16,6 +16,11 @@ export * from "./registerOpenAi";
 import { OPENAI_RUN_FN_SPECS } from "./common/OpenAI_Capabilities";
 import { getReasoningConfig, resolvePromptCacheKey } from "./common/OpenAI_Client";
 import { OPENAI_RUN_FNS } from "./common/OpenAI_JobRunFns";
+import {
+  _resetOpenAIResponsesWarnings,
+  warnPenaltyDroppedOnce,
+  warnStrictDowngradedOnce,
+} from "./common/OpenAI_ResponsesWarnings";
 import { isStrictCompatibleSchema } from "./common/OpenAI_StructuredGeneration";
 import { OpenAiQueuedProvider } from "./OpenAiQueuedProvider";
 
@@ -29,4 +34,7 @@ export const _testOnly = {
   getReasoningConfig,
   resolvePromptCacheKey,
   isStrictCompatibleSchema,
+  warnPenaltyDroppedOnce,
+  warnStrictDowngradedOnce,
+  _resetOpenAIResponsesWarnings,
 } as const;

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -14,7 +14,7 @@
     "packages/tasks": 207022,
     "packages/test": 1077658,
     "packages/util": 27100,
-    "packages/workglow": 157,
+    "packages/workglow": 242,
     "providers/anthropic": 12793,
     "providers/aws": 2510,
     "providers/bun-webview": 225,


### PR DESCRIPTION
## Summary

Two HIGH-severity findings from a scheduled security/DX/correctness review of `main`. Each fix is a self-contained commit.

### H1 — HFT stale-session UAF after LRU pipeline eviction

`removeCachedPipeline` and `clearPipelineCache` disposed the ONNX session via `pipeline.model.dispose()` but did not touch `hftSessions`. `HftPrefixRewindSession` caches `baseEntries: Tensor[]` backed by the disposed session; a second generation turn on the same model rebuilt `DynamicCache` from tensors whose underlying session was freed — use-after-free of GPU buffers on WebGPU, silently corrupted KV state on WASM. Each session is now tagged with its `cacheKey` at creation and swept per-cacheKey inside `removeCachedPipeline`; `clearPipelineCache` sweeps every session. Sibling dtype/device variants that share a `model_path` (e.g. `q4:webgpu` vs `fp32:wasm`) are untouched because the sweep is per cacheKey, not per model.

### H2 — OpenAI Responses-API silent regressions from 0.3.26

The 0.3.25→0.3.26 patch bump migrated the OpenAI text run-fns to the Responses API. Two behaviours silently disappeared with no CHANGELOG entry: `frequencyPenalty`/`presencePenalty` are dropped (Responses does not accept them) and structured-generation `strict:true` downshifts to `isStrictCompatibleSchema(schema)` — schemas that used to error on strict incompatibilities now silently return non-conforming JSON. Behaviour is unchanged; this PR only makes both visible via warn-once (per model per process) log lines and a `CHANGELOG` 0.3.27 entry that documents the drop/downshift and the workaround (pin `@workglow/openai@0.3.25` or route to a non-OpenAI model).

## Test plan

- [x] `bun scripts/test.ts provider-hft vitest` — 61 passing (5 skipped integration) including new race/eviction cases for the cacheKey sweep and `clearPipelineCache` session disposal
- [x] `bunx vitest run packages/test/src/test/ai-provider/` — 209 passing including 18 new tests covering `firstNonStrictReason` branches, penalty-drop warn-once dedupe (same model dedupes; different model re-warns; freq/presence dedupe independently), and strict-downshift warn-once dedupe
- [x] `bun run build:types --force` — 40/40 packages clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015He9Aox6jTwMgzWfzZH5QE

---
_Generated by [Claude Code](https://claude.ai/code/session_015He9Aox6jTwMgzWfzZH5QE)_