### PR TITLE
feat(tf-mediapipe): MediaPipe GenAI LLM inference + GPU-by-default delegates

### DIFF
--- a/packages/test/src/test/ai-provider-api/Gemini_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider-api/Gemini_Generic.integration.test.ts
@@ -20,7 +20,11 @@ import { runAiProviderConformance } from "../../contract/ai-provider/runAiProvid
 const RUN = !!process.env.GOOGLE_API_KEY || !!process.env.GEMINI_API_KEY;
 // gemini-2.5-flash was retired from the v1beta API. Exercise a current
 // "thinking" model so the thought-signature and structured-generation paths
-// are covered live.
+// are covered live. The record pins an explicit thinking_budget: 3.5-flash
+// spends ~90+ thought tokens even on trivial prompts and Gemini counts
+// thoughts against maxOutputTokens, so without the budget padding the
+// fixture's small maxTokens is consumed by thinking and the model returns
+// MAX_TOKENS with no visible text (or tool call) at all.
 const MODEL_ID = "gemini:gemini-3.5-flash";
 const EMBED_MODEL_ID = "gemini:gemini-embedding-001";
 
@@ -41,7 +45,7 @@ runAiProviderConformance({
         description: "Google Gemini 3.5 Flash",
         capabilities: ["text.generation", "text.rewriter", "text.summary", "tool-use", "json-mode"],
         provider: GOOGLE_GEMINI as typeof GOOGLE_GEMINI,
-        provider_config: { model_name: "gemini-3.5-flash" },
+        provider_config: { model_name: "gemini-3.5-flash", thinking_budget: 1024 },
         metadata: {},
       });
       await getGlobalModelRepository().addModel({

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -7,7 +7,13 @@
 import { _testOnly } from "@workglow/tf-mediapipe/ai";
 import { describe, expect, it } from "vitest";
 
-const { buildGenaiPrompt, optionsMatch, resolveTfmpChatTemplate, resolveTfmpDelegate } = _testOnly;
+const {
+  buildGenaiPrompt,
+  extractJsonFromText,
+  optionsMatch,
+  resolveTfmpChatTemplate,
+  resolveTfmpDelegate,
+} = _testOnly;
 
 describe("resolveTfmpDelegate", () => {
   it("defaults vision to GPU", () => {
@@ -128,5 +134,33 @@ describe("optionsMatch", () => {
   it("rejects differing key sets", () => {
     expect(optionsMatch({ a: 1 }, { a: 1, b: 2 })).toBe(false);
     expect(optionsMatch({ a: 1 }, { b: 1 })).toBe(false);
+  });
+});
+
+describe("extractJsonFromText", () => {
+  it("parses a bare JSON object", () => {
+    expect(extractJsonFromText('{"a": 1}')).toEqual({ a: 1 });
+  });
+
+  it("unwraps a ```json fence", () => {
+    expect(extractJsonFromText('```json\n{"a": 1}\n```')).toEqual({ a: 1 });
+  });
+
+  it("unwraps an anonymous fence", () => {
+    expect(extractJsonFromText('```\n{"a": 1}\n```')).toEqual({ a: 1 });
+  });
+
+  it("extracts an object embedded in prose", () => {
+    expect(extractJsonFromText('Sure! Here you go: {"a": 1} Hope that helps.')).toEqual({
+      a: 1,
+    });
+  });
+
+  it("recovers a truncated object via partial parsing", () => {
+    expect(extractJsonFromText('{"a": 1, "b": {"c": 2')).toEqual({ a: 1, b: { c: 2 } });
+  });
+
+  it("returns an empty object when no JSON is present", () => {
+    expect(extractJsonFromText("no json here")).toEqual({});
   });
 });

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -7,7 +7,7 @@
 import { _testOnly } from "@workglow/tf-mediapipe/ai";
 import { describe, expect, it } from "vitest";
 
-const { buildGenaiPrompt, resolveTfmpChatTemplate, resolveTfmpDelegate } = _testOnly;
+const { buildGenaiPrompt, optionsMatch, resolveTfmpChatTemplate, resolveTfmpDelegate } = _testOnly;
 
 describe("resolveTfmpDelegate", () => {
   it("defaults vision to GPU", () => {
@@ -99,5 +99,34 @@ describe("resolveTfmpChatTemplate", () => {
   });
   it("honors none", () => {
     expect(resolveTfmpChatTemplate("none")).toBe("none");
+  });
+});
+
+describe("optionsMatch", () => {
+  it("deep-compares nested baseOptions", () => {
+    expect(
+      optionsMatch(
+        { baseOptions: { delegate: "GPU", modelAssetPath: "m" } },
+        { baseOptions: { delegate: "GPU", modelAssetPath: "m" } }
+      )
+    ).toBe(true);
+    expect(
+      optionsMatch(
+        { baseOptions: { delegate: "GPU", modelAssetPath: "m" } },
+        { baseOptions: { delegate: "CPU", modelAssetPath: "m" } }
+      )
+    ).toBe(false);
+  });
+
+  it("still compares scalars and arrays", () => {
+    expect(optionsMatch({ numHands: 2 }, { numHands: 2 })).toBe(true);
+    expect(optionsMatch({ numHands: 2 }, { numHands: 1 })).toBe(false);
+    expect(optionsMatch({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+    expect(optionsMatch({ a: [1, 2] }, { a: [2, 1] })).toBe(false);
+  });
+
+  it("rejects differing key sets", () => {
+    expect(optionsMatch({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(optionsMatch({ a: 1 }, { b: 1 })).toBe(false);
   });
 });

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { _testOnly } from "@workglow/tf-mediapipe/ai";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const {
@@ -14,6 +17,7 @@ const {
   optionsMatch,
   resolveTfmpChatTemplate,
   resolveTfmpDelegate,
+  TFMP_GENAI_WASM_VERSION,
   withGenaiLock,
 } = _testOnly;
 
@@ -99,6 +103,40 @@ describe("buildGenaiPrompt", () => {
   });
 });
 
+describe("buildGenaiPrompt chatml", () => {
+  it("renders system natively and opens an assistant turn", () => {
+    const prompt = buildGenaiPrompt(
+      [
+        { role: "system", content: "Be terse." },
+        { role: "user", content: "Hi" },
+      ],
+      "chatml"
+    );
+    expect(prompt).toBe(
+      "<|im_start|>system\nBe terse.<|im_end|>\n" +
+        "<|im_start|>user\nHi<|im_end|>\n" +
+        "<|im_start|>assistant\n"
+    );
+  });
+
+  it("renders multi-turn history", () => {
+    const prompt = buildGenaiPrompt(
+      [
+        { role: "user", content: "One" },
+        { role: "assistant", content: "Two" },
+        { role: "user", content: "Three" },
+      ],
+      "chatml"
+    );
+    expect(prompt).toBe(
+      "<|im_start|>user\nOne<|im_end|>\n" +
+        "<|im_start|>assistant\nTwo<|im_end|>\n" +
+        "<|im_start|>user\nThree<|im_end|>\n" +
+        "<|im_start|>assistant\n"
+    );
+  });
+});
+
 describe("resolveTfmpChatTemplate", () => {
   it("defaults to gemma", () => {
     expect(resolveTfmpChatTemplate(undefined)).toBe("gemma");
@@ -107,6 +145,24 @@ describe("resolveTfmpChatTemplate", () => {
   });
   it("honors none", () => {
     expect(resolveTfmpChatTemplate("none")).toBe("none");
+  });
+  it("honors chatml", () => {
+    expect(resolveTfmpChatTemplate("chatml")).toBe("chatml");
+  });
+});
+
+describe("TFMP_GENAI_WASM_VERSION", () => {
+  it("matches the installed @mediapipe/tasks-genai version", () => {
+    const requireFromTfmp = createRequire(
+      join(process.cwd(), "providers/tf-mediapipe/package.json")
+    );
+    // The SDK's "exports" map does not expose ./package.json, so resolve its
+    // entry point and read the manifest sitting next to it.
+    const entry = requireFromTfmp.resolve("@mediapipe/tasks-genai");
+    const pkg = JSON.parse(readFileSync(join(dirname(entry), "package.json"), "utf8")) as {
+      version: string;
+    };
+    expect(TFMP_GENAI_WASM_VERSION).toBe(pkg.version);
   });
 });
 

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -7,7 +7,7 @@
 import { _testOnly } from "@workglow/tf-mediapipe/ai";
 import { describe, expect, it } from "vitest";
 
-const { resolveTfmpDelegate } = _testOnly;
+const { buildGenaiPrompt, resolveTfmpChatTemplate, resolveTfmpDelegate } = _testOnly;
 
 describe("resolveTfmpDelegate", () => {
   it("defaults vision to GPU", () => {
@@ -30,5 +30,74 @@ describe("resolveTfmpDelegate", () => {
   it("leaves genai to the genai runtime", () => {
     expect(resolveTfmpDelegate("genai", true)).toBeUndefined();
     expect(resolveTfmpDelegate("genai", false)).toBeUndefined();
+  });
+});
+
+describe("buildGenaiPrompt", () => {
+  it("wraps a single user message and opens a model turn", () => {
+    const prompt = buildGenaiPrompt([{ role: "user", content: "Hello" }], "gemma");
+    expect(prompt).toBe("<start_of_turn>user\nHello<end_of_turn>\n<start_of_turn>model\n");
+  });
+
+  it("folds the system prompt into the first user turn", () => {
+    const prompt = buildGenaiPrompt(
+      [
+        { role: "system", content: "Be terse." },
+        { role: "user", content: "Hi" },
+      ],
+      "gemma"
+    );
+    expect(prompt).toBe(
+      "<start_of_turn>user\nBe terse.\n\nHi<end_of_turn>\n<start_of_turn>model\n"
+    );
+  });
+
+  it("renders multi-turn history with model turns", () => {
+    const prompt = buildGenaiPrompt(
+      [
+        { role: "user", content: "One" },
+        { role: "assistant", content: "Two" },
+        { role: "user", content: "Three" },
+      ],
+      "gemma"
+    );
+    expect(prompt).toBe(
+      "<start_of_turn>user\nOne<end_of_turn>\n" +
+        "<start_of_turn>model\nTwo<end_of_turn>\n" +
+        "<start_of_turn>user\nThree<end_of_turn>\n" +
+        "<start_of_turn>model\n"
+    );
+  });
+
+  it("emits a lone system prompt as a user turn", () => {
+    const prompt = buildGenaiPrompt([{ role: "system", content: "Rules." }], "gemma");
+    expect(prompt).toBe("<start_of_turn>user\nRules.<end_of_turn>\n<start_of_turn>model\n");
+  });
+
+  it("none template passes a single message through verbatim", () => {
+    expect(buildGenaiPrompt([{ role: "user", content: "raw prompt" }], "none")).toBe("raw prompt");
+  });
+
+  it("none template joins messages with blank lines", () => {
+    expect(
+      buildGenaiPrompt(
+        [
+          { role: "system", content: "S" },
+          { role: "user", content: "U" },
+        ],
+        "none"
+      )
+    ).toBe("S\n\nU");
+  });
+});
+
+describe("resolveTfmpChatTemplate", () => {
+  it("defaults to gemma", () => {
+    expect(resolveTfmpChatTemplate(undefined)).toBe("gemma");
+    expect(resolveTfmpChatTemplate("gemma")).toBe("gemma");
+    expect(resolveTfmpChatTemplate("bogus")).toBe("gemma");
+  });
+  it("honors none", () => {
+    expect(resolveTfmpChatTemplate("none")).toBe("none");
   });
 });

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -10,9 +10,11 @@ import { describe, expect, it } from "vitest";
 const {
   buildGenaiPrompt,
   extractJsonFromText,
+  isGenaiBusy,
   optionsMatch,
   resolveTfmpChatTemplate,
   resolveTfmpDelegate,
+  withGenaiLock,
 } = _testOnly;
 
 describe("resolveTfmpDelegate", () => {
@@ -105,6 +107,34 @@ describe("resolveTfmpChatTemplate", () => {
   });
   it("honors none", () => {
     expect(resolveTfmpChatTemplate("none")).toBe("none");
+  });
+});
+
+describe("withGenaiLock", () => {
+  it("serializes calls FIFO per model path", async () => {
+    const order: number[] = [];
+    const gate = Promise.withResolvers<void>();
+    const first = withGenaiLock("m", async () => {
+      await gate.promise;
+      order.push(1);
+    });
+    const second = withGenaiLock("m", async () => {
+      order.push(2);
+    });
+    expect(isGenaiBusy("m")).toBe(true);
+    gate.resolve();
+    await Promise.all([first, second]);
+    expect(order).toEqual([1, 2]);
+    expect(isGenaiBusy("m")).toBe(false);
+  });
+
+  it("keeps chaining after a rejection", async () => {
+    await expect(
+      withGenaiLock("m2", async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    await expect(withGenaiLock("m2", async () => "ok")).resolves.toBe("ok");
   });
 });
 

--- a/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
+++ b/packages/test/src/test/ai-provider/TFMP_GenaiHelpers.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _testOnly } from "@workglow/tf-mediapipe/ai";
+import { describe, expect, it } from "vitest";
+
+const { resolveTfmpDelegate } = _testOnly;
+
+describe("resolveTfmpDelegate", () => {
+  it("defaults vision to GPU", () => {
+    expect(resolveTfmpDelegate("vision", undefined)).toBe("GPU");
+    expect(resolveTfmpDelegate("vision", true)).toBe("GPU");
+  });
+
+  it("respects explicit gpu=false for vision", () => {
+    expect(resolveTfmpDelegate("vision", false)).toBe("CPU");
+  });
+
+  it("never sets a delegate for CPU-only engines", () => {
+    for (const engine of ["text", "audio"]) {
+      expect(resolveTfmpDelegate(engine, true)).toBeUndefined();
+      expect(resolveTfmpDelegate(engine, false)).toBeUndefined();
+      expect(resolveTfmpDelegate(engine, undefined)).toBeUndefined();
+    }
+  });
+
+  it("leaves genai to the genai runtime", () => {
+    expect(resolveTfmpDelegate("genai", true)).toBeUndefined();
+    expect(resolveTfmpDelegate("genai", false)).toBeUndefined();
+  });
+});

--- a/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
+++ b/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
@@ -106,6 +106,12 @@ describe("TensorFlowMediaPipeQueuedProvider.inferCapabilities", () => {
     expect(caps).toContain("model.count-tokens");
   });
 
+  it("infers text.generation for qwen bundles", () => {
+    expect(
+      provider.inferCapabilities(model("Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task"))
+    ).toContain("text.generation");
+  });
+
   it("infers text.generation for .litertlm files", () => {
     expect(provider.inferCapabilities(model("some_model.litertlm"))).toContain("text.generation");
   });

--- a/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
+++ b/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
@@ -8,7 +8,8 @@ import type { ModelRecord } from "@workglow/ai";
 import { _testOnly } from "@workglow/tf-mediapipe/ai";
 import { describe, expect, it } from "vitest";
 
-const { TensorFlowMediaPipeQueuedProvider, TFMP_RUN_FN_SPECS, TFMP_RUN_FNS } = _testOnly;
+const { TensorFlowMediaPipeQueuedProvider, TFMP_PREVIEW_TASKS, TFMP_RUN_FN_SPECS, TFMP_RUN_FNS } =
+  _testOnly;
 
 function model(model_id: string, capabilities: readonly string[] = []): ModelRecord {
   return {
@@ -149,5 +150,9 @@ describe("TFMP_RUN_FNS shape", () => {
     expect(sets).toContain("text.generation");
     expect(sets).toContain("json-mode,text.generation");
     expect(sets).toContain("model.count-tokens");
+  });
+
+  it("previews only count-tokens (generation previews would load the model)", () => {
+    expect(Object.keys(TFMP_PREVIEW_TASKS)).toEqual(["CountTokensTask"]);
   });
 });

--- a/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
+++ b/packages/test/src/test/ai-provider/TensorFlowMediaPipeProvider.test.ts
@@ -97,6 +97,23 @@ describe("TensorFlowMediaPipeQueuedProvider.inferCapabilities", () => {
     const caps = provider.inferCapabilities(model("some-unrecognized-model.tflite"));
     expect(caps).toEqual(["model.search", "model.info"]);
   });
+
+  it("infers text.generation for gemma bundles", () => {
+    const caps = provider.inferCapabilities(model("gemma3-1b-it-int4-web.task"));
+    expect(caps).toContain("text.generation");
+    expect(caps).toContain("json-mode");
+    expect(caps).toContain("model.count-tokens");
+  });
+
+  it("infers text.generation for .litertlm files", () => {
+    expect(provider.inferCapabilities(model("some_model.litertlm"))).toContain("text.generation");
+  });
+
+  it("does not misclassify llm-substring words as genai", () => {
+    expect(provider.inferCapabilities(model("hand_landmarker.task"))).not.toContain(
+      "text.generation"
+    );
+  });
 });
 
 describe("capability-set parity", () => {
@@ -127,8 +144,10 @@ describe("TFMP_RUN_FNS shape", () => {
     expect(sets).toContain("model.info");
   });
 
-  it("does NOT register text.generation (TFMP has no text-gen capability)", () => {
+  it("registers genai text-generation capability sets", () => {
     const sets = TFMP_RUN_FNS.map((r) => [...r.serves].sort().join(","));
-    expect(sets).not.toContain("text.generation");
+    expect(sets).toContain("text.generation");
+    expect(sets).toContain("json-mode,text.generation");
+    expect(sets).toContain("model.count-tokens");
   });
 });

--- a/providers/tf-mediapipe/README.md
+++ b/providers/tf-mediapipe/README.md
@@ -29,26 +29,34 @@ import { Workflow } from "@workglow/task-graph";
 // 1. Register the provider (inline; see registerTensorFlowMediaPipe for worker-backed)
 await registerTensorFlowMediaPipeInline();
 
-// 2. Register an LLM model (Gemma 3 1B, int4 web bundle — requires WebGPU)
+// 2. Register an LLM model (Qwen2.5 1.5B, int8 bundle — requires WebGPU)
 await getGlobalModelRepository().addModel({
-  model_id: "gemma3-1b-it",
-  title: "Gemma 3 1B IT",
+  model_id: "qwen2.5-1.5b-instruct",
+  title: "Qwen2.5 1.5B Instruct",
   description: "On-device LLM via MediaPipe",
-  capabilities: ["text.generation", "json-mode", "model.count-tokens"],
+  capabilities: [
+    "text.generation",
+    "json-mode",
+    "model.count-tokens",
+    "model.download-remove",
+    "model.info",
+    "model.search",
+  ],
   provider: "TENSORFLOW_MEDIAPIPE",
   provider_config: {
     task_engine: "genai",
     pipeline: "genai-text",
     model_path:
-      "https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4-web.task",
-    max_tokens: 1000,
+      "https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task",
+    max_tokens: 1280,
+    chat_template: "chatml",
   },
   metadata: {},
 });
 
 // 3. Use it in a workflow (streams tokens as they generate)
 const workflow = new Workflow();
-workflow.pipe(new TextGenerationTask({ model: "gemma3-1b-it", prompt: "Hello!" }));
+workflow.pipe(new TextGenerationTask({ model: "qwen2.5-1.5b-instruct", prompt: "Hello!" }));
 const result = await workflow.run();
 ```
 
@@ -62,10 +70,14 @@ unavailable). Text and audio tasks are CPU-only on web and ignore the flag.
 ### GenAI notes
 
 - Chat and prompt inputs are rendered with the Gemma turn format by default
-  (`provider_config.chat_template: "gemma" | "none"`).
+  (`provider_config.chat_template: "gemma" | "chatml" | "none"`).
 - `max_tokens` (combined input+output budget), `top_k`, `temperature`, and
-  `random_seed` are set at model load from `provider_config`; a per-run
-  `temperature` input is applied via `setOptions` without reloading.
+  `random_seed` are fixed at model load from `provider_config` — the web SDK
+  cannot change sampler options after load, so per-run temperature inputs are
+  ignored.
+- Gemma bundles on Hugging Face are license-gated (anonymous downloads fail);
+  accept the Gemma license and host the file yourself, or use an ungated bundle
+  such as Qwen2.5 (`chat_template: "chatml"`).
 - Structured generation (`json-mode`) is prompt-engineered; the task layer
   validates against the output schema and retries.
 

--- a/providers/tf-mediapipe/README.md
+++ b/providers/tf-mediapipe/README.md
@@ -22,22 +22,52 @@ yarn add @workglow/tf-mediapipe
 ## Usage
 
 ```typescript
-import { registerTfMediapipe } from "@workglow/tf-mediapipe/ai-runtime";
-import { TextGenerationTask } from "@workglow/ai";
+import { registerTensorFlowMediaPipeInline } from "@workglow/tf-mediapipe/ai-runtime";
+import { getGlobalModelRepository, TextGenerationTask } from "@workglow/ai";
 import { Workflow } from "@workglow/task-graph";
 
-// 1. Register the provider
-await registerTfMediapipe();
+// 1. Register the provider (inline; see registerTensorFlowMediaPipe for worker-backed)
+await registerTensorFlowMediaPipeInline();
 
-// 2. Use it in a workflow
+// 2. Register an LLM model (Gemma 3 1B, int4 web bundle — requires WebGPU)
+await getGlobalModelRepository().addModel({
+  model_id: "gemma3-1b-it",
+  title: "Gemma 3 1B IT",
+  description: "On-device LLM via MediaPipe",
+  capabilities: ["text.generation", "json-mode", "model.count-tokens"],
+  provider: "TENSORFLOW_MEDIAPIPE",
+  provider_config: {
+    task_engine: "genai",
+    pipeline: "genai-text",
+    model_path:
+      "https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4-web.task",
+    max_tokens: 1000,
+  },
+  metadata: {},
+});
+
+// 3. Use it in a workflow (streams tokens as they generate)
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
-  model: "default-model",
-  prompt: "Hello world!"
-}));
-
+workflow.pipe(new TextGenerationTask({ model: "gemma3-1b-it", prompt: "Hello!" }));
 const result = await workflow.run();
 ```
+
+### GPU acceleration
+
+`provider_config.gpu` defaults to `true`: vision tasks use the MediaPipe GPU
+delegate (with automatic CPU fallback when GPU creation fails), and genai LLM
+inference always runs on WebGPU (a clear error is raised when WebGPU is
+unavailable). Text and audio tasks are CPU-only on web and ignore the flag.
+
+### GenAI notes
+
+- Chat and prompt inputs are rendered with the Gemma turn format by default
+  (`provider_config.chat_template: "gemma" | "none"`).
+- `max_tokens` (combined input+output budget), `top_k`, `temperature`, and
+  `random_seed` are set at model load from `provider_config`; a per-run
+  `temperature` input is applied via `setOptions` without reloading.
+- Structured generation (`json-mode`) is prompt-engineered; the task layer
+  validates against the output schema and retries.
 
 ## License
 

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
@@ -36,6 +36,18 @@ export function inferTfmpCapabilities(model: CapabilityHints): readonly Capabili
   );
   const baseName = (id.split("/").pop() ?? id).toLowerCase();
 
+  // LLM bundles for the genai engine (Gemma-family .task / .litertlm files).
+  if (/gemma|\.litertlm$|(?:^|[-_])llm(?:[-_.]|$)/.test(baseName)) {
+    return [
+      "text.generation",
+      "json-mode",
+      "model.count-tokens",
+      "model.download-remove",
+      "model.info",
+      "model.search",
+    ];
+  }
+
   // Hand landmarker / gesture recognizer share `hand_*` filenames.
   if (/gesture_recognizer/.test(baseName)) {
     return [

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Capabilities.ts
@@ -36,8 +36,8 @@ export function inferTfmpCapabilities(model: CapabilityHints): readonly Capabili
   );
   const baseName = (id.split("/").pop() ?? id).toLowerCase();
 
-  // LLM bundles for the genai engine (Gemma-family .task / .litertlm files).
-  if (/gemma|\.litertlm$|(?:^|[-_])llm(?:[-_.]|$)/.test(baseName)) {
+  // LLM bundles for the genai engine (e.g. Gemma/Qwen .task / .litertlm files).
+  if (/gemma|qwen|\.litertlm$|(?:^|[-_])llm(?:[-_.]|$)/.test(baseName)) {
     return [
       "text.generation",
       "json-mode",

--- a/providers/tf-mediapipe/src/ai/common/TFMP_CapabilitySets.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_CapabilitySets.ts
@@ -22,6 +22,9 @@ export const TFMP_VISION_FACE_LANDMARKS = ["vision.face-landmarks"] as const sat
 export const TFMP_VISION_HAND_LANDMARKS = ["vision.hand-landmarks"] as const satisfies Capability[];
 export const TFMP_VISION_POSE_LANDMARKS = ["vision.pose-landmarks"] as const satisfies Capability[];
 export const TFMP_VISION_GESTURE = ["vision.gesture"] as const satisfies Capability[];
+export const TFMP_TEXT_GENERATION = ["text.generation"] as const satisfies Capability[];
+export const TFMP_JSON_MODE = ["text.generation", "json-mode"] as const satisfies Capability[];
+export const TFMP_COUNT_TOKENS = ["model.count-tokens"] as const satisfies Capability[];
 export const TFMP_MODEL_DOWNLOAD = ["model.download"] as const satisfies Capability[];
 export const TFMP_MODEL_UNLOAD = ["model.download-remove"] as const satisfies Capability[];
 export const TFMP_MODEL_SEARCH = ["model.search"] as const satisfies Capability[];
@@ -40,6 +43,9 @@ export const TFMP_CAPABILITY_SETS = [
   TFMP_VISION_HAND_LANDMARKS,
   TFMP_VISION_POSE_LANDMARKS,
   TFMP_VISION_GESTURE,
+  TFMP_TEXT_GENERATION,
+  TFMP_JSON_MODE,
+  TFMP_COUNT_TOKENS,
   TFMP_MODEL_DOWNLOAD,
   TFMP_MODEL_UNLOAD,
   TFMP_MODEL_SEARCH,

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ChatTemplate.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ChatTemplate.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TextFlatMessage } from "@workglow/ai/worker";
+
+export type TfmpChatTemplate = "gemma" | "none";
+
+/**
+ * Resolve the stored `chat_template` provider-config value ("gemma" default).
+ */
+export function resolveTfmpChatTemplate(raw: unknown): TfmpChatTemplate {
+  return raw === "none" ? "none" : "gemma";
+}
+
+/**
+ * Render flattened chat messages into a single LLM prompt string.
+ *
+ * MediaPipe web exposes no tokenizer or chat-template API, so the turn markers
+ * must be rendered here. The "gemma" template is the Gemma-family format used
+ * by all current MediaPipe web LLM bundles; Gemma has no system role, so a
+ * system message folds into the first user turn. The prompt always ends with
+ * an open model turn so the LLM generates the assistant reply.
+ *
+ * "none" renders message contents joined by blank lines with no markers (a
+ * single user message passes through verbatim) — an escape hatch for base
+ * models or bundles with a different native format.
+ */
+export function buildGenaiPrompt(
+  messages: readonly TextFlatMessage[],
+  template: TfmpChatTemplate
+): string {
+  if (template === "none") {
+    return messages
+      .map((m) => m.content)
+      .filter((c) => c.length > 0)
+      .join("\n\n");
+  }
+
+  const systemText = messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n")
+    .trim();
+
+  const turns = messages.filter((m) => m.role !== "system");
+  const parts: string[] = [];
+  let pendingSystem = systemText;
+
+  for (const msg of turns) {
+    // Gemma knows only "user" and "model" turns; tool results render as user turns.
+    const role = msg.role === "assistant" ? "model" : "user";
+    let content = msg.content;
+    if (role === "user" && pendingSystem) {
+      content = `${pendingSystem}\n\n${content}`;
+      pendingSystem = "";
+    }
+    parts.push(`<start_of_turn>${role}\n${content}<end_of_turn>\n`);
+  }
+
+  if (pendingSystem) {
+    parts.push(`<start_of_turn>user\n${pendingSystem}<end_of_turn>\n`);
+  }
+
+  parts.push("<start_of_turn>model\n");
+  return parts.join("");
+}

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ChatTemplate.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ChatTemplate.ts
@@ -6,23 +6,36 @@
 
 import type { TextFlatMessage } from "@workglow/ai/worker";
 
-export type TfmpChatTemplate = "gemma" | "none";
+export type TfmpChatTemplate = "gemma" | "chatml" | "none";
 
 /**
  * Resolve the stored `chat_template` provider-config value ("gemma" default).
  */
 export function resolveTfmpChatTemplate(raw: unknown): TfmpChatTemplate {
+  if (raw === "chatml") return "chatml";
   return raw === "none" ? "none" : "gemma";
+}
+
+function buildChatmlPrompt(messages: readonly TextFlatMessage[]): string {
+  const parts: string[] = [];
+  for (const msg of messages) {
+    // ChatML knows system/user/assistant; tool results render as user turns.
+    const role = msg.role === "assistant" ? "assistant" : msg.role === "system" ? "system" : "user";
+    parts.push(`<|im_start|>${role}\n${msg.content}<|im_end|>\n`);
+  }
+  parts.push("<|im_start|>assistant\n");
+  return parts.join("");
 }
 
 /**
  * Render flattened chat messages into a single LLM prompt string.
  *
  * MediaPipe web exposes no tokenizer or chat-template API, so the turn markers
- * must be rendered here. The "gemma" template is the Gemma-family format used
- * by all current MediaPipe web LLM bundles; Gemma has no system role, so a
- * system message folds into the first user turn. The prompt always ends with
- * an open model turn so the LLM generates the assistant reply.
+ * must be rendered here. The "gemma" template is the Gemma-family format;
+ * Gemma has no system role, so a system message folds into the first user
+ * turn. The "chatml" template is the Qwen-family format, where the system role
+ * is native and needs no folding. Both always end with an open assistant turn
+ * so the LLM generates the reply.
  *
  * "none" renders message contents joined by blank lines with no markers (a
  * single user message passes through verbatim) — an escape hatch for base
@@ -37,6 +50,10 @@ export function buildGenaiPrompt(
       .map((m) => m.content)
       .filter((c) => c.length > 0)
       .join("\n\n");
+  }
+
+  if (template === "chatml") {
+    return buildChatmlPrompt(messages);
   }
 
   const systemText = messages

--- a/providers/tf-mediapipe/src/ai/common/TFMP_CountTokens.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_CountTokens.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderPreviewRunFn,
+  AiProviderRunFn,
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+} from "@workglow/ai";
+import { PermanentJobError } from "@workglow/job-queue";
+import { getGenaiLlm, peekGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
+import type { TFMPModelConfig } from "./TFMP_ModelSchema";
+
+export const TFMP_CountTokens: AiProviderRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  TFMPModelConfig
+> = async (input, model, signal, emit) => {
+  const llm = await getGenaiLlm(model!, emit, signal);
+  const count = await withGenaiLock(model!.provider_config.model_path, async () =>
+    llm.sizeInTokens(input.text)
+  );
+  if (typeof count !== "number") {
+    throw new PermanentJobError("Failed to tokenize input for count-tokens");
+  }
+  emit({ type: "finish", data: { count } });
+};
+
+/**
+ * Preview must never trigger a multi-hundred-MB model load; it answers only
+ * when the instance is already resident.
+ */
+export const TFMP_CountTokens_Preview: AiProviderPreviewRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  TFMPModelConfig
+> = async (input, model) => {
+  const llm = peekGenaiLlm(model!);
+  if (!llm) return undefined;
+  const count = await withGenaiLock(model!.provider_config.model_path, async () =>
+    llm.sizeInTokens(input.text)
+  );
+  return typeof count === "number" ? { count } : undefined;
+};

--- a/providers/tf-mediapipe/src/ai/common/TFMP_CountTokens.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_CountTokens.ts
@@ -11,7 +11,7 @@ import type {
   CountTokensTaskOutput,
 } from "@workglow/ai";
 import { PermanentJobError } from "@workglow/job-queue";
-import { getGenaiLlm, peekGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
+import { getGenaiLlm, isGenaiBusy, peekGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
 
 export const TFMP_CountTokens: AiProviderRunFn<
@@ -19,10 +19,10 @@ export const TFMP_CountTokens: AiProviderRunFn<
   CountTokensTaskOutput,
   TFMPModelConfig
 > = async (input, model, signal, emit) => {
-  const llm = await getGenaiLlm(model!, emit, signal);
-  const count = await withGenaiLock(model!.provider_config.model_path, async () =>
-    llm.sizeInTokens(input.text)
-  );
+  const count = await withGenaiLock(model!.provider_config.model_path, async () => {
+    const llm = await getGenaiLlm(model!, emit, signal);
+    return llm.sizeInTokens(input.text);
+  });
   if (typeof count !== "number") {
     throw new PermanentJobError("Failed to tokenize input for count-tokens");
   }
@@ -30,18 +30,19 @@ export const TFMP_CountTokens: AiProviderRunFn<
 };
 
 /**
- * Preview must never trigger a multi-hundred-MB model load; it answers only
- * when the instance is already resident.
+ * Preview must never trigger a multi-hundred-MB model load, nor queue behind a
+ * running generation: it answers only when the instance is already resident and
+ * the model is idle.
  */
 export const TFMP_CountTokens_Preview: AiProviderPreviewRunFn<
   CountTokensTaskInput,
   CountTokensTaskOutput,
   TFMPModelConfig
 > = async (input, model) => {
+  const model_path = model!.provider_config.model_path;
+  if (isGenaiBusy(model_path)) return undefined;
   const llm = peekGenaiLlm(model!);
   if (!llm) return undefined;
-  const count = await withGenaiLock(model!.provider_config.model_path, async () =>
-    llm.sizeInTokens(input.text)
-  );
+  const count = await withGenaiLock(model_path, async () => llm.sizeInTokens(input.text));
   return typeof count === "number" ? { count } : undefined;
 };

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Delegate.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Delegate.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type TfmpDelegate = "CPU" | "GPU";
+
+/**
+ * Resolve the stored high-level `gpu` flag (default true) into the concrete
+ * MediaPipe `baseOptions.delegate` for a task engine.
+ *
+ * - vision: GPU delegate unless `gpu` is explicitly false.
+ * - text/audio: MediaPipe web runs these tasks on CPU only; never set a delegate.
+ * - genai: WebGPU is managed by the genai runtime (`gpuOptions.device`), not via
+ *   the delegate option.
+ */
+export function resolveTfmpDelegate(
+  task_engine: string,
+  gpu: boolean | undefined
+): TfmpDelegate | undefined {
+  if (task_engine === "vision") {
+    return gpu === false ? "CPU" : "GPU";
+  }
+  return undefined;
+}

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Download.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Download.ts
@@ -11,7 +11,7 @@ import type {
 } from "@workglow/ai";
 import { PermanentJobError } from "@workglow/job-queue";
 import { loadTfmpTasksTextSDK, loadTfmpTasksVisionSDK } from "./TFMP_Client";
-import { getGenaiLlm } from "./TFMP_GenaiRuntime";
+import { closeGenaiLlm, getGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
 import { TFMPModelConfig } from "./TFMP_ModelSchema";
 import type { TaskInstance } from "./TFMP_Runtime";
 import { getModelTask, modelTaskCache, wasm_reference_counts, wasm_tasks } from "./TFMP_Runtime";
@@ -97,9 +97,13 @@ export const TFMP_Download: AiProviderRunFn<
       break;
     }
     case "genai-text": {
-      const llm = await getGenaiLlm(model!, emit, signal);
-      task = llm as unknown as TaskInstance;
-      break;
+      await withGenaiLock(model!.provider_config.model_path, async () => {
+        await getGenaiLlm(model!, emit, signal);
+      });
+      emit({ type: "phase", message: "Pipeline loaded", progress: 0.9 });
+      await closeGenaiLlm(model!.provider_config.model_path);
+      emit({ type: "finish", data: { model: input.model } });
+      return;
     }
     default:
       throw new PermanentJobError(

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Download.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Download.ts
@@ -11,6 +11,7 @@ import type {
 } from "@workglow/ai";
 import { PermanentJobError } from "@workglow/job-queue";
 import { loadTfmpTasksTextSDK, loadTfmpTasksVisionSDK } from "./TFMP_Client";
+import { getGenaiLlm } from "./TFMP_GenaiRuntime";
 import { TFMPModelConfig } from "./TFMP_ModelSchema";
 import type { TaskInstance } from "./TFMP_Runtime";
 import { getModelTask, modelTaskCache, wasm_reference_counts, wasm_tasks } from "./TFMP_Runtime";
@@ -95,9 +96,14 @@ export const TFMP_Download: AiProviderRunFn<
       task = await getModelTask(model!, {}, emit, signal, PoseLandmarker);
       break;
     }
+    case "genai-text": {
+      const llm = await getGenaiLlm(model!, emit, signal);
+      task = llm as unknown as TaskInstance;
+      break;
+    }
     default:
       throw new PermanentJobError(
-        `Invalid pipeline: ${pipeline}. Supported pipelines: text-embedder, text-classifier, text-language-detector, vision-image-classifier, vision-image-embedder, vision-image-segmenter, vision-object-detector, vision-face-detector, vision-face-landmarker, vision-gesture-recognizer, vision-hand-landmarker, vision-pose-landmarker`
+        `Invalid pipeline: ${pipeline}. Supported pipelines: text-embedder, text-classifier, text-language-detector, genai-text, vision-image-classifier, vision-image-embedder, vision-image-segmenter, vision-object-detector, vision-face-detector, vision-face-landmarker, vision-gesture-recognizer, vision-hand-landmarker, vision-pose-landmarker`
       );
   }
 

--- a/providers/tf-mediapipe/src/ai/common/TFMP_GenaiRuntime.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_GenaiRuntime.ts
@@ -10,7 +10,7 @@ import type { StreamPhase } from "@workglow/task-graph";
 import { loadTfmpTasksGenaiSDK } from "./TFMP_Client";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
 import type { TaskInstance } from "./TFMP_Runtime";
-import { getWasmTask, modelTaskCache, wasm_reference_counts } from "./TFMP_Runtime";
+import { getWasmTask, modelTaskCache, wasm_reference_counts, wasm_tasks } from "./TFMP_Runtime";
 
 interface GenaiProviderConfig {
   readonly model_path: string;
@@ -20,11 +20,11 @@ interface GenaiProviderConfig {
   readonly random_seed?: number;
 }
 
-/** Sampler values applied to a live instance (per-run overrides via setOptions). */
-const appliedTemperature = new WeakMap<object, number | undefined>();
-
 /** Per-model promise chain: the SDK allows one generateResponse at a time per instance. */
 const genaiLocks = new Map<string, Promise<unknown>>();
+
+/** In-flight creations: single-flight per model path (cleared when settled). */
+const genaiCreations = new Map<string, Promise<LlmInference>>();
 
 let _webGpuDevicePromise: Promise<unknown> | undefined;
 
@@ -74,6 +74,11 @@ export async function withGenaiLock<T>(model_path: string, fn: () => Promise<T>)
   }
 }
 
+/** True when a run currently holds (or is queued on) the model's lock. */
+export function isGenaiBusy(model_path: string): boolean {
+  return genaiLocks.has(model_path);
+}
+
 function findCachedGenai(model_path: string): LlmInference | undefined {
   const entries = modelTaskCache.get(model_path);
   const entry = entries?.find((cached) => cached.task_engine === "genai");
@@ -87,11 +92,11 @@ export function peekGenaiLlm(model: TFMPModelConfig): LlmInference | undefined {
 
 /**
  * Get (or create) the single LlmInference instance for a model. Creation
- * options come from `provider_config` only; per-run sampler overrides go
- * through {@link applyGenaiSamplerOverrides} so the multi-GB instance is
- * never re-created for a sampler change. The instance registers into the
- * shared modelTaskCache, so `model.download-remove` (TFMP_Unload) and
- * `model.info` (is_loaded) work unchanged.
+ * options come from `provider_config` only — the web SDK cannot change sampler
+ * options after load, so there are no per-run overrides. The instance registers
+ * into the shared modelTaskCache, so `model.download-remove` (TFMP_Unload) and
+ * `model.info` (is_loaded) work unchanged. Concurrent cold starts share one
+ * creation instead of loading the multi-GB model twice.
  */
 export async function getGenaiLlm(
   model: TFMPModelConfig,
@@ -102,6 +107,25 @@ export async function getGenaiLlm(
 
   const cached = findCachedGenai(model_path);
   if (cached) return cached;
+
+  const inFlight = genaiCreations.get(model_path);
+  if (inFlight) return inFlight;
+
+  const creation = createGenaiLlm(model, emit, signal);
+  genaiCreations.set(model_path, creation);
+  try {
+    return await creation;
+  } finally {
+    genaiCreations.delete(model_path);
+  }
+}
+
+async function createGenaiLlm(
+  model: TFMPModelConfig,
+  emit: (event: StreamPhase) => void,
+  signal: AbortSignal
+): Promise<LlmInference> {
+  const model_path = model.provider_config.model_path;
 
   if (signal.aborted) {
     throw new PermanentJobError("Aborted job");
@@ -132,8 +156,6 @@ export async function getGenaiLlm(
     throw new PermanentJobError(`Failed to load MediaPipe LLM model: ${message}`);
   }
 
-  appliedTemperature.set(llm, pc.temperature);
-
   if (!modelTaskCache.has(model_path)) {
     modelTaskCache.set(model_path, []);
   }
@@ -146,26 +168,43 @@ export async function getGenaiLlm(
 }
 
 /**
- * Apply a per-run temperature override via setOptions when it differs from
- * the value applied to the live instance. Never touches baseOptions (that
- * would reload the model). Call under {@link withGenaiLock}.
+ * Close and uncache every genai instance for a model under the per-model
+ * lock, so an in-flight generateResponse/sizeInTokens finishes first. Must
+ * NOT be called from inside a withGenaiLock closure (it takes the lock).
  */
-export async function applyGenaiSamplerOverrides(
-  llm: LlmInference,
-  input: { readonly temperature?: number }
-): Promise<void> {
-  const desired = input.temperature;
-  if (desired === undefined) return;
-  if (appliedTemperature.get(llm) === desired) return;
-  await llm.setOptions({ temperature: desired });
-  appliedTemperature.set(llm, desired);
+export async function closeGenaiLlm(model_path: string): Promise<void> {
+  await withGenaiLock(model_path, async () => {
+    const entries = modelTaskCache.get(model_path);
+    if (!entries) return;
+    const remaining = entries.filter((cached) => {
+      if (cached.task_engine !== "genai") return true;
+      try {
+        cached.task.close();
+      } catch {
+        // already closed
+      }
+      const newCount = (wasm_reference_counts.get("genai") ?? 1) - 1;
+      if (newCount <= 0) {
+        wasm_tasks.delete("genai");
+        wasm_reference_counts.delete("genai");
+      } else {
+        wasm_reference_counts.set("genai", newCount);
+      }
+      return false;
+    });
+    if (remaining.length > 0) {
+      modelTaskCache.set(model_path, remaining);
+    } else {
+      modelTaskCache.delete(model_path);
+    }
+  });
 }
 
 /**
  * Run one streaming generation. The SDK's progressListener receives newly
- * generated partial text (a delta); abort maps to cancelProcessing(), and
- * cancel signals are cleared afterwards so the next run is not
- * insta-cancelled. Call under {@link withGenaiLock}.
+ * generated partial text (a delta); abort maps to cancelProcessing(), and any
+ * cancel signal is cleared afterwards where the SDK supports it. Call under
+ * {@link withGenaiLock}.
  */
 export async function generateGenaiResponse(
   llm: LlmInference,
@@ -190,10 +229,16 @@ export async function generateGenaiResponse(
     });
   } finally {
     signal.removeEventListener("abort", onAbort);
-    try {
-      llm.clearCancelSignals();
-    } catch {
-      // instance may already be closed
+    // 0.10.29 ships without clearCancelSignals (declared in the d.ts but not
+    // exported from the bundle); the SDK also self-resets its cancel flag at
+    // the start of each generation, so this is a best-effort call for newer SDKs.
+    const clear = (llm as { clearCancelSignals?: () => void }).clearCancelSignals;
+    if (typeof clear === "function") {
+      try {
+        clear.call(llm);
+      } catch {
+        // instance may already be closed
+      }
     }
   }
 }

--- a/providers/tf-mediapipe/src/ai/common/TFMP_GenaiRuntime.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_GenaiRuntime.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { LlmInference } from "@mediapipe/tasks-genai";
+import { PermanentJobError } from "@workglow/job-queue";
+import type { StreamPhase } from "@workglow/task-graph";
+import { loadTfmpTasksGenaiSDK } from "./TFMP_Client";
+import type { TFMPModelConfig } from "./TFMP_ModelSchema";
+import type { TaskInstance } from "./TFMP_Runtime";
+import { getWasmTask, modelTaskCache, wasm_reference_counts } from "./TFMP_Runtime";
+
+interface GenaiProviderConfig {
+  readonly model_path: string;
+  readonly max_tokens?: number;
+  readonly top_k?: number;
+  readonly temperature?: number;
+  readonly random_seed?: number;
+}
+
+/** Sampler values applied to a live instance (per-run overrides via setOptions). */
+const appliedTemperature = new WeakMap<object, number | undefined>();
+
+/** Per-model promise chain: the SDK allows one generateResponse at a time per instance. */
+const genaiLocks = new Map<string, Promise<unknown>>();
+
+let _webGpuDevicePromise: Promise<unknown> | undefined;
+
+function webGpuUnavailableError(): PermanentJobError {
+  return new PermanentJobError(
+    "MediaPipe LLM inference requires WebGPU, which is not available in this context. " +
+      "Use a WebGPU-enabled browser (e.g. Chrome 113+) and ensure WebGPU is exposed to this window/worker."
+  );
+}
+
+/**
+ * Create (once) the shared high-performance WebGPU device used by every
+ * LlmInference instance in this runtime.
+ */
+async function getWebGpuDevice(): Promise<unknown> {
+  if (typeof navigator === "undefined" || !(navigator as { gpu?: unknown }).gpu) {
+    throw webGpuUnavailableError();
+  }
+  if (!_webGpuDevicePromise) {
+    _webGpuDevicePromise = (async () => {
+      const { LlmInference: LlmInferenceClass } = await loadTfmpTasksGenaiSDK();
+      try {
+        return await LlmInferenceClass.createWebGpuDevice();
+      } catch (error) {
+        _webGpuDevicePromise = undefined;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new PermanentJobError(
+          `Failed to create a WebGPU device for MediaPipe LLM inference: ${message}`
+        );
+      }
+    })();
+  }
+  return _webGpuDevicePromise;
+}
+
+/** Serialize all SDK calls against one model's LlmInference instance. */
+export async function withGenaiLock<T>(model_path: string, fn: () => Promise<T>): Promise<T> {
+  const prev = genaiLocks.get(model_path) ?? Promise.resolve();
+  const next = prev.catch(() => {}).then(fn);
+  genaiLocks.set(model_path, next);
+  try {
+    return await next;
+  } finally {
+    if (genaiLocks.get(model_path) === next) {
+      genaiLocks.delete(model_path);
+    }
+  }
+}
+
+function findCachedGenai(model_path: string): LlmInference | undefined {
+  const entries = modelTaskCache.get(model_path);
+  const entry = entries?.find((cached) => cached.task_engine === "genai");
+  return entry?.task as LlmInference | undefined;
+}
+
+/** Return the cached LlmInference for a model, or undefined when not loaded. */
+export function peekGenaiLlm(model: TFMPModelConfig): LlmInference | undefined {
+  return findCachedGenai(model.provider_config.model_path);
+}
+
+/**
+ * Get (or create) the single LlmInference instance for a model. Creation
+ * options come from `provider_config` only; per-run sampler overrides go
+ * through {@link applyGenaiSamplerOverrides} so the multi-GB instance is
+ * never re-created for a sampler change. The instance registers into the
+ * shared modelTaskCache, so `model.download-remove` (TFMP_Unload) and
+ * `model.info` (is_loaded) work unchanged.
+ */
+export async function getGenaiLlm(
+  model: TFMPModelConfig,
+  emit: (event: StreamPhase) => void,
+  signal: AbortSignal
+): Promise<LlmInference> {
+  const model_path = model.provider_config.model_path;
+
+  const cached = findCachedGenai(model_path);
+  if (cached) return cached;
+
+  if (signal.aborted) {
+    throw new PermanentJobError("Aborted job");
+  }
+
+  const device = await getWebGpuDevice();
+  const wasmFileset = await getWasmTask(model, emit, signal);
+
+  emit({ type: "phase", message: "Creating model task", progress: 0.2 });
+
+  const { LlmInference: LlmInferenceClass } = await loadTfmpTasksGenaiSDK();
+  const pc = model.provider_config as GenaiProviderConfig;
+
+  let llm: LlmInference;
+  try {
+    llm = await LlmInferenceClass.createFromOptions(wasmFileset, {
+      baseOptions: {
+        modelAssetPath: model_path,
+        gpuOptions: { device: device as never },
+      },
+      ...(pc.max_tokens !== undefined ? { maxTokens: pc.max_tokens } : {}),
+      ...(pc.top_k !== undefined ? { topK: pc.top_k } : {}),
+      ...(pc.temperature !== undefined ? { temperature: pc.temperature } : {}),
+      ...(pc.random_seed !== undefined ? { randomSeed: pc.random_seed } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new PermanentJobError(`Failed to load MediaPipe LLM model: ${message}`);
+  }
+
+  appliedTemperature.set(llm, pc.temperature);
+
+  if (!modelTaskCache.has(model_path)) {
+    modelTaskCache.set(model_path, []);
+  }
+  modelTaskCache
+    .get(model_path)!
+    .push({ task: llm as unknown as TaskInstance, options: {}, task_engine: "genai" });
+  wasm_reference_counts.set("genai", (wasm_reference_counts.get("genai") || 0) + 1);
+
+  return llm;
+}
+
+/**
+ * Apply a per-run temperature override via setOptions when it differs from
+ * the value applied to the live instance. Never touches baseOptions (that
+ * would reload the model). Call under {@link withGenaiLock}.
+ */
+export async function applyGenaiSamplerOverrides(
+  llm: LlmInference,
+  input: { readonly temperature?: number }
+): Promise<void> {
+  const desired = input.temperature;
+  if (desired === undefined) return;
+  if (appliedTemperature.get(llm) === desired) return;
+  await llm.setOptions({ temperature: desired });
+  appliedTemperature.set(llm, desired);
+}
+
+/**
+ * Run one streaming generation. The SDK's progressListener receives newly
+ * generated partial text (a delta); abort maps to cancelProcessing(), and
+ * cancel signals are cleared afterwards so the next run is not
+ * insta-cancelled. Call under {@link withGenaiLock}.
+ */
+export async function generateGenaiResponse(
+  llm: LlmInference,
+  prompt: string,
+  signal: AbortSignal,
+  onDelta: ((text: string) => void) | undefined
+): Promise<string> {
+  if (signal.aborted) {
+    throw new PermanentJobError("Aborted job");
+  }
+  const onAbort = () => {
+    try {
+      llm.cancelProcessing();
+    } catch {
+      // instance may already be closed
+    }
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await llm.generateResponse(prompt, (partialResult: string, _done: boolean) => {
+      if (partialResult && onDelta) onDelta(partialResult);
+    });
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    try {
+      llm.clearCancelSignals();
+    } catch {
+      // instance may already be closed
+    }
+  }
+}

--- a/providers/tf-mediapipe/src/ai/common/TFMP_JobRunFns.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_JobRunFns.ts
@@ -4,18 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { AiProviderRunFnRegistration } from "@workglow/ai";
+import type { AiProviderPreviewRunFn, AiProviderRunFnRegistration } from "@workglow/ai";
 import {
+  TFMP_COUNT_TOKENS,
   TFMP_IMAGE_CLASSIFICATION,
   TFMP_IMAGE_EMBEDDING,
   TFMP_IMAGE_OBJECT_DETECTION,
   TFMP_IMAGE_SEGMENTATION,
+  TFMP_JSON_MODE,
   TFMP_MODEL_DOWNLOAD,
   TFMP_MODEL_INFO,
   TFMP_MODEL_SEARCH,
   TFMP_MODEL_UNLOAD,
   TFMP_TEXT_CLASSIFICATION,
   TFMP_TEXT_EMBEDDING,
+  TFMP_TEXT_GENERATION,
   TFMP_TEXT_LANGUAGE_DETECTION,
   TFMP_VISION_FACE_DETECTION,
   TFMP_VISION_FACE_LANDMARKS,
@@ -25,6 +28,7 @@ import {
 } from "./TFMP_CapabilitySets";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
 
+import { TFMP_CountTokens, TFMP_CountTokens_Preview } from "./TFMP_CountTokens";
 import { TFMP_Download } from "./TFMP_Download";
 import { TFMP_FaceDetector } from "./TFMP_FaceDetector";
 import { TFMP_FaceLandmarker } from "./TFMP_FaceLandmarker";
@@ -37,8 +41,10 @@ import { TFMP_ModelInfo } from "./TFMP_ModelInfo";
 import { TFMP_ModelSearch } from "./TFMP_ModelSearch";
 import { TFMP_ObjectDetection } from "./TFMP_ObjectDetection";
 import { TFMP_PoseLandmarker } from "./TFMP_PoseLandmarker";
+import { TFMP_StructuredGeneration } from "./TFMP_StructuredGeneration";
 import { TFMP_TextClassification } from "./TFMP_TextClassification";
 import { TFMP_TextEmbedding } from "./TFMP_TextEmbedding";
+import { TFMP_TextGeneration } from "./TFMP_TextGeneration";
 import { TFMP_TextLanguageDetection } from "./TFMP_TextLanguageDetection";
 import { TFMP_Unload } from "./TFMP_Unload";
 
@@ -47,7 +53,10 @@ export { loadTfmpTasksTextSDK, loadTfmpTasksVisionSDK } from "./TFMP_Client";
 /**
  * Capability-set run-fn registrations for TensorFlow MediaPipe.
  *
- * All TFMP inference ops are one-shot run-fns that emit a single `finish` event.
+ * The vision/text/audio inference ops are one-shot run-fns that emit a single
+ * `finish` event. The genai LLM run-fns are the exception: they stream
+ * incremental `text-delta` / `object-delta` events while decoding, and the
+ * consumer accumulates them.
  * {@link ModelDownloadTask} (`["model.download"]`) reports real download progress
  * via `phase` events emitted directly from {@link getModelTask}.
  */
@@ -64,8 +73,18 @@ export const TFMP_RUN_FNS: readonly AiProviderRunFnRegistration<any, any, TFMPMo
   { serves: TFMP_VISION_HAND_LANDMARKS, runFn: TFMP_HandLandmarker },
   { serves: TFMP_VISION_POSE_LANDMARKS, runFn: TFMP_PoseLandmarker },
   { serves: TFMP_VISION_GESTURE, runFn: TFMP_GestureRecognizer },
+  { serves: TFMP_TEXT_GENERATION, runFn: TFMP_TextGeneration },
+  { serves: TFMP_JSON_MODE, runFn: TFMP_StructuredGeneration },
+  { serves: TFMP_COUNT_TOKENS, runFn: TFMP_CountTokens },
   { serves: TFMP_MODEL_DOWNLOAD, runFn: TFMP_Download },
   { serves: TFMP_MODEL_UNLOAD, runFn: TFMP_Unload },
   { serves: TFMP_MODEL_SEARCH, runFn: TFMP_ModelSearch },
   { serves: TFMP_MODEL_INFO, runFn: TFMP_ModelInfo },
 ];
+
+export const TFMP_PREVIEW_TASKS: Record<
+  string,
+  AiProviderPreviewRunFn<any, any, TFMPModelConfig>
+> = {
+  CountTokensTask: TFMP_CountTokens_Preview,
+};

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
@@ -65,9 +65,9 @@ export const TFMPModelSchema = {
         },
         chat_template: {
           type: "string",
-          enum: ["gemma", "none"],
+          enum: ["gemma", "chatml", "none"],
           description:
-            "GenAI only: how prompts and chat messages are rendered into the LLM's turn format. MediaPipe web LLM bundles are Gemma-family, so 'gemma' is the default; 'none' passes text through verbatim.",
+            "GenAI only: how prompts and chat messages are rendered into the LLM's turn format. Use 'gemma' for Gemma-family bundles (default), 'chatml' for Qwen-family bundles, 'none' to pass text through verbatim.",
           default: "gemma",
         },
       },

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
@@ -56,7 +56,7 @@ export const TFMPModelSchema = {
           type: "number",
           minimum: 0,
           description:
-            "GenAI only: default sampling temperature; a per-run temperature input overrides it.",
+            "GenAI only: sampling temperature, fixed at model load (the web SDK cannot change sampler options after load).",
           default: 0.8,
         },
         random_seed: {

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ModelSchema.ts
@@ -33,6 +33,43 @@ export const TFMPModelSchema = {
           enum: Object.values(TextPipelineTask),
           description: "Pipeline task type for the MediaPipe model.",
         },
+        gpu: {
+          type: "boolean",
+          description:
+            "Use GPU acceleration where the engine supports it: vision tasks use the GPU delegate; genai always requires WebGPU; text and audio tasks are CPU-only on web and ignore this option.",
+          default: true,
+        },
+        max_tokens: {
+          type: "integer",
+          minimum: 1,
+          description:
+            "GenAI only: combined input+output token budget, fixed at model load. Must not exceed the converted bundle's KV-cache size.",
+          default: 512,
+        },
+        top_k: {
+          type: "integer",
+          minimum: 1,
+          description: "GenAI only: number of candidate tokens for top-k sampling.",
+          default: 40,
+        },
+        temperature: {
+          type: "number",
+          minimum: 0,
+          description:
+            "GenAI only: default sampling temperature; a per-run temperature input overrides it.",
+          default: 0.8,
+        },
+        random_seed: {
+          type: "integer",
+          description: "GenAI only: random seed for sampling.",
+        },
+        chat_template: {
+          type: "string",
+          enum: ["gemma", "none"],
+          description:
+            "GenAI only: how prompts and chat messages are rendered into the LLM's turn format. MediaPipe web LLM bundles are Gemma-family, so 'gemma' is the default; 'none' passes text through verbatim.",
+          default: "gemma",
+        },
       },
       required: ["model_path", "task_engine", "pipeline"],
       additionalProperties: false,

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ModelSearch.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ModelSearch.ts
@@ -15,6 +15,27 @@ import { TENSORFLOW_MEDIAPIPE } from "./TFMP_Constants";
 
 const TFMP_MODEL_RESULTS: ModelSearchResultItem[] = [
   {
+    id: "gemma3-1b-it",
+    label: "Gemma 3 1B IT",
+    description: "On-device LLM (int4, ~0.5 GB); streaming text generation; requires WebGPU",
+    record: {
+      provider: TENSORFLOW_MEDIAPIPE,
+      title: "Gemma 3 1B IT",
+      description:
+        "Gemma 3 1B instruction-tuned (int4 web bundle) running locally via MediaPipe LLM inference; requires WebGPU",
+      capabilities: ["text.generation", "json-mode", "model.count-tokens"],
+      provider_config: {
+        model_path:
+          "https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4-web.task",
+        task_engine: "genai",
+        pipeline: "genai-text",
+        max_tokens: 1000,
+      },
+      metadata: {},
+    },
+    raw: { source: "mediapipe" },
+  },
+  {
     id: "universal-sentence-encoder",
     label: "Universal Sentence Encoder",
     description: "Text embedding model",

--- a/providers/tf-mediapipe/src/ai/common/TFMP_ModelSearch.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_ModelSearch.ts
@@ -15,15 +15,53 @@ import { TENSORFLOW_MEDIAPIPE } from "./TFMP_Constants";
 
 const TFMP_MODEL_RESULTS: ModelSearchResultItem[] = [
   {
+    id: "qwen2.5-1.5b-instruct",
+    label: "Qwen2.5 1.5B Instruct",
+    description:
+      "On-device LLM (int8, ~1.6 GB, Apache-2.0); streaming text generation; requires WebGPU",
+    record: {
+      provider: TENSORFLOW_MEDIAPIPE,
+      title: "Qwen2.5 1.5B Instruct",
+      description:
+        "Qwen2.5 1.5B instruction-tuned (int8 bundle, Apache-2.0) running locally via MediaPipe LLM inference; requires WebGPU",
+      capabilities: [
+        "text.generation",
+        "json-mode",
+        "model.count-tokens",
+        "model.download-remove",
+        "model.info",
+        "model.search",
+      ],
+      provider_config: {
+        model_path:
+          "https://huggingface.co/litert-community/Qwen2.5-1.5B-Instruct/resolve/main/Qwen2.5-1.5B-Instruct_multi-prefill-seq_q8_ekv1280.task",
+        task_engine: "genai",
+        pipeline: "genai-text",
+        max_tokens: 1280,
+        chat_template: "chatml",
+      },
+      metadata: {},
+    },
+    raw: { source: "mediapipe" },
+  },
+  {
     id: "gemma3-1b-it",
     label: "Gemma 3 1B IT",
-    description: "On-device LLM (int4, ~0.5 GB); streaming text generation; requires WebGPU",
+    description:
+      "On-device LLM (int4, ~0.5 GB); requires WebGPU. Gated: accept the Gemma license on Hugging Face and host the file yourself — anonymous downloads fail",
     record: {
       provider: TENSORFLOW_MEDIAPIPE,
       title: "Gemma 3 1B IT",
       description:
-        "Gemma 3 1B instruction-tuned (int4 web bundle) running locally via MediaPipe LLM inference; requires WebGPU",
-      capabilities: ["text.generation", "json-mode", "model.count-tokens"],
+        "Gemma 3 1B instruction-tuned (int4 web bundle) via MediaPipe LLM inference; requires WebGPU. The Hugging Face file is license-gated: accept the Gemma license and replace model_path with a copy you host",
+      capabilities: [
+        "text.generation",
+        "json-mode",
+        "model.count-tokens",
+        "model.download-remove",
+        "model.info",
+        "model.search",
+      ],
       provider_config: {
         model_path:
           "https://huggingface.co/litert-community/Gemma3-1B-IT/resolve/main/gemma3-1b-it-int4-web.task",

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Runtime.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Runtime.ts
@@ -12,6 +12,8 @@ import {
   loadTfmpTasksTextSDK,
   loadTfmpTasksVisionSDK,
 } from "./TFMP_Client";
+import type { TfmpDelegate } from "./TFMP_Delegate";
+import { resolveTfmpDelegate } from "./TFMP_Delegate";
 import { TFMPModelConfig } from "./TFMP_ModelSchema";
 
 export interface TFMPWasmFileset {
@@ -23,6 +25,15 @@ export interface TFMPWasmFileset {
 
 export const wasm_tasks = new Map<string, TFMPWasmFileset>();
 export const wasm_reference_counts = new Map<string, number>();
+
+/**
+ * Pinned WASM version for the genai engine. The genai JS↔WASM ABI moves
+ * quickly and the npm dependency (^0.10.29) trails the other task packages
+ * (^0.10.35), so the genai CDN assets are pinned to the bundled SDK version
+ * rather than `@latest`. Keep in sync with the `@mediapipe/tasks-genai`
+ * catalog entry in the root package.json.
+ */
+export const TFMP_GENAI_WASM_VERSION = "0.10.29";
 
 type TaskConstructor = {
   createFromOptions(
@@ -44,25 +55,28 @@ export interface CachedModelTask {
 
 export const modelTaskCache = new Map<string, CachedModelTask[]>();
 
-const optionsMatch = (opts1: Record<string, unknown>, opts2: Record<string, unknown>): boolean => {
+const valuesMatch = (val1: unknown, val2: unknown): boolean => {
+  if (val1 === val2) return true;
+  if (val1 && val2 && typeof val1 === "object" && typeof val2 === "object") {
+    return JSON.stringify(val1) === JSON.stringify(val2);
+  }
+  return false;
+};
+
+export const optionsMatch = (
+  opts1: Record<string, unknown>,
+  opts2: Record<string, unknown>
+): boolean => {
   const keys1 = Object.keys(opts1).sort();
   const keys2 = Object.keys(opts2).sort();
 
   if (keys1.length !== keys2.length) return false;
+  if (!keys1.every((key, i) => key === keys2[i])) return false;
 
-  return keys1.every((key) => {
-    const val1 = opts1[key];
-    const val2 = opts2[key];
-
-    if (Array.isArray(val1) && Array.isArray(val2)) {
-      return JSON.stringify(val1) === JSON.stringify(val2);
-    }
-
-    return val1 === val2;
-  });
+  return keys1.every((key) => valuesMatch(opts1[key], opts2[key]));
 };
 
-const getWasmTask = async (
+export const getWasmTask = async (
   model: TFMPModelConfig,
   emit: (event: StreamPhase) => void,
   signal: AbortSignal
@@ -106,7 +120,7 @@ const getWasmTask = async (
     case "genai": {
       const { FilesetResolver } = await loadTfmpTasksGenaiSDK();
       wasmFileset = await FilesetResolver.forGenAiTasks(
-        "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-genai@latest/wasm"
+        `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-genai@${TFMP_GENAI_WASM_VERSION}/wasm`
       );
       break;
     }
@@ -127,10 +141,29 @@ export const getModelTask = async (
 ): Promise<any> => {
   const model_path = model.provider_config.model_path;
   const task_engine = model.provider_config.task_engine;
+  const gpu = (model.provider_config as { gpu?: boolean }).gpu;
+
+  const { baseOptions: rawCallerBase, ...rest } = options;
+  const callerBase = (rawCallerBase as Record<string, unknown> | undefined) ?? {};
+
+  // An explicit caller delegate wins over the model-level gpu flag.
+  const delegate =
+    (callerBase.delegate as TfmpDelegate | undefined) ?? resolveTfmpDelegate(task_engine, gpu);
+
+  const buildOptions = (del: TfmpDelegate | undefined): Record<string, unknown> => ({
+    ...rest,
+    baseOptions: {
+      ...callerBase,
+      ...(del ? { delegate: del } : {}),
+      modelAssetPath: model_path,
+    },
+  });
+
+  const lookupOptions = buildOptions(delegate);
 
   const cachedTasks = modelTaskCache.get(model_path);
   if (cachedTasks) {
-    const matchedTask = cachedTasks.find((cached) => optionsMatch(cached.options, options));
+    const matchedTask = cachedTasks.find((cached) => optionsMatch(cached.options, lookupOptions));
     if (matchedTask) {
       return matchedTask.task;
     }
@@ -140,14 +173,24 @@ export const getModelTask = async (
 
   emit({ type: "phase", message: "Creating model task", progress: 0.2 });
 
-  const task = await TaskType.createFromOptions(wasmFileset, {
-    baseOptions: {
-      modelAssetPath: model_path,
-    },
-    ...options,
-  });
+  let task: TaskInstance;
+  try {
+    task = await TaskType.createFromOptions(wasmFileset, lookupOptions);
+  } catch (error) {
+    if (delegate !== "GPU") throw error;
+    // Some contexts (headless, missing WebGL2) cannot create GPU-delegate
+    // tasks; retry once on CPU rather than failing the model outright.
+    emit({
+      type: "phase",
+      message: "GPU delegate unavailable, falling back to CPU",
+      progress: 0.2,
+    });
+    task = await TaskType.createFromOptions(wasmFileset, buildOptions("CPU"));
+  }
 
-  const cachedTask: CachedModelTask = { task, options, task_engine };
+  // Cache under the *requested* options so the next identical request hits
+  // even when creation fell back to CPU.
+  const cachedTask: CachedModelTask = { task, options: lookupOptions, task_engine };
   if (!modelTaskCache.has(model_path)) {
     modelTaskCache.set(model_path, []);
   }

--- a/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
@@ -11,12 +11,7 @@ import type {
 } from "@workglow/ai";
 import { parsePartialJson } from "@workglow/util/worker";
 import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./TFMP_ChatTemplate";
-import {
-  applyGenaiSamplerOverrides,
-  generateGenaiResponse,
-  getGenaiLlm,
-  withGenaiLock,
-} from "./TFMP_GenaiRuntime";
+import { generateGenaiResponse, getGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
 
 function buildStructuredGenerationPrompt(input: StructuredGenerationTaskInput): string {
@@ -81,13 +76,11 @@ export const TFMP_StructuredGeneration: AiProviderRunFn<
     template
   );
 
-  const llm = await getGenaiLlm(model!, emit, signal);
-
   let fullText = "";
   let jsonStart = -1;
 
   await withGenaiLock(model!.provider_config.model_path, async () => {
-    await applyGenaiSamplerOverrides(llm, input);
+    const llm = await getGenaiLlm(model!, emit, signal);
     await generateGenaiResponse(llm, prompt, signal, (piece) => {
       fullText += piece;
       if (jsonStart === -1) {

--- a/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
@@ -51,6 +51,12 @@ export function extractJsonFromText(text: string): Record<string, unknown> {
         return (parsePartialJson(match[0]) as Record<string, unknown>) ?? {};
       }
     }
+    // Output truncated mid-object never closes its brace, so the balanced-object
+    // match above finds nothing; recover whatever was emitted after the first `{`.
+    const start = cleaned.indexOf("{");
+    if (start !== -1) {
+      return (parsePartialJson(cleaned.slice(start)) as Record<string, unknown>) ?? {};
+    }
     return {};
   }
 }

--- a/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_StructuredGeneration.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+} from "@workglow/ai";
+import { parsePartialJson } from "@workglow/util/worker";
+import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./TFMP_ChatTemplate";
+import {
+  applyGenaiSamplerOverrides,
+  generateGenaiResponse,
+  getGenaiLlm,
+  withGenaiLock,
+} from "./TFMP_GenaiRuntime";
+import type { TFMPModelConfig } from "./TFMP_ModelSchema";
+
+function buildStructuredGenerationPrompt(input: StructuredGenerationTaskInput): string {
+  const schemaStr = JSON.stringify(input.outputSchema, null, 2);
+  return (
+    `${input.prompt}\n\n` +
+    `You MUST respond with ONLY a valid JSON object conforming to this JSON schema:\n${schemaStr}\n\n` +
+    `Output ONLY the JSON object, no other text.`
+  );
+}
+
+/**
+ * Strip a Markdown code fence (``` or ```json) wrapping the payload, if present.
+ * Surrounding whitespace is left on the capture; the caller trims it (matching
+ * it here would make the pattern ambiguous and super-linear).
+ */
+function stripCodeFences(text: string): string {
+  const fenceMatch = text.match(/```(?:json)?([\s\S]*?)```/);
+  return fenceMatch ? fenceMatch[1] : text;
+}
+
+export function extractJsonFromText(text: string): Record<string, unknown> {
+  const cleaned = stripCodeFences(text).trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        return JSON.parse(match[0]);
+      } catch {
+        return (parsePartialJson(match[0]) as Record<string, unknown>) ?? {};
+      }
+    }
+    return {};
+  }
+}
+
+/**
+ * `["text.generation", "json-mode"]` run-fn. MediaPipe web has no constrained
+ * decoding, so JSON conformance is prompt-engineered; StructuredGenerationTask
+ * validates the parsed object against the schema and retries on failure. The
+ * parsed final object rides in `finish.data.object` per the structured
+ * generation convention.
+ */
+export const TFMP_StructuredGeneration: AiProviderRunFn<
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+  TFMPModelConfig
+> = async (input, model, signal, emit) => {
+  const template = resolveTfmpChatTemplate(
+    (model!.provider_config as { chat_template?: string }).chat_template
+  );
+  const prompt = buildGenaiPrompt(
+    [{ role: "user", content: buildStructuredGenerationPrompt(input) }],
+    template
+  );
+
+  const llm = await getGenaiLlm(model!, emit, signal);
+
+  let fullText = "";
+  let jsonStart = -1;
+
+  await withGenaiLock(model!.provider_config.model_path, async () => {
+    await applyGenaiSamplerOverrides(llm, input);
+    await generateGenaiResponse(llm, prompt, signal, (piece) => {
+      fullText += piece;
+      if (jsonStart === -1) {
+        jsonStart = fullText.indexOf("{");
+      }
+      if (jsonStart !== -1) {
+        const partial = parsePartialJson(fullText.slice(jsonStart));
+        if (partial !== undefined) {
+          emit({
+            type: "object-delta",
+            port: "object",
+            objectDelta: partial as Record<string, unknown>,
+          });
+          return;
+        }
+      }
+      emit({ type: "text-delta", port: "text", textDelta: piece });
+    });
+  });
+
+  const object = extractJsonFromText(fullText);
+  emit({ type: "finish", data: { object } as StructuredGenerationTaskOutput });
+};

--- a/providers/tf-mediapipe/src/ai/common/TFMP_TextGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_TextGeneration.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, ToolCallingTaskInput } from "@workglow/ai";
+import { toTextFlatMessages } from "@workglow/ai/worker";
+import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./TFMP_ChatTemplate";
+import {
+  applyGenaiSamplerOverrides,
+  generateGenaiResponse,
+  getGenaiLlm,
+  withGenaiLock,
+} from "./TFMP_GenaiRuntime";
+import type { TFMPModelConfig } from "./TFMP_ModelSchema";
+
+/**
+ * Unified `["text.generation"]` run-fn: serves TextGenerationTask (prompt)
+ * and AiChatTask (messages). Streams text-delta events; the consumer
+ * accumulates, so finish carries an empty output.
+ */
+export const TFMP_TextGeneration: AiProviderRunFn<any, any, TFMPModelConfig> = async (
+  input,
+  model,
+  signal,
+  emit
+) => {
+  const template = resolveTfmpChatTemplate(
+    (model!.provider_config as { chat_template?: string }).chat_template
+  );
+  const messages = toTextFlatMessages(input as ToolCallingTaskInput);
+  const prompt = buildGenaiPrompt(messages, template);
+
+  const llm = await getGenaiLlm(model!, emit, signal);
+  await withGenaiLock(model!.provider_config.model_path, async () => {
+    await applyGenaiSamplerOverrides(llm, input as { temperature?: number });
+    await generateGenaiResponse(llm, prompt, signal, (piece) =>
+      emit({ type: "text-delta", port: "text", textDelta: piece })
+    );
+  });
+
+  emit({ type: "finish", data: {} });
+};

--- a/providers/tf-mediapipe/src/ai/common/TFMP_TextGeneration.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_TextGeneration.ts
@@ -7,12 +7,7 @@
 import type { AiProviderRunFn, ToolCallingTaskInput } from "@workglow/ai";
 import { toTextFlatMessages } from "@workglow/ai/worker";
 import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./TFMP_ChatTemplate";
-import {
-  applyGenaiSamplerOverrides,
-  generateGenaiResponse,
-  getGenaiLlm,
-  withGenaiLock,
-} from "./TFMP_GenaiRuntime";
+import { generateGenaiResponse, getGenaiLlm, withGenaiLock } from "./TFMP_GenaiRuntime";
 import type { TFMPModelConfig } from "./TFMP_ModelSchema";
 
 /**
@@ -32,9 +27,8 @@ export const TFMP_TextGeneration: AiProviderRunFn<any, any, TFMPModelConfig> = a
   const messages = toTextFlatMessages(input as ToolCallingTaskInput);
   const prompt = buildGenaiPrompt(messages, template);
 
-  const llm = await getGenaiLlm(model!, emit, signal);
   await withGenaiLock(model!.provider_config.model_path, async () => {
-    await applyGenaiSamplerOverrides(llm, input as { temperature?: number });
+    const llm = await getGenaiLlm(model!, emit, signal);
     await generateGenaiResponse(llm, prompt, signal, (piece) =>
       emit({ type: "text-delta", port: "text", textDelta: piece })
     );

--- a/providers/tf-mediapipe/src/ai/common/TFMP_Unload.ts
+++ b/providers/tf-mediapipe/src/ai/common/TFMP_Unload.ts
@@ -9,6 +9,7 @@ import type {
   ModelDownloadRemoveTaskRunInput,
   ModelDownloadRemoveTaskRunOutput,
 } from "@workglow/ai";
+import { closeGenaiLlm } from "./TFMP_GenaiRuntime";
 import { TFMPModelConfig } from "./TFMP_ModelSchema";
 import { modelTaskCache, wasm_reference_counts, wasm_tasks } from "./TFMP_Runtime";
 
@@ -18,6 +19,13 @@ export const TFMP_Unload: AiProviderRunFn<
   TFMPModelConfig
 > = async (input, model, _signal, emit) => {
   const model_path = model!.provider_config.model_path;
+
+  // Genai instances close under the per-model lock so an in-flight generation
+  // finishes first; the loop below then handles any remaining engines.
+  if (modelTaskCache.get(model_path)?.some((cached) => cached.task_engine === "genai")) {
+    await closeGenaiLlm(model_path);
+  }
+
   if (modelTaskCache.has(model_path)) {
     const cachedTasks = modelTaskCache.get(model_path)!;
 

--- a/providers/tf-mediapipe/src/ai/index.ts
+++ b/providers/tf-mediapipe/src/ai/index.ts
@@ -14,6 +14,7 @@ export * from "./registerTensorFlowMediaPipe";
 import { TFMP_RUN_FN_SPECS } from "./common/TFMP_Capabilities";
 import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./common/TFMP_ChatTemplate";
 import { resolveTfmpDelegate } from "./common/TFMP_Delegate";
+import { isGenaiBusy, withGenaiLock } from "./common/TFMP_GenaiRuntime";
 import { TFMP_PREVIEW_TASKS, TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
 import { optionsMatch } from "./common/TFMP_Runtime";
 import { extractJsonFromText } from "./common/TFMP_StructuredGeneration";
@@ -32,4 +33,6 @@ export const _testOnly = {
   resolveTfmpDelegate,
   optionsMatch,
   extractJsonFromText,
+  withGenaiLock,
+  isGenaiBusy,
 } as const;

--- a/providers/tf-mediapipe/src/ai/index.ts
+++ b/providers/tf-mediapipe/src/ai/index.ts
@@ -12,7 +12,11 @@ export * from "./common/TFMP_ModelSearch";
 export * from "./registerTensorFlowMediaPipe";
 
 import { TFMP_RUN_FN_SPECS } from "./common/TFMP_Capabilities";
-import { TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
+import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./common/TFMP_ChatTemplate";
+import { resolveTfmpDelegate } from "./common/TFMP_Delegate";
+import { TFMP_PREVIEW_TASKS, TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
+import { optionsMatch } from "./common/TFMP_Runtime";
+import { extractJsonFromText } from "./common/TFMP_StructuredGeneration";
 import { TensorFlowMediaPipeQueuedProvider } from "./TensorFlowMediaPipeQueuedProvider";
 
 /**
@@ -22,4 +26,10 @@ export const _testOnly = {
   TensorFlowMediaPipeQueuedProvider,
   TFMP_RUN_FN_SPECS,
   TFMP_RUN_FNS,
+  TFMP_PREVIEW_TASKS,
+  buildGenaiPrompt,
+  resolveTfmpChatTemplate,
+  resolveTfmpDelegate,
+  optionsMatch,
+  extractJsonFromText,
 } as const;

--- a/providers/tf-mediapipe/src/ai/index.ts
+++ b/providers/tf-mediapipe/src/ai/index.ts
@@ -16,7 +16,7 @@ import { buildGenaiPrompt, resolveTfmpChatTemplate } from "./common/TFMP_ChatTem
 import { resolveTfmpDelegate } from "./common/TFMP_Delegate";
 import { isGenaiBusy, withGenaiLock } from "./common/TFMP_GenaiRuntime";
 import { TFMP_PREVIEW_TASKS, TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
-import { optionsMatch } from "./common/TFMP_Runtime";
+import { optionsMatch, TFMP_GENAI_WASM_VERSION } from "./common/TFMP_Runtime";
 import { extractJsonFromText } from "./common/TFMP_StructuredGeneration";
 import { TensorFlowMediaPipeQueuedProvider } from "./TensorFlowMediaPipeQueuedProvider";
 
@@ -28,6 +28,7 @@ export const _testOnly = {
   TFMP_RUN_FN_SPECS,
   TFMP_RUN_FNS,
   TFMP_PREVIEW_TASKS,
+  TFMP_GENAI_WASM_VERSION,
   buildGenaiPrompt,
   resolveTfmpChatTemplate,
   resolveTfmpDelegate,

--- a/providers/tf-mediapipe/src/ai/registerTensorFlowMediaPipeInline.ts
+++ b/providers/tf-mediapipe/src/ai/registerTensorFlowMediaPipeInline.ts
@@ -6,14 +6,14 @@
 
 import type { AiProviderRegisterOptions } from "@workglow/ai";
 import { registerProviderInline } from "@workglow/ai/provider-utils";
-import { TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
+import { TFMP_PREVIEW_TASKS, TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
 import { TensorFlowMediaPipeQueuedProvider } from "./TensorFlowMediaPipeQueuedProvider";
 
 export async function registerTensorFlowMediaPipeInline(
   options?: AiProviderRegisterOptions
 ): Promise<void> {
   await registerProviderInline(
-    new TensorFlowMediaPipeQueuedProvider(TFMP_RUN_FNS),
+    new TensorFlowMediaPipeQueuedProvider(TFMP_RUN_FNS, TFMP_PREVIEW_TASKS),
     "TensorFlow MediaPipe",
     options
   );

--- a/providers/tf-mediapipe/src/ai/registerTensorFlowMediaPipeWorker.ts
+++ b/providers/tf-mediapipe/src/ai/registerTensorFlowMediaPipeWorker.ts
@@ -5,12 +5,13 @@
  */
 
 import { registerProviderWorker } from "@workglow/ai/provider-utils";
-import { TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
+import { TFMP_PREVIEW_TASKS, TFMP_RUN_FNS } from "./common/TFMP_JobRunFns";
 import { TensorFlowMediaPipeProvider } from "./TensorFlowMediaPipeProvider";
 
 export async function registerTensorFlowMediaPipeWorker(): Promise<void> {
   await registerProviderWorker(
-    (ws) => new TensorFlowMediaPipeProvider(TFMP_RUN_FNS).registerOnWorkerServer(ws),
+    (ws) =>
+      new TensorFlowMediaPipeProvider(TFMP_RUN_FNS, TFMP_PREVIEW_TASKS).registerOnWorkerServer(ws),
     "TensorFlow MediaPipe"
   );
 }

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -36,7 +36,7 @@
     "providers/sqlite": 24926,
     "providers/stable-diffusion-server": 10552,
     "providers/supabase": 29221,
-    "providers/tf-mediapipe": 22598,
+    "providers/tf-mediapipe": 26188,
     "providers/xai": 10645
   }
 }


### PR DESCRIPTION
## Summary

Integrates `@mediapipe/tasks-genai` into `@workglow/tf-mediapipe` so the provider actually uses the dependency it has been carrying, and turns on GPU delegates by default across the provider.

**GenAI (LLM inference, browser/WebGPU):**
- Streaming `["text.generation"]` run-fn serving both `TextGenerationTask` and `AiChatTask` (unified prompt+chat via `toTextFlatMessages`), with chat templating (`gemma`, `chatml`, `none`)
- `["text.generation", "json-mode"]` prompt-based structured generation: partial-object deltas while streaming, fence-strip + truncation-recovery JSON extraction, parsed object in `finish.data.object`
- `["model.count-tokens"]` via `sizeInTokens`, plus a preview fn that answers only from an already-loaded instance and bails while a generation holds the model lock
- `ModelDownloadTask` support for `genai-text` (warm the browser cache, then close under the lock)
- `TFMP_GenaiRuntime`: one `LlmInference` per model (single-flight creation), shared high-performance WebGPU device, per-model FIFO mutex around every SDK call, lock-guarded teardown, abort → `cancelProcessing()`
- GenAI WASM CDN pinned to the installed SDK version, with a parity unit test so the pin cannot drift from the caret-ranged dependency

**GPU by default:**
- New `provider_config.gpu` flag (default **true**): vision tasks get `baseOptions.delegate: "GPU"` with a one-shot CPU fallback on creation failure; genai always requires WebGPU; text/audio stay CPU (unsupported by the web SDK)
- `getModelTask` now deep-merges caller `baseOptions` and deep-compares cached options, so delegate variants cache correctly

**Models/wiring:** genai capability inference (gemma/qwen/`.litertlm`/llm filenames), two search catalog entries — ungated **Qwen2.5 1.5B Instruct** (int8, Apache-2.0, `chatml`) as the default and **Gemma 3 1B IT** with its Hugging Face license gate documented (anonymous downloads 401) — README usage docs, and worker/inline registration incl. preview tasks.

Sampler params (`max_tokens`, `top_k`, `temperature`, `random_seed`) are fixed at model load: the shipped 0.10.29 web SDK cannot change sampler options after load (`setOptions` requires a model asset and reloads), so per-run temperature inputs are deliberately ignored and documented as such.

## Test plan

- `bun run build:packages` — 79/79 tasks green
- `bun scripts/test.ts provider vitest` — 18 files passed, 241 tests passed (5 skipped): chat-template rendering (gemma + chatml), JSON extraction, delegate resolution, capability inference, worker/inline registration parity (order-sensitive), model-search schema validity, genai lock FIFO/rejection semantics, WASM version parity
- Adversarial multi-lens code review completed; all confirmed findings fixed (single-flight creation, lock-guarded close, preview busy-bail, `clearCancelSignals` existence guard, ungated default model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRs5utsw2pvZybjx7y3MP6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRs5utsw2pvZybjx7y3MP6)_