### PR TITLE
Enforce worker-boundary import contract for *_JobRunFns.ts via ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,5 +50,38 @@ export default defineConfig(
       "@typescript-eslint/no-explicit-any": "off",
       "react/react-in-jsx-scope": "off",
     },
+  },
+  {
+    // `*_JobRunFns.ts` files execute inside workers, which have an isolated
+    // runtime with their own `globalServiceRegistry`. Importing main-thread-only
+    // state (the global service registry or credential stores) resolves against a
+    // different, empty registry at runtime. Resolve such state in the task class on
+    // the main thread and pass it through the serialized job input instead.
+    files: ["**/*_JobRunFns.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@workglow/util",
+              importNames: [
+                "globalServiceRegistry",
+                "getGlobalCredentialStore",
+                "setGlobalCredentialStore",
+              ],
+              message:
+                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
+            },
+            {
+              name: "@workglow/util/worker",
+              importNames: ["globalServiceRegistry"],
+              message:
+                "Main-thread-only state is unavailable in workers. Resolve it in the task class (e.g. AiTask.getJobInput()) and pass it through the serialized job input.",
+            },
+          ],
+        },
+      ],
+    },
   }
 );


### PR DESCRIPTION
Closes #569

## Summary

`*_JobRunFns.ts` files execute inside workers, which have an isolated runtime with their own `globalServiceRegistry`. Importing main-thread-only state (the global service registry or credential stores) resolves against a different, empty registry at runtime. This contract is documented in AGENTS.md / CLAUDE.md but was not enforced in CI.

This PR adds a scoped ESLint config object (appended to the `defineConfig` array in the root `eslint.config.js`) that targets only `**/*_JobRunFns.ts` and sets `no-restricted-imports` to **error**, banning these named specifiers:

- from `@workglow/util`: `globalServiceRegistry`, `getGlobalCredentialStore`, `setGlobalCredentialStore`
- from `@workglow/util/worker`: `globalServiceRegistry`

It bans specific named imports (via `importNames`) rather than whole modules, so legitimate worker-safe imports from the same modules (e.g. `getLogger`, `WORKER_SERVER`, `WorkerManager`) still pass.

## Verification

Banned symbols and their source modules were determined by grepping the codebase (`git grep -n "getGlobalCredentialStore\|globalServiceRegistry"`): `globalServiceRegistry` is re-exported by both `@workglow/util` and `@workglow/util/worker` (via `./di`); `getGlobalCredentialStore` / `setGlobalCredentialStore` come from `@workglow/util` only (the worker entry does not re-export credentials).

**Clean pass** — all 14 committed `*_JobRunFns.ts` files lint with zero errors:

```
$ eslint <all *_JobRunFns.ts>
EXIT: 0
```

**Rule fires** — a throwaway fixture importing the banned symbols (since deleted, not committed) was correctly flagged:

```
Fixture_JobRunFns.ts
  7:10  error  'globalServiceRegistry' import from '@workglow/util' is restricted...      no-restricted-imports
  7:33  error  'getGlobalCredentialStore' import from '@workglow/util' is restricted...   no-restricted-imports
  8:10  error  'globalServiceRegistry' import from '@workglow/util/worker' is restricted... no-restricted-imports

✖ 3 problems (3 errors, 0 warnings)
```

**Scoping confirmed** — the same imports in a non-`_JobRunFns.ts` file produce 0 restricted-import errors, so the rule applies only to worker run-fn files.

No existing `*_JobRunFns.ts` file violates the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkb4R6B7zBTdWWHeddycnQ)_