### PR TITLE
Add task-graph performance benchmarks (wide/deep/streaming)

### DIFF
--- a/packages/task-graph/bench/README.md
+++ b/packages/task-graph/bench/README.md
@@ -1,0 +1,30 @@
+# task-graph benchmarks
+
+Micro-benchmarks for the `@workglow/task-graph` execution engine, written with
+[Vitest's built-in `bench` API](https://vitest.dev/api/#bench). Each file builds
+and runs **real** `TaskGraph` instances (real `Task` subclasses, real
+`Dataflow` edges) — nothing is stubbed — so the numbers reflect the actual
+scheduler, edge materializer, and stream pump.
+
+## Scenarios
+
+| File                      | Axis              | What it stresses                                                                                                                                                     |
+| ------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wide-graph.bench.ts`     | fan-out breadth   | One source task feeding many independent leaf tasks (50 and 200). Measures dispatching a wide frontier of ready tasks and materializing many outgoing edges at once. |
+| `deep-graph.bench.ts`     | dependency depth  | A long linear chain where each task consumes the previous one's output (50 and 200 deep). Nothing runs in parallel, so this isolates per-hop scheduler overhead.     |
+| `streaming-pump.bench.ts` | stream throughput | An append-mode streaming task emitting many `text-delta` events (500 and 2000) into a downstream non-streaming consumer. Exercises the StreamPump accumulation path. |
+
+## Running
+
+Benchmarks are **not** part of the normal test run. Run them explicitly:
+
+```sh
+npx vitest bench packages/task-graph/bench
+# or, without npx:
+node_modules/.bin/vitest bench packages/task-graph/bench
+```
+
+`vitest bench` reports throughput (`hz`) and latency (`min` / `mean` / `p75` /
+`p99`) per scenario. There are no hard perf-threshold assertions — the goal is
+runnable, comparable coverage of the wide / deep / streaming axes, useful for
+spotting regressions between revisions.

--- a/packages/task-graph/bench/deep-graph.bench.ts
+++ b/packages/task-graph/bench/deep-graph.bench.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Deep-graph benchmark: dependency-chain depth.
+ *
+ * A long linear chain where each task consumes the previous task's output.
+ * Nothing can run in parallel, so this isolates the per-hop overhead of the
+ * scheduler: edge materialization, status propagation, and the topological
+ * step from one task to the next.
+ */
+
+import type { CachePolicy, IExecuteContext } from "@workglow/task-graph";
+import { Dataflow, Task, TaskGraph } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { bench, describe } from "vitest";
+
+interface CounterInput {
+  readonly n: number;
+}
+
+interface CounterOutput {
+  readonly n: number;
+}
+
+class ChainCounterTask extends Task<CounterInput, CounterOutput> {
+  public static override type = "Bench_ChainCounterTask";
+  public static override category = "Benchmark";
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { n: { type: "number", default: 0 } },
+      required: ["n"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { n: { type: "number" } },
+      required: ["n"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: CounterInput, _context: IExecuteContext): Promise<CounterOutput> {
+    return { n: input.n + 1 };
+  }
+}
+
+function buildDeepGraph(depth: number): TaskGraph {
+  const graph = new TaskGraph();
+  graph.addTask(new ChainCounterTask({ id: "node-0", defaults: { n: 0 } }));
+  for (let i = 1; i < depth; i++) {
+    const id = `node-${i}`;
+    graph.addTask(new ChainCounterTask({ id }));
+    graph.addDataflow(new Dataflow(`node-${i - 1}`, "n", id, "n"));
+  }
+  return graph;
+}
+
+describe("deep-graph chain", () => {
+  bench("50-deep chain", async () => {
+    const graph = buildDeepGraph(50);
+    await graph.run();
+  });
+
+  bench("200-deep chain", async () => {
+    const graph = buildDeepGraph(200);
+    await graph.run();
+  });
+});

--- a/packages/task-graph/bench/streaming-pump.bench.ts
+++ b/packages/task-graph/bench/streaming-pump.bench.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Streaming-pump benchmark: stream-event throughput.
+ *
+ * An append-mode source task emits many `text-delta` events which the runner
+ * accumulates and hands to a downstream non-streaming consumer. This exercises
+ * the StreamPump / StreamProcessor path — teeing, per-delta accumulation, and
+ * the enriched finish event — rather than the plain topological scheduler.
+ */
+
+import type { CachePolicy, IExecuteContext, StreamEvent } from "@workglow/task-graph";
+import { Dataflow, Task, TaskGraph } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { bench, describe } from "vitest";
+
+interface PromptInput {
+  readonly deltas: number;
+}
+
+interface TextOutput {
+  readonly text: string;
+}
+
+/**
+ * Emits `input.deltas` incremental text-delta events on the `text` port, then a
+ * finish event. Mirrors real provider streaming: deltas carry the payload and
+ * the runner accumulates them into the append port.
+ */
+class StreamSourceTask extends Task<PromptInput, TextOutput> {
+  public static override type = "Bench_StreamSourceTask";
+  public static override category = "Benchmark";
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { deltas: { type: "number", default: 100 } },
+      required: ["deltas"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", "x-stream": "append" } },
+      required: ["text"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async *executeStream(
+    input: PromptInput,
+    _context: IExecuteContext
+  ): AsyncIterable<StreamEvent<TextOutput>> {
+    for (let i = 0; i < input.deltas; i++) {
+      yield { type: "text-delta", port: "text", textDelta: "tok " };
+    }
+    yield { type: "finish", data: {} as TextOutput };
+  }
+
+  override async execute(input: PromptInput, _context: IExecuteContext): Promise<TextOutput> {
+    return { text: "tok ".repeat(input.deltas) };
+  }
+}
+
+interface LengthOutput {
+  readonly length: number;
+}
+
+class ConsumeTextTask extends Task<TextOutput, LengthOutput> {
+  public static override type = "Bench_ConsumeTextTask";
+  public static override category = "Benchmark";
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { text: { type: "string", default: "" } },
+      required: ["text"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { length: { type: "number" } },
+      required: ["length"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: TextOutput, _context: IExecuteContext): Promise<LengthOutput> {
+    return { length: input.text.length };
+  }
+}
+
+function buildStreamingGraph(deltas: number): TaskGraph {
+  const graph = new TaskGraph();
+  graph.addTask(new StreamSourceTask({ id: "source", defaults: { deltas } }));
+  graph.addTask(new ConsumeTextTask({ id: "consumer" }));
+  graph.addDataflow(new Dataflow("source", "text", "consumer", "text"));
+  return graph;
+}
+
+describe("streaming-pump throughput", () => {
+  bench("500 deltas", async () => {
+    const graph = buildStreamingGraph(500);
+    await graph.run();
+  });
+
+  bench("2000 deltas", async () => {
+    const graph = buildStreamingGraph(2000);
+    await graph.run();
+  });
+});

--- a/packages/task-graph/bench/wide-graph.bench.ts
+++ b/packages/task-graph/bench/wide-graph.bench.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Wide-graph benchmark: fan-out breadth.
+ *
+ * A single source task feeds its output into many independent leaf tasks that
+ * have no dependencies on one another. This stresses the scheduler's ability to
+ * dispatch a large number of ready tasks and materialize edges across a wide
+ * frontier rather than a long chain.
+ */
+
+import type { CachePolicy, IExecuteContext } from "@workglow/task-graph";
+import { Dataflow, Task, TaskGraph } from "@workglow/task-graph";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { bench, describe } from "vitest";
+
+interface CounterInput {
+  readonly n: number;
+}
+
+interface CounterOutput {
+  readonly n: number;
+}
+
+class WideCounterTask extends Task<CounterInput, CounterOutput> {
+  public static override type = "Bench_WideCounterTask";
+  public static override category = "Benchmark";
+  public static override cachePolicy: CachePolicy = { kind: "none" };
+
+  public static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { n: { type: "number", default: 0 } },
+      required: ["n"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  public static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: { n: { type: "number" } },
+      required: ["n"],
+      additionalProperties: false,
+    } as const satisfies DataPortSchema;
+  }
+
+  override async execute(input: CounterInput, _context: IExecuteContext): Promise<CounterOutput> {
+    return { n: input.n + 1 };
+  }
+}
+
+function buildWideGraph(width: number): TaskGraph {
+  const graph = new TaskGraph();
+  graph.addTask(new WideCounterTask({ id: "source", defaults: { n: 0 } }));
+  for (let i = 0; i < width; i++) {
+    const leafId = `leaf-${i}`;
+    graph.addTask(new WideCounterTask({ id: leafId }));
+    graph.addDataflow(new Dataflow("source", "n", leafId, "n"));
+  }
+  return graph;
+}
+
+describe("wide-graph fan-out", () => {
+  bench("50 parallel leaves", async () => {
+    const graph = buildWideGraph(50);
+    await graph.run();
+  });
+
+  bench("200 parallel leaves", async () => {
+    const graph = buildWideGraph(200);
+    await graph.run();
+  });
+});


### PR DESCRIPTION
Closes #575

## Summary

Adds a `bench/` directory to `packages/task-graph` with Vitest `bench` files covering three performance axes. Each bench builds and runs **real** `TaskGraph` instances (real `Task` subclasses, real `Dataflow` edges) — nothing is stubbed — so numbers reflect the actual scheduler, edge materializer, and stream pump.

- **`wide-graph.bench.ts`** — fan-out breadth: one source task feeding many independent parallel leaf tasks (50 and 200).
- **`deep-graph.bench.ts`** — dependency-chain depth: a long linear chain where each task consumes the previous one's output (50 and 200 deep).
- **`streaming-pump.bench.ts`** — stream-event throughput: an append-mode streaming task emitting many `text-delta` events (500 and 2000) into a downstream non-streaming consumer, exercising the StreamPump accumulation path.

A `bench/README.md` documents the three scenarios and the run command. No hard perf-threshold assertions — the goal is runnable, comparable coverage on the wide/deep/streaming axes for spotting regressions.

`packages/task-graph/package.json` is intentionally left untouched; the run command is documented in the README instead.

## How to run

```sh
npx vitest bench packages/task-graph/bench
# or
node_modules/.bin/vitest bench packages/task-graph/bench
```

## Verification

All three benches run green and report throughput/latency numbers:

```
 ✓ packages/task-graph/bench/deep-graph.bench.ts > deep-graph chain 1896ms
     name                 hz      min      max     mean      p75      p99      rme  samples
   · 50-deep chain    117.48   3.2979  59.6180   8.5122   8.6072  59.6180  ±25.49%       59
   · 200-deep chain  13.2918  53.4693  95.0260  75.2342  84.9035  95.0260  ±12.12%       10

 ✓ packages/task-graph/bench/streaming-pump.bench.ts > streaming-pump throughput 1217ms
     name             hz     min      max    mean     p75      p99      rme  samples
   · 500 deltas   615.37  0.6134  25.3564  1.6250  0.9527  14.8661  ±18.65%      308
   · 2000 deltas  405.31  1.6576  31.7975  2.4672  2.3380   8.0943  ±13.29%      203

 ✓ packages/task-graph/bench/wide-graph.bench.ts > wide-graph fan-out 1354ms
     name                      hz      min      max     mean      p75      p99      rme  samples
   · 50 parallel leaves    115.81   2.2861  25.3959   8.6349  12.4870  25.3959  ±17.13%       59
   · 200 parallel leaves  60.2954  12.0224  36.8995  16.5850  17.8865  36.8995  ±12.51%       31

 BENCH  Summary
  50-deep chain          8.84x faster than 200-deep chain
  500 deltas             1.52x faster than 2000 deltas
  50 parallel leaves     1.92x faster than 200 parallel leaves
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkb4R6B7zBTdWWHeddycnQ)_