### PR TITLE
fix(knowledge-base): route console.warn through the structured logger

### DIFF
--- a/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
+++ b/packages/knowledge-base/src/knowledge-base/KnowledgeBase.ts
@@ -6,6 +6,7 @@
 
 import type { ITextIndex, TextFields, VectorSearchOptions } from "@workglow/storage";
 import type { IRunConfig } from "@workglow/task-graph";
+import { getLogger } from "@workglow/util";
 import type { TypedArray } from "@workglow/util/schema";
 import type { ChunkRecord } from "../chunk/ChunkSchema";
 import type {
@@ -337,7 +338,7 @@ export class KnowledgeBase {
     if (!index) return;
     const fields = chunkTextFields(stored.metadata);
     const warn = (err: unknown): void => {
-      console.warn(
+      getLogger().warn(
         `KnowledgeBase[${this.name}]: text index write failed for chunk ${stored.chunk_id}; ` +
           `index is now stale for this chunk. Call kb.reindexText() to recover. ` +
           `Error: ${err instanceof Error ? err.message : String(err)}`

--- a/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
+++ b/packages/knowledge-base/src/knowledge-base/ScopedTabularStorage.ts
@@ -22,7 +22,7 @@ import type {
   TabularSubscribeOptions,
 } from "@workglow/storage";
 import { decodeCursor, StorageValidationError } from "@workglow/storage";
-import { EventEmitter } from "@workglow/util";
+import { EventEmitter, getLogger } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 
 /**
@@ -59,7 +59,7 @@ export class ScopedTabularStorage<
     // field. We read it via a structural cast to fail loudly at
     // construction rather than leaking rows on a future `get` / `getBulk`.
     // Storages that don't expose `primaryKeyNames` (third-party impls)
-    // get a `console.warn` instead of a throw, so legitimate custom
+    // get a logged warning instead of a throw, so legitimate custom
     // backends keep working.
     const innerPkNames = (inner as { primaryKeyNames?: ReadonlyArray<unknown> }).primaryKeyNames;
     if (Array.isArray(innerPkNames)) {
@@ -72,7 +72,7 @@ export class ScopedTabularStorage<
         );
       }
     } else {
-      console.warn(
+      getLogger().warn(
         "ScopedTabularStorage: inner.primaryKeyNames is not exposed; cannot verify kb_id is in PK. " +
           "Scoping correctness requires `kb_id` to be part of the inner storage's primary key — " +
           "SQL backends drop fields not in PK from `get`/`getBulk` WHERE clauses."

--- a/packages/knowledge-base/src/knowledge-base/ScopedVectorStorage.ts
+++ b/packages/knowledge-base/src/knowledge-base/ScopedVectorStorage.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AnyVectorStorage, IVectorStorage, VectorSearchOptions } from "@workglow/storage";
+import { getLogger } from "@workglow/util";
 import type { DataPortSchemaObject, TypedArray } from "@workglow/util/schema";
 import { ScopedTabularStorage } from "./ScopedTabularStorage";
 
@@ -48,7 +49,7 @@ export class ScopedVectorStorage<
     // returned exactly as many results as we requested (overfetch limit) and
     // filtering still left us short of topK.
     if (topK && overfetchLimit && results.length >= overfetchLimit && filtered.length < topK) {
-      console.warn(
+      getLogger().warn(
         `ScopedVectorStorage: search returned ${filtered.length}/${topK} results after ` +
           `kb_id filtering. Consider increasing overFetchMultiplier (currently ${this.overFetchMultiplier}).`
       );

--- a/packages/test/src/test/rag/KnowledgeBaseHybridSearch.test.ts
+++ b/packages/test/src/test/rag/KnowledgeBaseHybridSearch.test.ts
@@ -6,7 +6,8 @@
 
 import { createKnowledgeBase } from "@workglow/knowledge-base";
 import { BM25Index } from "@workglow/storage";
-import { uuid4 } from "@workglow/util";
+import type { ILogger } from "@workglow/util";
+import { getLogger, NullLogger, setLogger, uuid4 } from "@workglow/util";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { report, snap } from "../../binding/testTiming";
@@ -320,11 +321,22 @@ describe("KnowledgeBase hybrid search (RRF over vector + BM25)", () => {
     report("hybrid: reindex-rollback", s);
   });
 
-  it("upsertChunk surfaces a warning when textIndex.add throws but keeps the chunk", async () => {
+  it("upsertChunk routes its index-write warning through the logger, not console", async () => {
     const s = snap();
-    const errors: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (msg: string) => errors.push(msg);
+    const warnings: string[] = [];
+    const capturing: ILogger = Object.assign(new NullLogger(), {
+      warn(message: string): void {
+        warnings.push(message);
+      },
+    });
+    const previousLogger = getLogger();
+    const originalConsoleWarn = console.warn;
+    let consoleWarnCalls = 0;
+    console.warn = ((...args: unknown[]) => {
+      consoleWarnCalls += 1;
+      return originalConsoleWarn.apply(console, args as []);
+    }) as typeof console.warn;
+    setLogger(capturing);
     try {
       const stub = {
         add() {
@@ -354,10 +366,13 @@ describe("KnowledgeBase hybrid search (RRF over vector + BM25)", () => {
       // Chunk is in the vector store even though the index write failed.
       expect(stored.chunk_id).toBe("c1");
       expect(await kb.getChunk("c1")).toBeDefined();
-      // And a warning was emitted naming the chunk.
-      expect(errors.some((m) => m.includes("c1"))).toBe(true);
+      // The warning was emitted through the structured logger, naming the chunk.
+      expect(warnings.some((m) => m.includes("c1"))).toBe(true);
+      // And it did NOT reach console.warn directly.
+      expect(consoleWarnCalls).toBe(0);
     } finally {
-      console.warn = originalWarn;
+      console.warn = originalConsoleWarn;
+      setLogger(previousLogger);
     }
     report("hybrid: index-warn", s);
   });


### PR DESCRIPTION
Closes #646

## Summary

Replaces the three raw `console.warn` calls in `@workglow/knowledge-base` with the structured `getLogger().warn(...)` so warnings flow through the DI-configured logger rather than writing to `console` directly.

- `KnowledgeBase.ts` — `syncTextIndexForChunk`'s local `warn` closure now calls `getLogger().warn(...)`. The exact message content and the fire-and-forget semantics are preserved: a text-index write failure still warns and never fails the upsert (the chunk is already durably stored).
- `ScopedVectorStorage.ts` — the overfetch/`kb_id`-filtering shortfall warning.
- `ScopedTabularStorage.ts` — the "inner `primaryKeyNames` not exposed" warning (added `getLogger` to the existing `@workglow/util` import; also updated a now-stale doc comment that referenced `console.warn`).

`getLogger` is imported as a value from `@workglow/util` (the package already depends on it, and sibling packages `storage`/`task-graph`/`mcp` import `getLogger` from the same entry).

## Verification

- Grep confirms zero `console.warn`/`console.log`/`console.error` remain in `packages/knowledge-base/src`.
- Updated the existing warn test to assert the index-write warning routes **through the logger, not `console`**: it installs a capturing `ILogger` via `setLogger`, wraps `console.warn` to count direct calls, and asserts `consoleWarnCalls === 0` while the captured warning still names the chunk (and the chunk survives the failed index write).
- `vitest run packages/test/src/test/rag/KnowledgeBaseHybridSearch.test.ts` → 17 passed
- `vitest run packages/knowledge-base` → 3 files, 20 passed
- `vitest run packages/test/src/test/rag/ScopedStorage.test.ts` → 28 passed
- Full `packages/test/src/test/rag` suite → 24 files, 225 passed
- Type check introduces no new errors (pre-existing implicit-`any` and use-source composite-reference noise are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkb4R6B7zBTdWWHeddycnQ)_