### PR TITLE
Add DeepSeek provider for @workglow/ai

### DIFF
--- a/.secrets/README.md
+++ b/.secrets/README.md
@@ -69,13 +69,16 @@ as separate CI secrets.
 
 ## Known credential keys
 
-| Credential key      | Env var hydrated     |
-| ------------------- | -------------------- |
-| `anthropic-api-key` | `ANTHROPIC_API_KEY`  |
-| `openai-api-key`    | `OPENAI_API_KEY`     |
-| `google-api-key`    | `GOOGLE_API_KEY`     |
-| `gemini-api-key`    | `GEMINI_API_KEY`     |
-| `hf-token`          | `HF_TOKEN`           |
+| Credential key       | Env var hydrated     |
+| -------------------- | -------------------- |
+| `anthropic-api-key`  | `ANTHROPIC_API_KEY`  |
+| `openai-api-key`     | `OPENAI_API_KEY`     |
+| `google-api-key`     | `GOOGLE_API_KEY`     |
+| `gemini-api-key`     | `GEMINI_API_KEY`     |
+| `hf-token`           | `HF_TOKEN`           |
+| `xai-api-key`        | `XAI_API_KEY`        |
+| `openrouter-api-key` | `OPENROUTER_API_KEY` |
+| `deepseek-api-key`   | `DEEPSEEK_API_KEY`   |
 
 To add another, edit `CREDENTIAL_TO_ENV` in `scripts/lib/test-credentials.ts`.
 

--- a/.secrets/credentials/8ba7cae724a568336246a8c2484316f6a7dfcddbe53a87795e696d3c7764a331.json
+++ b/.secrets/credentials/8ba7cae724a568336246a8c2484316f6a7dfcddbe53a87795e696d3c7764a331.json
@@ -1,0 +1,1 @@
+{"key":"deepseek-api-key","value":"{\"encrypted\":\"phxHdLmM959fXANdtIv100VntoYkLvHa9kTy9IzjEwSFPtja1oUsaG1xK8SGTniomAre02Mw0WQSFzK0Y18i/1sJGQ==\",\"iv\":\"vBvfAWqFKXtz+ENE\",\"createdAt\":\"2026-07-31T23:57:20.103Z\",\"updatedAt\":\"2026-07-31T23:57:20.103Z\"}"}

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@workglow/anthropic": "workspace:*",
         "@workglow/browser-control": "workspace:*",
         "@workglow/bun-webview": "workspace:*",
+        "@workglow/deepseek": "workspace:*",
         "@workglow/google-gemini": "workspace:*",
         "@workglow/huggingface-inference": "workspace:*",
         "@workglow/huggingface-transformers": "workspace:*",
@@ -96,6 +97,7 @@
         "@huggingface/transformers": "catalog:",
         "@workglow/ai": "workspace:*",
         "@workglow/anthropic": "workspace:*",
+        "@workglow/deepseek": "workspace:*",
         "@workglow/google-gemini": "workspace:*",
         "@workglow/huggingface-transformers": "workspace:*",
         "@workglow/node-llama-cpp": "workspace:*",
@@ -320,6 +322,7 @@
         "@workglow/cactus": "workspace:*",
         "@workglow/chrome-ai": "workspace:*",
         "@workglow/cloudflare": "workspace:*",
+        "@workglow/deepseek": "workspace:*",
         "@workglow/duckdb": "workspace:*",
         "@workglow/electron": "workspace:*",
         "@workglow/google-gemini": "workspace:*",
@@ -375,6 +378,7 @@
         "@workglow/anthropic": "workspace:*",
         "@workglow/browser-control": "workspace:*",
         "@workglow/chrome-ai": "workspace:*",
+        "@workglow/deepseek": "workspace:*",
         "@workglow/duckdb": "workspace:*",
         "@workglow/google-gemini": "workspace:*",
         "@workglow/huggingface-inference": "workspace:*",
@@ -497,6 +501,29 @@
       "peerDependencies": {
         "@cloudflare/workers-types": "^5.20260731.1",
         "@workglow/job-queue": "workspace:*",
+        "@workglow/util": "workspace:*",
+      },
+    },
+    "providers/deepseek": {
+      "name": "@workglow/deepseek",
+      "version": "0.3.32",
+      "dependencies": {
+        "js-tiktoken": "catalog:",
+        "openai": "catalog:",
+        "tiktoken": "catalog:",
+      },
+      "devDependencies": {
+        "@workglow/ai": "workspace:*",
+        "@workglow/job-queue": "workspace:*",
+        "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
+        "@workglow/util": "workspace:*",
+      },
+      "peerDependencies": {
+        "@workglow/ai": "workspace:*",
+        "@workglow/job-queue": "workspace:*",
+        "@workglow/storage": "workspace:*",
+        "@workglow/task-graph": "workspace:*",
         "@workglow/util": "workspace:*",
       },
     },
@@ -1553,6 +1580,8 @@
     "@workglow/cli": ["@workglow/cli@workspace:examples/cli"],
 
     "@workglow/cloudflare": ["@workglow/cloudflare@workspace:providers/cloudflare"],
+
+    "@workglow/deepseek": ["@workglow/deepseek@workspace:providers/deepseek"],
 
     "@workglow/duckdb": ["@workglow/duckdb@workspace:providers/duckdb"],
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
+    "@workglow/deepseek": "workspace:*",
     "@workglow/google-gemini": "workspace:*",
     "@workglow/huggingface-transformers": "workspace:*",
     "@workglow/huggingface-inference": "workspace:*",

--- a/examples/cli/src/commands/model.ts
+++ b/examples/cli/src/commands/model.ts
@@ -7,6 +7,7 @@
 import type { ModelRecord, ModelSearchResultItem } from "@workglow/ai";
 import { ModelRecordSchema, modelSearch } from "@workglow/ai";
 import { AnthropicModelRecordSchema } from "@workglow/anthropic/ai";
+import { DeepSeekModelRecordSchema } from "@workglow/deepseek/ai";
 import { GeminiModelRecordSchema } from "@workglow/google-gemini/ai";
 import { HfInferenceModelRecordSchema } from "@workglow/huggingface-inference/ai";
 import {
@@ -38,6 +39,7 @@ const PROVIDER_SCHEMAS: Record<string, DataPortSchemaObject> = {
   ANTHROPIC: AnthropicModelRecordSchema,
   OPENAI: OpenAiModelRecordSchema,
   XAI: XaiModelRecordSchema,
+  DEEPSEEK: DeepSeekModelRecordSchema,
   GOOGLE_GEMINI: GeminiModelRecordSchema,
   OLLAMA: OllamaModelRecordSchema,
   HF_INFERENCE: HfInferenceModelRecordSchema,

--- a/examples/cli/tsconfig.json
+++ b/examples/cli/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "../../packages/browser-control" },
     { "path": "../../providers/anthropic" },
     { "path": "../../providers/bun-webview" },
+    { "path": "../../providers/deepseek" },
     { "path": "../../providers/google-gemini" },
     { "path": "../../providers/huggingface-inference" },
     { "path": "../../providers/huggingface-transformers" },

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -117,6 +117,7 @@ setup needed:
 | `gpt-*`, `o<n>*`, `text-embedding-*`     | OpenAI (`OPENAI_API_KEY`)           |
 | `gemini-*`                               | Google Gemini (`GEMINI_API_KEY`)    |
 | `grok-*`                                 | xAI (`XAI_API_KEY`)                 |
+| `deepseek-*`                             | DeepSeek (`DEEPSEEK_API_KEY`)       |
 | `org/name` (optionally `org/name:dtype`) | Local HuggingFace Transformers ONNX |
 | `gguf:org/repo:Quant` or `gguf:*.gguf`   | Local node-llama-cpp (GGUF)         |
 

--- a/examples/eval/package.json
+++ b/examples/eval/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@workglow/ai": "workspace:*",
     "@workglow/anthropic": "workspace:*",
+    "@workglow/deepseek": "workspace:*",
     "@workglow/google-gemini": "workspace:*",
     "@workglow/huggingface-transformers": "workspace:*",
     "@workglow/node-llama-cpp": "workspace:*",

--- a/examples/eval/src/models.ts
+++ b/examples/eval/src/models.ts
@@ -30,6 +30,7 @@ const GGUF_PREFIX = "gguf:";
  * - `gpt-*`, `o<n>*`, `chatgpt-*`, `text-embedding-*` → OpenAI
  * - `gemini-*` → Google Gemini
  * - `grok-*` → xAI
+ * - `deepseek-*` → DeepSeek
  *
  * The slash check runs after the `gguf:` prefix but before the cloud
  * prefixes: hub paths are unambiguous, and org names can legitimately start
@@ -77,9 +78,12 @@ export function resolveModelConfig(id: string, kind: EvalKind): ModelConfig {
   if (/^grok-/.test(id)) {
     return { provider: "XAI", provider_config: { model_name: id } };
   }
+  if (/^deepseek-/.test(id)) {
+    return { provider: "DEEPSEEK", provider_config: { model_name: id } };
+  }
   throw new Error(
-    `cannot infer a provider for model "${id}" — use a claude-*/gpt-*/gemini-*/grok-* cloud id ` +
-      `or an org/name HuggingFace ONNX model path`
+    `cannot infer a provider for model "${id}" — use a claude-*/gpt-*/gemini-*/grok-*/deepseek-* ` +
+      `cloud id or an org/name HuggingFace ONNX model path`
   );
 }
 

--- a/examples/eval/src/providers.ts
+++ b/examples/eval/src/providers.ts
@@ -6,6 +6,7 @@
 
 import { registerAiTasks } from "@workglow/ai";
 import { registerAnthropicInline } from "@workglow/anthropic/ai-runtime";
+import { registerDeepSeekInline } from "@workglow/deepseek/ai-runtime";
 import { registerGeminiInline } from "@workglow/google-gemini/ai-runtime";
 import { registerHuggingFaceTransformers } from "@workglow/huggingface-transformers/ai";
 import { registerLlamaCpp } from "@workglow/node-llama-cpp/ai";
@@ -18,7 +19,7 @@ import type { EvalConfig } from "./config";
 /**
  * Register task types and every AI provider the eval can route to. Cloud
  * providers read their API keys from the environment (ANTHROPIC_API_KEY,
- * OPENAI_API_KEY, GEMINI_API_KEY, XAI_API_KEY) at call time; the local
+ * OPENAI_API_KEY, GEMINI_API_KEY, XAI_API_KEY, DEEPSEEK_API_KEY) at call time; the local
  * HuggingFace Transformers (ONNX) and node-llama-cpp (GGUF) providers run in
  * workers with their caches under the eval home. Each registration is
  * defensive: a provider that fails to load only fails runs that target it,
@@ -55,6 +56,7 @@ export async function registerEvalProviders(config: EvalConfig): Promise<void> {
     ["OPENAI", () => registerOpenAiInline()],
     ["GOOGLE_GEMINI", () => registerGeminiInline()],
     ["XAI", () => registerXaiInline()],
+    ["DEEPSEEK", () => registerDeepSeekInline()],
   ];
 
   for (const [name, register] of registrations) {

--- a/examples/eval/src/test/models.test.ts
+++ b/examples/eval/src/test/models.test.ts
@@ -15,6 +15,8 @@ describe("resolveModelConfig", () => {
     expect(resolveModelConfig("text-embedding-3-small", "similarity").provider).toBe("OPENAI");
     expect(resolveModelConfig("gemini-3-flash-preview", "classify").provider).toBe("GOOGLE_GEMINI");
     expect(resolveModelConfig("grok-4.5", "classify").provider).toBe("XAI");
+    expect(resolveModelConfig("deepseek-v4-flash", "classify").provider).toBe("DEEPSEEK");
+    expect(resolveModelConfig("deepseek-v4-pro", "classify").provider).toBe("DEEPSEEK");
   });
 
   it("passes the id through as the provider model name", () => {

--- a/examples/eval/tsconfig.json
+++ b/examples/eval/tsconfig.json
@@ -24,6 +24,9 @@
       "path": "../../providers/anthropic"
     },
     {
+      "path": "../../providers/deepseek"
+    },
+    {
       "path": "../../providers/google-gemini"
     },
     {

--- a/packages/ai/src/provider-utils/CloudProviderClient.ts
+++ b/packages/ai/src/provider-utils/CloudProviderClient.ts
@@ -59,7 +59,7 @@ export function isBrowserLike(): boolean {
 
 export interface ValidateProviderBaseUrlArgs {
   /** Discriminator used only for error messages. */
-  readonly vendor: "openai" | "anthropic" | "xai";
+  readonly vendor: "openai" | "anthropic" | "xai" | "deepseek";
   /**
    * Allow-list of acceptable hostnames or hostname suffixes. Matching is
    * label-boundary: a hostname matches if it equals the entry, or if it ends

--- a/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
+++ b/packages/ai/src/provider-utils/OpenAIShapedJsonSchema.ts
@@ -15,7 +15,7 @@
  *
  * Shared across every provider that speaks the OpenAI `json_schema`
  * `response_format` (chat completions) or `text.format` (Responses) — OpenAI,
- * xAI, OpenRouter, and any future OpenAI-compatible provider.
+ * xAI, OpenRouter, DeepSeek, and any future OpenAI-compatible provider.
  */
 export function isStrictCompatibleSchema(schema: unknown): boolean {
   if (schema === null || typeof schema !== "object") return true;

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -25,11 +25,11 @@ import { McpCallToolTask } from "@workglow/mcp/tasks";
 import { Workflow } from "@workglow/task-graph";
 
 const workflow = new Workflow();
-workflow.add(new McpCallToolTask({
+workflow.addTask(McpCallToolTask, {
   server: "my-server",
   toolName: "my-tool",
-  arguments: { arg1: "value" }
-}));
+  arguments: { arg1: "value" },
+});
 
 await workflow.run();
 ```

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -45,6 +45,7 @@
     "@workglow/cactus": "workspace:*",
     "@workglow/chrome-ai": "workspace:*",
     "@workglow/cloudflare": "workspace:*",
+    "@workglow/deepseek": "workspace:*",
     "@workglow/duckdb": "workspace:*",
     "@workglow/electron": "workspace:*",
     "@workglow/google-gemini": "workspace:*",

--- a/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeekProvider.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModelRecord } from "@workglow/ai";
+import {
+  _testOnly,
+  DEEPSEEK_ALLOWED_HOSTS,
+  DEEPSEEK_DEFAULT_BASE_URL,
+} from "@workglow/deepseek/ai";
+import { describe, expect, it } from "vitest";
+
+const { DeepSeekQueuedProvider, DEEPSEEK_RUN_FN_SPECS, DEEPSEEK_RUN_FNS } = _testOnly;
+
+function model(model_id: string, capabilities: readonly string[] = []): ModelRecord {
+  return {
+    model_id,
+    title: model_id,
+    description: "",
+    provider: "DEEPSEEK",
+    provider_config: { model_name: model_id },
+    capabilities: [...capabilities],
+    metadata: {},
+  } as ModelRecord;
+}
+
+describe("DeepSeekQueuedProvider.inferCapabilities", () => {
+  const provider = new DeepSeekQueuedProvider(DEEPSEEK_RUN_FNS);
+
+  it("infers chat + tool-use + json-mode for the deepseek-v4 family", () => {
+    for (const id of ["deepseek-v4-flash", "deepseek-v4-pro"]) {
+      const caps = provider.inferCapabilities(model(id));
+      expect(caps).toContain("text.generation");
+      expect(caps).toContain("tool-use");
+      expect(caps).toContain("json-mode");
+      expect(caps).toContain("model.count-tokens");
+    }
+  });
+
+  it("never infers vision-input or image.generation (the chat models are text-only)", () => {
+    const caps = provider.inferCapabilities(model("deepseek-v4-pro"));
+    expect(caps).not.toContain("vision-input");
+    expect(caps).not.toContain("image.generation");
+  });
+
+  it("falls back to declared capabilities when the model id is unknown", () => {
+    const caps = provider.inferCapabilities(
+      model("totally-unknown-model", ["text.classification"])
+    );
+    expect(caps).toEqual(["text.classification"]);
+  });
+
+  it("falls back to a baseline of meta-ops when nothing matches and nothing is declared", () => {
+    const caps = provider.inferCapabilities(model("totally-unknown-model"));
+    expect(caps).toContain("model.search");
+    expect(caps).toContain("model.info");
+    expect(caps).not.toContain("text.generation");
+  });
+
+  it("infers the full capability set for deepseek-v4-flash", () => {
+    const caps = provider.inferCapabilities(model("deepseek-v4-flash"));
+    const sorted = [...caps].sort();
+    expect(sorted).toEqual([
+      "json-mode",
+      "model.count-tokens",
+      "model.info",
+      "model.search",
+      "text.generation",
+      "text.rewriter",
+      "text.summary",
+      "tool-use",
+    ]);
+  });
+});
+
+describe("capability-set parity", () => {
+  it("DEEPSEEK_RUN_FN_SPECS matches DEEPSEEK_RUN_FNS serves shapes", () => {
+    const fnsServes = DEEPSEEK_RUN_FNS.map((r) => [...r.serves].sort().join(","));
+    const specsServes = DEEPSEEK_RUN_FN_SPECS.map((s) => [...s.serves].sort().join(","));
+    expect(specsServes).toEqual(fnsServes);
+  });
+});
+
+describe("DEEPSEEK_RUN_FNS shape", () => {
+  it("registers a runFn for every capability set the provider claims to serve", () => {
+    const sets = DEEPSEEK_RUN_FNS.map((r) => [...r.serves].sort().join(","));
+    expect(sets).toContain("text.generation");
+    expect(sets).toContain("text.generation,tool-use");
+    expect(sets).toContain("json-mode,text.generation");
+    expect(sets).toContain("text.rewriter");
+    expect(sets).toContain("text.summary");
+    expect(sets).toContain("model.count-tokens");
+    expect(sets).toContain("model.search");
+    expect(sets).toContain("model.info");
+  });
+
+  it("tiebreaks `text.generation` to the smallest serves entry (plain text-gen)", () => {
+    const candidates = DEEPSEEK_RUN_FNS.filter((r) => r.serves.includes("text.generation"));
+    expect(candidates.some((r) => r.serves.length === 1)).toBe(true);
+  });
+});
+
+describe("base URL", () => {
+  it("defaults to the documented DeepSeek host, which is also the only allow-listed one", () => {
+    expect(DEEPSEEK_DEFAULT_BASE_URL).toBe("https://api.deepseek.com");
+    expect(DEEPSEEK_ALLOWED_HOSTS).toEqual(["api.deepseek.com"]);
+    expect(DEEPSEEK_ALLOWED_HOSTS).toContain(new URL(DEEPSEEK_DEFAULT_BASE_URL).hostname);
+  });
+});

--- a/packages/test/src/test/ai-provider-api/DeepSeek_Generic.integration.test.ts
+++ b/packages/test/src/test/ai-provider-api/DeepSeek_Generic.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getGlobalModelRepository,
+  InMemoryModelRepository,
+  setGlobalModelRepository,
+} from "@workglow/ai";
+import { DEEPSEEK } from "@workglow/deepseek/ai";
+import { registerDeepSeekInline } from "@workglow/deepseek/ai-runtime";
+import { setTaskQueueRegistry } from "@workglow/task-graph";
+import { setLogger } from "@workglow/util";
+
+import { getTestingLogger } from "../../binding/TestingLogger";
+import { runAiProviderConformance } from "../../contract/ai-provider/runAiProviderConformance";
+
+const RUN = !!process.env.DEEPSEEK_API_KEY;
+// The cheaper of the two v4 tiers — the conformance suite only needs a model
+// that can chat, call a tool, and emit json-mode output, not the strongest one.
+const MODEL_ID = "deepseek:deepseek-v4-flash";
+
+runAiProviderConformance({
+  name: "DeepSeek",
+  skip: !RUN,
+  timeout: 30_000,
+  factory: async () => ({
+    register: async () => {
+      const logger = getTestingLogger();
+      setLogger(logger);
+      await setTaskQueueRegistry(null);
+      setGlobalModelRepository(new InMemoryModelRepository());
+      await registerDeepSeekInline();
+      await getGlobalModelRepository().addModel({
+        model_id: MODEL_ID,
+        title: "DeepSeek V4 Flash",
+        description: "DeepSeek V4 Flash",
+        capabilities: ["text.generation", "text.rewriter", "text.summary", "tool-use", "json-mode"],
+        provider: DEEPSEEK as typeof DEEPSEEK,
+        provider_config: { model_name: "deepseek-v4-flash" },
+        metadata: {},
+      });
+    },
+    dispose: async () => {
+      await setTaskQueueRegistry(null);
+    },
+    inspect: () => ({}),
+  }),
+  capabilities: {
+    streaming: true,
+    tools: true,
+    structured: true,
+    // The DeepSeek chat models are text-only and the provider registers no
+    // embedding run-fn, so these stay false.
+    embeddings: false,
+    sessions: false,
+    abortMidStream: true,
+  },
+  models: {
+    textGeneration: MODEL_ID,
+    toolCalling: MODEL_ID,
+    structured: MODEL_ID,
+  },
+});

--- a/packages/test/src/test/ai/ProviderRuntimeMetadata.test.ts
+++ b/packages/test/src/test/ai/ProviderRuntimeMetadata.test.ts
@@ -6,6 +6,7 @@
 
 import { _testOnly as _anthropicTestOnly } from "@workglow/anthropic/ai";
 import { _testOnly } from "@workglow/chrome-ai/ai";
+import { _testOnly as _deepseekTestOnly } from "@workglow/deepseek/ai";
 import { _testOnly as _ollamaTestOnly } from "@workglow/ollama/ai";
 import { _testOnly as _openaiTestOnly } from "@workglow/openai/ai";
 import { _testOnly as _xaiTestOnly } from "@workglow/xai/ai";
@@ -15,6 +16,7 @@ const { WebBrowserProvider } = _testOnly;
 const { AnthropicQueuedProvider } = _anthropicTestOnly;
 const { OpenAiQueuedProvider } = _openaiTestOnly;
 const { XaiQueuedProvider } = _xaiTestOnly;
+const { DeepSeekQueuedProvider } = _deepseekTestOnly;
 const { OllamaQueuedProvider } = _ollamaTestOnly;
 
 describe("WebBrowserProvider.isAvailable", () => {
@@ -73,6 +75,13 @@ describe("provider runtime-placement metadata", () => {
       // XaiQueuedProvider: mixin default makes supportsBrowser=true
       {
         provider: new XaiQueuedProvider(),
+        supportsBrowser: true,
+        supportsServer: true,
+        isLocal: false,
+      },
+      // DeepSeekQueuedProvider: mixin default makes supportsBrowser=true
+      {
+        provider: new DeepSeekQueuedProvider(),
         supportsBrowser: true,
         supportsServer: true,
         isLocal: false,

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -23,6 +23,7 @@
     { "path": "../browser-control" },
     { "path": "../../providers/anthropic" },
     { "path": "../../providers/bun-webview" },
+    { "path": "../../providers/deepseek" },
     { "path": "../../providers/electron" },
     { "path": "../../providers/google-gemini" },
     { "path": "../../providers/huggingface-inference" },

--- a/packages/workglow/package.json
+++ b/packages/workglow/package.json
@@ -56,6 +56,22 @@
       "types": "./dist/anthropic-runtime.d.ts",
       "import": "./dist/anthropic-runtime.js"
     },
+    "./deepseek": {
+      "browser": {
+        "types": "./dist/deepseek.d.ts",
+        "import": "./dist/deepseek.browser.js"
+      },
+      "bun": {
+        "types": "./dist/deepseek.d.ts",
+        "import": "./dist/deepseek.bun.js"
+      },
+      "types": "./dist/deepseek.d.ts",
+      "import": "./dist/deepseek.js"
+    },
+    "./deepseek/runtime": {
+      "types": "./dist/deepseek-runtime.d.ts",
+      "import": "./dist/deepseek-runtime.js"
+    },
     "./gemini": {
       "browser": {
         "types": "./dist/google-gemini.d.ts",
@@ -233,6 +249,7 @@
     "@workglow/openai": "workspace:*",
     "@workglow/openrouter": "workspace:*",
     "@workglow/xai": "workspace:*",
+    "@workglow/deepseek": "workspace:*",
     "@workglow/google-gemini": "workspace:*",
     "@workglow/ollama": "workspace:*",
     "@workglow/huggingface-transformers": "workspace:*",

--- a/packages/workglow/src/deepseek-runtime.ts
+++ b/packages/workglow/src/deepseek-runtime.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/deepseek/ai-runtime";

--- a/packages/workglow/src/deepseek.browser.ts
+++ b/packages/workglow/src/deepseek.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/deepseek/ai";

--- a/packages/workglow/src/deepseek.bun.ts
+++ b/packages/workglow/src/deepseek.bun.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/deepseek/ai";

--- a/packages/workglow/src/deepseek.ts
+++ b/packages/workglow/src/deepseek.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "@workglow/deepseek/ai";

--- a/packages/workglow/tsconfig.json
+++ b/packages/workglow/tsconfig.json
@@ -22,6 +22,7 @@
     { "path": "../browser-control" },
     { "path": "../../providers/anthropic" },
     { "path": "../../providers/chrome-ai" },
+    { "path": "../../providers/deepseek" },
     { "path": "../../providers/google-gemini" },
     { "path": "../../providers/huggingface-inference" },
     { "path": "../../providers/huggingface-transformers" },

--- a/providers/anthropic/README.md
+++ b/providers/anthropic/README.md
@@ -31,10 +31,10 @@ await registerAnthropic();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/chrome-ai/README.md
+++ b/providers/chrome-ai/README.md
@@ -31,10 +31,10 @@ await registerChromeAi();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/deepseek/CHANGELOG.md
+++ b/providers/deepseek/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.3.32
+
+### Features
+
+#### deepseek
+
+- Initial DeepSeek provider: text generation, tool calling, structured (JSON)
+  generation, rewriting, summarization, token counting, and model search/info
+  against the OpenAI-compatible `https://api.deepseek.com` API.

--- a/providers/deepseek/README.md
+++ b/providers/deepseek/README.md
@@ -1,0 +1,64 @@
+# @workglow/deepseek
+
+DeepSeek provider for @workglow/ai.
+
+DeepSeek exposes an OpenAI-compatible REST API, so this provider reuses the
+`openai` SDK pointed at `https://api.deepseek.com`. It covers the DeepSeek chat
+models (text generation, tool use, structured/JSON output, rewriting,
+summarization).
+
+## Features
+
+- Integration with the DeepSeek API for Workglow AI tasks
+- Supports standard Workglow AI task interfaces
+- Works seamlessly with `@workglow/task-graph` and `@workglow/ai`
+- Built-in job queue support for rate limiting and concurrency
+
+## Installation
+
+```bash
+npm install @workglow/deepseek
+# or
+bun add @workglow/deepseek
+# or
+yarn add @workglow/deepseek
+```
+
+## Usage
+
+```typescript
+import { registerDeepSeekInline } from "@workglow/deepseek/ai-runtime";
+import { getGlobalModelRepository } from "@workglow/ai";
+import { DEEPSEEK } from "@workglow/deepseek/ai";
+import { TextGenerationTask } from "@workglow/ai";
+import { Workflow } from "@workglow/task-graph";
+
+// 1. Register the provider (reads DEEPSEEK_API_KEY from the environment)
+await registerDeepSeekInline();
+
+// 2. Register a DeepSeek model
+await getGlobalModelRepository().addModel({
+  model_id: "deepseek:deepseek-v4-flash",
+  title: "DeepSeek V4 Flash",
+  description: "DeepSeek V4 Flash",
+  capabilities: ["text.generation", "tool-use", "json-mode"],
+  provider: DEEPSEEK,
+  provider_config: { model_name: "deepseek-v4-flash" },
+  metadata: {},
+});
+
+// 3. Use it in a workflow
+const workflow = new Workflow();
+workflow.add(
+  new TextGenerationTask({
+    model: "deepseek:deepseek-v4-flash",
+    prompt: "Hello world!",
+  })
+);
+
+const result = await workflow.run();
+```
+
+## License
+
+Apache 2.0 - See [LICENSE](../../LICENSE) for details.

--- a/providers/deepseek/README.md
+++ b/providers/deepseek/README.md
@@ -49,12 +49,10 @@ await getGlobalModelRepository().addModel({
 
 // 3. Use it in a workflow
 const workflow = new Workflow();
-workflow.addTask(
-  new TextGenerationTask({
-    model: "deepseek:deepseek-v4-flash",
-    prompt: "Hello world!",
-  })
-);
+workflow.addTask(TextGenerationTask, {
+  model: "deepseek:deepseek-v4-flash",
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/deepseek/README.md
+++ b/providers/deepseek/README.md
@@ -49,7 +49,7 @@ await getGlobalModelRepository().addModel({
 
 // 3. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(
+workflow.addTask(
   new TextGenerationTask({
     model: "deepseek:deepseek-v4-flash",
     prompt: "Hello world!",

--- a/providers/deepseek/package.json
+++ b/providers/deepseek/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@workglow/deepseek",
+  "type": "module",
+  "sideEffects": false,
+  "version": "0.3.32",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/workglow-dev/libs.git",
+    "directory": "providers/deepseek"
+  },
+  "bugs": {
+    "url": "https://github.com/workglow-dev/libs/issues"
+  },
+  "description": "DeepSeek provider for @workglow/ai.",
+  "homepage": "https://workglow.dev",
+  "scripts": {
+    "watch": "concurrently -c 'auto' 'bun:watch-*'",
+    "watch-code": "bun build --watch --no-clear-screen --sourcemap=external --packages=external --root ./src --outdir ./dist ./src/ai.ts ./src/ai-runtime.ts",
+    "watch-browser": "bun build --watch --no-clear-screen --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/ai.browser.ts ./src/ai-runtime.browser.ts",
+    "watch-types": "tsc --watch --preserveWatchOutput",
+    "build-package": "concurrently -c 'auto' -n 'code,browser,types' 'bun run build-code' 'bun run build-browser' 'bun run build-types'",
+    "build-js": "concurrently -m 12 --timings -c 'auto' -n 'code,browser' 'bun run build-code' 'bun run build-browser'",
+    "build-clean": "rm -fr dist/* tsconfig.tsbuildinfo",
+    "build-code": "bun build --sourcemap=external --packages=external --root ./src --outdir ./dist ./src/ai.ts ./src/ai-runtime.ts",
+    "build-browser": "bun build --target=browser --sourcemap=external --packages=external --outdir ./dist ./src/ai.browser.ts ./src/ai-runtime.browser.ts",
+    "build-types": "rm -f tsconfig.tsbuildinfo && tsgo",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "exports": {
+    "./ai": {
+      "browser": {
+        "types": "./dist/ai.d.ts",
+        "import": "./dist/ai.browser.js"
+      },
+      "types": "./dist/ai.d.ts",
+      "import": "./dist/ai.js"
+    },
+    "./ai-runtime": {
+      "browser": {
+        "types": "./dist/ai-runtime.d.ts",
+        "import": "./dist/ai-runtime.browser.js"
+      },
+      "types": "./dist/ai-runtime.d.ts",
+      "import": "./dist/ai-runtime.js"
+    }
+  },
+  "dependencies": {
+    "openai": "catalog:",
+    "tiktoken": "catalog:",
+    "js-tiktoken": "catalog:"
+  },
+  "peerDependencies": {
+    "@workglow/ai": "workspace:*",
+    "@workglow/job-queue": "workspace:*",
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@workglow/ai": {
+      "optional": false
+    },
+    "@workglow/job-queue": {
+      "optional": false
+    },
+    "@workglow/storage": {
+      "optional": false
+    },
+    "@workglow/task-graph": {
+      "optional": false
+    },
+    "@workglow/util": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@workglow/ai": "workspace:*",
+    "@workglow/job-queue": "workspace:*",
+    "@workglow/storage": "workspace:*",
+    "@workglow/task-graph": "workspace:*",
+    "@workglow/util": "workspace:*"
+  },
+  "files": [
+    "dist",
+    "src/**/*.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/providers/deepseek/src/ai-runtime.browser.ts
+++ b/providers/deepseek/src/ai-runtime.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/runtime.browser";

--- a/providers/deepseek/src/ai-runtime.ts
+++ b/providers/deepseek/src/ai-runtime.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/runtime";

--- a/providers/deepseek/src/ai.browser.ts
+++ b/providers/deepseek/src/ai.browser.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/index.browser";

--- a/providers/deepseek/src/ai.ts
+++ b/providers/deepseek/src/ai.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export * from "./ai/index";

--- a/providers/deepseek/src/ai/DeepSeekProvider.ts
+++ b/providers/deepseek/src/ai/DeepSeekProvider.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createCloudProviderClass } from "@workglow/ai/provider-utils";
+import type { Capability, ModelRecord } from "@workglow/ai/worker";
+import { AiProvider } from "@workglow/ai/worker";
+import {
+  deepSeekWorkerRunFnSpecs,
+  inferDeepSeekCapabilities,
+} from "./common/DeepSeek_Capabilities";
+import { DEEPSEEK } from "./common/DeepSeek_Constants";
+import type { DeepSeekModelConfig } from "./common/DeepSeek_ModelSchema";
+
+/**
+ * Worker-server registration for DeepSeek cloud models. Imports `AiProvider`
+ * from `@workglow/ai/worker` so the SDK is only loaded in the worker.
+ *
+ * The class extends the {@link createCloudProviderClass} mixin (which supplies
+ * `name` / `displayName` / `isLocal` / `supportsBrowser`) and adds the
+ * DeepSeek-specific {@link AiProvider.inferCapabilities} and
+ * {@link AiProvider.workerRunFnSpecs} overrides.
+ */
+export class DeepSeekProvider extends createCloudProviderClass<DeepSeekModelConfig>(AiProvider, {
+  name: DEEPSEEK,
+  displayName: "DeepSeek",
+}) {
+  override inferCapabilities(model: ModelRecord): readonly Capability[] {
+    return inferDeepSeekCapabilities(model);
+  }
+
+  protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {
+    return deepSeekWorkerRunFnSpecs();
+  }
+}

--- a/providers/deepseek/src/ai/DeepSeekQueuedProvider.ts
+++ b/providers/deepseek/src/ai/DeepSeekQueuedProvider.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability, ModelRecord } from "@workglow/ai";
+import { AiProvider } from "@workglow/ai";
+import { createCloudProviderClass } from "@workglow/ai/provider-utils";
+import {
+  deepSeekWorkerRunFnSpecs,
+  inferDeepSeekCapabilities,
+} from "./common/DeepSeek_Capabilities";
+import { DEEPSEEK } from "./common/DeepSeek_Constants";
+import type { DeepSeekModelConfig } from "./common/DeepSeek_ModelSchema";
+
+/**
+ * Main-thread registration shell for DeepSeek. Used both for inline mode
+ * (constructed with the run-fn registrations array) and worker-backed mode
+ * (constructed empty so the base class registers worker proxies). No queue is
+ * created — DeepSeek uses {@link DirectExecutionStrategy}.
+ */
+export class DeepSeekQueuedProvider extends createCloudProviderClass<DeepSeekModelConfig>(
+  AiProvider,
+  {
+    name: DEEPSEEK,
+    displayName: "DeepSeek",
+  }
+) {
+  override inferCapabilities(model: ModelRecord): readonly Capability[] {
+    return inferDeepSeekCapabilities(model);
+  }
+
+  protected override workerRunFnSpecs(): readonly { serves: readonly Capability[] }[] {
+    return deepSeekWorkerRunFnSpecs();
+  }
+}

--- a/providers/deepseek/src/ai/common/DeepSeek_Capabilities.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Capabilities.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability, ModelRecord } from "@workglow/ai/worker";
+import { DEEPSEEK_CAPABILITY_SETS } from "./DeepSeek_CapabilitySets";
+
+/**
+ * Closed list of capability-set specs the DeepSeek provider serves. Derived
+ * from {@link DEEPSEEK_CAPABILITY_SETS}. Used by the main-thread provider
+ * shells when registering worker-mode proxies so the dispatcher can route
+ * requests to the worker proxy.
+ */
+export const DEEPSEEK_RUN_FN_SPECS = DEEPSEEK_CAPABILITY_SETS.map((serves) => ({ serves }));
+
+export function deepSeekWorkerRunFnSpecs(): readonly { readonly serves: readonly Capability[] }[] {
+  return DEEPSEEK_RUN_FN_SPECS;
+}
+
+/**
+ * Shape used by the model-name regexes — `model_id` is required, the rest is
+ * loosely-typed metadata only used to opportunistically widen the inferred
+ * capability set.
+ */
+type CapabilityHints = Pick<ModelRecord, "model_id" | "provider_config" | "capabilities">;
+
+/**
+ * Heuristic capability inference for a DeepSeek {@link ModelRecord}. Pattern-
+ * matches the canonical DeepSeek model id strings (and the `provider_config.
+ * model_name` if present) to a closed set of {@link Capability}s. Falls back
+ * to the model's stored `capabilities` array (or a baseline of search + info)
+ * when no pattern matches.
+ *
+ * The DeepSeek chat models are text-only — no vision input and no image
+ * generation — so the inferred set never includes those.
+ *
+ * Main-thread method only — workers do not run capability inference.
+ */
+export function inferDeepSeekCapabilities(model: CapabilityHints): readonly Capability[] {
+  const id = String(
+    model.model_id ??
+      (model.provider_config as { model_name?: string } | undefined)?.model_name ??
+      ""
+  );
+
+  // Chat / reasoning models — deepseek-chat, deepseek-reasoner, deepseek-v4-*,
+  // and future deepseek-* ids.
+  if (/^deepseek/i.test(id)) {
+    return [
+      "text.generation",
+      "text.rewriter",
+      "text.summary",
+      "tool-use",
+      "json-mode",
+      "model.count-tokens",
+      "model.info",
+      "model.search",
+    ];
+  }
+
+  // Unknown model — fall back to whatever the record declared, or just expose
+  // the meta-ops so the model can still be searched / inspected.
+  const declared = (model.capabilities as readonly Capability[] | undefined) ?? [];
+  if (declared.length > 0) return declared;
+  return ["model.search", "model.info"];
+}

--- a/providers/deepseek/src/ai/common/DeepSeek_CapabilitySets.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_CapabilitySets.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Capability } from "@workglow/ai/worker";
+
+/**
+ * Single source of truth for DeepSeek's capability sets.
+ *
+ * Both `DEEPSEEK_RUN_FNS` (the worker-side registration list) and
+ * `workerRunFnSpecs()` (the main-thread proxy declaration) derive their
+ * `serves` arrays from these named exports. SDK-free so the main thread can
+ * import without paying the OpenAI client cost.
+ *
+ * To add a new capability set: declare a new `as const` constant here, then
+ * reference it from both `DEEPSEEK_RUN_FNS` and `DEEPSEEK_RUN_FN_SPECS`.
+ */
+export const DEEPSEEK_TEXT_GENERATION = ["text.generation"] as const satisfies Capability[];
+export const DEEPSEEK_TOOL_USE = ["text.generation", "tool-use"] as const satisfies Capability[];
+export const DEEPSEEK_JSON_MODE = ["text.generation", "json-mode"] as const satisfies Capability[];
+export const DEEPSEEK_TEXT_REWRITER = ["text.rewriter"] as const satisfies Capability[];
+export const DEEPSEEK_TEXT_SUMMARY = ["text.summary"] as const satisfies Capability[];
+export const DEEPSEEK_COUNT_TOKENS = ["model.count-tokens"] as const satisfies Capability[];
+export const DEEPSEEK_MODEL_SEARCH = ["model.search"] as const satisfies Capability[];
+export const DEEPSEEK_MODEL_INFO = ["model.info"] as const satisfies Capability[];
+
+/** Aggregated list — for `workerRunFnSpecs()` derivation. Order MUST match `DEEPSEEK_RUN_FNS`. */
+export const DEEPSEEK_CAPABILITY_SETS = [
+  DEEPSEEK_TEXT_GENERATION,
+  DEEPSEEK_TOOL_USE,
+  DEEPSEEK_JSON_MODE,
+  DEEPSEEK_TEXT_REWRITER,
+  DEEPSEEK_TEXT_SUMMARY,
+  DEEPSEEK_COUNT_TOKENS,
+  DEEPSEEK_MODEL_SEARCH,
+  DEEPSEEK_MODEL_INFO,
+] as const;

--- a/providers/deepseek/src/ai/common/DeepSeek_Client.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Client.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBrowserLike, resolveApiKey, validateProviderBaseUrl } from "@workglow/ai/provider-utils";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Default base URL for the DeepSeek OpenAI-compatible API. DeepSeek serves the
+ * same routes with and without a `/v1` prefix; the un-prefixed form is what the
+ * vendor documents, and it is what makes `client.models.list()` hit the
+ * documented `GET /models` endpoint.
+ */
+export const DEEPSEEK_DEFAULT_BASE_URL = "https://api.deepseek.com";
+
+/**
+ * Hostnames (or hostname suffixes) accepted for DeepSeek `base_url` without the
+ * explicit `trustedBaseUrl` opt-out.
+ */
+export const DEEPSEEK_ALLOWED_HOSTS: readonly string[] = ["api.deepseek.com"];
+
+type OpenAIClientClass = new (config: any) => any;
+
+let _loadPromise: Promise<OpenAIClientClass> | undefined;
+
+// DeepSeek is OpenAI wire-compatible, so we reuse the `openai` SDK. Keep the
+// direct string-literal import so bundlers (vite) can resolve it statically.
+export async function loadOpenAISDK(): Promise<OpenAIClientClass> {
+  _loadPromise ??= import(/* @vite-ignore */ "openai")
+
+    .then((mod) => mod.default as OpenAIClientClass)
+    .catch(() => {
+      _loadPromise = undefined;
+      throw new Error("openai is required for DeepSeek tasks. Install it with: bun add openai");
+    });
+  return _loadPromise;
+}
+
+interface ResolvedProviderConfig {
+  readonly credential_key?: string;
+  readonly api_key?: string;
+  readonly model_name?: string;
+  readonly base_url?: string;
+  /**
+   * When `true`, accept the `base_url` even if its hostname is not in
+   * {@link DEEPSEEK_ALLOWED_HOSTS}. Use only for known-good custom gateways.
+   * The URL still has to parse and use a safe scheme.
+   */
+  readonly trustedBaseUrl?: boolean;
+}
+
+export async function getClient(model: DeepSeekModelConfig | undefined) {
+  const OpenAI = await loadOpenAISDK();
+  const config = model?.provider_config as ResolvedProviderConfig | undefined;
+  const apiKey = resolveApiKey({
+    config,
+    envVar: "DEEPSEEK_API_KEY",
+    providerLabel: "DeepSeek",
+  });
+  // Throw before SDK construction on a rejected base_url so the API key is
+  // never sent to an unvalidated host.
+  const baseURL =
+    validateProviderBaseUrl(config?.base_url, {
+      vendor: "deepseek",
+      allowHosts: DEEPSEEK_ALLOWED_HOSTS,
+      trustedBaseUrl: config?.trustedBaseUrl,
+      providerLabel: "DeepSeek",
+    }) ?? DEEPSEEK_DEFAULT_BASE_URL;
+  try {
+    return new OpenAI({
+      apiKey,
+      baseURL,
+      dangerouslyAllowBrowser: isBrowserLike(),
+    });
+  } catch (err) {
+    throw new Error(
+      `Failed to create DeepSeek client: ${err instanceof Error ? err.message : "unknown error"}`
+    );
+  }
+}
+
+export function getModelName(model: DeepSeekModelConfig | undefined): string {
+  const name = model?.provider_config?.model_name;
+  if (!name) {
+    throw new Error("Missing model name in provider_config.model_name.");
+  }
+  return name;
+}

--- a/providers/deepseek/src/ai/common/DeepSeek_Constants.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_Constants.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DEEPSEEK = "DEEPSEEK";

--- a/providers/deepseek/src/ai/common/DeepSeek_CountTokens.browser.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_CountTokens.browser.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderPreviewRunFn,
+  AiProviderRunFn,
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+} from "@workglow/ai";
+import type { Tiktoken, TiktokenModel } from "js-tiktoken";
+import { getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+let _tiktoken: typeof import("js-tiktoken") | undefined;
+
+async function loadTiktoken() {
+  if (!_tiktoken) {
+    try {
+      _tiktoken = await import("js-tiktoken");
+    } catch {
+      throw new Error(
+        "js-tiktoken is required for DeepSeek token counting in the browser. Install it with: bun add js-tiktoken"
+      );
+    }
+  }
+  return _tiktoken;
+}
+
+const _encoderCache = new Map<string, Tiktoken>();
+
+// DeepSeek ships its tokenizer only as a downloadable archive, not as a
+// package we can depend on, so token counts are approximated with tiktoken's
+// cl100k_base encoding (deepseek model ids are unknown to `encodingForModel`,
+// so the fallback path is the normal case here).
+async function getEncoder(modelName: string) {
+  const tiktoken = await loadTiktoken();
+  if (!_encoderCache.has(modelName)) {
+    try {
+      _encoderCache.set(modelName, tiktoken.encodingForModel(modelName as TiktokenModel));
+    } catch {
+      const fallback = "cl100k_base";
+      if (!_encoderCache.has(fallback)) {
+        _encoderCache.set(fallback, tiktoken.getEncoding(fallback));
+      }
+      _encoderCache.set(modelName, _encoderCache.get(fallback)!);
+    }
+  }
+  return _encoderCache.get(modelName)!;
+}
+
+async function countTokens(
+  input: CountTokensTaskInput,
+  model: DeepSeekModelConfig | undefined
+): Promise<CountTokensTaskOutput> {
+  const enc = await getEncoder(getModelName(model));
+  const tokens = enc.encode(input.text);
+  return { count: tokens.length };
+}
+
+/**
+ * One-shot run-fn for `["model.count-tokens"]` in the browser. Emits a single
+ * `finish` event carrying the token count.
+ */
+export const DeepSeek_CountTokens_Stream: AiProviderRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, _signal, emit) => {
+  const result = await countTokens(input, model);
+  emit({ type: "finish", data: result });
+};
+
+/** Lightweight preview path used by `AiTask.executePreview()`. */
+export const DeepSeek_CountTokens_Preview: AiProviderPreviewRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model) => {
+  return countTokens(input, model);
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_CountTokens.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_CountTokens.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderPreviewRunFn,
+  AiProviderRunFn,
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+} from "@workglow/ai";
+import type { Tiktoken, TiktokenModel } from "tiktoken";
+import { getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+let _tiktoken: typeof import("tiktoken") | undefined;
+
+async function loadTiktoken() {
+  if (!_tiktoken) {
+    try {
+      _tiktoken = await import("tiktoken");
+    } catch {
+      throw new Error(
+        "tiktoken is required for DeepSeek token counting. Install it with: bun add tiktoken"
+      );
+    }
+  }
+  return _tiktoken;
+}
+
+const _encoderCache = new Map<string, Tiktoken>();
+
+// DeepSeek ships its tokenizer only as a downloadable archive, not as a
+// package we can depend on, so token counts are approximated with tiktoken's
+// cl100k_base encoding (deepseek model ids are unknown to
+// `encoding_for_model`, so the fallback path is the normal case here).
+async function getEncoder(modelName: string) {
+  const tiktoken = await loadTiktoken();
+  if (!_encoderCache.has(modelName)) {
+    try {
+      _encoderCache.set(modelName, tiktoken.encoding_for_model(modelName as TiktokenModel));
+    } catch {
+      const fallback = "cl100k_base";
+      if (!_encoderCache.has(fallback)) {
+        _encoderCache.set(fallback, tiktoken.get_encoding(fallback));
+      }
+      _encoderCache.set(modelName, _encoderCache.get(fallback)!);
+    }
+  }
+  return _encoderCache.get(modelName)!;
+}
+
+async function countTokens(
+  input: CountTokensTaskInput,
+  model: DeepSeekModelConfig | undefined
+): Promise<CountTokensTaskOutput> {
+  const enc = await getEncoder(getModelName(model));
+  const tokens = enc.encode(input.text);
+  return { count: tokens.length };
+}
+
+/**
+ * One-shot run-fn for `["model.count-tokens"]`. Emits a single `finish` event
+ * carrying the token count.
+ */
+export const DeepSeek_CountTokens_Stream: AiProviderRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, _signal, emit) => {
+  const result = await countTokens(input, model);
+  emit({ type: "finish", data: result });
+};
+
+/** Lightweight preview path used by `AiTask.executePreview()`. */
+export const DeepSeek_CountTokens_Preview: AiProviderPreviewRunFn<
+  CountTokensTaskInput,
+  CountTokensTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model) => {
+  return countTokens(input, model);
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_JobRunFns.browser.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_JobRunFns.browser.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderPreviewRunFn, AiProviderRunFnRegistration } from "@workglow/ai";
+import {
+  DEEPSEEK_COUNT_TOKENS,
+  DEEPSEEK_JSON_MODE,
+  DEEPSEEK_MODEL_INFO,
+  DEEPSEEK_MODEL_SEARCH,
+  DEEPSEEK_TEXT_GENERATION,
+  DEEPSEEK_TEXT_REWRITER,
+  DEEPSEEK_TEXT_SUMMARY,
+  DEEPSEEK_TOOL_USE,
+} from "./DeepSeek_CapabilitySets";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+export { getClient, getModelName, loadOpenAISDK } from "./DeepSeek_Client";
+
+import {
+  DeepSeek_CountTokens_Preview,
+  DeepSeek_CountTokens_Stream,
+} from "./DeepSeek_CountTokens.browser";
+import { DeepSeek_ModelInfo_Stream } from "./DeepSeek_ModelInfo";
+import { DeepSeek_ModelSearch_Stream } from "./DeepSeek_ModelSearch";
+import { DeepSeek_StructuredGeneration_Stream } from "./DeepSeek_StructuredGeneration";
+import { DeepSeek_TextGeneration_Stream } from "./DeepSeek_TextGeneration";
+import { DeepSeek_TextRewriter_Stream } from "./DeepSeek_TextRewriter";
+import { DeepSeek_TextSummary_Stream } from "./DeepSeek_TextSummary";
+import { DeepSeek_ToolCalling_Stream } from "./DeepSeek_ToolCalling";
+
+/**
+ * Browser build of {@link DEEPSEEK_RUN_FNS}. Identical to the node build except
+ * for the count-tokens import (uses `js-tiktoken` rather than the WASM
+ * `tiktoken` package).
+ */
+export const DEEPSEEK_RUN_FNS: readonly AiProviderRunFnRegistration<
+  any,
+  any,
+  DeepSeekModelConfig
+>[] = [
+  { serves: DEEPSEEK_TEXT_GENERATION, runFn: DeepSeek_TextGeneration_Stream },
+  { serves: DEEPSEEK_TOOL_USE, runFn: DeepSeek_ToolCalling_Stream },
+  { serves: DEEPSEEK_JSON_MODE, runFn: DeepSeek_StructuredGeneration_Stream },
+  { serves: DEEPSEEK_TEXT_REWRITER, runFn: DeepSeek_TextRewriter_Stream },
+  { serves: DEEPSEEK_TEXT_SUMMARY, runFn: DeepSeek_TextSummary_Stream },
+  { serves: DEEPSEEK_COUNT_TOKENS, runFn: DeepSeek_CountTokens_Stream },
+  { serves: DEEPSEEK_MODEL_SEARCH, runFn: DeepSeek_ModelSearch_Stream },
+  { serves: DEEPSEEK_MODEL_INFO, runFn: DeepSeek_ModelInfo_Stream },
+];
+
+export const DEEPSEEK_PREVIEW_TASKS: Record<
+  string,
+  AiProviderPreviewRunFn<any, any, DeepSeekModelConfig>
+> = {
+  CountTokensTask: DeepSeek_CountTokens_Preview,
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_JobRunFns.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_JobRunFns.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderPreviewRunFn, AiProviderRunFnRegistration } from "@workglow/ai";
+import {
+  DEEPSEEK_COUNT_TOKENS,
+  DEEPSEEK_JSON_MODE,
+  DEEPSEEK_MODEL_INFO,
+  DEEPSEEK_MODEL_SEARCH,
+  DEEPSEEK_TEXT_GENERATION,
+  DEEPSEEK_TEXT_REWRITER,
+  DEEPSEEK_TEXT_SUMMARY,
+  DEEPSEEK_TOOL_USE,
+} from "./DeepSeek_CapabilitySets";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+export { getClient, getModelName, loadOpenAISDK } from "./DeepSeek_Client";
+
+import { DeepSeek_CountTokens_Preview, DeepSeek_CountTokens_Stream } from "./DeepSeek_CountTokens";
+import { DeepSeek_ModelInfo_Stream } from "./DeepSeek_ModelInfo";
+import { DeepSeek_ModelSearch_Stream } from "./DeepSeek_ModelSearch";
+import { DeepSeek_StructuredGeneration_Stream } from "./DeepSeek_StructuredGeneration";
+import { DeepSeek_TextGeneration_Stream } from "./DeepSeek_TextGeneration";
+import { DeepSeek_TextRewriter_Stream } from "./DeepSeek_TextRewriter";
+import { DeepSeek_TextSummary_Stream } from "./DeepSeek_TextSummary";
+import { DeepSeek_ToolCalling_Stream } from "./DeepSeek_ToolCalling";
+
+/**
+ * Capability-set run-fn registrations for the DeepSeek provider. Order is
+ * significant only as a tiebreaker — the dispatcher prefers the smallest
+ * `serves` set that is a superset of the task's `requires`, so the bare
+ * `["text.generation"]` entry wins for a plain {@link TextGenerationTask} or
+ * {@link AiChatTask} while the `["text.generation", "tool-use"]` entry wins
+ * for {@link ToolCallingTask}.
+ */
+export const DEEPSEEK_RUN_FNS: readonly AiProviderRunFnRegistration<
+  any,
+  any,
+  DeepSeekModelConfig
+>[] = [
+  { serves: DEEPSEEK_TEXT_GENERATION, runFn: DeepSeek_TextGeneration_Stream },
+  { serves: DEEPSEEK_TOOL_USE, runFn: DeepSeek_ToolCalling_Stream },
+  { serves: DEEPSEEK_JSON_MODE, runFn: DeepSeek_StructuredGeneration_Stream },
+  { serves: DEEPSEEK_TEXT_REWRITER, runFn: DeepSeek_TextRewriter_Stream },
+  { serves: DEEPSEEK_TEXT_SUMMARY, runFn: DeepSeek_TextSummary_Stream },
+  { serves: DEEPSEEK_COUNT_TOKENS, runFn: DeepSeek_CountTokens_Stream },
+  { serves: DEEPSEEK_MODEL_SEARCH, runFn: DeepSeek_ModelSearch_Stream },
+  { serves: DEEPSEEK_MODEL_INFO, runFn: DeepSeek_ModelInfo_Stream },
+];
+
+export const DEEPSEEK_PREVIEW_TASKS: Record<
+  string,
+  AiProviderPreviewRunFn<any, any, DeepSeekModelConfig>
+> = {
+  CountTokensTask: DeepSeek_CountTokens_Preview,
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_ModelInfo.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ModelInfo.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, ModelInfoTaskInput, ModelInfoTaskOutput } from "@workglow/ai";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * One-shot run-fn for `["model.info"]`. Returns a synchronous info record;
+ * DeepSeek does not expose an HTTP endpoint for this metadata. Emits a single
+ * `finish` event.
+ */
+export const DeepSeek_ModelInfo_Stream: AiProviderRunFn<
+  ModelInfoTaskInput,
+  ModelInfoTaskOutput,
+  DeepSeekModelConfig
+> = async (input, _model, _signal, emit) => {
+  emit({
+    type: "finish",
+    data: {
+      model: input.model,
+      is_local: false,
+      is_remote: true,
+      supports_browser: true,
+      supports_node: true,
+      is_cached: false,
+      is_loaded: false,
+      file_sizes: null,
+    },
+  });
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_ModelSchema.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ModelSchema.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ModelConfigSchema, ModelRecordSchema } from "@workglow/ai/worker";
+import { DataPortSchemaObject, FromSchema } from "@workglow/util/worker";
+import { DEEPSEEK } from "./DeepSeek_Constants";
+
+export const DeepSeekModelSchema = {
+  type: "object",
+  properties: {
+    provider: {
+      const: DEEPSEEK,
+      description: "Discriminator: DeepSeek cloud provider.",
+    },
+    provider_config: {
+      type: "object",
+      description: "DeepSeek-specific configuration.",
+      properties: {
+        model_name: {
+          type: "string",
+          description:
+            "The DeepSeek model identifier (e.g., 'deepseek-v4-flash', 'deepseek-v4-pro').",
+        },
+        credential_key: {
+          type: "string",
+          format: "credential",
+          description: "Key to look up in the credential store for the API key.",
+          "x-ui-hidden": true,
+        },
+        base_url: {
+          type: "string",
+          description: "Base URL for the DeepSeek API. Useful for proxy servers.",
+          default: "https://api.deepseek.com",
+        },
+        trustedBaseUrl: {
+          type: "boolean",
+          description:
+            "When true, accept a base_url whose hostname is not in the built-in allow-list. Use only for known-good custom enterprise gateways — otherwise an attacker can exfiltrate the API key by pointing base_url at their own server.",
+          default: false,
+          "x-ui-hidden": true,
+        },
+      },
+      required: ["model_name"],
+      additionalProperties: false,
+    },
+  },
+  required: ["provider", "provider_config"],
+  additionalProperties: true,
+} as const satisfies DataPortSchemaObject;
+
+export const DeepSeekModelRecordSchema = {
+  type: "object",
+  properties: {
+    ...ModelRecordSchema.properties,
+    ...DeepSeekModelSchema.properties,
+  },
+  required: [...ModelRecordSchema.required, ...DeepSeekModelSchema.required],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+export type DeepSeekModelRecord = FromSchema<typeof DeepSeekModelRecordSchema>;
+
+export const DeepSeekModelConfigSchema = {
+  type: "object",
+  properties: {
+    ...ModelConfigSchema.properties,
+    ...DeepSeekModelSchema.properties,
+  },
+  required: [...ModelConfigSchema.required, ...DeepSeekModelSchema.required],
+  additionalProperties: false,
+} as const satisfies DataPortSchemaObject;
+
+export type DeepSeekModelConfig = FromSchema<typeof DeepSeekModelConfigSchema>;

--- a/providers/deepseek/src/ai/common/DeepSeek_ModelSearch.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ModelSearch.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  ModelSearchResultItem,
+  ModelSearchTaskInput,
+  ModelSearchTaskOutput,
+} from "@workglow/ai";
+import { filterLabeledModelsByQuery } from "@workglow/ai/provider-utils";
+import { getClient } from "./DeepSeek_Client";
+import { DEEPSEEK } from "./DeepSeek_Constants";
+
+interface DeepSeekModelListItem {
+  readonly label: string;
+  readonly value: string;
+  readonly description?: string;
+}
+
+const DEEPSEEK_FALLBACK: Array<{ label: string; value: string }> = [
+  { label: "deepseek-v4-flash", value: "deepseek-v4-flash" },
+  { label: "deepseek-v4-pro", value: "deepseek-v4-pro" },
+];
+
+async function listDeepSeekModels(credentialKey: string): Promise<DeepSeekModelListItem[]> {
+  const client = await getClient({
+    provider: DEEPSEEK,
+    provider_config: { model_name: "", credential_key: credentialKey },
+  });
+  const models: DeepSeekModelListItem[] = [];
+  for await (const m of client.models.list()) {
+    models.push({ label: m.id, value: m.id, description: m.owned_by });
+  }
+  models.sort((a, b) => a.value.localeCompare(b.value));
+  return models;
+}
+
+function mapModelList(models: DeepSeekModelListItem[]): ModelSearchResultItem[] {
+  return models.map((m) => ({
+    id: m.value,
+    label: m.label,
+    description: m.description ?? "",
+    record: {
+      model_id: m.value,
+      provider: DEEPSEEK,
+      title: m.value,
+      description: "",
+      capabilities: [],
+      provider_config: { model_name: m.value },
+      metadata: {},
+    },
+    raw: m,
+  }));
+}
+
+/**
+ * One-shot run-fn for `["model.search"]`. Emits a single `finish` event with
+ * the search results. When no credential key is provided, falls back to a
+ * curated static list of well-known DeepSeek models.
+ */
+export const DeepSeek_ModelSearch_Stream: AiProviderRunFn<
+  ModelSearchTaskInput,
+  ModelSearchTaskOutput
+> = async (input, _model, _signal, emit) => {
+  let models: DeepSeekModelListItem[];
+  if (!input.credential_key) {
+    models = DEEPSEEK_FALLBACK;
+  } else {
+    models = await listDeepSeekModels(input.credential_key);
+  }
+  models = filterLabeledModelsByQuery(models, input.query);
+  emit({ type: "finish", data: { results: mapModelList(models) } });
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
@@ -9,10 +9,34 @@ import type {
   StructuredGenerationTaskInput,
   StructuredGenerationTaskOutput,
 } from "@workglow/ai";
-import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
 import { parsePartialJson } from "@workglow/util/worker";
 import { getClient, getModelName } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Build the user message for DeepSeek's JSON mode.
+ *
+ * DeepSeek supports only `response_format: { type: "json_object" }` — passing
+ * OpenAI's `json_schema` form returns `400 This response_format type is
+ * unavailable now`. That type does no schema enforcement, and the vendor
+ * additionally requires the word "json" to appear in the prompt (otherwise the
+ * request can come back with empty content). So the schema has to travel in the
+ * prompt instead of in `response_format`, and the wording below deliberately
+ * contains a lowercase "json" to satisfy that requirement.
+ *
+ * `StructuredGenerationTask` re-validates the parsed object against the output
+ * schema, so a model that ignores the shape still fails loudly downstream
+ * rather than silently returning the wrong thing.
+ */
+function buildJsonPrompt(prompt: string, schema: unknown): string {
+  if (schema === undefined || schema === null) {
+    return `${prompt}\n\nRespond with valid json only: a single JSON object, no prose and no code fences.`;
+  }
+  return (
+    `${prompt}\n\nRespond with valid json only: a single JSON object conforming to this ` +
+    `JSON Schema, with no prose and no code fences.\n\nJSON Schema:\n${JSON.stringify(schema)}`
+  );
+}
 
 /**
  * Streaming run-fn for `["text.generation", "json-mode"]`. Emits
@@ -33,15 +57,8 @@ export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
   const stream = await client.chat.completions.create(
     {
       model: modelName,
-      messages: [{ role: "user", content: input.prompt }],
-      response_format: {
-        type: "json_schema" as never,
-        json_schema: {
-          name: "structured_output",
-          schema: schema,
-          strict: isStrictCompatibleSchema(schema),
-        },
-      } as never,
+      messages: [{ role: "user", content: buildJsonPrompt(input.prompt, schema) }],
+      response_format: { type: "json_object" } as never,
       max_tokens: input.maxTokens,
       temperature: input.temperature,
       stream: true,

--- a/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_StructuredGeneration.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+} from "@workglow/ai";
+import { isStrictCompatibleSchema } from "@workglow/ai/provider-utils";
+import { parsePartialJson } from "@workglow/util/worker";
+import { getClient, getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Streaming run-fn for `["text.generation", "json-mode"]`. Emits
+ * `object-delta` events with progressively-completed partial JSON snapshots
+ * on the `object` port, ending with a `finish` event carrying the parsed
+ * final object.
+ */
+export const DeepSeek_StructuredGeneration_Stream: AiProviderRunFn<
+  StructuredGenerationTaskInput,
+  StructuredGenerationTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, signal, emit, outputSchema) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const schema = input.outputSchema ?? outputSchema;
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [{ role: "user", content: input.prompt }],
+      response_format: {
+        type: "json_schema" as never,
+        json_schema: {
+          name: "structured_output",
+          schema: schema,
+          strict: isStrictCompatibleSchema(schema),
+        },
+      } as never,
+      max_tokens: input.maxTokens,
+      temperature: input.temperature,
+      stream: true,
+    },
+    { signal }
+  );
+
+  let accumulatedJson = "";
+  let refusal = "";
+  for await (const chunk of stream) {
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
+    if (delta) {
+      accumulatedJson += delta;
+      const partial = parsePartialJson(accumulatedJson);
+      if (partial !== undefined) {
+        emit({ type: "object-delta", port: "object", objectDelta: partial });
+      }
+    }
+    refusal += chunk.choices?.[0]?.delta?.refusal ?? "";
+  }
+
+  if (refusal) {
+    emit({ type: "refusal", refusal });
+  }
+
+  let finalObject: Record<string, unknown>;
+  try {
+    finalObject = JSON.parse(accumulatedJson);
+  } catch {
+    finalObject = parsePartialJson(accumulatedJson) ?? {};
+  }
+  emit({ type: "finish", data: { object: finalObject } as StructuredGenerationTaskOutput });
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_TextGeneration.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextGeneration.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  TextGenerationTaskInput,
+  TextGenerationTaskOutput,
+} from "@workglow/ai";
+import { toOpenAIMessages } from "@workglow/ai/worker";
+import { getLogger } from "@workglow/util/worker";
+import { getClient, getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Inputs that the unified `["text.generation"]` runFn handles. Both
+ * {@link TextGenerationTask} and {@link AiChatTask} declare
+ * `requires: ["text.generation"]`, so the capability dispatcher routes both
+ * here. AiChatTask supplies a populated `messages` array; TextGenerationTask
+ * (and other simple prompt callers) supply a `prompt` string only.
+ */
+interface UnifiedTextGenerationInput extends TextGenerationTaskInput {
+  readonly messages?: readonly unknown[];
+  readonly systemPrompt?: string;
+}
+
+/**
+ * Build the chat-completion request parameters from the unified input shape —
+ * preferring a populated `messages` array (AiChatTask) and falling back to
+ * wrapping `prompt` as a single user message (TextGenerationTask).
+ */
+function buildChatParams(
+  input: UnifiedTextGenerationInput,
+  model: DeepSeekModelConfig | undefined
+): Record<string, unknown> {
+  const hasMessages = Array.isArray(input.messages) && input.messages.length > 0;
+  const messages = hasMessages
+    ? toOpenAIMessages({
+        messages: input.messages,
+        systemPrompt: input.systemPrompt,
+        prompt: "",
+        tools: [],
+      } as never)
+    : [{ role: "user" as const, content: input.prompt }];
+
+  const params: Record<string, unknown> = {
+    model: getModelName(model),
+    messages,
+  };
+  if (input.maxTokens !== undefined) params.max_tokens = input.maxTokens;
+  if (input.temperature !== undefined) params.temperature = input.temperature;
+  if ((input as { topP?: number }).topP !== undefined)
+    params.top_p = (input as { topP?: number }).topP;
+  if ((input as { frequencyPenalty?: number }).frequencyPenalty !== undefined)
+    params.frequency_penalty = (input as { frequencyPenalty?: number }).frequencyPenalty;
+  if ((input as { presencePenalty?: number }).presencePenalty !== undefined)
+    params.presence_penalty = (input as { presencePenalty?: number }).presencePenalty;
+  return params;
+}
+
+/**
+ * Streaming run-fn for the `["text.generation"]` capability. Used by both
+ * {@link TextGenerationTask} (prompt-only input) and {@link AiChatTask}
+ * (full conversation history). Emits `text-delta` events on the `text` port
+ * and a final empty `finish` event per the streaming convention (consumer
+ * accumulates).
+ */
+export const DeepSeek_TextGeneration_Stream: AiProviderRunFn<
+  TextGenerationTaskInput,
+  TextGenerationTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, signal, emit) => {
+  const logger = getLogger();
+  const timerLabel = `deepseek:TextGeneration:${getModelName(model)}`;
+  logger.time(timerLabel, { model: getModelName(model) });
+  try {
+    const client = await getClient(model);
+    const params = buildChatParams(input as UnifiedTextGenerationInput, model);
+
+    const stream = await client.chat.completions.create(
+      { ...params, stream: true } as Parameters<typeof client.chat.completions.create>[0],
+      { signal }
+    );
+
+    for await (const chunk of stream as AsyncIterable<{
+      choices?: Array<{ delta?: { content?: string | null; refusal?: string | null } }>;
+    }>) {
+      const delta = chunk.choices?.[0]?.delta?.content ?? "";
+      if (delta) {
+        emit({ type: "text-delta", port: "text", textDelta: delta });
+      }
+      const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
+      if (refusalDelta) {
+        emit({ type: "refusal", refusal: refusalDelta });
+      }
+    }
+    emit({ type: "finish", data: {} as TextGenerationTaskOutput });
+  } finally {
+    logger.timeEnd(timerLabel, { model: getModelName(model) });
+  }
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_TextRewriter.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextRewriter.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, TextRewriterTaskInput, TextRewriterTaskOutput } from "@workglow/ai";
+import { getClient, getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Streaming run-fn for `["text.rewriter"]`. Emits `text-delta` events on the
+ * `text` port and a final empty `finish` event.
+ */
+export const DeepSeek_TextRewriter_Stream: AiProviderRunFn<
+  TextRewriterTaskInput,
+  TextRewriterTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [
+        { role: "system", content: input.prompt },
+        { role: "user", content: input.text },
+      ],
+      stream: true,
+    },
+    { signal }
+  );
+
+  for await (const chunk of stream) {
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
+    if (delta) {
+      emit({ type: "text-delta", port: "text", textDelta: delta });
+    }
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
+    if (refusalDelta) {
+      emit({ type: "refusal", refusal: refusalDelta });
+    }
+  }
+  emit({ type: "finish", data: {} as TextRewriterTaskOutput });
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_TextSummary.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_TextSummary.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRunFn, TextSummaryTaskInput, TextSummaryTaskOutput } from "@workglow/ai";
+import { getClient, getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Streaming run-fn for `["text.summary"]`. Emits `text-delta` events on the
+ * `text` port and a final empty `finish` event.
+ */
+export const DeepSeek_TextSummary_Stream: AiProviderRunFn<
+  TextSummaryTaskInput,
+  TextSummaryTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages: [
+        { role: "system", content: "Summarize the following text concisely." },
+        { role: "user", content: input.text },
+      ],
+      stream: true,
+    },
+    { signal }
+  );
+
+  for await (const chunk of stream) {
+    const delta = chunk.choices?.[0]?.delta?.content ?? "";
+    if (delta) {
+      emit({ type: "text-delta", port: "text", textDelta: delta });
+    }
+    const refusalDelta = chunk.choices?.[0]?.delta?.refusal ?? "";
+    if (refusalDelta) {
+      emit({ type: "refusal", refusal: refusalDelta });
+    }
+  }
+  emit({ type: "finish", data: {} as TextSummaryTaskOutput });
+};

--- a/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
@@ -10,14 +10,28 @@ import type {
   ToolCallingTaskOutput,
   ToolCalls,
 } from "@workglow/ai";
-import {
-  accumulateOpenAIChatStream,
-  buildOpenAITools,
-  mapOpenAIToolChoice,
-} from "@workglow/ai/provider-utils";
+import { accumulateOpenAIChatStream, buildOpenAITools } from "@workglow/ai/provider-utils";
 import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
 import { getClient, getModelName } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Map a workglow `toolChoice` to what DeepSeek actually accepts.
+ *
+ * The v4 models are thinking models, and thinking mode rejects any tool_choice
+ * beyond `auto` / `none` — `"required"` and the named-function object both come
+ * back as `400 Thinking mode does not support this tool_choice`. So we cannot
+ * use the shared {@link mapOpenAIToolChoice}, which emits both.
+ *
+ * A forcing choice is therefore downgraded to `auto` rather than rejected: the
+ * request succeeds and the model still calls the tool when the prompt calls for
+ * one. The caveat is that `auto` is a hint, not a guarantee — a caller that
+ * passes `"required"` is not getting a hard guarantee of a tool call from this
+ * provider. `none` is passed through, since suppressing calls is honored.
+ */
+function mapDeepSeekToolChoice(toolChoice: string | undefined): "auto" | "none" {
+  return toolChoice === "none" ? "none" : "auto";
+}
 
 /**
  * Streaming run-fn for `["text.generation", "tool-use"]`. Calls the DeepSeek
@@ -39,7 +53,7 @@ export const DeepSeek_ToolCalling_Stream: AiProviderRunFn<
 
   const tools = buildOpenAITools(input.tools);
   const messages = toOpenAIMessages(input);
-  const toolChoice = mapOpenAIToolChoice(input.toolChoice, true);
+  const toolChoice = mapDeepSeekToolChoice(input.toolChoice);
 
   const stream = await client.chat.completions.create(
     {

--- a/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
@@ -16,21 +16,86 @@ import { getClient, getModelName } from "./DeepSeek_Client";
 import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
 
 /**
- * Map a workglow `toolChoice` to what DeepSeek actually accepts.
+ * Thrown when the caller demanded a tool call that the model did not make.
+ *
+ * Retryable: the model was *asked* for the call and simply didn't produce one,
+ * which is nondeterministic rather than structurally impossible — a re-roll is
+ * a legitimate remedy, so the job-queue retry policy applies.
+ */
+export class DeepSeekToolChoiceNotHonoredError extends Error {
+  public readonly retryable = true;
+  constructor(
+    public readonly modelId: string,
+    public readonly requestedToolChoice: string,
+    detail: string
+  ) {
+    super(
+      `DeepSeek model "${modelId}" did not honor tool_choice "${requestedToolChoice}": ${detail}`
+    );
+    this.name = "DeepSeekToolChoiceNotHonoredError";
+  }
+}
+
+/**
+ * Whether `toolChoice` demands a call — i.e. `"required"` (any tool) or a
+ * specific function name. `undefined` / `"auto"` / `"none"` demand nothing.
+ */
+function isForcingToolChoice(toolChoice: string | undefined): toolChoice is string {
+  return toolChoice !== undefined && toolChoice !== "auto" && toolChoice !== "none";
+}
+
+/**
+ * Map a workglow `toolChoice` to what DeepSeek actually accepts on the wire.
  *
  * The v4 models are thinking models, and thinking mode rejects any tool_choice
  * beyond `auto` / `none` — `"required"` and the named-function object both come
- * back as `400 Thinking mode does not support this tool_choice`. So we cannot
- * use the shared {@link mapOpenAIToolChoice}, which emits both.
+ * back as `400 Thinking mode does not support this tool_choice`. So the shared
+ * {@link mapOpenAIToolChoice}, which emits both, cannot be used here.
  *
- * A forcing choice is therefore downgraded to `auto` rather than rejected: the
- * request succeeds and the model still calls the tool when the prompt calls for
- * one. The caveat is that `auto` is a hint, not a guarantee — a caller that
- * passes `"required"` is not getting a hard guarantee of a tool call from this
- * provider. `none` is passed through, since suppressing calls is honored.
+ * A forcing choice is sent as `auto` so the request is accepted, and the
+ * constraint is then enforced on our side once the stream completes — see
+ * {@link assertToolChoiceHonored}. `none` is passed through, since suppressing
+ * calls is honored natively.
  */
 function mapDeepSeekToolChoice(toolChoice: string | undefined): "auto" | "none" {
   return toolChoice === "none" ? "none" : "auto";
+}
+
+/**
+ * Enforce a forcing `toolChoice` after the fact, since DeepSeek cannot enforce
+ * it server-side.
+ *
+ * This mirrors how json-mode is handled here: the vendor gives no guarantee, so
+ * the guarantee is re-established by checking the response rather than by
+ * silently dropping the caller's constraint. `"required"` needs at least one
+ * call; a named function needs that specific function to have been called.
+ *
+ * Only calls that survived {@link filterValidToolCalls} count — a hallucinated
+ * function name does not satisfy the request.
+ */
+function assertToolChoiceHonored(
+  toolChoice: string,
+  calledNames: readonly string[],
+  modelId: string
+): void {
+  if (toolChoice === "required") {
+    if (calledNames.length === 0) {
+      throw new DeepSeekToolChoiceNotHonoredError(
+        modelId,
+        toolChoice,
+        "the response contained no valid tool call"
+      );
+    }
+    return;
+  }
+  if (!calledNames.includes(toolChoice)) {
+    const seen = calledNames.length > 0 ? calledNames.join(", ") : "none";
+    throw new DeepSeekToolChoiceNotHonoredError(
+      modelId,
+      toolChoice,
+      `expected a call to "${toolChoice}" but the response called: ${seen}`
+    );
+  }
 }
 
 /**
@@ -68,15 +133,25 @@ export const DeepSeek_ToolCalling_Stream: AiProviderRunFn<
     { signal }
   );
 
+  // Deltas arrive per call and are upserted by id downstream, so track the
+  // latest name per id rather than counting events.
+  const calledByCallId = new Map<string, string>();
+
   await accumulateOpenAIChatStream(stream, (event) => {
     if (event.type === "object-delta" && event.port === "toolCalls") {
       const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
       if (validated.length > 0) {
+        for (const call of validated) calledByCallId.set(call.id, call.name);
         emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
       }
       return;
     }
     emit(event);
   });
+
+  if (isForcingToolChoice(input.toolChoice)) {
+    assertToolChoiceHonored(input.toolChoice, [...calledByCallId.values()], modelName);
+  }
+
   emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
 };

--- a/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
+++ b/providers/deepseek/src/ai/common/DeepSeek_ToolCalling.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  AiProviderRunFn,
+  ToolCallingTaskInput,
+  ToolCallingTaskOutput,
+  ToolCalls,
+} from "@workglow/ai";
+import {
+  accumulateOpenAIChatStream,
+  buildOpenAITools,
+  mapOpenAIToolChoice,
+} from "@workglow/ai/provider-utils";
+import { filterValidToolCalls, toOpenAIMessages } from "@workglow/ai/worker";
+import { getClient, getModelName } from "./DeepSeek_Client";
+import type { DeepSeekModelConfig } from "./DeepSeek_ModelSchema";
+
+/**
+ * Streaming run-fn for `["text.generation", "tool-use"]`. Calls the DeepSeek
+ * chat-completions endpoint (OpenAI-compatible) with `stream: true` and
+ * forwards delta events via {@link accumulateOpenAIChatStream}, which emits
+ * `text-delta` and tool-call `object-delta` events plus a final empty
+ * `finish`.
+ *
+ * Defence-in-depth: each tool-call `object-delta` is filtered against
+ * `input.tools` so a hallucinated function name never reaches the consumer.
+ */
+export const DeepSeek_ToolCalling_Stream: AiProviderRunFn<
+  ToolCallingTaskInput,
+  ToolCallingTaskOutput,
+  DeepSeekModelConfig
+> = async (input, model, signal, emit) => {
+  const client = await getClient(model);
+  const modelName = getModelName(model);
+
+  const tools = buildOpenAITools(input.tools);
+  const messages = toOpenAIMessages(input);
+  const toolChoice = mapOpenAIToolChoice(input.toolChoice, true);
+
+  const stream = await client.chat.completions.create(
+    {
+      model: modelName,
+      messages,
+      max_tokens: input.maxTokens,
+      temperature: input.temperature,
+      stream: true,
+      tools,
+      tool_choice: toolChoice,
+    },
+    { signal }
+  );
+
+  await accumulateOpenAIChatStream(stream, (event) => {
+    if (event.type === "object-delta" && event.port === "toolCalls") {
+      const validated = filterValidToolCalls(event.objectDelta as ToolCalls, input.tools);
+      if (validated.length > 0) {
+        emit({ type: "object-delta", port: "toolCalls", objectDelta: validated });
+      }
+      return;
+    }
+    emit(event);
+  });
+  emit({ type: "finish", data: { text: "", toolCalls: [] } as ToolCallingTaskOutput });
+};

--- a/providers/deepseek/src/ai/index.browser.ts
+++ b/providers/deepseek/src/ai/index.browser.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export { DEEPSEEK_ALLOWED_HOSTS, DEEPSEEK_DEFAULT_BASE_URL } from "./common/DeepSeek_Client";
+export * from "./common/DeepSeek_Constants";
+export * from "./common/DeepSeek_ModelSchema";
+export * from "./registerDeepSeek";

--- a/providers/deepseek/src/ai/index.ts
+++ b/providers/deepseek/src/ai/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// organize-imports-ignore
+
+export { DEEPSEEK_ALLOWED_HOSTS, DEEPSEEK_DEFAULT_BASE_URL } from "./common/DeepSeek_Client";
+export * from "./common/DeepSeek_Constants";
+export * from "./common/DeepSeek_ModelSchema";
+export * from "./common/DeepSeek_ModelSearch";
+export * from "./registerDeepSeek";
+
+import { DEEPSEEK_RUN_FN_SPECS } from "./common/DeepSeek_Capabilities";
+import { DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns";
+import { DeepSeekQueuedProvider } from "./DeepSeekQueuedProvider";
+
+/**
+ * @internal Symbols exported only for use by `@workglow/test`. Not part of the stable public API.
+ */
+export const _testOnly = {
+  DeepSeekQueuedProvider,
+  DEEPSEEK_RUN_FN_SPECS,
+  DEEPSEEK_RUN_FNS,
+} as const;

--- a/providers/deepseek/src/ai/registerDeepSeek.ts
+++ b/providers/deepseek/src/ai/registerDeepSeek.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRegisterOptions } from "@workglow/ai";
+import { registerProviderWithWorker } from "@workglow/ai/provider-utils";
+import { DeepSeekQueuedProvider } from "./DeepSeekQueuedProvider";
+
+export async function registerDeepSeek(
+  options: AiProviderRegisterOptions & {
+    worker: Worker | (() => Worker);
+  }
+): Promise<void> {
+  await registerProviderWithWorker(new DeepSeekQueuedProvider(), "DeepSeek", options);
+}

--- a/providers/deepseek/src/ai/registerDeepSeekInline.browser.ts
+++ b/providers/deepseek/src/ai/registerDeepSeekInline.browser.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRegisterOptions } from "@workglow/ai";
+import { registerProviderInline } from "@workglow/ai/provider-utils";
+import { DEEPSEEK_PREVIEW_TASKS, DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns.browser";
+import { DeepSeekQueuedProvider } from "./DeepSeekQueuedProvider";
+
+export async function registerDeepSeekInline(options?: AiProviderRegisterOptions): Promise<void> {
+  await registerProviderInline(
+    new DeepSeekQueuedProvider(DEEPSEEK_RUN_FNS, DEEPSEEK_PREVIEW_TASKS),
+    "DeepSeek",
+    options
+  );
+}

--- a/providers/deepseek/src/ai/registerDeepSeekInline.ts
+++ b/providers/deepseek/src/ai/registerDeepSeekInline.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AiProviderRegisterOptions } from "@workglow/ai";
+import { registerProviderInline } from "@workglow/ai/provider-utils";
+import { DEEPSEEK_PREVIEW_TASKS, DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns";
+import { DeepSeekQueuedProvider } from "./DeepSeekQueuedProvider";
+
+export async function registerDeepSeekInline(options?: AiProviderRegisterOptions): Promise<void> {
+  await registerProviderInline(
+    new DeepSeekQueuedProvider(DEEPSEEK_RUN_FNS, DEEPSEEK_PREVIEW_TASKS),
+    "DeepSeek",
+    options
+  );
+}

--- a/providers/deepseek/src/ai/registerDeepSeekWorker.browser.ts
+++ b/providers/deepseek/src/ai/registerDeepSeekWorker.browser.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerProviderWorker } from "@workglow/ai/provider-utils";
+import { DEEPSEEK_PREVIEW_TASKS, DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns.browser";
+import { DeepSeekProvider } from "./DeepSeekProvider";
+
+export async function registerDeepSeekWorker(): Promise<void> {
+  await registerProviderWorker(
+    (ws) =>
+      new DeepSeekProvider(DEEPSEEK_RUN_FNS, DEEPSEEK_PREVIEW_TASKS).registerOnWorkerServer(ws),
+    "DeepSeek"
+  );
+}

--- a/providers/deepseek/src/ai/registerDeepSeekWorker.ts
+++ b/providers/deepseek/src/ai/registerDeepSeekWorker.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerProviderWorker } from "@workglow/ai/provider-utils";
+import { DEEPSEEK_PREVIEW_TASKS, DEEPSEEK_RUN_FNS } from "./common/DeepSeek_JobRunFns";
+import { DeepSeekProvider } from "./DeepSeekProvider";
+
+export async function registerDeepSeekWorker(): Promise<void> {
+  await registerProviderWorker(
+    (ws) =>
+      new DeepSeekProvider(DEEPSEEK_RUN_FNS, DEEPSEEK_PREVIEW_TASKS).registerOnWorkerServer(ws),
+    "DeepSeek"
+  );
+}

--- a/providers/deepseek/src/ai/runtime.browser.ts
+++ b/providers/deepseek/src/ai/runtime.browser.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Browser build for DeepSeek runtime registration (uses `js-tiktoken` instead of WASM `tiktoken`).
+ * Import from `@workglow/deepseek/ai-runtime` — not from the main `deepseek` barrel.
+ *
+ * Use `export *` (not `export { … } from "…"`) so the Bun bundler keeps the module graph.
+ */
+// organize-imports-ignore
+
+export * from "./common/DeepSeek_Client";
+export * from "./registerDeepSeekInline.browser";
+export * from "./registerDeepSeekWorker.browser";

--- a/providers/deepseek/src/ai/runtime.ts
+++ b/providers/deepseek/src/ai/runtime.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Worker server and main-thread inline DeepSeek registration (pulls in
+ * `DeepSeek_JobRunFns`), plus SDK client helpers (`DeepSeek_Client`).
+ * Import from `@workglow/deepseek/ai-runtime` — not from the main `deepseek` barrel.
+ *
+ * Use `export *` (not `export { … } from "…"`) so the Bun bundler keeps the module graph.
+ */
+// organize-imports-ignore
+
+export * from "./common/DeepSeek_Client";
+export * from "./registerDeepSeekInline";
+export * from "./registerDeepSeekWorker";

--- a/providers/deepseek/tsconfig.json
+++ b/providers/deepseek/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/util"
+    },
+    {
+      "path": "../../packages/task-graph"
+    },
+    {
+      "path": "../../packages/storage"
+    },
+    {
+      "path": "../../packages/job-queue"
+    },
+    {
+      "path": "../../packages/ai"
+    }
+  ]
+}

--- a/providers/google-gemini/README.md
+++ b/providers/google-gemini/README.md
@@ -31,10 +31,10 @@ await registerGoogleGemini();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/huggingface-inference/README.md
+++ b/providers/huggingface-inference/README.md
@@ -31,10 +31,10 @@ await registerHuggingfaceInference();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/huggingface-transformers/README.md
+++ b/providers/huggingface-transformers/README.md
@@ -31,10 +31,10 @@ await registerHuggingfaceTransformers();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/node-llama-cpp/README.md
+++ b/providers/node-llama-cpp/README.md
@@ -31,10 +31,10 @@ await registerNodeLlamaCpp();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/ollama/README.md
+++ b/providers/ollama/README.md
@@ -31,10 +31,10 @@ await registerOllama();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/openai/README.md
+++ b/providers/openai/README.md
@@ -31,10 +31,10 @@ await registerOpenai();
 
 // 2. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(new TextGenerationTask({
+workflow.addTask(TextGenerationTask, {
   model: "default-model",
-  prompt: "Hello world!"
-}));
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/providers/xai/README.md
+++ b/providers/xai/README.md
@@ -49,12 +49,10 @@ await getGlobalModelRepository().addModel({
 
 // 3. Use it in a workflow
 const workflow = new Workflow();
-workflow.add(
-  new TextGenerationTask({
-    model: "xai:grok-4",
-    prompt: "Hello world!",
-  })
-);
+workflow.addTask(TextGenerationTask, {
+  model: "xai:grok-4",
+  prompt: "Hello world!",
+});
 
 const result = await workflow.run();
 ```

--- a/scripts/credentials.ts
+++ b/scripts/credentials.ts
@@ -27,6 +27,9 @@
  *   google-api-key     → GOOGLE_API_KEY
  *   gemini-api-key     → GEMINI_API_KEY
  *   hf-token           → HF_TOKEN
+ *   xai-api-key        → XAI_API_KEY
+ *   openrouter-api-key → OPENROUTER_API_KEY
+ *   deepseek-api-key   → DEEPSEEK_API_KEY
  */
 
 import {

--- a/scripts/lib/test-credentials.ts
+++ b/scripts/lib/test-credentials.ts
@@ -23,6 +23,7 @@ export const CREDENTIAL_TO_ENV: Readonly<Record<string, string>> = {
   "hf-token": "HF_TOKEN",
   "xai-api-key": "XAI_API_KEY",
   "openrouter-api-key": "OPENROUTER_API_KEY",
+  "deepseek-api-key": "DEEPSEEK_API_KEY",
 };
 
 export interface BuiltStore {

--- a/scripts/typecheck-budget.json
+++ b/scripts/typecheck-budget.json
@@ -21,6 +21,7 @@
     "providers/cactus": 15571,
     "providers/chrome-ai": 14588,
     "providers/cloudflare": 1138,
+    "providers/deepseek": 10543,
     "providers/electron": 203,
     "providers/google-gemini": 20464,
     "providers/huggingface-inference": 16988,


### PR DESCRIPTION
Adds a complete DeepSeek provider implementation for the Workglow AI framework, enabling integration with DeepSeek's OpenAI-compatible chat API.

## Summary

This PR introduces `@workglow/deepseek`, a new provider package that integrates DeepSeek's language models into the Workglow AI task system. DeepSeek exposes an OpenAI-compatible REST API, so the implementation reuses the `openai` SDK pointed at `https://api.deepseek.com`.

## Key Changes

- **New provider package** (`providers/deepseek/`) with full capability support:
  - Text generation (`text.generation`)
  - Tool calling (`tool-use`)
  - Structured/JSON output (`json-mode`)
  - Text rewriting (`text.rewriter`)
  - Text summarization (`text.summary`)
  - Token counting (`model.count-tokens`)
  - Model search and info (`model.search`, `model.info`)

- **Core implementation files**:
  - `DeepSeek_Client.ts` — OpenAI SDK initialization with API key resolution and base URL validation
  - `DeepSeek_TextGeneration.ts` — unified streaming run-fn for both chat and prompt-based text generation
  - `DeepSeek_ToolCalling.ts` — tool-use support with OpenAI-compatible tool definitions
  - `DeepSeek_StructuredGeneration.ts` — JSON schema mode for structured outputs
  - `DeepSeek_CountTokens.ts` / `.browser.ts` — token counting via tiktoken (with fallback to cl100k_base encoding)
  - `DeepSeek_TextRewriter.ts`, `DeepSeek_TextSummary.ts` — specialized text tasks
  - `DeepSeek_ModelSearch.ts` — model discovery via API or fallback list
  - `DeepSeek_Capabilities.ts` — capability inference for DeepSeek model IDs

- **Provider registration**:
  - `DeepSeekQueuedProvider` — main-thread shell supporting both inline and worker-backed modes
  - `DeepSeekProvider` — worker-side provider implementation
  - `registerDeepSeek()`, `registerDeepSeekInline()`, `registerDeepSeekWorker()` — registration entry points
  - Browser and Node.js variants (token counting uses `js-tiktoken` in browser, WASM `tiktoken` in Node)

- **Model schema** (`DeepSeek_ModelSchema.ts`):
  - Discriminator: `provider: "DEEPSEEK"`
  - Config: `model_name`, optional `credential_key`, `base_url`, `trustedBaseUrl`
  - Validates base URL against allow-list (`api.deepseek.com`) unless explicitly trusted

- **Capability inference**:
  - Pattern-matches model IDs (e.g., `deepseek-v4-flash`, `deepseek-v4-pro`) to inferred capability sets
  - Falls back to declared capabilities or baseline (`model.search`, `model.info`)
  - DeepSeek chat models are text-only (no vision input, no image generation)

- **Integration**:
  - Updated `@workglow/workglow` meta-package with DeepSeek exports
  - Added DeepSeek to example projects (`eval`, `cli`)
  - Comprehensive test suite (`DeepSeekProvider.test.ts`) covering capability inference, run-fn parity, and model metadata

- **Documentation**:
  - `README.md` with feature overview, installation, and usage examples

## Implementation Details

- **OpenAI SDK reuse**: DeepSeek's API is wire-compatible with OpenAI's chat completions endpoint, so the provider leverages the existing `openai` package rather than a custom HTTP client.
- **Streaming architecture**: All run-fns use streaming (even one-shot tasks like token counting) to maintain consistency with the Workglow event-driven model.
- **Token counting approximation**: DeepSeek doesn't ship a tokenizer package, so counts are approximated using tiktoken's `cl100k_base` encoding (

https://claude.ai/code/session_01LpPXCh7MGan15jGgvJEnb2