### PR TITLE
fix(sqlite): serialize putBulk across shared-connection SqliteTabularStorage instances

### DIFF
--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -377,3 +377,135 @@ describe("SqliteTabularStorage regressions", () => {
     expect(await storage.size()).toBe(1);
   });
 });
+
+describe("SqliteTabularStorage putBulk across shared connection", () => {
+  const SharedSchema = {
+    type: "object",
+    properties: {
+      id: { type: "integer" },
+      val: { type: "string" },
+    },
+    required: ["id", "val"],
+    additionalProperties: false,
+  } as const satisfies DataPortSchemaObject;
+
+  async function makeTwoOnSharedConnection() {
+    await Sqlite.init();
+    const db = new Sqlite.Database(":memory:");
+    const tableA = `A_${uuid4().replace(/-/g, "_")}`;
+    const tableB = `B_${uuid4().replace(/-/g, "_")}`;
+    const repoA = new SqliteTabularStorage<typeof SharedSchema, readonly ["id"]>(
+      db,
+      tableA,
+      SharedSchema,
+      ["id"] as const
+    );
+    const repoB = new SqliteTabularStorage<typeof SharedSchema, readonly ["id"]>(
+      db,
+      tableB,
+      SharedSchema,
+      ["id"] as const
+    );
+    await repoA.setupDatabase();
+    await repoB.setupDatabase();
+    return { db, repoA, repoB };
+  }
+
+  it("sibling putBulk survives when the other rolls back on the shared connection", async () => {
+    const { repoA, repoB } = await makeTwoOnSharedConnection();
+
+    // Multi-chunk batch (SQLite bulk dialect chunks by 900 params ÷ per-row
+    // params — with 2 columns per row, 2000 rows crosses at least 4 chunks
+    // and drops microtask yields between each chunk).
+    const largeBatch = Array.from({ length: 2000 }, (_, i) => ({ id: i, val: `a${i}` }));
+    const smallBatch = [
+      { id: 10001, val: "b1" },
+      { id: 10002, val: "b2" },
+      { id: 10003, val: "b3" },
+    ];
+
+    // Force A to throw AFTER its BEGIN but BEFORE its own writes commit — the
+    // spy replaces the shared runBulkPut engine, so `_putBulkInternal`'s BEGIN
+    // has already executed on the connection when it rejects.
+    const runBulkPutSpy = vi
+      .spyOn(
+        repoA as unknown as { runBulkPut: (...a: unknown[]) => Promise<unknown> },
+        "runBulkPut"
+      )
+      .mockImplementation(async () => {
+        // Yield a microtask so a sibling storage on the same connection has a
+        // chance to slip in between A's BEGIN and A's throw (which is the very
+        // window the connection-mutex fix has to close).
+        await Promise.resolve();
+        await Promise.resolve();
+        throw new Error("boom-A");
+      });
+
+    try {
+      const [aResult, bResult] = await Promise.allSettled([
+        repoA.putBulk(largeBatch),
+        repoB.putBulk(smallBatch),
+      ]);
+
+      expect(aResult.status).toBe("rejected");
+      if (aResult.status === "rejected") {
+        expect((aResult.reason as Error).message).toContain("boom-A");
+      }
+      expect(bResult.status).toBe("fulfilled");
+
+      // The invariant: without the connection-scoped lock, B's writes would
+      // execute inside A's open transaction and vanish when A rolls back. The
+      // fix serializes A's BEGIN..ROLLBACK bracket against B, so B's own
+      // transaction commits independently and its rows survive.
+      expect(await repoB.size()).toBe(smallBatch.length);
+      expect(await repoA.size()).toBe(0);
+    } finally {
+      runBulkPutSpy.mockRestore();
+    }
+  });
+
+  it("does not emit put events for rows that were rolled back on the shared connection", async () => {
+    const { repoA, repoB } = await makeTwoOnSharedConnection();
+
+    const aPuts: Array<{ id: number; val: string }> = [];
+    const bPuts: Array<{ id: number; val: string }> = [];
+    repoA.on("put", (entity) => aPuts.push(entity));
+    repoB.on("put", (entity) => bPuts.push(entity));
+
+    const largeBatch = Array.from({ length: 2000 }, (_, i) => ({ id: i, val: `a${i}` }));
+    const smallBatch = [
+      { id: 20001, val: "b1" },
+      { id: 20002, val: "b2" },
+    ];
+
+    const runBulkPutSpy = vi
+      .spyOn(
+        repoA as unknown as { runBulkPut: (...a: unknown[]) => Promise<unknown> },
+        "runBulkPut"
+      )
+      .mockImplementation(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        throw new Error("boom-A");
+      });
+
+    try {
+      await Promise.allSettled([repoA.putBulk(largeBatch), repoB.putBulk(smallBatch)]);
+    } finally {
+      runBulkPutSpy.mockRestore();
+    }
+
+    // A rolled back — no put events on A. (putBulk's catch path emits
+    // `rollback`, not `put`.)
+    expect(aPuts).toHaveLength(0);
+
+    // B's put events must match the rows actually persisted. Without the
+    // connection lock, B would emit put events for rows that were then
+    // silently rolled back with A, breaking this invariant.
+    const surviving = new Set((await repoB.getAll())?.map((r) => (r as { id: number }).id) ?? []);
+    for (const emitted of bPuts) {
+      expect(surviving.has(emitted.id)).toBe(true);
+    }
+    expect(bPuts.length).toBe(surviving.size);
+  });
+});

--- a/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
@@ -485,27 +485,37 @@ export class SqliteAiVectorStorage<
       return super._putBulkInternal(entities);
     }
 
-    const updatedEntities: Entity[] = [];
-    // better-sqlite3 / bun:sqlite expose `inTransaction` as a runtime getter
-    // on the underlying handle; the canonical API doesn't surface it. When it's
-    // present and true (e.g. an outer `withTransaction` BEGIN is open and the
-    // proxy routed `tx.putBulk` here), iterate rows directly so we don't open a
-    // nested SQLite transaction. Browser-WASM has no such flag and never wraps
-    // mutating calls in `withTransaction` via the Proxy, so falling through to
-    // the inner `db.transaction(...)` is safe there.
-    const dbWithFlag = this.database as unknown as { readonly inTransaction?: boolean };
-    if (dbWithFlag.inTransaction) {
-      for (const item of entities) {
-        updatedEntities.push(this.executeVectorPutSync(item, false));
-      }
-    } else {
-      const transaction = this.database.transaction((items: any[]) => {
-        for (const item of items) {
-          updatedEntities.push(this.executeVectorPutSync(item, false));
+    // Route on the parent's per-instance `inTransaction` flag, not the
+    // connection-global `db.inTransaction`: the driver flag would report true
+    // for a sibling storage's transaction on the same handle and let this
+    // batch land inside that foreign transaction. `this.inTransaction` (or
+    // the `createTxView` proxy's override of it) only reports true when the
+    // outer `withTransaction` for THIS instance is in flight.
+    const alreadyInTx = this.inTransaction;
+    const runBatch = (): Entity[] => {
+      const updated: Entity[] = [];
+      if (alreadyInTx) {
+        for (const item of entities) {
+          updated.push(this.executeVectorPutSync(item, false));
         }
-      });
-      transaction(entities);
-    }
+      } else {
+        const transaction = this.database.transaction((items: any[]) => {
+          for (const item of items) {
+            updated.push(this.executeVectorPutSync(item, false));
+          }
+        });
+        transaction(entities);
+      }
+      return updated;
+    };
+
+    // When we own the BEGIN/COMMIT (via `db.transaction`), serialize on the
+    // connection-scoped mutex so another storage sharing this handle cannot
+    // interleave writes into our transaction. When already inside an outer
+    // `withTransaction`, that transaction already holds the connection lock.
+    const updatedEntities = alreadyInTx
+      ? runBatch()
+      : await this.connectionMutex(async () => runBatch());
 
     for (const entity of updatedEntities) this.emitPut(entity);
     return updatedEntities;

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -46,6 +46,20 @@ export const SQLITE_TABULAR_REPOSITORY = createServiceToken<AnyTabularStorage>(
 );
 
 /**
+ * Promise-chain mutex shared by every {@link SqliteTabularStorage} that opens
+ * on the same underlying `Sqlite.Database`. When two storage instances (e.g.
+ * on different tables) share one connection, the per-instance mutex only
+ * serializes calls within a single instance; without this connection-scoped
+ * lock, one instance's `putBulk` could interleave chunks between another
+ * instance's `BEGIN` and `COMMIT` on the same handle, executing rows inside
+ * a foreign transaction that later rolls back and silently losing them.
+ *
+ * Keyed by the `Sqlite.Database` handle so entries drop when every storage
+ * holding a reference is collected.
+ */
+const CONNECTION_MUTEX_CHAINS = new WeakMap<Sqlite.Database, Promise<void>>();
+
+/**
  * A SQLite-based key-value repository implementation.
  * @template Schema - The schema definition for the entity
  * @template PrimaryKeyNames - Array of property names that form the primary key
@@ -761,28 +775,48 @@ export class SqliteTabularStorage<
     };
 
     // Manual BEGIN/COMMIT (not db.transaction, whose body must be sync) keeps
-    // every chunk in one atomic unit. All statement execution is synchronous
-    // sqlite work, so no other writer interleaves between BEGIN and COMMIT.
-    const alreadyInTx = (this.db as unknown as { inTransaction?: boolean }).inTransaction === true;
-    if (!alreadyInTx) this.db.exec("BEGIN");
-    let result: { aligned: Entity[]; distinct: Entity[] };
-    try {
-      result = await this.runBulkPut(entities, dialect, 900, runChunk);
-      if (!alreadyInTx) this.db.exec("COMMIT");
-    } catch (error) {
-      if (!alreadyInTx) {
+    // every chunk in one atomic unit. `runBulkPut` awaits between chunks, and
+    // better-sqlite3's driver-level `inTransaction` flag is CONNECTION-global,
+    // so a second storage on the same handle would see `true` during our
+    // inter-chunk gap and skip its own BEGIN/COMMIT — its rows would land
+    // inside our transaction and vanish if we rolled back. `this.inTransaction`
+    // is per-instance (only true when THIS instance is between BEGIN and
+    // COMMIT/ROLLBACK, either via `withTransaction` or a proxy hop through
+    // `createTxView`), and the connection-scoped mutex serializes the whole
+    // BEGIN..COMMIT bracket against every other storage on the same handle.
+    // The proxy tx path skips both: `withTransaction` already holds the
+    // connection lock, and its own BEGIN is what we are re-entering.
+    const alreadyInTx = this.inTransaction;
+    if (alreadyInTx) {
+      let result: { aligned: Entity[]; distinct: Entity[] };
+      try {
+        result = await this.runBulkPut(entities, dialect, 900, runChunk);
+      } catch (error) {
+        safeEmit(this.events, "rollback", { op: "putBulk", error, ids: [] });
+        throw error;
+      }
+      for (const entity of result.distinct) this.emitPut(entity);
+      return result.aligned;
+    }
+
+    return this.connectionMutex(async () => {
+      this.db.exec("BEGIN");
+      let result: { aligned: Entity[]; distinct: Entity[] };
+      try {
+        result = await this.runBulkPut(entities, dialect, 900, runChunk);
+        this.db.exec("COMMIT");
+      } catch (error) {
         try {
           this.db.exec("ROLLBACK");
         } catch {
           // prefer the original error if rollback fails
         }
+        safeEmit(this.events, "rollback", { op: "putBulk", error, ids: [] });
+        throw error;
       }
-      safeEmit(this.events, "rollback", { op: "putBulk", error, ids: [] });
-      throw error;
-    }
-
-    for (const entity of result.distinct) this.emitPut(entity);
-    return result.aligned;
+      for (const entity of result.distinct) this.emitPut(entity);
+      return result.aligned;
+    });
   }
 
   /**
@@ -808,6 +842,41 @@ export class SqliteTabularStorage<
     this.mutexChain = new Promise<void>((resolve) => {
       release = resolve;
     });
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Connection-scoped promise-chain mutex. Wraps a section of work that must
+   * not interleave with anything else running on the same underlying
+   * `Sqlite.Database` handle — specifically, the `BEGIN`/`COMMIT` bracket in
+   * {@link _putBulkInternal} and {@link withTransaction}. Two
+   * {@link SqliteTabularStorage} instances sharing one connection each have
+   * their own per-instance {@link mutex}, so without this lock a second
+   * instance's `putBulk` could execute its rows inside the first instance's
+   * open transaction (better-sqlite3's driver-level `db.inTransaction`
+   * reports true across ALL instances on that handle), then lose those rows
+   * silently when the first transaction rolls back.
+   *
+   * The chain lives in a module-level {@link WeakMap} keyed by `this.db`, so
+   * the entry is eligible for GC as soon as the last storage referencing
+   * that database handle is collected.
+   *
+   * Always take the instance mutex first and the connection mutex second so
+   * two instances on one connection cannot deadlock — every caller acquires
+   * the two locks in the same order.
+   */
+  protected async connectionMutex<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = CONNECTION_MUTEX_CHAINS.get(this.db) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    CONNECTION_MUTEX_CHAINS.set(this.db, next);
     await prev;
     try {
       return await fn();
@@ -843,6 +912,13 @@ export class SqliteTabularStorage<
             );
           };
         }
+        // `_putBulkInternal` keys off `this.inTransaction` to skip its own
+        // BEGIN/COMMIT and connection lock — the outer `withTransaction`
+        // already owns both. The parent's `inTransaction` field is set on
+        // the real instance during `withTransaction`, but routing through
+        // the proxy (which is what `tx.putBulk(...)` does) reads THIS
+        // property; return true so the tx path takes the nested branch.
+        if (prop === "inTransaction") return true;
         if (prop === "emitPut") {
           return (entity: Entity) => deferredPutEvents.push(entity);
         }
@@ -871,25 +947,42 @@ export class SqliteTabularStorage<
    * because `fn` is async — better-sqlite3's transaction wrapper requires a
    * synchronous body.
    *
-   * Concurrent ops on the same storage instance from *outside* `fn` queue
-   * on this storage's mutex until the transaction commits or rolls back, so
-   * unrelated work cannot accidentally run inside the open transaction.
+   * Two levels of serialization:
+   *   - The per-instance mutex holds off concurrent ops on *this* storage
+   *     from *outside* `fn` until the transaction commits or rolls back, so
+   *     unrelated work cannot accidentally run inside the open transaction.
+   *   - The connection-scoped {@link connectionMutex} holds off writes from
+   *     *other* {@link SqliteTabularStorage} instances that share the same
+   *     `Sqlite.Database` handle for the same duration — without it a
+   *     sibling's `putBulk` on a different table would execute rows inside
+   *     our transaction and roll back silently when `fn` throws.
+   *
    * The `tx` handle passed to `fn` is a Proxy that routes back to internal
    * (unlocked) implementations, so calls *through* `tx` inside `fn` do not
-   * deadlock against the mutex.
+   * deadlock against either mutex.
    *
    * Nested `withTransaction` calls on `tx` throw rather than reusing the
    * outer transaction implicitly. Use {@link Sqlite.Database} `SAVEPOINT`s
    * directly if you need nested rollback boundaries.
    */
   /**
-   * True while the parent instance is between `BEGIN` and `COMMIT`/`ROLLBACK`.
-   * Used only to fail fast when `fn` captures the *original* storage instead
-   * of the `tx` handle and tries to recursively call `withTransaction` —
-   * that would deadlock against its own mutex. Calls routed through `tx`
-   * hit the proxy's `withTransaction` override before reaching here.
+   * True while THIS instance is between `BEGIN` and `COMMIT`/`ROLLBACK`
+   * (via `withTransaction`). Used by:
+   *   - `withTransaction` itself, to fail fast on recursive calls that
+   *     captured the *original* storage instead of the `tx` handle — those
+   *     would deadlock against the mutex the outer call is already holding.
+   *   - {@link _putBulkInternal}, to skip its own BEGIN/COMMIT and
+   *     connection lock when called via the `tx` proxy (which overrides the
+   *     property to report `true`), because the outer `withTransaction`
+   *     already owns both.
+   *
+   * `protected` so subclass overrides of `_putBulkInternal` (e.g.
+   * {@link SqliteAiVectorStorage}) can key on the same per-instance flag
+   * instead of falling back to better-sqlite3's connection-global
+   * `db.inTransaction`, which would report true for a sibling storage's
+   * open transaction on the same handle.
    */
-  private inTransaction: boolean = false;
+  protected inTransaction: boolean = false;
 
   override async withTransaction<T>(fn: (tx: this) => Promise<T>): Promise<T> {
     if (this.inTransaction) {
@@ -900,27 +993,36 @@ export class SqliteTabularStorage<
     }
     return this.mutex(async () => {
       const deferredPutEvents: Entity[] = [];
-      this.inTransaction = true;
-      try {
-        this.db.exec("BEGIN");
-        let result: T;
+      // Instance-mutex-first / connection-mutex-second so two instances
+      // sharing one `Sqlite.Database` cannot deadlock — every caller acquires
+      // the two locks in the same order. Holding the connection mutex across
+      // the whole BEGIN/`fn`/COMMIT|ROLLBACK bracket keeps other storages on
+      // the same handle from writing between our BEGIN and COMMIT (their
+      // writes would otherwise land inside our transaction and roll back
+      // silently if `fn` throws).
+      return this.connectionMutex(async () => {
+        this.inTransaction = true;
         try {
-          result = await fn(this.createTxView(deferredPutEvents));
-          this.db.exec("COMMIT");
-        } catch (err) {
+          this.db.exec("BEGIN");
+          let result: T;
           try {
-            this.db.exec("ROLLBACK");
-          } catch {
-            // prefer the original error if rollback fails
+            result = await fn(this.createTxView(deferredPutEvents));
+            this.db.exec("COMMIT");
+          } catch (err) {
+            try {
+              this.db.exec("ROLLBACK");
+            } catch {
+              // prefer the original error if rollback fails
+            }
+            throw err;
           }
-          throw err;
+          // Flush deferred events only on commit success.
+          for (const entity of deferredPutEvents) safeEmit(this.events, "put", entity);
+          return result;
+        } finally {
+          this.inTransaction = false;
         }
-        // Flush deferred events only on commit success.
-        for (const entity of deferredPutEvents) safeEmit(this.events, "put", entity);
-        return result;
-      } finally {
-        this.inTransaction = false;
-      }
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

HIGH-priority correctness fix from a scheduled review of the last 24h of `main` (surfaced by review of the `putBulk` engine refactor in `chore: release 0.3.27`).

## The bug

`SqliteTabularStorage._putBulkInternal` guarded on better-sqlite3's driver-level `db.inTransaction`, which is scoped to the **connection**, not to the storage instance. When two `SqliteTabularStorage` instances share one `Sqlite.Database` (the normal case for repos on the same file), a second `putBulk` starting during another's inter-chunk `await` gap read `inTransaction === true`, skipped its own `BEGIN`/`COMMIT`, executed rows inside the OTHER instance's transaction, emitted `put` events, and returned success. If the first instance later rolled back on a unique-constraint violation, the second's rows silently disappeared even though its caller had received the returned entities and subscribers had already seen `put` events for phantom rows.

## The fix

- Module-scope `WeakMap<Sqlite.Database, Promise<void>>` plus a protected `connectionMutex()` helper — GC-safe, keyed by the DB handle.
- `_putBulkInternal` keys off `this.inTransaction` (per-instance) and wraps its `BEGIN`/`runBulkPut`/`COMMIT`|`ROLLBACK` bracket in `connectionMutex(...)` when not already in a transaction.
- `withTransaction` wraps its own bracket the same way, inside the existing per-instance mutex — instance-first / connection-second so two instances on one handle cannot deadlock.
- `createTxView` reports `inTransaction === true` through the proxy so the `tx`-routed `putBulk` path takes the nested branch and skips both `BEGIN` and the connection lock (the outer `withTransaction` already holds both).
- `SqliteAiVectorStorage`'s overridden `_putBulkInternal` mirrors the parent — keys off `this.inTransaction` and takes `connectionMutex` on the owned-transaction path.

## Verification

Regression tests added under `packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts`:

- Two `SqliteTabularStorage` instances on DIFFERENT tables sharing one `Sqlite.Database`.
- Race `Promise.allSettled([repoA.putBulk(large), repoB.putBulk(small)])` with `runBulkPut` spied to yield microtasks and then throw on A.
- Asserts A rejects, B fulfills, and repoB's rows survive.
- Second test asserts B's `put` event stream never includes rows that were rolled back with A.

Run:
```sh
bun x vitest run packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
```

## Rollback

Revert the single file (`providers/sqlite/src/storage/SqliteTabularStorage.ts`, plus the mirror in `SqliteAiVectorStorage.ts`, plus the test). No schema/migration/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb6ESTZqJBiW79n6vh1voz)_