### PR TITLE
fix(ai): stop AiTask.narrowInput from mutating its input argument

### DIFF
--- a/packages/ai/src/task/base/AiTask.ts
+++ b/packages/ai/src/task/base/AiTask.ts
@@ -433,6 +433,7 @@ export class AiTask<
       }
       return input;
     }
+    const narrowed = { ...input };
     const modelTaskProperties = Object.entries<JsonSchema>(
       (inputSchema.properties || {}) as Record<string, JsonSchema>
     ).filter(([, schema]) => modelSemanticFromPropertySchema(schema)?.startsWith("model:"));
@@ -447,15 +448,15 @@ export class AiTask<
         if (typeof requestedModel === "string") {
           const found = await modelRepo.findByName(requestedModel);
           if (!found || !modelMeetsRequires(found, requires)) {
-            (input as any)[key] = undefined;
+            (narrowed as any)[key] = undefined;
           }
         } else if (typeof requestedModel === "object" && requestedModel !== null) {
           if (!modelMeetsRequires(requestedModel as ModelConfig, requires)) {
-            (input as any)[key] = undefined;
+            (narrowed as any)[key] = undefined;
           }
         }
       }
     }
-    return input;
+    return narrowed;
   }
 }

--- a/packages/test/src/test/ai/AiTask.narrowInput.test.ts
+++ b/packages/test/src/test/ai/AiTask.narrowInput.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelRepository } from "@workglow/ai";
+import { AiTask, InMemoryModelRepository, MODEL_REPOSITORY } from "@workglow/ai";
+import type { TaskInput, TaskOutput } from "@workglow/task-graph";
+import { ServiceRegistry } from "@workglow/util";
+import type { DataPortSchema } from "@workglow/util/schema";
+import { describe, expect, it } from "vitest";
+
+interface NarrowTestInput extends TaskInput {
+  readonly model: string;
+  readonly keep: string;
+}
+
+interface NarrowTestOutput extends TaskOutput {
+  readonly out: string;
+}
+
+class NarrowTestTask extends AiTask<NarrowTestInput, NarrowTestOutput> {
+  static override readonly type = "NarrowInputTestTask";
+
+  static override inputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        model: { type: "string", format: "model:NarrowInputTestTask" },
+        keep: { type: "string" },
+      },
+    } as const satisfies DataPortSchema;
+  }
+
+  static override outputSchema(): DataPortSchema {
+    return {
+      type: "object",
+      properties: {
+        out: { type: "string" },
+      },
+    } as const satisfies DataPortSchema;
+  }
+}
+
+async function createRegistry(): Promise<ServiceRegistry> {
+  const registry = new ServiceRegistry();
+  const modelRepo: ModelRepository = new InMemoryModelRepository();
+  registry.registerInstance(MODEL_REPOSITORY, modelRepo);
+  return registry;
+}
+
+describe("AiTask.narrowInput — does not mutate the input argument", () => {
+  it("drops an unresolvable model on the returned copy while leaving the argument untouched", async () => {
+    const registry = await createRegistry();
+    const task = new NarrowTestTask();
+
+    const input: NarrowTestInput = { model: "does-not-exist", keep: "value" };
+    const snapshot = structuredClone(input);
+
+    const narrowed = await task.narrowInput(input, registry);
+
+    // (a) the returned object has the model key narrowed to undefined
+    expect(narrowed.model).toBeUndefined();
+    expect(narrowed.keep).toBe("value");
+
+    // (b) the original input object is unchanged and is a different reference
+    expect(input).toEqual(snapshot);
+    expect(input.model).toBe("does-not-exist");
+    expect(narrowed).not.toBe(input);
+  });
+
+  it("returns a fresh object even when nothing is narrowed", async () => {
+    const registry = await createRegistry();
+    const modelRepo = registry.get<ModelRepository>(MODEL_REPOSITORY);
+    await modelRepo.addModel({
+      model_id: "resolvable",
+      capabilities: [],
+      provider: "fake",
+      title: "Resolvable",
+      description: "Resolvable",
+      provider_config: {},
+      metadata: {},
+    });
+    const task = new NarrowTestTask();
+
+    const input: NarrowTestInput = { model: "resolvable", keep: "value" };
+
+    const narrowed = await task.narrowInput(input, registry);
+
+    expect(narrowed.model).toBe("resolvable");
+    expect(narrowed.keep).toBe("value");
+    expect(narrowed).not.toBe(input);
+  });
+});


### PR DESCRIPTION
Closes #647

## Summary

`AiTask.narrowInput` narrowed unresolvable/incompatible `model:*` ports by setting them to `undefined` **directly on the caller's `input` object**, mutating a value the caller still held a reference to.

This refactors the method to shallow-copy the input once (`const narrowed = { ...input }`) and set the narrowed keys to `undefined` on the copy, returning the copy. The exact narrowing behavior (which keys are dropped, under which conditions) and the declared `Promise<Input>` return type are unchanged — only the mutation of the caller's object is removed. The localized `as any` cast style is preserved.

## Verification

Added `packages/test/src/test/ai/AiTask.narrowInput.test.ts` proving the argument is not mutated:
- the returned object has the unresolvable model key set to `undefined`;
- the original input is deep-equal to a pre-call snapshot and is a different reference from the return value;
- a fresh object is returned even when nothing is narrowed.

Targeted specs pass:

```
 RUN  v4.1.10

 Test Files  3 passed (3)
      Tests  20 passed (20)
```

(AiTask.narrowInput, AiTask.requires, AiTask.validateInput specs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jkb4R6B7zBTdWWHeddycnQ)_