### PR TITLE
fix(storage,ai,gemini,llamacpp): shared-connection safety + bulk BigInt + Gemini NOT_FOUND + checkpoint scoping

### DIFF
--- a/packages/storage/src/common.ts
+++ b/packages/storage/src/common.ts
@@ -9,6 +9,8 @@
 export * from "./tabular/BaseTabularStorage";
 export * from "./tabular/BaseSqlTabularStorage";
 export * from "./tabular/CachedTabularStorage";
+export * from "./tabular/ConnectionMutex";
+export * from "./tabular/pkFingerprint";
 export * from "./tabular/CoveringIndexMissingError";
 export { pickCoveringIndex } from "./tabular/coveringIndexPicker";
 export type {

--- a/packages/storage/src/tabular/BaseSqlTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseSqlTabularStorage.ts
@@ -22,6 +22,7 @@ import {
   SimplifyPrimaryKey,
   ValueOptionType,
 } from "./ITabularStorage";
+import { pkFingerprint } from "./pkFingerprint";
 
 /**
  * Per-dialect hooks for the shared multi-row bulk-insert engine. Mirrors the
@@ -559,7 +560,7 @@ export abstract class BaseSqlTabularStorage<
    */
   protected bulkKeyOf(row: Record<string, unknown>): string {
     const pkCols = this.primaryKeyColumns() as unknown as string[];
-    return JSON.stringify(pkCols.map((c) => this.jsToSqlValue(c, row[c] as Entity[keyof Entity])));
+    return pkFingerprint(pkCols.map((c) => this.jsToSqlValue(c, row[c] as Entity[keyof Entity])));
   }
 
   /**

--- a/packages/storage/src/tabular/BaseSqlTabularStorage.ts
+++ b/packages/storage/src/tabular/BaseSqlTabularStorage.ts
@@ -103,6 +103,19 @@ export abstract class BaseSqlTabularStorage<
   /** Maps a JSON Schema type to its dialect-specific SQL type. */
   protected abstract mapTypeToSQL(typeDef: JsonSchema): string;
 
+  /**
+   * Returns the underlying connection handle when this storage may share it
+   * with other in-process storage instances (SQLite `Database`, PGlite
+   * session). A backend whose isolation is per-connection (a real `pg.Pool`
+   * that hands out a fresh client per query) returns `null` so writes stay
+   * un-serialized. When non-null the value keys the shared
+   * `ConnectionMutex` chain, so every instance that binds the same handle
+   * queues through one lock and can detect cross-instance re-entry.
+   */
+  protected connectionHandle(): object | null {
+    return null;
+  }
+
   protected constructPrimaryKeyColumns($delimiter: string = ""): string {
     let cached = this._pkColsCache.get($delimiter);
     if (cached === undefined) {

--- a/packages/storage/src/tabular/ConnectionMutex.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.ts
@@ -19,12 +19,15 @@
  *
  * This module keeps a module-level {@link WeakMap} keyed on the connection
  * handle so every instance that binds the same handle chains through the same
- * promise. A `node:async_hooks` {@link AsyncLocalStorage} carries owner
- * identity across `await` boundaries so calls made through a `tx` proxy
- * routed to the same instance (same-instance re-entry) can run inline instead
- * of deadlocking against the transaction's own lock, while a call from a
- * different instance while the transaction is open (cross-instance re-entry)
- * fails fast with a {@link ConnectionReentryError} — not by hanging.
+ * promise. Cross-instance re-entry detection lives on the handle state
+ * itself (`txOwner`), so it is **ALS-independent**: the module works
+ * identically on Node (real `AsyncLocalStorage`) and in the browser (the
+ * synchronous shim), even when the caller `await`s between the outer
+ * transaction opening and the sibling call. `AsyncLocalStorage` is only an
+ * **inline optimization on Node**: when the store exists and matches, a
+ * same-instance re-entry can run inline without re-taking the chain.
+ * Without it (browser shim), same-instance re-entry falls back to the chain
+ * — slower, but safe.
  */
 
 interface AlsContext {
@@ -42,9 +45,9 @@ let alsPromise: Promise<Als> | undefined;
 
 function createShimAls(): Als {
   // The browser bundle has no `node:async_hooks`. This shim carries the store
-  // synchronously across the same tick, which is enough for the same-instance
-  // re-entry detection here: the storage helpers acquire the ALS store and
-  // dispatch the wrapped body synchronously before any `await`.
+  // synchronously across the same tick. It cannot cross `await` boundaries,
+  // so cross-instance re-entry MUST NOT rely on the ALS store here — it
+  // relies on `state.txOwner` instead.
   let current: AlsContext | undefined;
   return {
     getStore(): AlsContext | undefined {
@@ -77,6 +80,18 @@ async function ensureAls(): Promise<Als> {
   return alsPromise;
 }
 
+/**
+ * Test-only: clears the cached `alsPromise` so the next `ensureAls()` call
+ * re-runs the factory. When `useShim` is true, immediately installs a fresh
+ * browser-shim ALS so subsequent calls exercise the ALS-less path (the same
+ * path a browser bundle takes when `node:async_hooks` is unavailable). Not
+ * part of the public runtime API — only exported for the ConnectionMutex
+ * test suite.
+ */
+export function __resetAlsForTesting(useShim: boolean = false): void {
+  alsPromise = useShim ? Promise.resolve(createShimAls()) : undefined;
+}
+
 interface HandleState {
   chain: Promise<void>;
   txOwner: object | null;
@@ -106,16 +121,72 @@ function ownerTable(owner: object): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+type ReentryDecision = "throw" | "inline" | "chain";
+
+/**
+ * Classify the current call against the state of the shared handle. Order
+ * matters: an active `txOwner` that is **not** our owner is always a
+ * cross-instance re-entry — regardless of whether the ALS store is present.
+ * Only if the caller is provably the same owner (matching ALS store) do we
+ * inline; anything else queues through the chain.
+ */
+function classifyReentry(
+  state: HandleState,
+  owner: object,
+  alsStore: AlsContext | undefined,
+  handle: object
+): ReentryDecision {
+  if (state.txOwner !== null && state.txOwner !== owner) {
+    return "throw";
+  }
+  if (alsStore !== undefined && alsStore.handle === handle && alsStore.owner === owner) {
+    return "inline";
+  }
+  return "chain";
+}
+
+/**
+ * Thrown when a storage instance tries to reach a shared connection while a
+ * *different* instance holds it — either a sibling single-op that hit an
+ * open transaction on the same handle, or a call that tried to open its own
+ * `withTransaction` while another instance's transaction is still running.
+ *
+ * The three supported refactors, in order of preference:
+ *
+ *   1. **Route the sibling call through the `tx` proxy on the same
+ *      instance.** The `tx` handle passed to `withTransaction(async (tx) =>
+ *      ...)` bypasses the mutex and joins the outer transaction directly.
+ *   2. **Open a SAVEPOINT on `tx` for a nested rollback boundary.** SQLite
+ *      and PostgreSQL have no autonomous `BEGIN`; a nested rollback
+ *      boundary is expressed as a `SAVEPOINT` inside the outer transaction,
+ *      not a nested `withTransaction`.
+ *   3. **Collapse to a single storage instance, or give each instance its
+ *      own connection.** Two instances that must run truly independent
+ *      transactions cannot share one connection; give each one a separate
+ *      handle (or a pooled client per query).
+ */
 export class ConnectionReentryError extends Error {
   constructor(
     readonly activeTable: string | undefined,
-    readonly blockedTable: string | undefined
+    readonly blockedTable: string | undefined,
+    readonly mode: "sibling-op" | "nested-transaction"
   ) {
     const active = activeTable ?? "another storage instance";
     const blocked = blockedTable ?? "an unlabeled storage instance";
-    super(
-      `Cross-instance re-entry on shared connection: ${blocked} attempted an operation while ${active} holds the connection.`
-    );
+    const modeLine =
+      mode === "nested-transaction"
+        ? `${blocked} attempted to open its own transaction while ${active} holds the connection.`
+        : `${blocked} attempted a sibling operation while ${active} holds the connection.`;
+    const message = [
+      "Cross-instance re-entry on a shared database connection.",
+      modeLine,
+      "",
+      "Supported refactors:",
+      `  (a) Route the ${blocked} call through the 'tx' proxy on the ${active} instance — tx bypasses the mutex and joins the outer transaction.`,
+      `  (b) Open a SAVEPOINT on 'tx' for a nested rollback boundary — SQLite/Postgres have no autonomous BEGIN, so a nested boundary is a SAVEPOINT, not a nested withTransaction.`,
+      `  (c) Collapse to a single storage instance, or give each instance its own connection — two instances that must run independent transactions cannot share one connection.`,
+    ].join("\n");
+    super(message);
     this.name = "ConnectionReentryError";
   }
 }
@@ -123,30 +194,42 @@ export class ConnectionReentryError extends Error {
 /**
  * Runs `fn` in a chain shared across every caller bound to `handle`.
  *
- * Same-instance re-entry (an active `AsyncLocalStorage` store on this handle
- * reports our `owner`) runs `fn` inline — the caller is already inside its
- * own `runInTransactionOnConnection` and re-taking the chain would deadlock.
+ * The handle state (`txOwner`) is checked first: if another instance holds
+ * the transaction, this throws {@link ConnectionReentryError} synchronously
+ * — no `await ensureAls()` needed on the throw path, so browser shim and
+ * Node behave identically.
  *
- * Cross-instance re-entry (the store reports a different owner) throws
- * {@link ConnectionReentryError} synchronously — hanging forever on a shared
- * connection is worse than failing loudly.
- *
- * No ALS context → normal chain wait.
+ * Same-instance re-entry that presents a matching `AsyncLocalStorage` store
+ * runs `fn` inline — the caller is already inside its own
+ * `runInTransactionOnConnection` and re-taking the chain would deadlock.
+ * On the browser shim, same-instance re-entry across an `await` falls back
+ * to the chain wait (safe; the outer transaction's chain slot has already
+ * been released by the time descendants queue).
  */
 export async function runOnConnection<T>(
   handle: object,
   owner: object,
   fn: () => Promise<T>
 ): Promise<T> {
-  const als = await ensureAls();
-  const store = als.getStore();
-  if (store !== undefined && store.handle === handle) {
-    if (store.owner === owner) {
-      return fn();
-    }
-    throw new ConnectionReentryError(ownerTable(store.owner), ownerTable(owner));
-  }
   const state = getState(handle);
+  // Fast, synchronous throw on cross-instance sibling ops — do NOT await
+  // ensureAls first, so the shim path (browser) still fails fast.
+  if (state.txOwner !== null && state.txOwner !== owner) {
+    throw new ConnectionReentryError(ownerTable(state.txOwner), ownerTable(owner), "sibling-op");
+  }
+  const als = await ensureAls();
+  const alsStore = als.getStore();
+  const decision = classifyReentry(state, owner, alsStore, handle);
+  if (decision === "throw") {
+    throw new ConnectionReentryError(
+      ownerTable(state.txOwner ?? owner),
+      ownerTable(owner),
+      "sibling-op"
+    );
+  }
+  if (decision === "inline") {
+    return fn();
+  }
   const prev = state.chain;
   let release!: () => void;
   state.chain = new Promise<void>((resolve) => {
@@ -167,26 +250,41 @@ export async function runOnConnection<T>(
  * enclosing owner and re-enter inline.
  *
  * Cross-instance re-entry from `fn`'s descendants throws
- * {@link ConnectionReentryError} the same way {@link runOnConnection} does.
+ * {@link ConnectionReentryError} the same way {@link runOnConnection} does,
+ * with `mode === "nested-transaction"` at the transaction-opening call
+ * site. The synchronous throw path here is symmetric with `runOnConnection`
+ * — the handle state is checked before awaiting ALS.
  */
 export async function runInTransactionOnConnection<T>(
   handle: object,
   owner: object,
   fn: () => Promise<T>
 ): Promise<T> {
-  const als = await ensureAls();
-  const store = als.getStore();
-  if (store !== undefined && store.handle === handle) {
-    if (store.owner === owner) {
-      // Nested-tx from the same owner: the caller is expected to have already
-      // guarded against this at its own call site (SQLite / PGlite have no
-      // autonomous BEGIN). Run inline so we surface a clearer downstream error
-      // instead of deadlocking here.
-      return fn();
-    }
-    throw new ConnectionReentryError(ownerTable(store.owner), ownerTable(owner));
-  }
   const state = getState(handle);
+  if (state.txOwner !== null && state.txOwner !== owner) {
+    throw new ConnectionReentryError(
+      ownerTable(state.txOwner),
+      ownerTable(owner),
+      "nested-transaction"
+    );
+  }
+  const als = await ensureAls();
+  const alsStore = als.getStore();
+  const decision = classifyReentry(state, owner, alsStore, handle);
+  if (decision === "throw") {
+    throw new ConnectionReentryError(
+      ownerTable(state.txOwner ?? owner),
+      ownerTable(owner),
+      "nested-transaction"
+    );
+  }
+  if (decision === "inline") {
+    // Nested-tx from the same owner: the caller is expected to have already
+    // guarded against this at its own call site (SQLite / PGlite have no
+    // autonomous BEGIN). Run inline so we surface a clearer downstream error
+    // instead of deadlocking here.
+    return fn();
+  }
   const prev = state.chain;
   let release!: () => void;
   state.chain = new Promise<void>((resolve) => {

--- a/packages/storage/src/tabular/ConnectionMutex.ts
+++ b/packages/storage/src/tabular/ConnectionMutex.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Cross-instance connection safety for storage backends that share a single
+ * underlying database handle across multiple in-process
+ * {@link BaseSqlTabularStorage} instances (e.g. two SqliteTabularStorage
+ * repositories wrapping the same `better-sqlite3` `Database`, or two
+ * PostgresTabularStorage repositories over one PGlite session).
+ *
+ * A per-instance mutex only serializes calls that reach a single storage
+ * object; it cannot see writes another storage sends to the same handle. That
+ * shows up as `SQLITE_BUSY` under concurrency, and — worse — as a second
+ * instance's `_putBulkInternal` interleaving between the first instance's
+ * `BEGIN` and `COMMIT`, corrupting the transaction boundary.
+ *
+ * This module keeps a module-level {@link WeakMap} keyed on the connection
+ * handle so every instance that binds the same handle chains through the same
+ * promise. A `node:async_hooks` {@link AsyncLocalStorage} carries owner
+ * identity across `await` boundaries so calls made through a `tx` proxy
+ * routed to the same instance (same-instance re-entry) can run inline instead
+ * of deadlocking against the transaction's own lock, while a call from a
+ * different instance while the transaction is open (cross-instance re-entry)
+ * fails fast with a {@link ConnectionReentryError} — not by hanging.
+ */
+
+interface AlsContext {
+  readonly txId: symbol;
+  readonly owner: object;
+  readonly handle: object;
+}
+
+interface Als {
+  getStore(): AlsContext | undefined;
+  run<T>(store: AlsContext, callback: () => T): T;
+}
+
+let alsPromise: Promise<Als> | undefined;
+
+function createShimAls(): Als {
+  // The browser bundle has no `node:async_hooks`. This shim carries the store
+  // synchronously across the same tick, which is enough for the same-instance
+  // re-entry detection here: the storage helpers acquire the ALS store and
+  // dispatch the wrapped body synchronously before any `await`.
+  let current: AlsContext | undefined;
+  return {
+    getStore(): AlsContext | undefined {
+      return current;
+    },
+    run<T>(store: AlsContext, callback: () => T): T {
+      const prev = current;
+      current = store;
+      try {
+        return callback();
+      } finally {
+        current = prev;
+      }
+    },
+  };
+}
+
+async function ensureAls(): Promise<Als> {
+  if (alsPromise) return alsPromise;
+  alsPromise = (async (): Promise<Als> => {
+    try {
+      const mod = (await import("node:async_hooks")) as {
+        readonly AsyncLocalStorage: new () => Als;
+      };
+      return new mod.AsyncLocalStorage();
+    } catch {
+      return createShimAls();
+    }
+  })();
+  return alsPromise;
+}
+
+interface HandleState {
+  chain: Promise<void>;
+  txOwner: object | null;
+  txId: symbol | null;
+  txCallerTable: string | undefined;
+}
+
+const handleStates = new WeakMap<object, HandleState>();
+
+function getState(handle: object): HandleState {
+  let state = handleStates.get(handle);
+  if (state === undefined) {
+    state = { chain: Promise.resolve(), txOwner: null, txId: null, txCallerTable: undefined };
+    handleStates.set(handle, state);
+  }
+  return state;
+}
+
+/**
+ * Best-effort label lookup for an owner. Storage instances expose their
+ * table name as a protected `table` property; when present it is included in
+ * a {@link ConnectionReentryError} message so operators can see both
+ * offending callers without leaking arbitrary object state.
+ */
+function ownerTable(owner: object): string | undefined {
+  const value = (owner as { readonly table?: unknown }).table;
+  return typeof value === "string" ? value : undefined;
+}
+
+export class ConnectionReentryError extends Error {
+  constructor(
+    readonly activeTable: string | undefined,
+    readonly blockedTable: string | undefined
+  ) {
+    const active = activeTable ?? "another storage instance";
+    const blocked = blockedTable ?? "an unlabeled storage instance";
+    super(
+      `Cross-instance re-entry on shared connection: ${blocked} attempted an operation while ${active} holds the connection.`
+    );
+    this.name = "ConnectionReentryError";
+  }
+}
+
+/**
+ * Runs `fn` in a chain shared across every caller bound to `handle`.
+ *
+ * Same-instance re-entry (an active `AsyncLocalStorage` store on this handle
+ * reports our `owner`) runs `fn` inline — the caller is already inside its
+ * own `runInTransactionOnConnection` and re-taking the chain would deadlock.
+ *
+ * Cross-instance re-entry (the store reports a different owner) throws
+ * {@link ConnectionReentryError} synchronously — hanging forever on a shared
+ * connection is worse than failing loudly.
+ *
+ * No ALS context → normal chain wait.
+ */
+export async function runOnConnection<T>(
+  handle: object,
+  owner: object,
+  fn: () => Promise<T>
+): Promise<T> {
+  const als = await ensureAls();
+  const store = als.getStore();
+  if (store !== undefined && store.handle === handle) {
+    if (store.owner === owner) {
+      return fn();
+    }
+    throw new ConnectionReentryError(ownerTable(store.owner), ownerTable(owner));
+  }
+  const state = getState(handle);
+  const prev = state.chain;
+  let release!: () => void;
+  state.chain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Runs `fn` as a transaction body on the shared connection. Acquires the
+ * chain lock, then establishes an {@link AsyncLocalStorage} store so nested
+ * `runOnConnection` calls from `fn`'s async descendants can detect the
+ * enclosing owner and re-enter inline.
+ *
+ * Cross-instance re-entry from `fn`'s descendants throws
+ * {@link ConnectionReentryError} the same way {@link runOnConnection} does.
+ */
+export async function runInTransactionOnConnection<T>(
+  handle: object,
+  owner: object,
+  fn: () => Promise<T>
+): Promise<T> {
+  const als = await ensureAls();
+  const store = als.getStore();
+  if (store !== undefined && store.handle === handle) {
+    if (store.owner === owner) {
+      // Nested-tx from the same owner: the caller is expected to have already
+      // guarded against this at its own call site (SQLite / PGlite have no
+      // autonomous BEGIN). Run inline so we surface a clearer downstream error
+      // instead of deadlocking here.
+      return fn();
+    }
+    throw new ConnectionReentryError(ownerTable(store.owner), ownerTable(owner));
+  }
+  const state = getState(handle);
+  const prev = state.chain;
+  let release!: () => void;
+  state.chain = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await prev;
+  const txId = Symbol("connection-tx");
+  state.txId = txId;
+  state.txOwner = owner;
+  state.txCallerTable = ownerTable(owner);
+  try {
+    return await als.run({ txId, owner, handle }, () => fn());
+  } finally {
+    if (state.txId === txId) {
+      state.txId = null;
+      state.txOwner = null;
+      state.txCallerTable = undefined;
+    }
+    release();
+  }
+}

--- a/packages/storage/src/tabular/pkFingerprint.ts
+++ b/packages/storage/src/tabular/pkFingerprint.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stable, collision-resistant fingerprint over an ordered tuple of primary-key
+ * values. Used by SQL backends to match rows across a `putBulk` input list and
+ * the database's `RETURNING *` response, and to dedupe last-wins when the same
+ * primary key is submitted multiple times in one batch.
+ *
+ * `JSON.stringify` alone silently drops `bigint` values (throws in strict mode
+ * on some runtimes) and stringifies `Uint8Array` as the ordered object of its
+ * indices — either mode gives two different `123n` and `"123"` primary keys
+ * the same fingerprint (`"[null]"` for both), which then collapses distinct
+ * rows in `runBulkPut`'s dedupe map or misaligns the response. A typed wrapper
+ * around the affected values keeps fingerprints byte-identical to today for
+ * every other primary-key value type (number / string / boolean / null /
+ * plain-object / array), while giving `bigint` and `Uint8Array` unambiguous
+ * encodings that cannot collide with those.
+ */
+export function pkFingerprint(values: readonly unknown[]): string {
+  return JSON.stringify(values, pkReplacer);
+}
+
+function pkReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return { __t: "n", v: value.toString() };
+  }
+  if (value instanceof Uint8Array) {
+    return { __t: "u8", v: bytesToHex(value) };
+  }
+  return value;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    out += (b < 16 ? "0" : "") + b.toString(16);
+  }
+  return out;
+}

--- a/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
+++ b/packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts
@@ -19,6 +19,7 @@ import {
   resolvedPaths,
   setLlamaCppSession,
   withSequence,
+  withSessionLock,
   withVramEviction,
 } from "@workglow/node-llama-cpp/ai-runtime";
 import type {
@@ -409,5 +410,76 @@ describe("getOrCreateEmbeddingContext under VRAM pressure", () => {
     expect(llamaCppModels.has("/tmp/lru.gguf")).toBe(false);
     expect(llamaCppTextContexts.has("/tmp/lru.gguf")).toBe(false);
     expect(llamaCppEmbeddingContexts.get("/tmp/target.gguf")).toBe(stubEmbeddingContext);
+  });
+});
+
+describe("withSessionLock", () => {
+  it("serializes two concurrent callers on the same sessionId", async () => {
+    const sessionId = "shared-session-a";
+    let release1: () => void = () => {};
+    const finish1 = new Promise<void>((resolve) => {
+      release1 = resolve;
+    });
+    const events: string[] = [];
+
+    const first = withSessionLock(sessionId, async () => {
+      events.push("first:start");
+      await finish1;
+      events.push("first:end");
+      return "one";
+    });
+    const second = withSessionLock(sessionId, async () => {
+      events.push("second:start");
+      return "two";
+    });
+
+    // Give the microtask queue a couple of ticks — if the lock is missing, the
+    // second body would race in and log its start before the first is released.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(events).toEqual(["first:start"]);
+
+    release1();
+    expect(await first).toEqual("one");
+    expect(await second).toEqual("two");
+    expect(events).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  it("allows unrelated sessionIds to run in parallel", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    let bStarted = false;
+    const a = withSessionLock("session-a", async () => {
+      await gate;
+      return "a";
+    });
+    const b = withSessionLock("session-b", async () => {
+      bStarted = true;
+      return "b";
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    // If sessionLocks were global, `b` would still be waiting on `a`.
+    expect(bStarted).toBe(true);
+    expect(await b).toEqual("b");
+
+    release();
+    expect(await a).toEqual("a");
+  });
+
+  it("releases the lock even when the body throws", async () => {
+    const sessionId = "throwing-session";
+    await expect(
+      withSessionLock(sessionId, async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    // A subsequent call must be able to proceed immediately.
+    const result = await withSessionLock(sessionId, async () => "ok");
+    expect(result).toEqual("ok");
   });
 });

--- a/packages/test/src/test/ai-provider/Gemini_CachedContentFallback.test.ts
+++ b/packages/test/src/test/ai-provider/Gemini_CachedContentFallback.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "vitest";
+
+// Plan C — Gemini NOT_FOUND matcher two-tier — needs
+// `providers/google-gemini/src/ai/common/Gemini_CachedContentFallback.ts`, which
+// only exists on the `ai-provider-cache-checkpoints` feature branch. Once the
+// checkpoint plumbing lands on `main` this suite must:
+//
+//   1. Assert the structured NOT_FOUND matcher consults `err.details` /
+//      `err.error.details` for a `ResourceInfo`-shaped entry, treating a
+//      `cachedContents/…` prefix as a positive and any other prefix (models/,
+//      files/, tunedModels/, …) as a negative.
+//   2. Confirm the fallback path when the response has no structured details
+//      (caller has gated on `useCachedContent && checkpointId`).
+//   3. Extend the message-only fallback to accept the reversed clause order and
+//      the widened wording (`expired|stale|removed|deleted|no longer exists`)
+//      within the `{0,120}` distance.
+//   4. Cover the negative cases: model 404 with `ResourceInfo.resourceName =
+//      "models/…"`, cache 404 gated at the caller level, and the existing nine
+//      message-only negatives that the current matcher already rejects.
+//
+// Landing this before the fallback file exists on `main` would fail resolution.
+describe.skip("TODO — Plan C: Gemini NOT_FOUND matcher two-tier", () => {
+  it("cachedContents ResourceInfo → cache-not-found (positive)", () => {
+    // See TODO block above.
+  });
+
+  it("models/... ResourceInfo → not cache-not-found (negative)", () => {
+    // See TODO block above.
+  });
+
+  it("structured NOT_FOUND without details, caller-gated → cache-not-found", () => {
+    // See TODO block above.
+  });
+
+  it("widened message wording within {0,120} distance → cache-not-found", () => {
+    // See TODO block above.
+  });
+
+  it("existing negative wording set still rejected", () => {
+    // See TODO block above.
+  });
+});

--- a/packages/test/src/test/resource/ResourceScope.test.ts
+++ b/packages/test/src/test/resource/ResourceScope.test.ts
@@ -8,6 +8,22 @@ import { ResourceScope } from "@workglow/util";
 import { describe, expect, it, vi } from "vitest";
 
 describe("ResourceScope", () => {
+  it("mints a distinct id per instance", () => {
+    const a = new ResourceScope();
+    const b = new ResourceScope();
+    expect(typeof a.id).toEqual("string");
+    expect(a.id.length).toBeGreaterThan(0);
+    expect(a.id).not.toEqual(b.id);
+  });
+
+  it("keeps its id stable across dispose and reuse", async () => {
+    const scope = new ResourceScope();
+    const before = scope.id;
+    scope.register("k", async () => {});
+    await scope.disposeAll();
+    expect(scope.id).toEqual(before);
+  });
+
   it("should register and dispose a single resource", async () => {
     const scope = new ResourceScope();
     const disposer = vi.fn(async () => {});

--- a/packages/test/src/test/storage-tabular/ConnectionMutex.test.ts
+++ b/packages/test/src/test/storage-tabular/ConnectionMutex.test.ts
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ConnectionReentryError,
+  __resetAlsForTesting,
+  runInTransactionOnConnection,
+  runOnConnection,
+} from "@workglow/storage";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("ConnectionMutex F1: cross-instance re-entry is ALS-independent", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  describe.each([
+    ["real ALS (Node async_hooks)", false],
+    ["browser shim (no async_hooks)", true],
+  ] as const)("%s", (_label, useShim) => {
+    beforeEach(() => {
+      __resetAlsForTesting(useShim);
+    });
+
+    it("runOnConnection throws ConnectionReentryError when a sibling instance calls during a transaction", async () => {
+      const handle = {};
+      const ownerA = { table: "table_a" };
+      const ownerB = { table: "table_b" };
+
+      let releaseTx: () => void = () => {};
+      const txCanFinish = new Promise<void>((resolve) => {
+        releaseTx = resolve;
+      });
+      let signalTxStarted: () => void = () => {};
+      const txStarted = new Promise<void>((resolve) => {
+        signalTxStarted = resolve;
+      });
+
+      const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+        // signal runs *inside* als.run's synchronous entry, which is after
+        // state.txOwner has been set. Awaiting txStarted below guarantees
+        // the sibling call sees the established transaction owner.
+        signalTxStarted();
+        await txCanFinish;
+      });
+      await txStarted;
+
+      const start = Date.now();
+      let error: unknown;
+      try {
+        await runOnConnection(handle, ownerB, async () => "unreachable");
+      } catch (err) {
+        error = err;
+      }
+      const elapsed = Date.now() - start;
+
+      expect(error).toBeInstanceOf(ConnectionReentryError);
+      expect((error as ConnectionReentryError).mode).toBe("sibling-op");
+      expect((error as ConnectionReentryError).activeTable).toBe("table_a");
+      expect((error as ConnectionReentryError).blockedTable).toBe("table_b");
+      // No hang: even on the shim path the throw is synchronous relative to
+      // the pending outer tx (no chain wait needed).
+      expect(elapsed).toBeLessThan(200);
+
+      releaseTx();
+      await txPromise;
+    });
+
+    it("runInTransactionOnConnection throws ConnectionReentryError when a different owner tries a nested transaction", async () => {
+      const handle = {};
+      const ownerA = { table: "table_a" };
+      const ownerB = { table: "table_b" };
+
+      let releaseTx: () => void = () => {};
+      const txCanFinish = new Promise<void>((resolve) => {
+        releaseTx = resolve;
+      });
+      let signalTxStarted: () => void = () => {};
+      const txStarted = new Promise<void>((resolve) => {
+        signalTxStarted = resolve;
+      });
+
+      const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+        signalTxStarted();
+        await txCanFinish;
+      });
+      await txStarted;
+
+      const start = Date.now();
+      let error: unknown;
+      try {
+        await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
+      } catch (err) {
+        error = err;
+      }
+      const elapsed = Date.now() - start;
+
+      expect(error).toBeInstanceOf(ConnectionReentryError);
+      expect((error as ConnectionReentryError).mode).toBe("nested-transaction");
+      expect(elapsed).toBeLessThan(200);
+
+      releaseTx();
+      await txPromise;
+    });
+
+    it("cross-instance sibling throw does not corrupt the outer transaction's chain", async () => {
+      const handle = {};
+      const ownerA = { table: "table_a" };
+      const ownerB = { table: "table_b" };
+      let signalTxStarted: () => void = () => {};
+      const txStarted = new Promise<void>((resolve) => {
+        signalTxStarted = resolve;
+      });
+
+      let step = "before-tx";
+      const txDone = runInTransactionOnConnection(handle, ownerA, async () => {
+        signalTxStarted();
+        step = "in-tx";
+      });
+      await txStarted;
+
+      await expect(
+        runOnConnection(handle, ownerB, async () => "unreachable")
+      ).rejects.toBeInstanceOf(ConnectionReentryError);
+
+      await txDone;
+      expect(step).toBe("in-tx");
+
+      // The chain slot must be released — a subsequent A op runs cleanly.
+      const secondOp = await runOnConnection(handle, ownerA, async () => "ok");
+      expect(secondOp).toBe("ok");
+    });
+  });
+
+  it("same-instance nested via captured `this` inlines under real ALS", async () => {
+    // With real AsyncLocalStorage (Node) the store survives across `await`,
+    // so a call reaching back to runOnConnection with the same owner inlines
+    // rather than chain-waiting (which would deadlock — the outer tx still
+    // holds the chain slot). This is the "captured this" pattern that the
+    // ALS optimization exists for.
+    __resetAlsForTesting();
+    const handle = {};
+    const ownerA = { table: "table_a" };
+
+    let innerRan = false;
+    await runInTransactionOnConnection(handle, ownerA, async () => {
+      // Nested call with the same owner — must inline (no chain wait) or
+      // else this deadlocks.
+      const value = await runOnConnection(handle, ownerA, async () => {
+        innerRan = true;
+        return "inlined";
+      });
+      expect(value).toBe("inlined");
+    });
+
+    expect(innerRan).toBe(true);
+  });
+});
+
+describe("ConnectionMutex F2: ConnectionReentryError message and mode", () => {
+  afterEach(() => {
+    __resetAlsForTesting();
+  });
+
+  it("carries mode='sibling-op' for a sibling reach-through and includes the three refactor hints", async () => {
+    const handle = {};
+    const ownerA = { table: "issuer" };
+    const ownerB = { table: "filing" };
+    let releaseTx: () => void = () => {};
+    const txCanFinish = new Promise<void>((resolve) => {
+      releaseTx = resolve;
+    });
+    let signalTxStarted: () => void = () => {};
+    const txStarted = new Promise<void>((resolve) => {
+      signalTxStarted = resolve;
+    });
+
+    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+      signalTxStarted();
+      await txCanFinish;
+    });
+    await txStarted;
+
+    let err: unknown;
+    try {
+      await runOnConnection(handle, ownerB, async () => "unreachable");
+    } catch (e) {
+      err = e;
+    }
+    const casted = err as ConnectionReentryError;
+    expect(casted).toBeInstanceOf(ConnectionReentryError);
+    expect(casted.mode).toBe("sibling-op");
+    expect(casted.activeTable).toBe("issuer");
+    expect(casted.blockedTable).toBe("filing");
+    expect(casted.message).toContain("issuer");
+    expect(casted.message).toContain("filing");
+    expect(casted.message).toContain("sibling operation");
+    expect(casted.message).toContain("'tx' proxy");
+    expect(casted.message).toContain("SAVEPOINT");
+    expect(casted.message).toContain("single storage instance");
+
+    releaseTx();
+    await txPromise;
+  });
+
+  it("carries mode='nested-transaction' for a nested withTransaction reach-through", async () => {
+    const handle = {};
+    const ownerA = { table: "issuer" };
+    const ownerB = { table: "filing" };
+    let releaseTx: () => void = () => {};
+    const txCanFinish = new Promise<void>((resolve) => {
+      releaseTx = resolve;
+    });
+    let signalTxStarted: () => void = () => {};
+    const txStarted = new Promise<void>((resolve) => {
+      signalTxStarted = resolve;
+    });
+
+    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+      signalTxStarted();
+      await txCanFinish;
+    });
+    await txStarted;
+
+    let err: unknown;
+    try {
+      await runInTransactionOnConnection(handle, ownerB, async () => "unreachable");
+    } catch (e) {
+      err = e;
+    }
+    const casted = err as ConnectionReentryError;
+    expect(casted).toBeInstanceOf(ConnectionReentryError);
+    expect(casted.mode).toBe("nested-transaction");
+    expect(casted.message).toContain("open its own transaction");
+    expect(casted.message).toContain("SAVEPOINT");
+
+    releaseTx();
+    await txPromise;
+  });
+
+  it("falls back to generic labels when the owner has no `table` property", async () => {
+    const handle = {};
+    const ownerA = {}; // no table property
+    const ownerB = {};
+    let releaseTx: () => void = () => {};
+    const txCanFinish = new Promise<void>((resolve) => {
+      releaseTx = resolve;
+    });
+    let signalTxStarted: () => void = () => {};
+    const txStarted = new Promise<void>((resolve) => {
+      signalTxStarted = resolve;
+    });
+
+    const txPromise = runInTransactionOnConnection(handle, ownerA, async () => {
+      signalTxStarted();
+      await txCanFinish;
+    });
+    await txStarted;
+
+    let err: unknown;
+    try {
+      await runOnConnection(handle, ownerB, async () => "unreachable");
+    } catch (e) {
+      err = e;
+    }
+    const casted = err as ConnectionReentryError;
+    expect(casted).toBeInstanceOf(ConnectionReentryError);
+    expect(casted.activeTable).toBeUndefined();
+    expect(casted.blockedTable).toBeUndefined();
+    expect(casted.message).toContain("another storage instance");
+    expect(casted.message).toContain("an unlabeled storage instance");
+
+    releaseTx();
+    await txPromise;
+  });
+});

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -6,7 +6,7 @@
 
 import { PGlite } from "@electric-sql/pglite";
 import { PostgresTabularStorage } from "@workglow/postgres/storage";
-import { StorageValidationError } from "@workglow/storage";
+import { ConnectionReentryError, StorageValidationError } from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
 import type { Pool } from "pg";
 import { afterAll, describe, expect, it, vi } from "vitest";
@@ -323,6 +323,86 @@ describe("PostgresTabularStorage", () => {
         releaseInner();
         await txP;
         await externalP;
+      } finally {
+        await pglite.close();
+      }
+    });
+  });
+
+  describe("shared-connection safety (PGlite path)", () => {
+    async function makeSharedPair(): Promise<
+      readonly [
+        PostgresTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>,
+        PostgresTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>,
+        PGlite,
+      ]
+    > {
+      const pglite = new PGlite();
+      const shared = pglite as unknown as Pool;
+      const a = new PostgresTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>(
+        shared,
+        `shared_a_${uuid4().replace(/-/g, "_")}`,
+        CompoundSchema,
+        CompoundPrimaryKeyNames
+      );
+      const b = new PostgresTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>(
+        shared,
+        `shared_b_${uuid4().replace(/-/g, "_")}`,
+        CompoundSchema,
+        CompoundPrimaryKeyNames
+      );
+      await a.setupDatabase();
+      await b.setupDatabase();
+      return [a, b, pglite] as const;
+    }
+
+    it("sibling single-op blocks across a transaction on the same handle", async () => {
+      const [a, b, pglite] = await makeSharedPair();
+      try {
+        let releaseInner: () => void = () => {};
+        const innerCanFinish = new Promise<void>((resolve) => {
+          releaseInner = resolve;
+        });
+
+        const txPromise = a.withTransaction(async (tx) => {
+          await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+          await innerCanFinish;
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        let bDidWrite = false;
+        const siblingPut = b
+          .put({ name: "sibling-row", type: "x", option: "sib", success: true })
+          .then(() => {
+            bDidWrite = true;
+          });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(bDidWrite).toBe(false);
+
+        releaseInner();
+        await txPromise;
+        await siblingPut;
+
+        expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
+        expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+      } finally {
+        await pglite.close();
+      }
+    });
+
+    it("rejects cross-instance nested withTransaction within 500ms (no hang)", async () => {
+      const [a, b, pglite] = await makeSharedPair();
+      try {
+        const start = Date.now();
+        const attempt = a.withTransaction(async () => {
+          await b.withTransaction(async () => {
+            // unreachable
+          });
+        });
+        await expect(attempt).rejects.toBeInstanceOf(ConnectionReentryError);
+        expect(Date.now() - start).toBeLessThan(500);
       } finally {
         await pglite.close();
       }

--- a/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts
@@ -356,37 +356,51 @@ describe("PostgresTabularStorage", () => {
       return [a, b, pglite] as const;
     }
 
-    it("sibling single-op blocks across a transaction on the same handle", async () => {
+    it("sibling single-op throws ConnectionReentryError during a transaction on the same handle", async () => {
       const [a, b, pglite] = await makeSharedPair();
       try {
         let releaseInner: () => void = () => {};
         const innerCanFinish = new Promise<void>((resolve) => {
           releaseInner = resolve;
         });
+        let signalTxStarted: () => void = () => {};
+        const txStarted = new Promise<void>((resolve) => {
+          signalTxStarted = resolve;
+        });
 
         const txPromise = a.withTransaction(async (tx) => {
           await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+          signalTxStarted();
           await innerCanFinish;
         });
-        await Promise.resolve();
-        await Promise.resolve();
 
-        let bDidWrite = false;
-        const siblingPut = b
+        await txStarted;
+
+        // Sibling put from a different instance on the same handle: must
+        // fail fast with ConnectionReentryError(mode="sibling-op"), not
+        // silently block until the tx releases.
+        let siblingErr: unknown;
+        await b
           .put({ name: "sibling-row", type: "x", option: "sib", success: true })
-          .then(() => {
-            bDidWrite = true;
+          .catch((err) => {
+            siblingErr = err;
           });
 
-        await new Promise((r) => setTimeout(r, 50));
-        expect(bDidWrite).toBe(false);
+        expect(siblingErr).toBeInstanceOf(ConnectionReentryError);
+        const reentry = siblingErr as ConnectionReentryError;
+        expect(reentry.mode).toBe("sibling-op");
+        expect(reentry.message).toContain("sibling operation");
+        expect(reentry.message).toContain("'tx' proxy");
+        expect(reentry.message).toContain("SAVEPOINT");
+        expect(reentry.message).toContain("single storage instance");
 
         releaseInner();
         await txPromise;
-        await siblingPut;
 
         expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
-        expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+        // After the tx releases the connection, a sibling put succeeds.
+        await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
+        expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
       } finally {
         await pglite.close();
       }
@@ -396,13 +410,42 @@ describe("PostgresTabularStorage", () => {
       const [a, b, pglite] = await makeSharedPair();
       try {
         const start = Date.now();
-        const attempt = a.withTransaction(async () => {
-          await b.withTransaction(async () => {
-            // unreachable
+        let caught: unknown;
+        try {
+          await a.withTransaction(async () => {
+            await b.withTransaction(async () => {
+              // unreachable
+            });
           });
-        });
-        await expect(attempt).rejects.toBeInstanceOf(ConnectionReentryError);
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(ConnectionReentryError);
+        const reentry = caught as ConnectionReentryError;
+        expect(reentry.mode).toBe("nested-transaction");
+        expect(reentry.message).toContain("open its own transaction");
+        expect(reentry.message).toContain("'tx' proxy");
+        expect(reentry.message).toContain("SAVEPOINT");
+        expect(reentry.message).toContain("single storage instance");
         expect(Date.now() - start).toBeLessThan(500);
+      } finally {
+        await pglite.close();
+      }
+    });
+
+    it("same-instance nested writes via tx proxy still work", async () => {
+      const [a, , pglite] = await makeSharedPair();
+      try {
+        await a.withTransaction(async (tx) => {
+          await tx.put({ name: "n1", type: "x", option: "v1", success: true });
+          await tx.putBulk([
+            { name: "n2", type: "x", option: "v2", success: true },
+            { name: "n3", type: "x", option: "v3", success: true },
+          ]);
+        });
+        expect(await a.get({ name: "n1", type: "x" })).toBeDefined();
+        expect(await a.get({ name: "n2", type: "x" })).toBeDefined();
+        expect(await a.get({ name: "n3", type: "x" })).toBeDefined();
       } finally {
         await pglite.close();
       }

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -459,54 +459,77 @@ describe("SqliteTabularStorage shared-connection safety", () => {
     return [a, b, db] as const;
   }
 
-  it("sibling single-op blocks across a transaction on the same handle", async () => {
+  it("sibling single-op throws ConnectionReentryError during a transaction on the same handle", async () => {
     const [a, b] = await makeSharedPair();
     let releaseInner: () => void = () => {};
     const innerCanFinish = new Promise<void>((resolve) => {
       releaseInner = resolve;
     });
+    let signalTxStarted: () => void = () => {};
+    const txStarted = new Promise<void>((resolve) => {
+      signalTxStarted = resolve;
+    });
 
     const txPromise = a.withTransaction(async (tx) => {
+      // After this awaited put returns, we are provably inside the tx body,
+      // which means the shared ConnectionMutex has already set
+      // `state.txOwner = a`.
       await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+      signalTxStarted();
       await innerCanFinish;
     });
 
-    // Yield microtasks so the tx BEGIN runs before the sibling put queues.
-    await Promise.resolve();
-    await Promise.resolve();
+    await txStarted;
 
-    let bDidWrite = false;
-    const siblingPut = b
-      .put({ name: "sibling-row", type: "x", option: "sib", success: true })
-      .then(() => {
-        bDidWrite = true;
-      });
+    // A sibling put from a *different* storage instance on the same handle
+    // must fail fast, not sneak into the tx BEGIN/COMMIT window and not
+    // block silently. The connection mutex throws ConnectionReentryError
+    // synchronously with mode="sibling-op".
+    let siblingErr: unknown;
+    await b.put({ name: "sibling-row", type: "x", option: "sib", success: true }).catch((err) => {
+      siblingErr = err;
+    });
 
-    // Give the microtask queue an extra tick — if the connection lock leaks,
-    // b's put would sneak into the tx BEGIN/COMMIT window.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(bDidWrite).toBe(false);
+    expect(siblingErr).toBeInstanceOf(ConnectionReentryError);
+    const reentry = siblingErr as ConnectionReentryError;
+    expect(reentry.mode).toBe("sibling-op");
+    expect(reentry.message).toContain("sibling operation");
+    expect(reentry.message).toContain("'tx' proxy");
+    expect(reentry.message).toContain("SAVEPOINT");
+    expect(reentry.message).toContain("single storage instance");
 
     releaseInner();
     await txPromise;
-    await siblingPut;
 
+    // The outer tx still commits cleanly, and the shared connection is
+    // released so a normal sibling put now succeeds.
     expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
-    expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+    await b.put({ name: "post-tx-row", type: "x", option: "sib", success: true });
+    expect(await b.get({ name: "post-tx-row", type: "x" })).toBeDefined();
   });
 
   it("rejects cross-instance nested withTransaction within 500ms (no hang)", async () => {
     const [a, b] = await makeSharedPair();
     const start = Date.now();
-    const attempt = a.withTransaction(async () => {
-      // From inside a's transaction, another instance (b) tries to open its own
-      // withTransaction on the shared handle. This must fail, not deadlock.
-      await b.withTransaction(async () => {
-        // unreachable
+    let caught: unknown;
+    try {
+      await a.withTransaction(async () => {
+        // From inside a's transaction, another instance (b) tries to open its own
+        // withTransaction on the shared handle. This must fail, not deadlock.
+        await b.withTransaction(async () => {
+          // unreachable
+        });
       });
-    });
-    await expect(attempt).rejects.toBeInstanceOf(ConnectionReentryError);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ConnectionReentryError);
+    const reentry = caught as ConnectionReentryError;
+    expect(reentry.mode).toBe("nested-transaction");
+    expect(reentry.message).toContain("open its own transaction");
+    expect(reentry.message).toContain("'tx' proxy");
+    expect(reentry.message).toContain("SAVEPOINT");
+    expect(reentry.message).toContain("single storage instance");
     expect(Date.now() - start).toBeLessThan(500);
   });
 

--- a/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
+++ b/packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { Sqlite, SqliteTabularStorage } from "@workglow/sqlite/storage";
-import { StorageValidationError } from "@workglow/storage";
+import { ConnectionReentryError, StorageValidationError } from "@workglow/storage";
 import { setLogger, uuid4 } from "@workglow/util";
 import type { DataPortSchemaObject } from "@workglow/util/schema";
 import { describe, expect, it, vi } from "vitest";
@@ -375,5 +375,152 @@ describe("SqliteTabularStorage regressions", () => {
     const again = await storage.putBulk([{ a: "x", b: "y" }]);
     expect(again).toEqual([{ a: "x", b: "y" }]);
     expect(await storage.size()).toBe(1);
+  });
+});
+
+describe("SqliteTabularStorage BigInt primary keys", () => {
+  const BigIntSchema = {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 0 },
+      label: { type: "string" },
+    },
+    required: ["id", "label"],
+    additionalProperties: false,
+  } as const satisfies DataPortSchemaObject;
+  const BigIntPrimaryKeyNames = ["id"] as const;
+
+  it("aligns putBulk rows keyed by BigInt values above Number.MAX_SAFE_INTEGER", async () => {
+    const storage = new SqliteTabularStorage<typeof BigIntSchema, typeof BigIntPrimaryKeyNames>(
+      ":memory:",
+      `bigint_pk_${uuid4().replace(/-/g, "_")}`,
+      BigIntSchema,
+      BigIntPrimaryKeyNames
+    );
+    await storage.setupDatabase();
+
+    // 9007199254740993n is Number.MAX_SAFE_INTEGER + 2; it survives BigInt but
+    // would collide with 9007199254740992 (MAX_SAFE_INTEGER + 1 rounded) once
+    // coerced to a JS number.
+    const rows = await storage.putBulk([
+      { id: 9007199254740993n as unknown as number, label: "big-1" },
+      { id: 9007199254740995n as unknown as number, label: "big-2" },
+    ]);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.label)).toEqual(["big-1", "big-2"]);
+  });
+
+  it("collapses duplicate BigInt PKs last-wins in putBulk", async () => {
+    const storage = new SqliteTabularStorage<typeof BigIntSchema, typeof BigIntPrimaryKeyNames>(
+      ":memory:",
+      `bigint_pk_dup_${uuid4().replace(/-/g, "_")}`,
+      BigIntSchema,
+      BigIntPrimaryKeyNames
+    );
+    await storage.setupDatabase();
+
+    const returned = await storage.putBulk([
+      { id: 9007199254740993n as unknown as number, label: "first" },
+      { id: 9007199254740993n as unknown as number, label: "second" },
+    ]);
+    // Both input rows point at the same row after last-wins dedupe.
+    expect(returned).toHaveLength(2);
+    expect(returned[0].label).toEqual("second");
+    expect(returned[1].label).toEqual("second");
+    expect(await storage.size()).toEqual(1);
+  });
+});
+
+describe("SqliteTabularStorage shared-connection safety", () => {
+  async function makeSharedPair(): Promise<
+    readonly [
+      SqliteTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>,
+      SqliteTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>,
+      Sqlite.Database,
+    ]
+  > {
+    const db = new Sqlite.Database(":memory:");
+    const tableA = `shared_a_${uuid4().replace(/-/g, "_")}`;
+    const tableB = `shared_b_${uuid4().replace(/-/g, "_")}`;
+    const a = new SqliteTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>(
+      db,
+      tableA,
+      CompoundSchema,
+      CompoundPrimaryKeyNames
+    );
+    const b = new SqliteTabularStorage<typeof CompoundSchema, typeof CompoundPrimaryKeyNames>(
+      db,
+      tableB,
+      CompoundSchema,
+      CompoundPrimaryKeyNames
+    );
+    await a.setupDatabase();
+    await b.setupDatabase();
+    return [a, b, db] as const;
+  }
+
+  it("sibling single-op blocks across a transaction on the same handle", async () => {
+    const [a, b] = await makeSharedPair();
+    let releaseInner: () => void = () => {};
+    const innerCanFinish = new Promise<void>((resolve) => {
+      releaseInner = resolve;
+    });
+
+    const txPromise = a.withTransaction(async (tx) => {
+      await tx.put({ name: "tx-row", type: "x", option: "tx", success: true });
+      await innerCanFinish;
+    });
+
+    // Yield microtasks so the tx BEGIN runs before the sibling put queues.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    let bDidWrite = false;
+    const siblingPut = b
+      .put({ name: "sibling-row", type: "x", option: "sib", success: true })
+      .then(() => {
+        bDidWrite = true;
+      });
+
+    // Give the microtask queue an extra tick — if the connection lock leaks,
+    // b's put would sneak into the tx BEGIN/COMMIT window.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bDidWrite).toBe(false);
+
+    releaseInner();
+    await txPromise;
+    await siblingPut;
+
+    expect(await a.get({ name: "tx-row", type: "x" })).toBeDefined();
+    expect(await b.get({ name: "sibling-row", type: "x" })).toBeDefined();
+  });
+
+  it("rejects cross-instance nested withTransaction within 500ms (no hang)", async () => {
+    const [a, b] = await makeSharedPair();
+    const start = Date.now();
+    const attempt = a.withTransaction(async () => {
+      // From inside a's transaction, another instance (b) tries to open its own
+      // withTransaction on the shared handle. This must fail, not deadlock.
+      await b.withTransaction(async () => {
+        // unreachable
+      });
+    });
+    await expect(attempt).rejects.toBeInstanceOf(ConnectionReentryError);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it("same-instance nested writes via tx proxy still work", async () => {
+    const [a] = await makeSharedPair();
+    await a.withTransaction(async (tx) => {
+      await tx.put({ name: "n1", type: "x", option: "v1", success: true });
+      await tx.putBulk([
+        { name: "n2", type: "x", option: "v2", success: true },
+        { name: "n3", type: "x", option: "v3", success: true },
+      ]);
+    });
+    expect(await a.get({ name: "n1", type: "x" })).toBeDefined();
+    expect(await a.get({ name: "n2", type: "x" })).toBeDefined();
+    expect(await a.get({ name: "n3", type: "x" })).toBeDefined();
   });
 });

--- a/packages/test/src/test/storage-tabular/pkFingerprint.test.ts
+++ b/packages/test/src/test/storage-tabular/pkFingerprint.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { pkFingerprint } from "@workglow/storage";
+import { describe, expect, it } from "vitest";
+
+describe("pkFingerprint", () => {
+  it("returns byte-identical output for pre-BigInt primary-key shapes", () => {
+    // Anything the previous JSON.stringify pipeline could encode losslessly
+    // must produce the same fingerprint after the switch.
+    expect(pkFingerprint([1, "hello", true])).toEqual(JSON.stringify([1, "hello", true]));
+    expect(pkFingerprint(["only"])).toEqual(JSON.stringify(["only"]));
+    expect(pkFingerprint([null])).toEqual(JSON.stringify([null]));
+    expect(pkFingerprint([])).toEqual(JSON.stringify([]));
+    expect(pkFingerprint([{ a: 1 }])).toEqual(JSON.stringify([{ a: 1 }]));
+  });
+
+  it("distinguishes a BigInt PK from a numerically identical string or number", () => {
+    // Would-be BigInt encoding for 123n must not collide with the string "123",
+    // the number 123, or the marker string "n:123" that a naive encoding could
+    // choose. All four must be distinct fingerprints so dedup / response
+    // alignment doesn't collapse rows with different PK types.
+    const asBig = pkFingerprint([123n]);
+    const asStr = pkFingerprint(["123"]);
+    const asNum = pkFingerprint([123]);
+    const asMarker = pkFingerprint(["n:123"]);
+    expect(new Set([asBig, asStr, asNum, asMarker]).size).toEqual(4);
+  });
+
+  it("returns equal fingerprints for structurally identical BigInt inputs", () => {
+    expect(pkFingerprint([9007199254740993n, "row"])).toEqual(
+      pkFingerprint([9007199254740993n, "row"])
+    );
+  });
+
+  it("distinguishes a Uint8Array PK from a look-alike string or array", () => {
+    const bytes = pkFingerprint([new Uint8Array([1, 2, 3])]);
+    const str = pkFingerprint(["010203"]);
+    const arr = pkFingerprint([[1, 2, 3]]);
+    expect(new Set([bytes, str, arr]).size).toEqual(3);
+    expect(pkFingerprint([new Uint8Array([1, 2, 3])])).toEqual(
+      pkFingerprint([new Uint8Array([1, 2, 3])])
+    );
+    expect(pkFingerprint([new Uint8Array([1, 2, 3])])).not.toEqual(
+      pkFingerprint([new Uint8Array([1, 2, 4])])
+    );
+  });
+
+  it("returns a stable string for the empty tuple", () => {
+    expect(pkFingerprint([])).toEqual("[]");
+  });
+});

--- a/packages/util/src/resource/ResourceScope.ts
+++ b/packages/util/src/resource/ResourceScope.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { uuid4 } from "../crypto/Crypto";
 import { getLogger } from "../logging";
 import { DisposeStrategy, type IDisposeStrategy } from "./DisposeStrategy";
 
@@ -23,10 +24,22 @@ export interface ResourceScopeOptions {
  *
  * First-registration-wins: if a key is already present, subsequent
  * registrations for that key are silently ignored.
+ *
+ * Runs sharing the same `ResourceScope` share checkpoints; two runs with
+ * different scopes cannot consume each other's checkpoints even with matching
+ * provider/model. The scope's `id` is the tenant token downstream checkpoint
+ * plumbing keys on so cross-scope re-use is a first-class error.
  */
 export class ResourceScope {
   private readonly disposers = new Map<string, () => Promise<void>>();
   private readonly strategy: IDisposeStrategy;
+  /**
+   * Stable tenant identity for this scope. Downstream tenant-scoped resource
+   * caches (provider-side checkpoint entries, per-scope KV pools) key on this
+   * value so a consumer under a different scope cannot pick up a resource
+   * minted here.
+   */
+  readonly id: string = uuid4();
 
   constructor(options: ResourceScopeOptions = {}) {
     this.strategy = options.strategy ?? DisposeStrategy.runCompletion();

--- a/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
+++ b/providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts
@@ -63,6 +63,38 @@ export interface LlamaCppSessionState {
 
 export const llamaCppSessions = new Map<string, LlamaCppSessionState>();
 
+/**
+ * Per-`sessionId` promise-chain mutex. Two concurrent generation callers that
+ * consume the same immutable checkpoint (keep-parent flow) share one cached
+ * `LlamaChatSession`, so their `session.prompt` / `LlamaChat.generateResponse`
+ * calls must not overlap on the sequence. `withSessionLock` chains them so the
+ * second waits until the first has fully returned (and the wrapper has had a
+ * chance to rewind the KV cache back to the immutable prefix) before running.
+ * The lock is intentionally session-scoped, not global, so unrelated sessions
+ * still run in parallel.
+ */
+const sessionLocks = new Map<string, Promise<void>>();
+
+export async function withSessionLock<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = sessionLocks.get(sessionId) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  sessionLocks.set(sessionId, next);
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    // Drop the map entry when we're the trailing waiter, so a session that
+    // never runs again does not stay pinned in the map indefinitely.
+    if (sessionLocks.get(sessionId) === next) {
+      sessionLocks.delete(sessionId);
+    }
+    release();
+  }
+}
+
 export function getLlamaCppSession(sessionId: string): LlamaCppSessionState | undefined {
   return llamaCppSessions.get(sessionId);
 }

--- a/providers/postgres/src/storage/PostgresTabularStorage.ts
+++ b/providers/postgres/src/storage/PostgresTabularStorage.ts
@@ -24,6 +24,8 @@ import {
   pickCoveringIndex,
   PostgresDialect,
   QueryOptions,
+  runInTransactionOnConnection,
+  runOnConnection,
   safeEmit,
   SearchCriteria,
   SimplifyPrimaryKey,
@@ -740,6 +742,17 @@ export class PostgresTabularStorage<
   private get serializeOps(): boolean {
     return typeof (this.db as unknown as { connect?: unknown }).connect !== "function";
   }
+
+  /**
+   * On the PGlite / PGLitePool single-session path, expose the shared handle so
+   * two `PostgresTabularStorage` instances that bind the same session queue on
+   * a shared `ConnectionMutex` chain. A real `pg.Pool` isolates via `connect()`
+   * per query and returns `null` here so pool concurrency stays intact.
+   */
+  protected override connectionHandle(): object | null {
+    if (!this.serializeOps) return null;
+    return this.db as unknown as object;
+  }
   private async mutex<T>(fn: () => Promise<T>): Promise<T> {
     if (!this.serializeOps) return fn();
     const prev = this.mutexChain;
@@ -788,6 +801,14 @@ export class PostgresTabularStorage<
   }
 
   private async _putInternal(entity: InsertType): Promise<Entity> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runPutOnHandle(entity));
+    }
+    return this.runPutOnHandle(entity);
+  }
+
+  private async runPutOnHandle(entity: InsertType): Promise<Entity> {
     const { sql, params } = this.buildPutSql(entity);
     const result = await this.db.query(sql, params);
     const updatedEntity = this.hydrateRow(result.rows[0]);
@@ -818,6 +839,14 @@ export class PostgresTabularStorage<
   private async _putBulkInternal(entities: InsertType[]): Promise<Entity[]> {
     if (entities.length === 0) return [];
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runPutBulkOnHandle(entities));
+    }
+    return this.runPutBulkOnHandle(entities);
+  }
+
+  private async runPutBulkOnHandle(entities: InsertType[]): Promise<Entity[]> {
     const dialect = this.postgresBulkDialect();
     const execOn =
       (db: { query: Pool["query"] }) =>
@@ -973,13 +1002,23 @@ export class PostgresTabularStorage<
           "Use SAVEPOINT directly or refactor to a single transaction."
       );
     }
+    // Instance-first / connection-second: the per-instance mutex bounds work
+    // reaching THIS storage; the shared ConnectionMutex chain bounds work
+    // reaching the same PGlite session from any OTHER storage instance.
     return this.mutex(async () => {
-      this.inTransaction = true;
-      try {
-        return await this.runInTransaction(fn, { query: this.db.query.bind(this.db) });
-      } finally {
-        this.inTransaction = false;
+      const handle = this.connectionHandle();
+      const body = async (): Promise<T> => {
+        this.inTransaction = true;
+        try {
+          return await this.runInTransaction(fn, { query: this.db.query.bind(this.db) });
+        } finally {
+          this.inTransaction = false;
+        }
+      };
+      if (handle !== null) {
+        return runInTransactionOnConnection(handle, this, body);
       }
+      return body();
     });
   }
 
@@ -1119,6 +1158,14 @@ export class PostgresTabularStorage<
   }
 
   private async _deleteInternal(value: PrimaryKey | Entity): Promise<void> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runDeleteOnHandle(value));
+    }
+    return this.runDeleteOnHandle(value);
+  }
+
+  private async runDeleteOnHandle(value: PrimaryKey | Entity): Promise<void> {
     const db = this.db;
     const { key } = this.separateKeyValueFromCombined(value as Entity);
     const whereClauses = (this.primaryKeyColumns() as string[])
@@ -1184,6 +1231,14 @@ export class PostgresTabularStorage<
   }
 
   private async _deleteAllInternal(): Promise<void> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runDeleteAllOnHandle());
+    }
+    return this.runDeleteAllOnHandle();
+  }
+
+  private async runDeleteAllOnHandle(): Promise<void> {
     const db = this.db;
     await db.query(`DELETE FROM "${this.table}"`);
     safeEmit(this.events, "clearall");
@@ -1400,6 +1455,14 @@ export class PostgresTabularStorage<
       return;
     }
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runDeleteSearchOnHandle(criteria));
+    }
+    return this.runDeleteSearchOnHandle(criteria);
+  }
+
+  private async runDeleteSearchOnHandle(criteria: DeleteSearchCriteria<Entity>): Promise<void> {
     const db = this.db;
     const { whereClause, params } = this.buildDeleteSearchWhere(criteria);
     await db.query(`DELETE FROM "${this.table}" WHERE ${whereClause}`, params);
@@ -1427,6 +1490,20 @@ export class PostgresTabularStorage<
     const patchKeys = Object.keys(patch) as Array<keyof Entity>;
     if (patchKeys.length === 0) return undefined;
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () =>
+        this.runUpdateWhereOnHandle(match, patch, patchKeys)
+      );
+    }
+    return this.runUpdateWhereOnHandle(match, patch, patchKeys);
+  }
+
+  private async runUpdateWhereOnHandle(
+    match: SearchCriteria<Entity>,
+    patch: Partial<Entity>,
+    patchKeys: Array<keyof Entity>
+  ): Promise<Entity | undefined> {
     const setClause = patchKeys.map((col, i) => `"${String(col)}" = $${i + 1}`).join(", ");
     const setParams = patchKeys.map((col) => this.jsToSqlValue(String(col), patch[col] as never));
 

--- a/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
+++ b/providers/sqlite/src/storage/SqliteAiVectorStorage.ts
@@ -16,6 +16,7 @@ import {
   getMetadataProperty,
   getVectorProperty,
   matchesFilter,
+  runOnConnection,
   validateVectorEntities,
 } from "@workglow/storage";
 import type {
@@ -485,6 +486,21 @@ export class SqliteAiVectorStorage<
       return super._putBulkInternal(entities);
     }
 
+    // Route the vector-encoding write through the shared connection chain so
+    // two SqliteAiVectorStorage instances that wrap the same underlying handle
+    // (or one vector storage and one plain SqliteTabularStorage) queue on the
+    // same lock instead of racing on the shared connection. Skip when we are
+    // already inside an outer `withTransaction` — the chain lock is held there.
+    const dbWithFlag = this.database as unknown as { readonly inTransaction?: boolean };
+    const alreadyInTx = this.inTransaction || dbWithFlag.inTransaction === true;
+    const handle = this.connectionHandle();
+    if (handle !== null && !alreadyInTx) {
+      return runOnConnection(handle, this, () => this.runVectorPutBulkOnHandle(entities));
+    }
+    return this.runVectorPutBulkOnHandle(entities);
+  }
+
+  private async runVectorPutBulkOnHandle(entities: any[]): Promise<Entity[]> {
     const updatedEntities: Entity[] = [];
     // better-sqlite3 / bun:sqlite expose `inTransaction` as a runtime getter
     // on the underlying handle; the canonical API doesn't surface it. When it's

--- a/providers/sqlite/src/storage/SqliteTabularStorage.ts
+++ b/providers/sqlite/src/storage/SqliteTabularStorage.ts
@@ -23,6 +23,8 @@ import {
   PageRequest,
   pickCoveringIndex,
   QueryOptions,
+  runInTransactionOnConnection,
+  runOnConnection,
   safeEmit,
   SearchCriteria,
   SimplifyPrimaryKey,
@@ -68,6 +70,16 @@ export class SqliteTabularStorage<
   /** Protected accessor for subclasses that need direct database access */
   protected get database(): Sqlite.Database {
     return this.db;
+  }
+
+  /**
+   * Every SQLite operation runs on the wrapped `Database`, so two
+   * `SqliteTabularStorage` instances that were handed the same `Database`
+   * argument share one write path and need a shared lock. Returning the
+   * handle here plugs this storage into the shared `ConnectionMutex` chain.
+   */
+  protected override connectionHandle(): object | null {
+    return this.db as unknown as object;
   }
 
   /**
@@ -725,6 +737,10 @@ export class SqliteTabularStorage<
   }
 
   protected async _putInternal(entity: InsertType): Promise<Entity> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, async () => this.executePutSync(entity));
+    }
     return this.executePutSync(entity);
   }
 
@@ -747,6 +763,14 @@ export class SqliteTabularStorage<
   protected async _putBulkInternal(entities: InsertType[]): Promise<Entity[]> {
     if (entities.length === 0) return [];
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, () => this.runPutBulkOnHandle(entities));
+    }
+    return this.runPutBulkOnHandle(entities);
+  }
+
+  private async runPutBulkOnHandle(entities: InsertType[]): Promise<Entity[]> {
     const dialect = this.sqliteBulkDialect();
     const runChunk = async (sql: string, params: ValueOptionType[]): Promise<Entity[]> => {
       const stmt = this.db.prepare<ValueOptionType[], Entity>(sql);
@@ -763,7 +787,11 @@ export class SqliteTabularStorage<
     // Manual BEGIN/COMMIT (not db.transaction, whose body must be sync) keeps
     // every chunk in one atomic unit. All statement execution is synchronous
     // sqlite work, so no other writer interleaves between BEGIN and COMMIT.
-    const alreadyInTx = (this.db as unknown as { inTransaction?: boolean }).inTransaction === true;
+    // Prefer our own `inTransaction` flag: the driver-wrapped `Sqlite.Database`
+    // does not surface better-sqlite3's native `inTransaction` getter, so
+    // reading through the wrapper misses the nested-tx signal.
+    const nativeFlag = (this.db as unknown as { inTransaction?: boolean }).inTransaction === true;
+    const alreadyInTx = this.inTransaction || nativeFlag;
     if (!alreadyInTx) this.db.exec("BEGIN");
     let result: { aligned: Entity[]; distinct: Entity[] };
     try {
@@ -889,7 +917,7 @@ export class SqliteTabularStorage<
    * that would deadlock against its own mutex. Calls routed through `tx`
    * hit the proxy's `withTransaction` override before reaching here.
    */
-  private inTransaction: boolean = false;
+  protected inTransaction: boolean = false;
 
   override async withTransaction<T>(fn: (tx: this) => Promise<T>): Promise<T> {
     if (this.inTransaction) {
@@ -898,30 +926,43 @@ export class SqliteTabularStorage<
           "Run nested rollback boundaries with SAVEPOINT directly, or refactor to a single transaction."
       );
     }
+    // Instance-first / connection-second: the per-instance mutex still bounds
+    // work reaching THIS storage while the transaction body runs, then the
+    // shared ConnectionMutex chain bounds work reaching the same underlying
+    // handle from any OTHER storage instance.
     return this.mutex(async () => {
-      const deferredPutEvents: Entity[] = [];
-      this.inTransaction = true;
-      try {
-        this.db.exec("BEGIN");
-        let result: T;
-        try {
-          result = await fn(this.createTxView(deferredPutEvents));
-          this.db.exec("COMMIT");
-        } catch (err) {
-          try {
-            this.db.exec("ROLLBACK");
-          } catch {
-            // prefer the original error if rollback fails
-          }
-          throw err;
-        }
-        // Flush deferred events only on commit success.
-        for (const entity of deferredPutEvents) safeEmit(this.events, "put", entity);
-        return result;
-      } finally {
-        this.inTransaction = false;
+      const handle = this.connectionHandle();
+      const body = async (): Promise<T> => this.runWithTransactionBody(fn);
+      if (handle !== null) {
+        return runInTransactionOnConnection(handle, this, body);
       }
+      return body();
     });
+  }
+
+  private async runWithTransactionBody<T>(fn: (tx: this) => Promise<T>): Promise<T> {
+    const deferredPutEvents: Entity[] = [];
+    this.inTransaction = true;
+    try {
+      this.db.exec("BEGIN");
+      let result: T;
+      try {
+        result = await fn(this.createTxView(deferredPutEvents));
+        this.db.exec("COMMIT");
+      } catch (err) {
+        try {
+          this.db.exec("ROLLBACK");
+        } catch {
+          // prefer the original error if rollback fails
+        }
+        throw err;
+      }
+      // Flush deferred events only on commit success.
+      for (const entity of deferredPutEvents) safeEmit(this.events, "put", entity);
+      return result;
+    } finally {
+      this.inTransaction = false;
+    }
   }
 
   /**
@@ -1032,9 +1073,17 @@ export class SqliteTabularStorage<
   }
 
   private async _deleteInternal(key: PrimaryKey): Promise<void> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, async () => this.runDeleteOnHandle(key));
+    }
+    this.runDeleteOnHandle(key);
+  }
+
+  private runDeleteOnHandle(key: PrimaryKey): void {
     const db = this.db;
     const whereClauses = (this.primaryKeyColumns() as string[])
-      .map((key) => `${key} = ?`)
+      .map((keyColumn) => `${keyColumn} = ?`)
       .join(" AND ");
     const params = this.getPrimaryKeyAsOrderedArray(key);
     const stmt = db.prepare(`DELETE FROM \`${this.table}\` WHERE ${whereClauses}`);
@@ -1097,6 +1146,14 @@ export class SqliteTabularStorage<
   }
 
   private async _deleteAllInternal(): Promise<void> {
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, async () => this.runDeleteAllOnHandle());
+    }
+    this.runDeleteAllOnHandle();
+  }
+
+  private runDeleteAllOnHandle(): void {
     const db = this.db;
     db.exec(`DELETE FROM \`${this.table}\``);
     safeEmit(this.events, "clearall");
@@ -1301,6 +1358,14 @@ export class SqliteTabularStorage<
       return;
     }
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, async () => this.runDeleteSearchOnHandle(criteria));
+    }
+    this.runDeleteSearchOnHandle(criteria);
+  }
+
+  private runDeleteSearchOnHandle(criteria: DeleteSearchCriteria<Entity>): void {
     const db = this.db;
     const { whereClause, params } = this.buildDeleteSearchWhere(criteria);
     const stmt = db.prepare(`DELETE FROM \`${this.table}\` WHERE ${whereClause}`);
@@ -1330,6 +1395,20 @@ export class SqliteTabularStorage<
     const patchKeys = Object.keys(patch) as Array<keyof Entity>;
     if (patchKeys.length === 0) return undefined;
 
+    const handle = this.connectionHandle();
+    if (handle !== null && !this.inTransaction) {
+      return runOnConnection(handle, this, async () =>
+        this.runUpdateWhereOnHandle(match, patch, patchKeys)
+      );
+    }
+    return this.runUpdateWhereOnHandle(match, patch, patchKeys);
+  }
+
+  private runUpdateWhereOnHandle(
+    match: SearchCriteria<Entity>,
+    patch: Partial<Entity>,
+    patchKeys: Array<keyof Entity>
+  ): Entity | undefined {
     const setClause = patchKeys.map((col) => `\`${String(col)}\` = ?`).join(", ");
     const setParams = patchKeys.map((col) => this.jsToSqlValue(String(col), patch[col] as never));
 

--- a/providers/supabase/src/storage/SupabaseTabularStorage.ts
+++ b/providers/supabase/src/storage/SupabaseTabularStorage.ts
@@ -20,6 +20,7 @@ import {
   Page,
   PageRequest,
   pickCoveringIndex,
+  pkFingerprint,
   QueryOptions,
   safeEmit,
   SearchCriteria,
@@ -527,7 +528,7 @@ export class SupabaseTabularStorage<
     row: Record<string, unknown>,
     pkColumns: ReadonlyArray<string>
   ): string {
-    return JSON.stringify(
+    return pkFingerprint(
       pkColumns.map((c) => this.jsToSqlValue(c, row[c] as Entity[keyof Entity]))
     );
   }


### PR DESCRIPTION
## Summary

- **Plan A (storage — shared-connection concurrency, CRITICAL/HIGH):** Extract a module-level `ConnectionMutex` (`packages/storage/src/tabular/ConnectionMutex.ts`) keyed on the connection handle, backed by a lazy-loaded `node:async_hooks` `AsyncLocalStorage` (browser bundle degrades to a synchronous shim). `BaseSqlTabularStorage` gains a `connectionHandle()` hook; `SqliteTabularStorage`, `SqliteAiVectorStorage`, and `PostgresTabularStorage` (PGlite / PGLitePool branch only) opt in so two storages that share a `Database` / PGlite session queue on one chain, same-instance re-entry runs inline via ALS, and cross-instance re-entry throws `ConnectionReentryError` instead of hanging. Also fixes an existing latent bug where `Sqlite.Database`'s `inTransaction` check missed the wrapper — the code now consults our own `this.inTransaction` flag as well, unblocking `putBulk` via the `tx` proxy.
- **Plan B (storage — BigInt-safe bulk fingerprint, HIGH):** New `pkFingerprint()` (`packages/storage/src/tabular/pkFingerprint.ts`) tags `bigint` and `Uint8Array` with `{ __t: "n" | "u8", v: … }` while every other input shape stays byte-identical to the previous `JSON.stringify` output. `BaseSqlTabularStorage.bulkKeyOf` and `SupabaseTabularStorage.primaryKeyFingerprint` route through it so BigInt / byte-key primary keys no longer collide in the `runBulkPut` dedup map or Supabase's response alignment.
- **Plan C (gemini — NOT_FOUND matcher two-tier, HIGH):** **Deferred.** `providers/google-gemini/src/ai/common/Gemini_CachedContentFallback.ts` does not yet live on `main` — it is on the `ai-provider-cache-checkpoints` feature branch — so the matcher rewrite has no target file. Landed a `describe.skip("TODO — Plan C: …")` module (`packages/test/src/test/ai-provider/Gemini_CachedContentFallback.test.ts`) enumerating the five assertions to enable once the fallback file merges to `main`.
- **Plan D (util,llamacpp — checkpoint tenant scope + per-session lock, 2× HIGH):** **Partial.** Added `readonly id: string = uuid4()` to `ResourceScope` with tenant-scope tsdoc. Added a sessionId-keyed promise-chain `withSessionLock` helper on `providers/node-llama-cpp/src/ai/common/LlamaCpp_Runtime.ts` (map entry cleaned up in `finally` so a thrown body does not strand it). **Deferred** the rest of Plan D — `CheckpointEntry.scopeToken`, `validateParentCheckpoint` / `resolveCheckpointSession` / `finalizeEmittedCheckpoint` / `ResolvedCheckpoint` signature changes, the `CacheCheckpointTask` / `TextGenerationTask` / `ToolCallingTask` / `AiChatTask` caller threading, and the LlamaCpp keep-parent / supersede branches — because `packages/ai/src/provider/CheckpointRegistry.ts`, `packages/ai/src/task/base/CheckpointPorts.ts`, `CacheCheckpointTask.ts`, and the checkpoint-consumption blocks in `LlamaCpp_TextGeneration.ts` / `LlamaCpp_ToolCalling.ts` all live on the `ai-provider-cache-checkpoints` feature branch and are not present on `main`. Re-open once that branch merges.

## Test plan

- [x] `bunx vitest run packages/test/src/test/storage-tabular/` — 1345 passed / 14 skipped (Plan A + Plan B)
- [x] `bunx vitest run packages/test/src/test/storage-tabular/SqliteTabularStorage.integration.test.ts` — new: sibling single-op blocks across a tx on the shared handle, cross-instance nested `withTransaction` throws `ConnectionReentryError` under 500 ms, same-instance tx-proxy nested writes still work, BigInt PK alignment + last-wins dedupe
- [x] `bunx vitest run packages/test/src/test/storage-tabular/PostgresTabularStorage.integration.test.ts` — new: shared-connection safety on the PGlite path (sibling block + cross-instance ConnectionReentryError)
- [x] `bunx vitest run packages/test/src/test/storage-tabular/pkFingerprint.test.ts` — unit-level BigInt / Uint8Array / plain-value fingerprint distinctness (5 tests)
- [x] `bunx vitest run packages/test/src/test/resource/ResourceScope.test.ts` — new: id is minted, distinct per instance, stable across dispose (10 tests total)
- [x] `bunx vitest run packages/test/src/test/ai-provider-nodellama/LlamaCpp_Runtime.test.ts` — new: `withSessionLock` serializes same-session callers, unrelated sessions run in parallel, lock releases even when the body throws (29 tests total)
- [x] `bunx vitest run packages/test/src/test/ai-provider/Gemini_CachedContentFallback.test.ts` — skip block loads cleanly
- [x] `bun run build:types` (40 packages, all cache-miss on this branch) — clean

## Deferrals

- **Plan C** in full and **most of Plan D** are gated on files that only exist on the `ai-provider-cache-checkpoints` feature branch. See the summary bullets for the exact seam list. Re-open once that branch merges into `main`; the skipped Gemini test module holds the assertion checklist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXWNrDwDQnd59uksqbPC2E)_