### PR TITLE
fix(ai,node-llama-cpp,google-gemini): five HIGH-severity cache-checkpoint correctness fixes (follow-up to #641)

### DIFF
--- a/packages/ai/src/provider/CheckpointRegistry.ts
+++ b/packages/ai/src/provider/CheckpointRegistry.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TaskConfigurationError } from "@workglow/task-graph";
 import type { ModelConfig } from "../model/ModelSchema";
 import type { ChatMessage } from "../task/ChatMessage";
 import type { ToolDefinition } from "../task/ToolCallingUtils";
@@ -50,4 +51,22 @@ export function clearCheckpointsForTesting(): void {
 /** Model identity string used for checkpoint/model mismatch checks. */
 export function checkpointModelKey(model: ModelConfig): string {
   return typeof model.model_id === "string" ? model.model_id : "";
+}
+
+/**
+ * Strict sibling of {@link checkpointModelKey} — throws when the model has no
+ * usable identity string. Empty model keys used to silently pass through the
+ * short-circuited mismatch check, letting two keyless models on the same
+ * provider share a fungible checkpoint slot (cross-model contamination).
+ * Every mint / validate site must route through this helper.
+ */
+export function requireCheckpointModelKey(model: ModelConfig, taskType: string): string {
+  const key = checkpointModelKey(model);
+  if (!key) {
+    throw new TaskConfigurationError(
+      `${taskType}: model has no model_id — a cache checkpoint requires a stable ` +
+        `model identity to guard against cross-model contamination.`
+    );
+  }
+  return key;
 }

--- a/packages/ai/src/task/CacheCheckpointTask.ts
+++ b/packages/ai/src/task/CacheCheckpointTask.ts
@@ -13,9 +13,9 @@ import type { ModelConfig } from "../model/ModelSchema";
 import { getAiProviderRegistry } from "../provider/AiProviderRegistry";
 import type { CheckpointEntry, CheckpointPrefix } from "../provider/CheckpointRegistry";
 import {
-  checkpointModelKey,
   deleteCheckpoint,
   registerCheckpoint,
+  requireCheckpointModelKey,
 } from "../provider/CheckpointRegistry";
 import { AiTask } from "./base/AiTask";
 import { TypeModel } from "./base/AiTaskSchemas";
@@ -138,6 +138,12 @@ export class CacheCheckpointTask extends AiTask<
       );
     }
 
+    // Fail loudly if the model has no stable identity — a keyless mint is what
+    // let cross-model contamination slip through the mismatch guard before.
+    // Runs before validateParentCheckpoint / createSession so no session slot
+    // gets minted when we would only reject on the way out.
+    const modelKey = requireCheckpointModelKey(model, "CacheCheckpointTask");
+
     const parent: CheckpointEntry | undefined = input.checkpoint
       ? validateParentCheckpoint(input.checkpoint, model, "CacheCheckpointTask")
       : undefined;
@@ -153,7 +159,7 @@ export class CacheCheckpointTask extends AiTask<
     const id = registry.createSession(providerName, model);
     registerCheckpoint(id, {
       provider: providerName,
-      modelKey: checkpointModelKey(model),
+      modelKey,
       prefix,
       ...(input.checkpoint ? { parentId: input.checkpoint } : {}),
     });

--- a/packages/ai/src/task/base/CheckpointPorts.ts
+++ b/packages/ai/src/task/base/CheckpointPorts.ts
@@ -14,6 +14,7 @@ import {
   deleteCheckpoint,
   getCheckpoint,
   registerCheckpoint,
+  requireCheckpointModelKey,
 } from "../../provider/CheckpointRegistry";
 import type { ChatMessage, ContentBlock } from "../ChatMessage";
 import type { ToolDefinition } from "../ToolCallingUtils";
@@ -84,8 +85,10 @@ export function validateParentCheckpoint(
         `"${parentEntry.provider}" but the model uses "${model.provider}".`
     );
   }
-  const key = checkpointModelKey(model);
-  if (parentEntry.modelKey && key && parentEntry.modelKey !== key) {
+  // Route the current model's key through the strict helper so an unnameable
+  // model fails loudly instead of silently sharing a fungible checkpoint slot.
+  const key = requireCheckpointModelKey(model, taskType);
+  if (parentEntry.modelKey !== key) {
     throw new TaskConfigurationError(
       `${taskType}: checkpoint "${checkpointId}" was created for model ` +
         `"${parentEntry.modelKey}" but the task model is "${key}".`
@@ -136,6 +139,11 @@ export function resolveCheckpointSession(
         `(no run function serving ["cache.checkpoint"]).`
     );
   }
+
+  // A keyless model can never be safely tied to a checkpoint id — validate the
+  // current model up-front so an emit path (which never runs validateParent)
+  // also fails before createSession mints a slot that would later collide.
+  requireCheckpointModelKey(model, taskType);
 
   const parentEntry: CheckpointEntry | undefined = input.checkpoint
     ? validateParentCheckpoint(input.checkpoint, model, taskType)

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_CheckpointPrefixRender.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_CheckpointPrefixRender.test.ts
@@ -79,11 +79,13 @@ describe("renderLlamaCppPrefixChatHistory", () => {
             {
               type: "tool_result",
               tool_use_id: "call_b",
+              is_error: false,
               content: [{ type: "text", text: "second-result" }],
             },
             {
               type: "tool_result",
               tool_use_id: "call_a",
+              is_error: false,
               content: [{ type: "text", text: "first-result" }],
             },
           ],
@@ -121,7 +123,7 @@ describe("renderLlamaCppPrefixFunctions", () => {
   });
 
   it("renders each tool as a ChatModelFunction with description and params", () => {
-    const prefix: CheckpointPrefix = {
+    const prefix = {
       tools: [
         {
           name: "lookup",
@@ -132,12 +134,13 @@ describe("renderLlamaCppPrefixFunctions", () => {
             required: ["q"],
           },
         },
-        {
-          name: "noop",
-          description: "",
-        },
+        // Empty description + missing inputSchema — buildChatModelFunctions
+        // omits both from the emitted ChatModelFunction. The cast bypasses the
+        // ToolDefinition type's required-inputSchema field to exercise the
+        // defensive falsy check in the renderer.
+        { name: "noop", description: "" } as unknown as never,
       ],
-    };
+    } as unknown as CheckpointPrefix;
     expect(renderLlamaCppPrefixFunctions(prefix)).toEqual({
       lookup: {
         description: "Look up a query",

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_CheckpointPrefixRender.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_CheckpointPrefixRender.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CheckpointPrefix } from "@workglow/ai";
+import {
+  renderLlamaCppPrefixChatHistory,
+  renderLlamaCppPrefixFunctions,
+} from "@workglow/node-llama-cpp/ai-runtime";
+import { describe, expect, it } from "vitest";
+
+describe("renderLlamaCppPrefixChatHistory", () => {
+  it("renders a system-only prefix as a single system item (no synthetic user turn)", () => {
+    const prefix: CheckpointPrefix = { systemPrompt: "You are helpful." };
+    expect(renderLlamaCppPrefixChatHistory(prefix)).toEqual([
+      { type: "system", text: "You are helpful." },
+    ]);
+  });
+
+  it("returns [] when the prefix carries no system prompt and no messages", () => {
+    expect(renderLlamaCppPrefixChatHistory({})).toEqual([]);
+  });
+
+  it("renders a tools-only prefix as [] (tools go through the functions option)", () => {
+    const prefix: CheckpointPrefix = {
+      tools: [{ name: "lookup", description: "Look up a query", inputSchema: { type: "object" } }],
+    };
+    expect(renderLlamaCppPrefixChatHistory(prefix)).toEqual([]);
+  });
+
+  it("preserves assistant text + tool_use blocks as a `functionCall` inside a model turn", () => {
+    const prefix: CheckpointPrefix = {
+      systemPrompt: "Use the lookup tool.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "What's the weather?" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check." },
+            { type: "tool_use", id: "call_1", name: "lookup", input: { query: "weather" } },
+          ],
+        },
+      ],
+    };
+    expect(renderLlamaCppPrefixChatHistory(prefix)).toEqual([
+      { type: "system", text: "Use the lookup tool." },
+      { type: "user", text: "What's the weather?" },
+      {
+        type: "model",
+        response: [
+          "Let me check.",
+          {
+            type: "functionCall",
+            name: "lookup",
+            description: undefined,
+            params: { query: "weather" },
+            result: undefined,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("matches tool_result blocks onto the preceding assistant's functionCall by id", () => {
+    const prefix: CheckpointPrefix = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call_a", name: "lookup", input: { q: "1" } },
+            { type: "tool_use", id: "call_b", name: "lookup", input: { q: "2" } },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_b",
+              content: [{ type: "text", text: "second-result" }],
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "call_a",
+              content: [{ type: "text", text: "first-result" }],
+            },
+          ],
+        },
+      ],
+    };
+    expect(renderLlamaCppPrefixChatHistory(prefix)).toEqual([
+      {
+        type: "model",
+        response: [
+          {
+            type: "functionCall",
+            name: "lookup",
+            description: undefined,
+            params: { q: "1" },
+            result: "first-result",
+          },
+          {
+            type: "functionCall",
+            name: "lookup",
+            description: undefined,
+            params: { q: "2" },
+            result: "second-result",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("renderLlamaCppPrefixFunctions", () => {
+  it("returns undefined when the prefix has no tools", () => {
+    expect(renderLlamaCppPrefixFunctions({})).toBeUndefined();
+    expect(renderLlamaCppPrefixFunctions({ tools: [] })).toBeUndefined();
+  });
+
+  it("renders each tool as a ChatModelFunction with description and params", () => {
+    const prefix: CheckpointPrefix = {
+      tools: [
+        {
+          name: "lookup",
+          description: "Look up a query",
+          inputSchema: {
+            type: "object",
+            properties: { q: { type: "string" } },
+            required: ["q"],
+          },
+        },
+        {
+          name: "noop",
+          description: "",
+        },
+      ],
+    };
+    expect(renderLlamaCppPrefixFunctions(prefix)).toEqual({
+      lookup: {
+        description: "Look up a query",
+        params: {
+          type: "object",
+          properties: { q: { type: "string" } },
+          required: ["q"],
+        },
+      },
+      // Missing description / inputSchema are simply omitted.
+      noop: {},
+    });
+  });
+});

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -8,6 +8,7 @@ import {
   acquireContextSequence,
   acquireModelInUse,
   disposeLlamaCppSessionsForModel,
+  getLlamaCppSession,
   getOrCreateEmbeddingContext,
   isVramError,
   llamaCppEmbeddingContexts,
@@ -18,6 +19,7 @@ import {
   releaseModelInUse,
   resolvedPaths,
   setLlamaCppSession,
+  stealLlamaCppSession,
   withSequence,
   withVramEviction,
 } from "@workglow/node-llama-cpp/ai-runtime";
@@ -409,5 +411,49 @@ describe("getOrCreateEmbeddingContext under VRAM pressure", () => {
     expect(llamaCppModels.has("/tmp/lru.gguf")).toBe(false);
     expect(llamaCppTextContexts.has("/tmp/lru.gguf")).toBe(false);
     expect(llamaCppEmbeddingContexts.get("/tmp/target.gguf")).toBe(stubEmbeddingContext);
+  });
+});
+
+describe("stealLlamaCppSession", () => {
+  afterEach(() => {
+    llamaCppSessions.clear();
+  });
+
+  it("atomically returns and removes the state for a known session id", () => {
+    const state = {
+      mode: "prefix-rewind" as const,
+      sequence: { id: "seq-A" } as unknown,
+      session: { id: "session-A" } as unknown,
+      modelKey: "modelA",
+    };
+    setLlamaCppSession("ckpt-A", state);
+    // Sanity: present before the steal.
+    expect(getLlamaCppSession("ckpt-A")).toBe(state);
+
+    const stolen = stealLlamaCppSession("ckpt-A");
+
+    // Exactly one caller receives the state.
+    expect(stolen).toBe(state);
+    // Post-steal the entry is gone — the loser of a concurrent steal
+    // observes `undefined` and re-encodes via the missing-state fallback.
+    expect(getLlamaCppSession("ckpt-A")).toBeUndefined();
+    expect(llamaCppSessions.has("ckpt-A")).toBe(false);
+    // A second steal of the same id must not re-return the stale state.
+    expect(stealLlamaCppSession("ckpt-A")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown session id without mutating the map", () => {
+    const other = {
+      mode: "progressive" as const,
+      sequence: { id: "seq-B" } as unknown,
+      session: { id: "session-B" } as unknown,
+      modelKey: "modelB",
+    };
+    setLlamaCppSession("ckpt-B", other);
+
+    expect(stealLlamaCppSession("nonexistent")).toBeUndefined();
+    // Other entries are untouched.
+    expect(getLlamaCppSession("ckpt-B")).toBe(other);
+    expect(llamaCppSessions.size).toBe(1);
   });
 });

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_TextGenerationCheckpoint.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_TextGenerationCheckpoint.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  AiSessionContext,
+  CheckpointPrefix,
+  TextGenerationTaskInput,
+} from "@workglow/ai";
+import {
+  accumulatingEmit,
+  AiProviderRegistry,
+  getAiProviderRegistry,
+  setAiProviderRegistry,
+} from "@workglow/ai";
+import type { LlamaCppModelRecord } from "@workglow/node-llama-cpp/ai";
+import { LOCAL_LLAMACPP } from "@workglow/node-llama-cpp/ai";
+import {
+  deleteLlamaCppSession,
+  llamaCppSessions,
+  llamaCppTextContexts,
+  registerLlamaCppInline,
+  releaseLlamaCppTransientSessions,
+} from "@workglow/node-llama-cpp/ai-runtime";
+import type { TaskOutput } from "@workglow/task-graph";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TextGeneration mirror of `LlamaCpp_ToolCallingCheckpoint.test.ts` — proves
+ * the same checkpoint fallback + steal-serialization semantics hold on the
+ * text-generation code path (the plan's L3 test-coverage gap).
+ */
+const sdkState = {
+  sessionSequences: [] as unknown[],
+  sessionDisposeCount: 0,
+  preloadPrompts: [] as string[],
+  sessionHistories: [] as any[][],
+  promptCalls: [] as { readonly prompt: string; readonly sequence: unknown }[],
+};
+
+vi.mock("node-llama-cpp", () => ({
+  LlamaChatSession: class {
+    readonly sequence: unknown;
+    private history: any[];
+    private disposed = false;
+
+    constructor(options: { readonly contextSequence: unknown; readonly systemPrompt?: string }) {
+      this.sequence = options.contextSequence;
+      sdkState.sessionSequences.push(this.sequence);
+      this.history =
+        options.systemPrompt === undefined ? [] : [{ type: "system", text: options.systemPrompt }];
+    }
+
+    async preloadPrompt(prompt: string): Promise<void> {
+      sdkState.preloadPrompts.push(prompt);
+    }
+
+    getChatHistory(): any[] {
+      return structuredClone(this.history);
+    }
+
+    setChatHistory(history: any[]): void {
+      this.history = structuredClone(history);
+      sdkState.sessionHistories.push(structuredClone(history));
+    }
+
+    async prompt(
+      prompt: string,
+      options: {
+        readonly onTextChunk: (chunk: string) => void;
+        readonly signal: AbortSignal;
+      }
+    ): Promise<string> {
+      sdkState.promptCalls.push({ prompt, sequence: this.sequence });
+      if (options.signal.aborted) return Promise.reject(options.signal.reason);
+      options.onTextChunk("out");
+      return "out";
+    }
+
+    async dispose(): Promise<void> {
+      if (this.disposed) return;
+      this.disposed = true;
+      sdkState.sessionDisposeCount += 1;
+    }
+  },
+}));
+
+const model: LlamaCppModelRecord = {
+  model_id: "llamacpp:test-textgen-checkpoint",
+  title: "Test textgen checkpoint model",
+  description: "Provider-level checkpoint lifecycle fixture",
+  capabilities: ["text.generation", "cache.checkpoint"],
+  provider: LOCAL_LLAMACPP,
+  provider_config: {
+    model_path: "/tmp/test-textgen-checkpoint.gguf",
+  },
+  metadata: {},
+};
+
+const prefix: CheckpointPrefix = {
+  systemPrompt: "You are helpful.",
+  messages: [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Remember this checkpoint prefix." }],
+    },
+  ],
+};
+
+function getRunFn(capabilities: readonly string[]): AiProviderRunFn {
+  const runFn = getAiProviderRegistry().getRunFnFor(
+    LOCAL_LLAMACPP,
+    capabilities as Parameters<ReturnType<typeof getAiProviderRegistry>["getRunFnFor"]>[1]
+  );
+  expect(runFn).toBeDefined();
+  return runFn!;
+}
+
+async function run(
+  runFn: AiProviderRunFn,
+  input: Record<string, unknown>,
+  sessionContext: AiSessionContext | undefined
+): Promise<void> {
+  const { emit } = accumulatingEmit<TaskOutput>();
+  await runFn(input, model, new AbortController().signal, emit, undefined, sessionContext);
+}
+
+async function warmCheckpoint(checkpointId: string): Promise<void> {
+  await run(getRunFn(["cache.checkpoint"]), {}, { sessionId: checkpointId, prefix });
+}
+
+async function generate(
+  prompt: string,
+  sessionContext: AiSessionContext | undefined
+): Promise<void> {
+  const input: TextGenerationTaskInput = { model, prompt, maxTokens: 8 } as never;
+  await run(
+    getRunFn(["text.generation"]),
+    input as unknown as Record<string, unknown>,
+    sessionContext
+  );
+}
+
+describe("LlamaCpp text-generation checkpoint lifecycle", () => {
+  const sequences: Array<{ readonly id: number; readonly dispose: ReturnType<typeof vi.fn> }> = [];
+
+  beforeEach(async () => {
+    setAiProviderRegistry(new AiProviderRegistry());
+    await registerLlamaCppInline({ queue: { autoCreate: false } });
+    sdkState.sessionSequences.length = 0;
+    sdkState.sessionDisposeCount = 0;
+    sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
+    sdkState.promptCalls.length = 0;
+    sequences.length = 0;
+    llamaCppSessions.clear();
+    llamaCppTextContexts.clear();
+    llamaCppTextContexts.set(model.provider_config.model_path, {
+      get sequencesLeft() {
+        return 4;
+      },
+      getSequence() {
+        const sequence = { id: sequences.length, dispose: vi.fn(async () => {}) };
+        sequences.push(sequence);
+        return sequence;
+      },
+    } as never);
+  });
+
+  afterEach(async () => {
+    await releaseLlamaCppTransientSessions();
+    llamaCppTextContexts.clear();
+  });
+
+  it("consumes a warmed checkpoint session and retains it under the emitted id", async () => {
+    await warmCheckpoint("ckpt-parent");
+    const warmed = llamaCppSessions.get("ckpt-parent");
+    expect(warmed).toBeDefined();
+
+    await generate("continue the story", {
+      sessionId: "ckpt-parent",
+      emitCheckpointId: "ckpt-child",
+      prefix,
+    });
+
+    // The consumer ran on the warmed sequence (stolen atomically).
+    expect(sdkState.promptCalls.map((c) => c.sequence)).toEqual([warmed!.sequence]);
+    expect(sdkState.promptCalls[0].prompt).toBe("continue the story");
+    // The parent id is gone (superseded by the emit under a different id).
+    expect(llamaCppSessions.has("ckpt-parent")).toBe(false);
+    expect(llamaCppSessions.get("ckpt-child")?.sequence).toBe(warmed!.sequence);
+  });
+
+  it("reconstructs missing checkpoint state from the prefix", async () => {
+    await warmCheckpoint("ckpt-missing");
+    await deleteLlamaCppSession("ckpt-missing");
+    sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
+
+    await generate("continue", { sessionId: "ckpt-missing", prefix });
+
+    // Fallback preloads via the empty-string route (chat template via setChatHistory + functions).
+    expect(sdkState.preloadPrompts).toEqual([""]);
+    expect(sdkState.sessionHistories[0]).toEqual([
+      { type: "system", text: "You are helpful." },
+      { type: "user", text: "Remember this checkpoint prefix." },
+    ]);
+  });
+
+  it("serializes concurrent consumers — winner reuses the warmed sequence, loser re-encodes", async () => {
+    await warmCheckpoint("ckpt-shared");
+    const warmed = llamaCppSessions.get("ckpt-shared");
+    expect(warmed).toBeDefined();
+    sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
+
+    await Promise.all([
+      generate("Consumer A prompt.", { sessionId: "ckpt-shared", prefix }),
+      generate("Consumer B prompt.", { sessionId: "ckpt-shared", prefix }),
+    ]);
+
+    // Two distinct sequences drove the two prompts — the loser could not
+    // have shared the warmed sequence with the winner.
+    const distinct = new Set(sdkState.promptCalls.map((c) => c.sequence));
+    expect(distinct.size).toBe(2);
+    expect(sdkState.promptCalls.some((c) => c.sequence === warmed!.sequence)).toBe(true);
+    // Exactly one loser re-encoded via the fallback.
+    expect(sdkState.preloadPrompts).toEqual([""]);
+    // The checkpoint id was stolen atomically so no map entry survives.
+    expect(llamaCppSessions.has("ckpt-shared")).toBe(false);
+  });
+});

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_ToolCallingCheckpoint.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_ToolCallingCheckpoint.test.ts
@@ -282,6 +282,7 @@ describe("LlamaCpp tool-calling checkpoint lifecycle", () => {
     await warmCheckpoint("checkpoint-missing");
     await deleteLlamaCppSession("checkpoint-missing");
     sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
 
     await callTool({
       sessionId: "checkpoint-missing",
@@ -289,8 +290,15 @@ describe("LlamaCpp tool-calling checkpoint lifecycle", () => {
       prefix,
     });
 
-    expect(sdkState.preloadPrompts).toEqual([
-      "Available tools:\n- lookup: Look up a query\n\nuser: Remember this checkpoint prefix.",
+    // Fallback preloads an EMPTY prompt after setChatHistory + functions —
+    // the raw "role: text" text renderer was removed by the checkpoint-prefix
+    // fix so tool_use / tool_result blocks survive re-encoding.
+    expect(sdkState.preloadPrompts).toEqual([""]);
+    // The fallback's setChatHistory carries the prefix rendered through the
+    // pure chat-history helper (no trailing empty-user placeholder).
+    expect(sdkState.sessionHistories[0]).toEqual([
+      { type: "system", text: "Use the lookup tool." },
+      { type: "user", text: "Remember this checkpoint prefix." },
     ]);
     expect(sdkState.generatedHistories).toEqual([
       [
@@ -306,6 +314,75 @@ describe("LlamaCpp tool-calling checkpoint lifecycle", () => {
     ]);
     expect(llamaCppSessions.has("checkpoint-missing")).toBe(false);
     expect(llamaCppSessions.get("checkpoint-rebuilt")?.sequence).toBe(sdkState.chatSequences[0]);
+  });
+
+  it("preserves prior tool_use / tool_result blocks in the reconstructed checkpoint prefix", async () => {
+    // Emulate a checkpoint whose prefix already carries a prior tool exchange
+    // (assistant tool_use + tool result). Before the fix, the raw text
+    // renderer flattened messages to `role: text` and dropped these blocks
+    // entirely, so a fallback re-encode would silently lose the exchange.
+    const priorToolPrefix: CheckpointPrefix = {
+      systemPrompt: "You are a helpful assistant.",
+      tools: [tool],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "What's the weather?" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check." },
+            { type: "tool_use", id: "call_prior", name: "lookup", input: { query: "weather" } },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_prior",
+              content: [{ type: "text", text: "sunny" }],
+            },
+          ],
+        },
+      ],
+    };
+    await run(
+      getRunFn(["cache.checkpoint"]),
+      {},
+      {
+        sessionId: "ckpt-with-tools",
+        prefix: priorToolPrefix,
+      }
+    );
+    await deleteLlamaCppSession("ckpt-with-tools");
+    sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
+
+    await callToolWithPrompt("Any updates?", {
+      sessionId: "ckpt-with-tools",
+      prefix: priorToolPrefix,
+    });
+
+    expect(sdkState.preloadPrompts).toEqual([""]);
+    // The reconstructed fallback history must include the prior tool_use as a
+    // `functionCall` inside the model turn, with the tool's result merged in.
+    const fallbackHistory = sdkState.sessionHistories[0];
+    expect(fallbackHistory).toEqual([
+      { type: "system", text: "You are a helpful assistant." },
+      { type: "user", text: "What's the weather?" },
+      {
+        type: "model",
+        response: [
+          "Let me check.",
+          {
+            type: "functionCall",
+            name: "lookup",
+            description: undefined,
+            params: { query: "weather" },
+            result: "sunny",
+          },
+        ],
+      },
+    ]);
   });
 
   it("retains the emitted tool turn in session history and replays it on consumption", async () => {

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_ToolCallingCheckpoint.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_ToolCallingCheckpoint.test.ts
@@ -339,6 +339,7 @@ describe("LlamaCpp tool-calling checkpoint lifecycle", () => {
             {
               type: "tool_result",
               tool_use_id: "call_prior",
+              is_error: false,
               content: [{ type: "text", text: "sunny" }],
             },
           ],
@@ -566,5 +567,80 @@ describe("LlamaCpp tool-calling checkpoint lifecycle", () => {
     expect(sdkState.sessionDisposeCount).toBe(1);
     expect(sequences[0].dispose).toHaveBeenCalledTimes(1);
     expect(llamaCppSessions.has("checkpoint-failed")).toBe(false);
+  });
+
+  it("serializes concurrent consumers of the same checkpoint — winner reuses the warmed sequence, loser re-encodes on its own", async () => {
+    await warmCheckpoint("checkpoint-shared");
+    const warmed = llamaCppSessions.get("checkpoint-shared");
+    expect(warmed).toBeDefined();
+    // Isolate the assertions below to the consumer path — the warm-up's
+    // own preload / setChatHistory would otherwise be counted twice.
+    sdkState.preloadPrompts.length = 0;
+    sdkState.sessionHistories.length = 0;
+
+    // Two concurrent consumers of the same immutable checkpoint id.
+    // Before the fix, both took the same reference to `warmed` and both
+    // called generateResponse on the shared LlamaContextSequence — a live
+    // sequence advances in place, so the second consumer's turn was
+    // corrupted. With stealLlamaCppSession, exactly one wins; the other
+    // observes `undefined` and re-encodes via the missing-state fallback.
+    const [a, b] = await Promise.all([
+      callToolWithPrompt("Consumer A prompt.", { sessionId: "checkpoint-shared", prefix }),
+      callToolWithPrompt("Consumer B prompt.", { sessionId: "checkpoint-shared", prefix }),
+    ]);
+    void a;
+    void b;
+
+    // Exactly two LlamaChat generations happened — one on the warmed
+    // sequence (winner) and one on a re-encoded sequence (loser).
+    expect(sdkState.chatSequences).toHaveLength(2);
+    expect(sdkState.chatSequences).toContain(warmed!.sequence);
+    // The loser's sequence is a fresh one, not the warmed shared one.
+    const distinctSequences = new Set(sdkState.chatSequences);
+    expect(distinctSequences.size).toBe(2);
+    // The checkpoint id was stolen atomically so no map entry survives.
+    expect(llamaCppSessions.has("checkpoint-shared")).toBe(false);
+    // Exactly one loser preloaded via the fallback (empty preload after
+    // setChatHistory + functions); the winner did not preload.
+    expect(sdkState.preloadPrompts).toEqual([""]);
+  });
+
+  it("keeps ownedSession entries when two concurrent runs race for the same id", async () => {
+    // Regression: the ownedSession path (AiChatTask's per-turn mutable
+    // session) must NOT be stolen — only immutable checkpoints. Two racing
+    // ownedSession consumers still see the same cached session.
+    const state = {
+      mode: "progressive" as const,
+      sequence: { dispose: vi.fn(async () => {}) } as unknown,
+      session: {
+        setChatHistory: () => {},
+        getChatHistory: () => [],
+        preloadPrompt: async () => {},
+        dispose: async () => {
+          sdkState.sessionDisposeCount += 1;
+        },
+      } as unknown,
+      modelKey: "test",
+    };
+    llamaCppSessions.set("owned-session", state);
+
+    // Two racers with `ownedSession: true` (a checkpoint-seeded AiChat) —
+    // both observe the same cached state, and the entry survives.
+    await Promise.all([
+      callToolWithPrompt("Owned A.", {
+        sessionId: "owned-session",
+        prefix,
+        ownedSession: true,
+      }),
+      callToolWithPrompt("Owned B.", {
+        sessionId: "owned-session",
+        prefix,
+        ownedSession: true,
+      }),
+    ]);
+
+    // The map entry is preserved for the owning caller.
+    expect(llamaCppSessions.has("owned-session")).toBe(true);
+    expect(llamaCppSessions.get("owned-session")).toBe(state);
   });
 });

--- a/packages/test/src/test/ai-provider/LocalChatCheckpointSystemPrompt.test.ts
+++ b/packages/test/src/test/ai-provider/LocalChatCheckpointSystemPrompt.test.ts
@@ -124,6 +124,8 @@ describe("checkpoint-seeded local chat system prompts", () => {
         constructorOptions(options);
       }
 
+      setChatHistory(): void {}
+
       async preloadPrompt(): Promise<void> {}
 
       prompt = prompt;

--- a/packages/test/src/test/ai-provider/OpenAIGeminiCheckpointParams.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAIGeminiCheckpointParams.test.ts
@@ -7,20 +7,39 @@
 import type {
   AiProviderRunFn,
   AiSessionContext,
+  CacheCheckpointTaskInput,
   ToolCallingTaskInput,
   ToolDefinition,
 } from "@workglow/ai";
 import { GOOGLE_GEMINI, _testOnly } from "@workglow/google-gemini/ai";
+import * as GeminiRuntime from "@workglow/google-gemini/ai-runtime";
 import {
   buildGeminiPrefixedContents,
   deleteGeminiCachedContent,
   geminiCachedToolsMatch,
-  getGeminiCachedContent,
   _testOnly as runtimeTestOnly,
-  setGeminiCachedContent,
 } from "@workglow/google-gemini/ai-runtime";
 import { mergeOpenAICheckpointPrefix } from "@workglow/openai/ai-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/**
+ * The ai-runtime bundle carries its own copy of the cache-store map,
+ * independent of the ai bundle's. The pre-existing store-lifecycle test uses
+ * the ai-runtime copy because `deleteGeminiCachedContent` is imported off
+ * ai-runtime and clears its own map.
+ */
+const runtimeTestOnlyStore = {
+  setGeminiCachedContent: GeminiRuntime.setGeminiCachedContent,
+  getGeminiCachedContent: GeminiRuntime.getGeminiCachedContent,
+};
+
+// The ai bundle carries its own copy of the cache-store map (independent of
+// ai-runtime's). Route reads and writes through the ai bundle's `_testOnly`
+// helpers so the state the run-fns (also imported off the ai bundle) look at
+// is exactly what the test seeds and inspects.
+const setGeminiCachedContent = _testOnly.setGeminiCachedContent;
+const getGeminiCachedContent = _testOnly.getGeminiCachedContent;
+const _cacheStoreTestOnly = _testOnly.cacheStoreTestOnly;
 
 const geminiRequests: Array<Record<string, unknown>> = [];
 
@@ -50,11 +69,13 @@ beforeEach(() => {
   geminiRequests.length = 0;
   _testOnly.setGeminiClientForTests(fakeGeminiClient);
   runtimeTestOnly.setGeminiClientForTests(fakeGeminiClient);
+  _cacheStoreTestOnly.clearForTests();
 });
 
 afterEach(() => {
   _testOnly.setGeminiClientForTests(undefined);
   runtimeTestOnly.setGeminiClientForTests(undefined);
+  _cacheStoreTestOnly.clearForTests();
 });
 
 function getGeminiRequests(): Array<Record<string, unknown>> {
@@ -471,8 +492,13 @@ describe("Gemini tool-calling cached-content parity", () => {
 describe("Gemini cached-content store", () => {
   it("stores, retrieves, and idempotently deletes entries", async () => {
     const id = "test-ckpt-store";
-    expect(getGeminiCachedContent(id)).toBeUndefined();
-    setGeminiCachedContent(id, {
+    // Use the ai-runtime bundle's own set/get here — the ai-runtime delete path
+    // clears the ai-runtime map, so seeding via the same bundle keeps this
+    // test focused on store lifecycle without cross-bundle plumbing.
+    const set = runtimeTestOnlyStore.setGeminiCachedContent;
+    const get = runtimeTestOnlyStore.getGeminiCachedContent;
+    expect(get(id)).toBeUndefined();
+    set(id, {
       name: "cachedContents/abc",
       // Deletion lazily builds a client from this config; the entry is removed
       // from the map before the API call, and API failures are swallowed, so a
@@ -480,10 +506,175 @@ describe("Gemini cached-content store", () => {
       model: { provider_config: { api_key: "test", model_name: "gemini-x" } } as never,
       systemPrompt: "sys",
     });
-    expect(getGeminiCachedContent(id)?.name).toBe("cachedContents/abc");
+    expect(get(id)?.name).toBe("cachedContents/abc");
     await deleteGeminiCachedContent(id);
-    expect(getGeminiCachedContent(id)).toBeUndefined();
+    expect(get(id)).toBeUndefined();
     // second delete is a no-op
     await deleteGeminiCachedContent(id);
+  });
+});
+
+/**
+ * Overrides only the client methods the test cares about, keeping the shared
+ * `fakeGeminiClient` shape and the request-log seam intact so every override
+ * still exercises the same run-fn wiring.
+ */
+function installGeminiClient(overrides: {
+  cachesCreate?: (...args: unknown[]) => Promise<Record<string, unknown>>;
+  cachesDelete?: (arg: { name: string }) => Promise<void>;
+  generateContentStream?: (
+    request: Record<string, unknown>
+  ) => Promise<AsyncIterable<Record<string, unknown>>>;
+}): { deletedNames: string[]; createCalls: number } {
+  const deletedNames: string[] = [];
+  let createCalls = 0;
+  const client = {
+    models: {
+      generateContentStream:
+        overrides.generateContentStream ??
+        (async (request: Record<string, unknown>) => {
+          geminiRequests.push(request);
+          return { async *[Symbol.asyncIterator]() {} };
+        }),
+    },
+    caches: {
+      create: async (...args: unknown[]) => {
+        createCalls += 1;
+        if (overrides.cachesCreate) {
+          return await overrides.cachesCreate(...args);
+        }
+        return {};
+      },
+      delete: async (arg: { name: string }) => {
+        deletedNames.push(arg.name);
+        if (overrides.cachesDelete) await overrides.cachesDelete(arg);
+      },
+    },
+  } as never;
+  _testOnly.setGeminiClientForTests(client);
+  runtimeTestOnly.setGeminiClientForTests(client);
+  return {
+    deletedNames,
+    get createCalls() {
+      return createCalls;
+    },
+  } as { deletedNames: string[]; createCalls: number };
+}
+
+/** Registration lookup — the `serves` list of the run-fn we want to drive. */
+function findGeminiRunFn(capability: string): AiProviderRunFn {
+  const registration = _testOnly.GEMINI_RUN_FNS.find(({ serves }) =>
+    (serves as readonly string[]).includes(capability)
+  );
+  expect(registration).toBeDefined();
+  return registration!.runFn as AiProviderRunFn;
+}
+
+const testModel = {
+  provider: GOOGLE_GEMINI,
+  provider_config: { api_key: "test-key", model_name: "gemini-test" },
+} as never;
+
+describe("Gemini cache checkpoint warm-up error classification", () => {
+  const cacheCheckpointPrefix = {
+    systemPrompt: "sys",
+    messages: [{ role: "user" as const, content: [{ type: "text" as const, text: "hi" }] }],
+  };
+  const cacheCheckpointInput: CacheCheckpointTaskInput = {
+    model: "gemini-test",
+  };
+
+  it("rethrows an abort and best-effort deletes any resource created before the abort", async () => {
+    const checkpointId = "abort-before-create";
+    const controller = new AbortController();
+    const helper = installGeminiClient({
+      cachesCreate: async () => {
+        controller.abort();
+        const err = new Error("The user aborted the request.");
+        err.name = "AbortError";
+        throw err;
+      },
+    });
+    const runFn = findGeminiRunFn("cache.checkpoint");
+    const events: unknown[] = [];
+    await expect(
+      runFn(
+        cacheCheckpointInput,
+        testModel,
+        controller.signal,
+        (event) => events.push(event),
+        undefined,
+        { sessionId: checkpointId, prefix: cacheCheckpointPrefix }
+      )
+    ).rejects.toThrow(/abort/i);
+    expect(events).toEqual([]);
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
+    // No resource name was ever returned, so nothing to server-delete.
+    expect(helper.deletedNames).toEqual([]);
+  });
+
+  it("preserves the degrade-to-inline path on a prefix-too-small 400", async () => {
+    const checkpointId = "degrade-preserved";
+    installGeminiClient({
+      cachesCreate: async () => {
+        throw Object.assign(new Error("cached content prefix too small"), { status: 400 });
+      },
+    });
+    const runFn = findGeminiRunFn("cache.checkpoint");
+    const events: Array<Record<string, unknown>> = [];
+    await runFn(
+      cacheCheckpointInput,
+      testModel,
+      new AbortController().signal,
+      (event) => events.push(event as Record<string, unknown>),
+      undefined,
+      { sessionId: checkpointId, prefix: cacheCheckpointPrefix }
+    );
+    // finish emitted, store empty, no rethrow
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("finish");
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
+  });
+
+  it("rethrows a quota 429 without attempting to delete (no resource name)", async () => {
+    const checkpointId = "throws-429";
+    const helper = installGeminiClient({
+      cachesCreate: async () => {
+        throw Object.assign(new Error("quota"), { status: 429 });
+      },
+    });
+    const runFn = findGeminiRunFn("cache.checkpoint");
+    await expect(
+      runFn(cacheCheckpointInput, testModel, new AbortController().signal, () => {}, undefined, {
+        sessionId: checkpointId,
+        prefix: cacheCheckpointPrefix,
+      })
+    ).rejects.toMatchObject({ status: 429 });
+    expect(helper.deletedNames).toEqual([]);
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
+  });
+
+  it("cleans up the created resource when a post-create step throws", async () => {
+    const checkpointId = "partial-delete";
+    const helper = installGeminiClient({
+      cachesCreate: async () => ({ name: "cachedContents/abc" }),
+    });
+    // Inject a bookkeeping failure at the store-insert step so the classifier
+    // sees a non-abort, non-degrade throw *after* a resource has been minted.
+    _cacheStoreTestOnly.setPreSetHook(() => {
+      throw new Error("bookkeeping failed");
+    });
+    try {
+      const runFn = findGeminiRunFn("cache.checkpoint");
+      await expect(
+        runFn(cacheCheckpointInput, testModel, new AbortController().signal, () => {}, undefined, {
+          sessionId: checkpointId,
+          prefix: cacheCheckpointPrefix,
+        })
+      ).rejects.toThrow(/bookkeeping failed/);
+      expect(helper.deletedNames).toEqual(["cachedContents/abc"]);
+    } finally {
+      _cacheStoreTestOnly.setPreSetHook(undefined);
+    }
   });
 });

--- a/packages/test/src/test/ai-provider/OpenAIGeminiCheckpointParams.test.ts
+++ b/packages/test/src/test/ai-provider/OpenAIGeminiCheckpointParams.test.ts
@@ -8,6 +8,7 @@ import type {
   AiProviderRunFn,
   AiSessionContext,
   CacheCheckpointTaskInput,
+  TextGenerationTaskInput,
   ToolCallingTaskInput,
   ToolDefinition,
 } from "@workglow/ai";
@@ -676,5 +677,146 @@ describe("Gemini cache checkpoint warm-up error classification", () => {
     } finally {
       _cacheStoreTestOnly.setPreSetHook(undefined);
     }
+  });
+});
+describe("Gemini cachedContent NOT_FOUND fallback (text.generation)", () => {
+  it("evicts and retries inline once on a 404 NOT_FOUND", async () => {
+    const checkpointId = "not-found-text";
+    setGeminiCachedContent(checkpointId, {
+      name: "cachedContents/text",
+      model: testModel,
+      systemPrompt: "sys",
+    });
+    const requests: Record<string, unknown>[] = [];
+    let call = 0;
+    installGeminiClient({
+      generateContentStream: async (request) => {
+        requests.push(request);
+        call += 1;
+        if (call === 1) {
+          throw Object.assign(new Error("cachedContents/text NOT_FOUND"), {
+            status: 404,
+            code: "NOT_FOUND",
+          });
+        }
+        return { async *[Symbol.asyncIterator]() {} };
+      },
+    });
+    const runFn = findGeminiRunFn("text.generation");
+    const input: TextGenerationTaskInput = { model: "gemini-test", prompt: "tail" };
+    const session: AiSessionContext = {
+      sessionId: checkpointId,
+      prefix: {
+        systemPrompt: "sys",
+        messages: [{ role: "user", content: [{ type: "text", text: "prefix" }] }],
+      },
+    };
+    const events: Array<Record<string, unknown>> = [];
+    await runFn(
+      input,
+      testModel,
+      new AbortController().signal,
+      (event) => events.push(event as Record<string, unknown>),
+      undefined,
+      session
+    );
+    expect(requests).toHaveLength(2);
+    expect((requests[0].config as Record<string, unknown>).cachedContent).toBe(
+      "cachedContents/text"
+    );
+    expect((requests[1].config as Record<string, unknown>).cachedContent).toBeUndefined();
+    // Retry replays the prefix inline (prefix + tail messages).
+    const retryContents = requests[1].contents as Array<{ parts: Array<{ text?: string }> }>;
+    const retryTexts = retryContents.map((c) => c.parts[0]?.text);
+    expect(retryTexts).toContain("prefix");
+    expect(retryTexts).toContain("tail");
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
+    expect(events.some((e) => e.type === "finish")).toBe(true);
+  });
+});
+
+describe("Gemini cachedContent NOT_FOUND fallback (tool-use)", () => {
+  it("evicts and retries inline once on a NOT_FOUND", async () => {
+    const checkpointId = "not-found-tool";
+    setGeminiCachedContent(checkpointId, {
+      name: "cachedContents/tool",
+      model: testModel,
+      systemPrompt: undefined,
+    });
+    const requests: Record<string, unknown>[] = [];
+    let call = 0;
+    installGeminiClient({
+      generateContentStream: async (request) => {
+        requests.push(request);
+        call += 1;
+        if (call === 1) {
+          throw Object.assign(new Error("cache not found"), {
+            status: 404,
+            code: "NOT_FOUND",
+          });
+        }
+        return { async *[Symbol.asyncIterator]() {} };
+      },
+    });
+    const runFn = findGeminiRunFn("tool-use");
+    const tools = cachedTools;
+    const input: ToolCallingTaskInput = {
+      model: "gemini-test",
+      prompt: "run tool",
+      tools,
+      toolChoice: "auto",
+    };
+    const session: AiSessionContext = {
+      sessionId: checkpointId,
+      prefix: {
+        tools,
+        messages: [{ role: "user", content: [{ type: "text", text: "prefix" }] }],
+      },
+    };
+    await runFn(input, testModel, new AbortController().signal, () => {}, undefined, session);
+    expect(requests).toHaveLength(2);
+    expect((requests[0].config as Record<string, unknown>).cachedContent).toBe(
+      "cachedContents/tool"
+    );
+    const retryConfig = requests[1].config as {
+      cachedContent?: string;
+      tools?: Array<Record<string, unknown>>;
+    };
+    expect(retryConfig.cachedContent).toBeUndefined();
+    expect(retryConfig.tools).toBeDefined();
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
+  });
+});
+
+describe("Gemini cachedContent proactive stale fallback", () => {
+  it("skips the cached-content handle on a stale entry and does not re-issue", async () => {
+    const checkpointId = "proactive-stale";
+    // 3.6M ms > 3.5M default stale horizon
+    setGeminiCachedContent(checkpointId, {
+      name: "cachedContents/stale",
+      model: testModel,
+      systemPrompt: "sys",
+      createdAtMs: Date.now() - 3_600_000,
+    });
+    const requests: Record<string, unknown>[] = [];
+    installGeminiClient({
+      generateContentStream: async (request) => {
+        requests.push(request);
+        return { async *[Symbol.asyncIterator]() {} };
+      },
+    });
+    const runFn = findGeminiRunFn("text.generation");
+    const input: TextGenerationTaskInput = { model: "gemini-test", prompt: "tail" };
+    const session: AiSessionContext = {
+      sessionId: checkpointId,
+      prefix: {
+        systemPrompt: "sys",
+        messages: [{ role: "user", content: [{ type: "text", text: "prefix" }] }],
+      },
+    };
+    await runFn(input, testModel, new AbortController().signal, () => {}, undefined, session);
+    expect(requests).toHaveLength(1);
+    expect((requests[0].config as Record<string, unknown>).cachedContent).toBeUndefined();
+    expect(getGeminiCachedContent(checkpointId)).toBeUndefined();
   });
 });

--- a/packages/test/src/test/ai/CacheCheckpoint.test.ts
+++ b/packages/test/src/test/ai/CacheCheckpoint.test.ts
@@ -27,6 +27,7 @@ import {
   getAiProviderRegistry,
   getCheckpoint,
   registerCheckpoint,
+  requireCheckpointModelKey,
   setAiProviderRegistry,
 } from "@workglow/ai";
 import type { IExecuteContext, StreamEvent, TaskOutput } from "@workglow/task-graph";
@@ -73,6 +74,35 @@ describe("CheckpointRegistry", () => {
   it("checkpointModelKey uses model_id and falls back to empty string", () => {
     expect(checkpointModelKey({ model_id: "m1" } as unknown as ModelConfig)).toBe("m1");
     expect(checkpointModelKey({} as ModelConfig)).toBe("");
+  });
+});
+
+describe("requireCheckpointModelKey", () => {
+  it("returns model_id for a valid model", () => {
+    expect(
+      requireCheckpointModelKey({ model_id: "m1" } as unknown as ModelConfig, "TestTask")
+    ).toBe("m1");
+  });
+
+  it("throws TaskConfigurationError when model has no model_id", () => {
+    expect(() => requireCheckpointModelKey({} as ModelConfig, "TestTask")).toThrow(/no model_id/i);
+  });
+
+  it("throws when model_id is a non-string value", () => {
+    expect(() =>
+      requireCheckpointModelKey({ model_id: 42 } as unknown as ModelConfig, "TestTask")
+    ).toThrow(/no model_id/i);
+  });
+
+  it("carries the taskType in the error message", () => {
+    let caught: unknown;
+    try {
+      requireCheckpointModelKey({} as ModelConfig, "SpecificTaskName");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("SpecificTaskName");
   });
 });
 
@@ -625,5 +655,117 @@ describe("AiChatTask checkpoint consumption", () => {
     expect(session?.ownedSession).toBe(true);
     expect(session?.prefix?.systemPrompt).toBe("sys");
     expect(session?.emitCheckpointId).toBeUndefined();
+  });
+});
+
+/**
+ * Fail-closed model-key guards (L2). Before the fix, `checkpointModelKey`
+ * returned "" for a missing `model_id` and `validateParentCheckpoint`
+ * short-circuited its mismatch check on either side being empty, so two
+ * keyless models on the same provider could silently share a fungible
+ * checkpoint slot. Every mint / validate site now routes through
+ * `requireCheckpointModelKey`.
+ */
+describe("model-key fail-closed (L2)", () => {
+  function keylessModel(): ModelConfig {
+    // No `model_id` — the failure mode that used to slip through.
+    return {
+      title: "keyless",
+      description: "keyless",
+      capabilities: ["cache.checkpoint", "text.generation"],
+      provider: CKPT_PROVIDER,
+      provider_config: {},
+      metadata: {},
+    } as unknown as ModelConfig;
+  }
+
+  let warmupInvocations: number;
+
+  beforeEach(async () => {
+    setAiProviderRegistry(new AiProviderRegistry());
+    clearCheckpointsForTesting();
+    warmupInvocations = 0;
+    const warm: AiProviderRunFn = async (_i, _m, _s, emit, _o, session) => {
+      warmupInvocations += 1;
+      emit({ type: "finish", data: { checkpoint: session?.sessionId ?? "" } } as any);
+    };
+    const gen: AiProviderRunFn = async (_i, _m, _s, emit) => {
+      emit({ type: "text-delta", port: "text", textDelta: "x" } as any);
+      emit({ type: "finish", data: {} } as any);
+    };
+    const provider = new CheckpointTestProvider([
+      { serves: ["cache.checkpoint"] as Capability[], runFn: warm },
+      { serves: ["text.generation"] as Capability[], runFn: gen },
+    ]);
+    await provider.register({ queue: { autoCreate: false } });
+  });
+
+  it("cacheCheckpoint rejects a keyless model before invoking the warmup run-fn", async () => {
+    await expect(cacheCheckpoint({ model: keylessModel(), systemPrompt: "sys" })).rejects.toThrow(
+      /no model_id/i
+    );
+    expect(warmupInvocations).toBe(0);
+  });
+
+  it("parent-checkpoint lookup rejects a keyless task model before dispatch", async () => {
+    // A parent that WAS minted with a valid key — the failure mode is a
+    // keyless task model trying to consume it.
+    registerCheckpoint("ckpt-legit-parent", {
+      provider: CKPT_PROVIDER,
+      modelKey: "test:model:v1",
+      prefix: { systemPrompt: "sys" },
+    });
+    const task = new TextGenerationTask();
+    await expect(
+      task.run({ model: keylessModel(), prompt: "hi", checkpoint: "ckpt-legit-parent" })
+    ).rejects.toThrow(/no model_id/i);
+  });
+
+  it("cross-model contamination: a keyless-parent slot no longer matches a keyless task model", async () => {
+    // Simulate the state a pre-fix mint would have left behind: a parent with
+    // an empty modelKey. Under the old short-circuited guard, a keyless task
+    // model would silently consume it. Under the fix, the task model itself
+    // must have a key — the empty-vs-empty match is rejected before the
+    // mismatch check runs.
+    registerCheckpoint("ckpt-keyless-parent", {
+      provider: CKPT_PROVIDER,
+      modelKey: "",
+      prefix: { systemPrompt: "sys" },
+    });
+    const task = new TextGenerationTask();
+    await expect(
+      task.run({
+        model: keylessModel(),
+        prompt: "hi",
+        checkpoint: "ckpt-keyless-parent",
+      })
+    ).rejects.toThrow(/no model_id/i);
+  });
+
+  it("emit path rejects a keyless model before createSession mints a slot", async () => {
+    const createSpy = vi.spyOn(getAiProviderRegistry(), "createSession");
+    const task = new TextGenerationTask();
+    await expect(
+      task.run({ model: keylessModel(), prompt: "hi", emitCheckpoint: true })
+    ).rejects.toThrow(/no model_id/i);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("validateParentCheckpoint still rejects a mismatched keyed parent vs a keyed task model", async () => {
+    // Sanity-check the regular mismatch path — the fix must not break the
+    // existing keyed-vs-keyed rejection path.
+    registerCheckpoint("ckpt-parent-A", {
+      provider: CKPT_PROVIDER,
+      modelKey: "modelA",
+      prefix: {},
+    });
+    const modelB: ModelConfig = {
+      ...checkpointModel(),
+      model_id: "modelB",
+    } as ModelConfig;
+    const task = new TextGenerationTask();
+    await expect(
+      task.run({ model: modelB, prompt: "hi", checkpoint: "ckpt-parent-A" })
+    ).rejects.toThrow(/was created for model/i);
   });
 });

--- a/providers/google-gemini/src/ai/common/Gemini_CacheCheckpoint.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_CacheCheckpoint.ts
@@ -245,6 +245,43 @@ function promptTailMessages(prompt: unknown): ChatMessage[] {
  * applies. The consumed cache also expires by TTL, which the inline-replay
  * fallback covers as well.
  */
+/**
+ * Bucket a cache-creation (or subsequent) error into one of three fates:
+ *  - `"abort"` — the caller cancelled (via the AbortSignal or a bubbled-up
+ *    AbortError); the run-fn must rethrow so the abort surfaces to the run.
+ *  - `"degrade"` — the model rejected the prefix as too small / unsupported for
+ *    explicit caching (`400 INVALID_ARGUMENT` with a matching message); the
+ *    warm-up degrades to no entry and the consumer replays inline.
+ *  - `"throw"` — every other class (auth, quota, transport, server 5xx) is a
+ *    real failure; the run-fn rethrows so the caller sees it and can retry.
+ */
+function classifyGeminiCacheError(
+  err: unknown,
+  signal: AbortSignal | undefined
+): "abort" | "degrade" | "throw" {
+  const anyErr = err as { name?: unknown; message?: unknown; status?: unknown; code?: unknown };
+  const message = String(anyErr?.message ?? err ?? "");
+  const name = String(anyErr?.name ?? "");
+  if (
+    signal?.aborted ||
+    (typeof DOMException !== "undefined" &&
+      err instanceof DOMException &&
+      err.name === "AbortError") ||
+    name === "AbortError" ||
+    /aborted|AbortError/i.test(message)
+  ) {
+    return "abort";
+  }
+  const status = anyErr?.status;
+  const code = anyErr?.code;
+  const looksLikePrefixTooSmall =
+    /prefix.*too.*small|cached.*content.*not.*supported|minimum.*token/i.test(message);
+  if ((status === 400 || code === "INVALID_ARGUMENT") && looksLikePrefixTooSmall) {
+    return "degrade";
+  }
+  return "throw";
+}
+
 export const Gemini_CacheCheckpoint_Stream: AiProviderRunFn<
   CacheCheckpointTaskInput,
   CacheCheckpointTaskOutput,
@@ -264,6 +301,10 @@ export const Gemini_CacheCheckpoint_Stream: AiProviderRunFn<
       ? buildGeminiContents(prefix.messages, "")
       : [{ role: "user", parts: [{ text: "." }] }];
 
+  // Track the created resource name across the try / catch so a downstream
+  // failure (e.g. a bookkeeping throw from `setGeminiCachedContent`) can still
+  // cleanup the server-side entry it just minted.
+  let createdName: string | undefined;
   try {
     signal?.throwIfAborted?.();
     const cached = await ai.caches.create({
@@ -277,6 +318,7 @@ export const Gemini_CacheCheckpoint_Stream: AiProviderRunFn<
         ttl: GEMINI_CACHE_TTL,
       },
     } as Parameters<typeof ai.caches.create>[0]);
+    createdName = cached?.name ?? undefined;
     if (cached?.name) {
       setGeminiCachedContent(checkpointId, {
         name: cached.name,
@@ -285,6 +327,15 @@ export const Gemini_CacheCheckpoint_Stream: AiProviderRunFn<
       });
     }
   } catch (err) {
+    const fate = classifyGeminiCacheError(err, signal);
+    if (fate === "abort" || fate === "throw") {
+      if (createdName) {
+        await ai.caches
+          .delete({ name: createdName } as Parameters<typeof ai.caches.delete>[0])
+          .catch(() => {});
+      }
+      throw err;
+    }
     getLogger().warn(
       `Gemini cache checkpoint warm-up degraded to inline replay: ${
         err instanceof Error ? err.message : String(err)

--- a/providers/google-gemini/src/ai/common/Gemini_CacheStore.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_CacheStore.ts
@@ -22,16 +22,76 @@ export interface GeminiCachedContentEntry {
   readonly model: GeminiModelConfig;
   /** The prefix system prompt baked into the cache (consumption must not resend it). */
   readonly systemPrompt: string | undefined;
+  /**
+   * Wall-clock timestamp (ms since epoch) recorded when the entry was inserted,
+   * used by the proactive stale check so consumers can evict an entry before
+   * the server-side TTL burns them into a NOT_FOUND.
+   */
+  readonly createdAtMs: number;
 }
 
+/**
+ * Default staleness horizon (ms). Cache creation uses a 3600s TTL; treat
+ * entries older than ~58 minutes as stale so consumers proactively fall back to
+ * inline replay before the server-side entry actually expires.
+ */
+const GEMINI_CACHE_DEFAULT_MAX_AGE_MS = 3_500_000;
+
 const geminiCachedContents = new Map<string, GeminiCachedContentEntry>();
+
+let _preSetHook: ((id: string) => void) | undefined;
 
 export function getGeminiCachedContent(id: string): GeminiCachedContentEntry | undefined {
   return geminiCachedContents.get(id);
 }
 
-export function setGeminiCachedContent(id: string, entry: GeminiCachedContentEntry): void {
-  geminiCachedContents.set(id, entry);
+export function setGeminiCachedContent(
+  id: string,
+  entry: Omit<GeminiCachedContentEntry, "createdAtMs"> &
+    Partial<Pick<GeminiCachedContentEntry, "createdAtMs">>
+): void {
+  _preSetHook?.(id);
+  const createdAtMs = entry.createdAtMs ?? Date.now();
+  geminiCachedContents.set(id, { ...entry, createdAtMs });
+}
+
+/**
+ * @internal Test-only seam that lets `@workglow/test` inject a hook fired
+ * immediately before every `setGeminiCachedContent` insertion — used to
+ * simulate a bookkeeping failure so the run-fn's partial-delete cleanup path
+ * can be exercised. Pass `undefined` to clear. Not part of the stable API.
+ */
+export const _cacheStoreTestOnly = {
+  setPreSetHook(hook: ((id: string) => void) | undefined): void {
+    _preSetHook = hook;
+  },
+  clearForTests(): void {
+    geminiCachedContents.clear();
+    _preSetHook = undefined;
+  },
+} as const;
+
+/**
+ * Returns `true` when the entry is older than `maxAgeMs`. Consumers call this
+ * before referencing a cache handle so a soon-to-expire entry falls back to
+ * inline replay instead of erroring the request.
+ */
+export function isGeminiCacheEntryStale(
+  entry: GeminiCachedContentEntry,
+  maxAgeMs: number = GEMINI_CACHE_DEFAULT_MAX_AGE_MS
+): boolean {
+  return Date.now() - entry.createdAtMs > maxAgeMs;
+}
+
+/**
+ * Removes only the runtime-local map entry for `id`, leaving the server-side
+ * CachedContent alone. Consumers use this on a proactive stale eviction — the
+ * server-side entry is about to TTL out on its own, so a delete round-trip is
+ * unnecessary. Use {@link deleteGeminiCachedContent} when the server-side
+ * resource must also be released.
+ */
+export function deleteGeminiCachedContentLocal(id: string): void {
+  geminiCachedContents.delete(id);
 }
 
 /**

--- a/providers/google-gemini/src/ai/common/Gemini_CachedContentFallback.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_CachedContentFallback.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getLogger } from "@workglow/util/worker";
+import { deleteGeminiCachedContent } from "./Gemini_CacheStore";
+
+/**
+ * Reactive NOT_FOUND signature. A CachedContent that TTL-expires (or was
+ * disposed elsewhere) between the consumer's proactive check and the API call
+ * surfaces as a 404 / `NOT_FOUND` / "not found" from `generateContentStream`.
+ * When the caller was referencing that entry, the fallback is the same as the
+ * stale path: evict, rebuild the request without `cachedContent`, and retry
+ * once. Any other error propagates untouched.
+ */
+export function isGeminiCachedContentNotFoundError(err: unknown): boolean {
+  const anyErr = err as { status?: unknown; code?: unknown; message?: unknown };
+  if (anyErr?.status === 404) return true;
+  if (anyErr?.code === "NOT_FOUND") return true;
+  const message = String(anyErr?.message ?? err ?? "");
+  return /NOT_FOUND|not.*found/i.test(message);
+}
+
+interface ExecuteWithFallbackParams<TStream> {
+  /** Whether the pending request references a `cachedContent` handle. */
+  readonly useCachedContent: boolean;
+  /** Checkpoint id whose cache entry the pending request references. */
+  readonly checkpointId: string | undefined;
+  /** Build the current request — called once up front and again on retry. */
+  readonly buildRequest: (useCachedContent: boolean) => Record<string, unknown>;
+  /** Kick the request off (`ai.models.generateContentStream(request)`). */
+  readonly runStream: (request: Record<string, unknown>) => Promise<TStream>;
+}
+
+/**
+ * Runs `generateContentStream` with the reactive NOT_FOUND fallback: if the
+ * initial request references a `cachedContent` handle and the API returns a
+ * NOT_FOUND, evict the store entry (locally + best-effort server delete),
+ * rebuild the request inline, and retry **once**. All other errors — including
+ * a NOT_FOUND on a request that was never using cached content — propagate.
+ *
+ * The proactive stale check lives in the callers (they own the request-shape
+ * choice and want to log a different debug line); this helper covers only the
+ * reactive path.
+ */
+export async function generateGeminiStreamWithCacheFallback<TStream>(
+  params: ExecuteWithFallbackParams<TStream>
+): Promise<TStream> {
+  const { useCachedContent, checkpointId, buildRequest, runStream } = params;
+  const request = buildRequest(useCachedContent);
+  try {
+    return await runStream(request);
+  } catch (err) {
+    if (!useCachedContent || !checkpointId || !isGeminiCachedContentNotFoundError(err)) {
+      throw err;
+    }
+    getLogger().debug("Gemini cachedContent NOT_FOUND; replaying inline");
+    // Best-effort: also releases the server-side handle if it happens to still
+    // exist; on a genuine NOT_FOUND this is a no-op the helper swallows.
+    await deleteGeminiCachedContent(checkpointId);
+    const retryRequest = buildRequest(false);
+    return await runStream(retryRequest);
+  }
+}

--- a/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_TextGeneration.ts
@@ -11,7 +11,12 @@ import type {
 } from "@workglow/ai";
 import { getLogger } from "@workglow/util/worker";
 import { buildGeminiPrefixedContents } from "./Gemini_CacheCheckpoint";
-import { getGeminiCachedContent } from "./Gemini_CacheStore";
+import { generateGeminiStreamWithCacheFallback } from "./Gemini_CachedContentFallback";
+import {
+  deleteGeminiCachedContentLocal,
+  getGeminiCachedContent,
+  isGeminiCacheEntryStale,
+} from "./Gemini_CacheStore";
 import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
@@ -86,50 +91,91 @@ export const Gemini_TextGeneration_Stream: AiProviderRunFn<
     // TTL expiry — replay the prefix content inline; implicit caching still
     // applies there.
     const prefix = sessionContext?.prefix;
-    const cachedEntry = sessionContext?.sessionId
-      ? getGeminiCachedContent(sessionContext.sessionId)
-      : undefined;
+    const checkpointId = sessionContext?.sessionId;
+    const cachedEntry = checkpointId ? getGeminiCachedContent(checkpointId) : undefined;
     const ownSystemPrompt = hasMessages ? unified.systemPrompt || undefined : undefined;
-    const useCachedContent =
+    let useCachedContent =
       prefix !== undefined &&
       cachedEntry !== undefined &&
       (ownSystemPrompt === undefined || ownSystemPrompt === cachedEntry.systemPrompt);
 
-    let contents: any[];
-    let systemInstruction: string | undefined;
-    if (prefix && !useCachedContent) {
-      contents = buildGeminiPrefixedContents(
-        prefix,
-        hasMessages ? (unified.messages as Parameters<typeof buildGeminiContents>[0]) : undefined,
-        unified.prompt
-      );
-      systemInstruction = ownSystemPrompt ?? prefix.systemPrompt;
-    } else {
-      contents = hasMessages
-        ? buildGeminiContents(
-            unified.messages as Parameters<typeof buildGeminiContents>[0],
-            unified.prompt ?? ""
-          )
-        : [{ role: "user", parts: [{ text: input.prompt }] }];
-      systemInstruction = useCachedContent ? undefined : ownSystemPrompt;
+    // Proactive stale check. Explicit CachedContent is TTL-bound (~1h), and a
+    // consumer reaching a nearly-expired entry would eat a reactive NOT_FOUND
+    // that costs a round-trip. Evict the runtime-local entry (leave the server
+    // side to its own TTL) and fall back to inline replay up front.
+    if (useCachedContent && cachedEntry && isGeminiCacheEntryStale(cachedEntry) && checkpointId) {
+      logger.debug("Gemini cache entry stale; falling back to inline replay");
+      deleteGeminiCachedContentLocal(checkpointId);
+      useCachedContent = false;
     }
 
     // Thinking is opt-in here (no default budget); when a budget is configured,
     // the output cap is padded so reasoning can't starve the visible answer.
     const { thinkingConfig, maxOutputTokens } = resolveThinkingConfig(model, input.maxTokens);
 
-    const result = await ai.models.generateContentStream({
-      model: getModelName(model),
-      contents,
-      config: {
-        abortSignal: signal ?? undefined,
-        systemInstruction,
-        ...(useCachedContent ? { cachedContent: cachedEntry!.name } : {}),
-        ...buildGenerationConfig(input),
-        // Override maxOutputTokens from buildGenerationConfig with the thinking-aware value.
-        maxOutputTokens,
-        thinkingConfig,
-      },
+    /** Build the tail-only request that references the CachedContent handle. */
+    const buildCachedRequest = (): Record<string, unknown> => {
+      const contents = hasMessages
+        ? buildGeminiContents(
+            unified.messages as Parameters<typeof buildGeminiContents>[0],
+            unified.prompt ?? ""
+          )
+        : [{ role: "user", parts: [{ text: input.prompt }] }];
+      return {
+        model: getModelName(model),
+        contents,
+        config: {
+          abortSignal: signal ?? undefined,
+          systemInstruction: undefined,
+          cachedContent: cachedEntry!.name,
+          ...buildGenerationConfig(input),
+          maxOutputTokens,
+          thinkingConfig,
+        },
+      };
+    };
+
+    /** Build the full inline-replay request (prefix messages + tail). */
+    const buildInlineReplayRequest = (): Record<string, unknown> => {
+      let contents: any[];
+      let systemInstruction: string | undefined;
+      if (prefix) {
+        contents = buildGeminiPrefixedContents(
+          prefix,
+          hasMessages ? (unified.messages as Parameters<typeof buildGeminiContents>[0]) : undefined,
+          unified.prompt
+        );
+        systemInstruction = ownSystemPrompt ?? prefix.systemPrompt;
+      } else {
+        contents = hasMessages
+          ? buildGeminiContents(
+              unified.messages as Parameters<typeof buildGeminiContents>[0],
+              unified.prompt ?? ""
+            )
+          : [{ role: "user", parts: [{ text: input.prompt }] }];
+        systemInstruction = ownSystemPrompt;
+      }
+      return {
+        model: getModelName(model),
+        contents,
+        config: {
+          abortSignal: signal ?? undefined,
+          systemInstruction,
+          ...buildGenerationConfig(input),
+          maxOutputTokens,
+          thinkingConfig,
+        },
+      };
+    };
+
+    const result = await generateGeminiStreamWithCacheFallback({
+      useCachedContent,
+      checkpointId,
+      buildRequest: (useCached) => (useCached ? buildCachedRequest() : buildInlineReplayRequest()),
+      runStream: (request) =>
+        ai.models.generateContentStream(
+          request as unknown as Parameters<typeof ai.models.generateContentStream>[0]
+        ),
     });
 
     let refusalCategory: string | undefined;

--- a/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
+++ b/providers/google-gemini/src/ai/common/Gemini_ToolCalling.ts
@@ -12,12 +12,18 @@ import type {
   ToolCallingTaskOutput,
 } from "@workglow/ai";
 import { filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
+import { getLogger } from "@workglow/util/worker";
 import {
   buildGeminiFunctionDeclarations,
   buildGeminiPrefixedContents,
   geminiCachedToolsMatch,
 } from "./Gemini_CacheCheckpoint";
-import { getGeminiCachedContent } from "./Gemini_CacheStore";
+import { generateGeminiStreamWithCacheFallback } from "./Gemini_CachedContentFallback";
+import {
+  deleteGeminiCachedContentLocal,
+  getGeminiCachedContent,
+  isGeminiCacheEntryStale,
+} from "./Gemini_CacheStore";
 import { createGeminiClient, getModelName, resolveThinkingConfig } from "./Gemini_Client";
 import type { GeminiModelConfig } from "./Gemini_ModelSchema";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./Gemini_Refusal";
@@ -137,11 +143,10 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
   // ("auto") tool choice. Anything else — including after the cache's TTL
   // expiry — replays the prefix content inline; implicit caching still applies.
   const prefix = sessionContext?.prefix;
-  const cachedEntry = sessionContext?.sessionId
-    ? getGeminiCachedContent(sessionContext.sessionId)
-    : undefined;
+  const checkpointId = sessionContext?.sessionId;
+  const cachedEntry = checkpointId ? getGeminiCachedContent(checkpointId) : undefined;
   const defaultToolChoice = input.toolChoice === undefined || input.toolChoice === "auto";
-  const useCachedContent =
+  let useCachedContent =
     prefix !== undefined &&
     cachedEntry !== undefined &&
     defaultToolChoice &&
@@ -152,32 +157,64 @@ export const Gemini_ToolCalling_Stream: AiProviderRunFn<
       input.systemPrompt === "" ||
       input.systemPrompt === cachedEntry.systemPrompt);
 
-  const contents =
-    prefix && !useCachedContent
-      ? buildGeminiPrefixedContents(prefix, input.messages, input.prompt)
-      : buildGeminiContents(input.messages, input.prompt);
-  const systemInstruction = useCachedContent
-    ? undefined
-    : input.systemPrompt || (prefix ? prefix.systemPrompt : undefined);
+  // Proactive stale check. Explicit CachedContent is TTL-bound (~1h), and a
+  // consumer reaching a nearly-expired entry would eat a reactive NOT_FOUND
+  // that costs a round-trip. Evict the runtime-local entry (leave the server
+  // side to its own TTL) and fall back to inline replay up front.
+  if (useCachedContent && cachedEntry && isGeminiCacheEntryStale(cachedEntry) && checkpointId) {
+    getLogger().debug("Gemini cache entry stale; falling back to inline replay");
+    deleteGeminiCachedContentLocal(checkpointId);
+    useCachedContent = false;
+  }
 
   // Thinking is opt-in here (no default budget): the model uses its own default
   // reasoning unless `provider_config.thinking_budget` is set, in which case the
   // output cap is padded so reasoning can't starve the tool call / answer.
   const { thinkingConfig, maxOutputTokens } = resolveThinkingConfig(model, input.maxTokens);
 
-  const result = await ai.models.generateContentStream({
+  /** Build the tail-only request that references the CachedContent handle. */
+  const buildCachedRequest = (): Record<string, unknown> => ({
     model: getModelName(model),
-    contents,
+    contents: buildGeminiContents(input.messages, input.prompt),
     config: {
       abortSignal: signal ?? undefined,
-      systemInstruction,
+      systemInstruction: undefined,
       maxOutputTokens,
       temperature: input.temperature,
-      ...(useCachedContent
-        ? { cachedContent: cachedEntry!.name }
-        : { tools: [{ functionDeclarations }], toolConfig: toolConfig as any }),
+      cachedContent: cachedEntry!.name,
       thinkingConfig,
     },
+  });
+
+  /** Build the full inline-replay request (prefix messages + tail + tools). */
+  const buildInlineReplayRequest = (): Record<string, unknown> => {
+    const contents = prefix
+      ? buildGeminiPrefixedContents(prefix, input.messages, input.prompt)
+      : buildGeminiContents(input.messages, input.prompt);
+    const systemInstruction = input.systemPrompt || (prefix ? prefix.systemPrompt : undefined);
+    return {
+      model: getModelName(model),
+      contents,
+      config: {
+        abortSignal: signal ?? undefined,
+        systemInstruction,
+        maxOutputTokens,
+        temperature: input.temperature,
+        tools: [{ functionDeclarations }],
+        toolConfig: toolConfig as any,
+        thinkingConfig,
+      },
+    };
+  };
+
+  const result = await generateGeminiStreamWithCacheFallback({
+    useCachedContent,
+    checkpointId,
+    buildRequest: (useCached) => (useCached ? buildCachedRequest() : buildInlineReplayRequest()),
+    runStream: (request) =>
+      ai.models.generateContentStream(
+        request as unknown as Parameters<typeof ai.models.generateContentStream>[0]
+      ),
   });
 
   let callIndex = 0;

--- a/providers/google-gemini/src/ai/index.ts
+++ b/providers/google-gemini/src/ai/index.ts
@@ -14,13 +14,21 @@ export * from "./registerGemini";
 
 import { GEMINI_RUN_FN_SPECS } from "./common/Gemini_Capabilities";
 import { _testOnly as clientTestOnly } from "./common/Gemini_Client";
+import {
+  _cacheStoreTestOnly,
+  getGeminiCachedContent,
+  setGeminiCachedContent,
+} from "./common/Gemini_CacheStore";
 import { GEMINI_RUN_FNS } from "./common/Gemini_JobRunFns";
 import { emitGeminiRefusal, geminiRefusalCategory } from "./common/Gemini_Refusal";
 import { buildGeminiContents } from "./common/Gemini_ToolCalling";
 import { GoogleGeminiQueuedProvider } from "./GoogleGeminiQueuedProvider";
 
 /**
- * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
+ * @internal Symbols exported only for use by `@workglow/test`. Not part of the
+ * stable public API. The cache-store helpers are re-exported off this barrel
+ * (in addition to `ai-runtime`) so tests that drive the ai-bundle run-fns can
+ * seed / read the same runtime-local map the run-fns look at.
  */
 export const _testOnly = {
   GoogleGeminiQueuedProvider,
@@ -30,4 +38,7 @@ export const _testOnly = {
   geminiRefusalCategory,
   emitGeminiRefusal,
   setGeminiClientForTests: clientTestOnly.setGeminiClientForTests,
+  setGeminiCachedContent,
+  getGeminiCachedContent,
+  cacheStoreTestOnly: _cacheStoreTestOnly,
 } as const;

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_CacheCheckpoint.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_CacheCheckpoint.ts
@@ -8,7 +8,6 @@ import type {
   AiProviderRunFn,
   CacheCheckpointTaskInput,
   CacheCheckpointTaskOutput,
-  ChatMessage,
   CheckpointPrefix,
 } from "@workglow/ai";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
@@ -22,23 +21,34 @@ import {
   setLlamaCppSession,
   withModelInUse,
 } from "./LlamaCpp_Runtime";
+import {
+  buildChatModelFunctions,
+  messagesToPureChatHistoryForPrefix,
+} from "./LlamaCpp_ToolCalling";
 
-/** Flattens prefix messages (and tool descriptions) into a preloadable text prompt. */
-export function renderLlamaCppPrefixText(prefix: CheckpointPrefix): string {
-  const parts: string[] = [];
-  if (prefix.tools && prefix.tools.length > 0) {
-    parts.push(
-      "Available tools:\n" + prefix.tools.map((t) => `- ${t.name}: ${t.description}`).join("\n")
-    );
-  }
-  for (const msg of prefix.messages ?? []) {
-    const text = (msg as ChatMessage).content
-      .filter((b) => b.type === "text")
-      .map((b) => (b as { type: "text"; text: string }).text)
-      .join("");
-    if (text) parts.push(`${msg.role}: ${text}`);
-  }
-  return parts.join("\n\n");
+/**
+ * Renders a checkpoint prefix as node-llama-cpp `ChatHistoryItem[]` — routed
+ * through the model's chat wrapper via `session.setChatHistory(history)`.
+ * Preserves `tool_use` / `tool_result` blocks (dropped by any raw-text
+ * flattening) and matches the token stream the consumer's `generateResponse`
+ * will produce, so warmed KV state can actually be reused.
+ */
+export function renderLlamaCppPrefixChatHistory(prefix: CheckpointPrefix): any[] {
+  return messagesToPureChatHistoryForPrefix(prefix.messages ?? [], prefix.systemPrompt);
+}
+
+/**
+ * Renders a checkpoint prefix's tools as node-llama-cpp `ChatModelFunctions`,
+ * or `undefined` when the prefix has no tools. The consumer's `preloadPrompt`
+ * / `generateResponse` receives these so the chat wrapper embeds tool
+ * descriptions the same way — a required condition for KV reuse when the
+ * prefix carries tools.
+ */
+export function renderLlamaCppPrefixFunctions(
+  prefix: CheckpointPrefix
+): Record<string, { description?: string; params?: any }> | undefined {
+  if (!prefix.tools || prefix.tools.length === 0) return undefined;
+  return buildChatModelFunctions(prefix.tools);
 }
 
 export const LlamaCpp_CacheCheckpoint_Stream: AiProviderRunFn<
@@ -71,11 +81,18 @@ export const LlamaCpp_CacheCheckpoint_Stream: AiProviderRunFn<
         ...llamaCppChatSessionConstructorSpread(model),
       });
 
-      const prefixText = renderLlamaCppPrefixText(prefix);
-      if (prefixText) {
-        // Evaluate the prefix into the sequence's KV state without generating.
-        await chatSession.preloadPrompt(prefixText, { signal });
-      }
+      // Route the prefix through the model's chat wrapper. Rendering to raw
+      // "role: text" strings and preloading that would bypass the template
+      // and drop tool_use / tool_result blocks, so the warmed KV tokens would
+      // never match what the consumer's generateResponse produces.
+      const history = renderLlamaCppPrefixChatHistory(prefix);
+      chatSession.setChatHistory(history);
+      const functions = renderLlamaCppPrefixFunctions(prefix);
+      // Evaluate the prefix into the sequence's KV state without generating.
+      await chatSession.preloadPrompt("", {
+        signal,
+        ...(functions ? { functions } : {}),
+      });
 
       setLlamaCppSession(checkpointId, {
         mode: "prefix-rewind",

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
@@ -11,7 +11,10 @@ import type {
   AiSessionContext,
   ChatMessage,
 } from "@workglow/ai";
-import { renderLlamaCppPrefixText } from "./LlamaCpp_CacheCheckpoint";
+import {
+  renderLlamaCppPrefixChatHistory,
+  renderLlamaCppPrefixFunctions,
+} from "./LlamaCpp_CacheCheckpoint";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import {
   acquireContextSequence,
@@ -73,12 +76,19 @@ async function getOrCreateChatSession(
     });
 
     // Missing-state fallback: a checkpoint id was supplied but its worker-side
-    // sequence is gone. Re-encode the prefix so the turn continues from it.
+    // sequence is gone. Re-encode the prefix through the model's chat wrapper
+    // (setChatHistory + preloadPrompt with the tool set) so the KV tokens
+    // match the consumer's generateResponse — a raw-text preload would bypass
+    // the template and drop tool_use / tool_result blocks.
     if (isCheckpoint) {
-      const prefixText = renderLlamaCppPrefixText(sessionContext!.prefix!);
-      if (prefixText) {
-        await session.preloadPrompt(prefixText, { signal });
-      }
+      const prefix = sessionContext!.prefix!;
+      const history = renderLlamaCppPrefixChatHistory(prefix);
+      session.setChatHistory(history);
+      const functions = renderLlamaCppPrefixFunctions(prefix);
+      await session.preloadPrompt("", {
+        signal,
+        ...(functions ? { functions } : {}),
+      });
     }
 
     if (sessionId) {

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Chat.ts
@@ -46,6 +46,11 @@ async function getOrCreateChatSession(
   const isCheckpoint = sessionContext?.prefix !== undefined;
 
   if (sessionId) {
+    // AiChatTask uses `ownedSession` — the session id is the caller's mutable
+    // chat session, not an immutable checkpoint. That's why we use
+    // `getLlamaCppSession` (a non-consuming lookup) here rather than
+    // `stealLlamaCppSession`, which TextGen / ToolCalling use to serialize
+    // concurrent consumers of a shared checkpoint sequence.
     const existing = getLlamaCppSession(sessionId);
     if (existing !== undefined) {
       // Session already created with its prompt state baked in (progressive

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -71,6 +71,23 @@ export function setLlamaCppSession(sessionId: string, state: LlamaCppSessionStat
   llamaCppSessions.set(sessionId, state);
 }
 
+/**
+ * Atomic get-and-remove for a checkpoint session id. Two concurrent consumers
+ * of the same immutable checkpoint would otherwise both observe the cached
+ * state and both call `.generate()` on the shared `LlamaContextSequence` — a
+ * live sequence advances in place and cannot be safely shared. The
+ * synchronous `Map.get` + `Map.delete` here is race-free on JS's single
+ * thread: exactly one caller sees the state, every subsequent caller
+ * observes `undefined` and re-encodes via the existing missing-state fallback
+ * (which acquires its own sequence). Intentionally NOT used by AiChatTask,
+ * whose `ownedSession` mode is the caller's mutable session, not a checkpoint.
+ */
+export function stealLlamaCppSession(sessionId: string): LlamaCppSessionState | undefined {
+  const state = llamaCppSessions.get(sessionId);
+  if (state) llamaCppSessions.delete(sessionId);
+  return state;
+}
+
 export async function deleteLlamaCppSession(sessionId: string): Promise<boolean> {
   const session = llamaCppSessions.get(sessionId);
   if (session) {

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
@@ -23,9 +23,9 @@ import {
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
-  llamaCppSessions,
   loadSdk,
   setLlamaCppSession,
+  stealLlamaCppSession,
   streamFromSession,
   withModelInUse,
 } from "./LlamaCpp_Runtime";
@@ -43,12 +43,28 @@ export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
   const modelPath = getActualModelPath(model);
 
   await withModelInUse(modelPath, async () => {
-    let cached = sessionId ? getLlamaCppSession(sessionId) : undefined;
+    // Consuming an immutable checkpoint steals ownership atomically — two
+    // concurrent consumers of the same id would otherwise both call `.generate()`
+    // on the shared LlamaContextSequence, which advances in place. The loser of
+    // the steal observes `undefined` and re-encodes via the missing-state
+    // fallback below. AiChatTask's `ownedSession` mode is the caller's mutable
+    // session (not a checkpoint) so it uses the non-consuming getter.
+    const isCheckpointConsumption =
+      isCheckpoint && sessionId !== undefined && !sessionContext?.ownedSession;
+    let cached = sessionId
+      ? isCheckpointConsumption
+        ? stealLlamaCppSession(sessionId)
+        : getLlamaCppSession(sessionId)
+      : undefined;
+    // A stolen checkpoint session's map entry is already gone — track owned=false
+    // so the dispose path frees it unless we re-key it under an emitCheckpointId.
+    // A non-consumption cache hit keeps the map entry, so it stays map-owned.
+    let ownedByMap = Boolean(cached) && !isCheckpointConsumption;
 
     // Missing-state fallback: a checkpoint id was supplied but its worker-side
-    // sequence is gone (e.g. evicted). Re-encode the prefix into a fresh
-    // sequence for this turn (ownership is taken below, so it is not stored
-    // back under the checkpoint id).
+    // sequence is gone (e.g. evicted, or stolen by a concurrent consumer that
+    // won the race). Re-encode the prefix into a fresh sequence for this turn
+    // (ownership is taken below, so it is not stored back under the checkpoint id).
     if (sessionId && !cached && isCheckpoint) {
       const prefix = sessionContext!.prefix!;
       const context = await getOrCreateTextContext(model);
@@ -95,21 +111,10 @@ export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
       cached = state;
     }
 
-    // A live llama.cpp sequence advances in place during generation — there is
-    // no cheap KV clone like HFT's DynamicCache copy. Consuming a checkpoint
-    // therefore takes SOLE ownership of its live session: the map entry is
-    // removed so a later consumer of the same checkpoint id re-encodes a
-    // pristine prefix (registry fallback) instead of seeing this turn's tokens,
-    // and so an emitted checkpoint never aliases the parent id. The stolen
-    // session is disposed at turn end unless re-keyed under emitCheckpointId.
-    // An ownedSession id is the caller's mutable session, not a checkpoint —
-    // never steal it.
-    let ownedByMap = Boolean(cached);
-    if (isCheckpoint && !sessionContext?.ownedSession && sessionId && cached) {
-      llamaCppSessions.delete(sessionId);
-      ownedByMap = false;
-    }
-
+    // Ownership tracking (`ownedByMap`) was decided above alongside the
+    // steal-vs-get split: a stolen or freshly-encoded checkpoint session is
+    // caller-owned until we re-key it under an emitCheckpointId; a plain
+    // cache hit (progressive / ownedSession) stays map-owned.
     const context = cached ? undefined : await getOrCreateTextContext(model);
     const sequence = cached ? cached.sequence : await acquireContextSequence(context!, signal);
     // Sequence ownership only transfers to the session once its constructor

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_TextGeneration.ts
@@ -9,7 +9,10 @@ import type {
   TextGenerationTaskInput,
   TextGenerationTaskOutput,
 } from "@workglow/ai";
-import { renderLlamaCppPrefixText } from "./LlamaCpp_CacheCheckpoint";
+import {
+  renderLlamaCppPrefixChatHistory,
+  renderLlamaCppPrefixFunctions,
+} from "./LlamaCpp_CacheCheckpoint";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import type { LlamaCppSessionState } from "./LlamaCpp_Runtime";
 import {
@@ -60,10 +63,18 @@ export const LlamaCpp_TextGeneration_Stream: AiProviderRunFn<
           ...(prefix.systemPrompt !== undefined && { systemPrompt: prefix.systemPrompt }),
           ...llamaCppChatSessionConstructorSpread(model),
         });
-        const prefixText = renderLlamaCppPrefixText(prefix);
-        if (prefixText) {
-          await chatSession.preloadPrompt(prefixText, { signal });
-        }
+        // Route the prefix through the model's chat wrapper (setChatHistory +
+        // preloadPrompt with the tool set) so the re-encoded KV tokens match
+        // what the consumer's generation will produce. TextGen itself has no
+        // tool-calling, but an upstream-emitted checkpoint prefix can carry
+        // tool blocks that a raw-text preload would silently drop.
+        const history = renderLlamaCppPrefixChatHistory(prefix);
+        chatSession.setChatHistory(history);
+        const functions = renderLlamaCppPrefixFunctions(prefix);
+        await chatSession.preloadPrompt("", {
+          signal,
+          ...(functions ? { functions } : {}),
+        });
         state = {
           mode: "prefix-rewind" as const,
           sequence,

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
@@ -16,7 +16,10 @@ import type {
 import { extractMessageText, toolChoiceForcesToolCall } from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, sanitizeToolArgs } from "@workglow/ai/worker";
 import type { StreamEvent } from "@workglow/task-graph";
-import { renderLlamaCppPrefixText } from "./LlamaCpp_CacheCheckpoint";
+import {
+  renderLlamaCppPrefixChatHistory,
+  renderLlamaCppPrefixFunctions,
+} from "./LlamaCpp_CacheCheckpoint";
 import type { LlamaCppModelConfig } from "./LlamaCpp_ModelSchema";
 import type { LlamaCppSessionState } from "./LlamaCpp_Runtime";
 import {
@@ -72,27 +75,20 @@ function buildToolChatHistory(
 }
 
 /**
- * Convert workglow messages to node-llama-cpp's `ChatHistoryItem[]`.
- *
- * Key difference from OpenAI/Anthropic format: tool results are NOT separate
- * history items. They get merged into the preceding `model` response's
- * `ChatModelFunctionCall.result` fields, matched by `tool_use_id`.
+ * Pure message-array → `ChatHistoryItem[]` conversion — no trailing empty-user
+ * placeholder when `messages` is empty. Emits only `system` when a system
+ * prompt is provided and messages is empty; that shape is what a cache
+ * checkpoint prefix needs before running any turn. Unknown block types are
+ * skipped rather than throwing (mirrors HFT's posture).
  */
-export function convertMessagesToChatHistory(
-  messages: ReadonlyArray<ChatMessage> | undefined,
-  prompt: string | undefined,
+function messagesToPureChatHistory(
+  messages: ReadonlyArray<ChatMessage>,
   systemPrompt: string | undefined
 ): any[] {
   const history: any[] = [];
 
   if (systemPrompt) {
     history.push({ type: "system", text: systemPrompt });
-  }
-
-  if (!messages || messages.length === 0) {
-    const promptText = typeof prompt === "string" ? prompt : String(prompt ?? "");
-    history.push({ type: "user", text: promptText });
-    return history;
   }
 
   for (const msg of messages) {
@@ -177,7 +173,39 @@ export function convertMessagesToChatHistory(
   return history;
 }
 
-function buildChatModelFunctions(
+/**
+ * Convert workglow messages to node-llama-cpp's `ChatHistoryItem[]` for a
+ * one-shot generation call. When `messages` is empty, `prompt` is appended as
+ * the trailing user turn so the model has something to respond to.
+ *
+ * Key difference from OpenAI/Anthropic format: tool results are NOT separate
+ * history items. They get merged into the preceding `model` response's
+ * `ChatModelFunctionCall.result` fields, matched by `tool_use_id`.
+ */
+export function convertMessagesToChatHistory(
+  messages: ReadonlyArray<ChatMessage> | undefined,
+  prompt: string | undefined,
+  systemPrompt: string | undefined
+): any[] {
+  if (!messages || messages.length === 0) {
+    const history: any[] = [];
+    if (systemPrompt) history.push({ type: "system", text: systemPrompt });
+    const promptText = typeof prompt === "string" ? prompt : String(prompt ?? "");
+    history.push({ type: "user", text: promptText });
+    return history;
+  }
+  return messagesToPureChatHistory(messages, systemPrompt);
+}
+
+/** Pure history renderer for a checkpoint prefix — reused by the checkpoint module. */
+export function messagesToPureChatHistoryForPrefix(
+  messages: ReadonlyArray<ChatMessage>,
+  systemPrompt: string | undefined
+): any[] {
+  return messagesToPureChatHistory(messages, systemPrompt);
+}
+
+export function buildChatModelFunctions(
   tools: ReadonlyArray<ToolDefinition>
 ): Record<string, { description?: string; params?: any }> {
   const functions: Record<string, { description?: string; params?: any }> = {};
@@ -412,10 +440,17 @@ export const LlamaCpp_ToolCalling_Stream: AiProviderRunFn<
           ...(prefix.systemPrompt !== undefined && { systemPrompt: prefix.systemPrompt }),
           ...llamaCppChatSessionConstructorSpread(model),
         });
-        const prefixText = renderLlamaCppPrefixText(prefix);
-        if (prefixText) {
-          await chatSession.preloadPrompt(prefixText, { signal });
-        }
+        // Route the prefix through the model's chat template — feeding role/text
+        // strings via preloadPrompt would bypass the wrapper and drop
+        // tool_use / tool_result blocks. setChatHistory + preloadPrompt("", { functions })
+        // populates KV state via the same wrapper the consumer's generation uses.
+        const history = renderLlamaCppPrefixChatHistory(prefix);
+        chatSession.setChatHistory(history);
+        const functions = renderLlamaCppPrefixFunctions(prefix);
+        await chatSession.preloadPrompt("", {
+          signal,
+          ...(functions ? { functions } : {}),
+        });
         state = {
           mode: "prefix-rewind",
           sequence,

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_ToolCalling.ts
@@ -31,9 +31,9 @@ import {
   getOrCreateTextContext,
   llamaCppChatSessionConstructorSpread,
   llamaCppSeedPromptSpread,
-  llamaCppSessions,
   loadSdk,
   setLlamaCppSession,
+  stealLlamaCppSession,
   withModelInUse,
   withSequence,
 } from "./LlamaCpp_Runtime";
@@ -425,7 +425,23 @@ export const LlamaCpp_ToolCalling_Stream: AiProviderRunFn<
 
     const sessionId = sessionContext.sessionId;
     const isCheckpoint = sessionContext.prefix !== undefined;
-    let cached = sessionId ? getLlamaCppSession(sessionId) : undefined;
+    // Consuming an immutable checkpoint steals ownership atomically — two
+    // concurrent consumers of the same id would otherwise both call `.generate()`
+    // on the shared LlamaContextSequence, which advances in place. The loser of
+    // the steal observes `undefined` and re-encodes via the missing-state
+    // fallback below. AiChatTask's `ownedSession` mode is the caller's mutable
+    // session (not a checkpoint) so it uses the non-consuming getter.
+    const isCheckpointConsumption =
+      isCheckpoint && sessionId !== undefined && !sessionContext.ownedSession;
+    let cached = sessionId
+      ? isCheckpointConsumption
+        ? stealLlamaCppSession(sessionId)
+        : getLlamaCppSession(sessionId)
+      : undefined;
+    // A stolen checkpoint session's map entry is already gone — track owned=false
+    // so the dispose path frees it unless we re-key it under an emitCheckpointId.
+    // A non-consumption cache hit keeps the map entry, so it stays map-owned.
+    let ownedByMap = Boolean(cached) && !isCheckpointConsumption;
 
     if (sessionId && !cached && isCheckpoint) {
       const prefix = sessionContext.prefix!;
@@ -471,12 +487,10 @@ export const LlamaCpp_ToolCalling_Stream: AiProviderRunFn<
       cached = state;
     }
 
-    let ownedByMap = Boolean(cached);
-    if (isCheckpoint && !sessionContext.ownedSession && sessionId && cached) {
-      llamaCppSessions.delete(sessionId);
-      ownedByMap = false;
-    }
-
+    // Ownership tracking (`ownedByMap`) was decided above alongside the
+    // steal-vs-get split: a stolen or freshly-encoded checkpoint session is
+    // caller-owned until we re-key it under an emitCheckpointId; a plain
+    // cache hit (progressive / ownedSession) stays map-owned.
     const context = cached ? undefined : await getOrCreateTextContext(model);
     const sequence = cached ? cached.sequence : await acquireContextSequence(context!, signal);
     let session = cached?.session;

--- a/providers/node-llama-cpp/src/ai/runtime.ts
+++ b/providers/node-llama-cpp/src/ai/runtime.ts
@@ -14,5 +14,9 @@
 // organize-imports-ignore
 
 export * from "./common/LlamaCpp_Runtime";
+export {
+  renderLlamaCppPrefixChatHistory,
+  renderLlamaCppPrefixFunctions,
+} from "./common/LlamaCpp_CacheCheckpoint";
 export * from "./registerLlamaCppInline";
 export * from "./registerLlamaCppWorker";


### PR DESCRIPTION
## Summary

Consolidates the five HIGH-severity cache-checkpoint correctness fixes previously split across **#642** (node-llama-cpp / ai) and **#643** (google-gemini). Both of those targeted `main` / stacked awkwardly on the branch; this branch is cut directly from `ai-provider-cache-checkpoints` so the diff is exactly the five fixes and nothing else. Each fix is a self-contained commit with targeted tests.

### From #642 — node-llama-cpp / ai

**L1 — LlamaCpp checkpoint prefix rendered through the model's chat template.** `renderLlamaCppPrefixText` flattened the prefix to raw `"role: text"` strings and silently dropped `tool_use`/`tool_result` blocks, so warm-up KV tokens no longer matched the consumer's chat-template rendering — cache reuse was defeated and prior tool exchanges were lost. Replaced with a `ChatHistoryItem[]` renderer routed through `setChatHistory` + `preloadPrompt("", { functions })`; the raw-text renderer is deleted so no future path can silently drop tool blocks.

**L2 — CheckpointRegistry model-key fail-closed.** `checkpointModelKey` returned `""` for a missing `model_id` and `validateParentCheckpoint` short-circuited its mismatch check when either side was empty — two keyless models on the same provider shared a fungible checkpoint slot. Added `requireCheckpointModelKey` (throws `TaskConfigurationError`), routed all mint/validate sites through it, and made the mismatch comparison unconditional as defense in depth.

**L3 — LlamaCpp checkpoint concurrent-consumer race.** `get`+`delete` on the session map bracketed async work in `_TextGeneration` and `_ToolCalling`; two concurrent consumers of the same checkpoint id both generated on the shared `LlamaContextSequence`. Added `stealLlamaCppSession(id)` (synchronous get+delete, race-free on JS's single thread); under contention exactly one consumer wins, losers deterministically re-encode via the existing fallback.

### From #643 — google-gemini

**H1 — Narrow the warm-up catch.** The warm-up wrapped `ai.caches.create` in a blanket try/catch that swallowed *every* error, so an abort, a 401/403, a 429, and a 5xx all degraded to the same "no cache, replay inline" fate as a genuine prefix-too-small 400. Introduced `classifyGeminiCacheError` (abort / degrade / throw): abort and throw rethrow with a best-effort delete of any minted resource; only a 400/INVALID_ARGUMENT naming the too-small-prefix / unsupported condition degrades to inline replay. Adds `createdAtMs`, `isGeminiCacheEntryStale`, and `deleteGeminiCachedContentLocal` to `Gemini_CacheStore`.

**H2 — Fallback in the two consume paths.** The consumers treated the cache handle as guaranteed to resolve. Added `Gemini_CachedContentFallback.generateGeminiStreamWithCacheFallback`: a proactive stale check up front and, on a reactive 404/`NOT_FOUND`, evict (locally + best-effort server delete), rebuild inline, and retry once. Streaming contract unchanged.

## Verification (this branch, cut from `ai-provider-cache-checkpoints`)

- [x] `bun run build:types` — clean across all 40 packages
- [x] `bun scripts/test.ts provider-nodellama vitest` — 81 passed, 4 skipped (L1/L3)
- [x] `CacheCheckpoint.test.ts` — passes incl. the `requireCheckpointModelKey` / model-key fail-closed coverage (L2)
- [x] `OpenAIGeminiCheckpointParams.test.ts` + `Gemini_SessionDispose.test.ts` — passes (H1/H2, no regressions)
- [ ] Reviewer confirms behavior on a live llama.cpp model (no local model available in this environment)

## Provenance

Commits are cherry-picks of the fix commits from the two prior PRs, replayed cleanly onto the checkpoint branch:
- `9520ece` ← #642 L1 (`a64b086`)
- `b2570af` ← #642 L2 (`4a14d26`)
- `9b8077a` ← #642 L3 (`b1cdb68`)
- `e2703d8` ← #643 H1 (`46405c9`)
- `510c851` ← #643 H2 (`04fd0b9`)

Supersedes and closes #642 and #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMyipztz9RFDp4aZPSNqEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMyipztz9RFDp4aZPSNqEV)_