### PR TITLE
Display task titles in CLI UI instead of class type names

### DIFF
--- a/examples/cli/src/test/cliTaskLabel.test.ts
+++ b/examples/cli/src/test/cliTaskLabel.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Steven Roussey <sroussey@gmail.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ITask } from "@workglow/task-graph";
+import { describe, expect, it } from "vitest";
+import { cliTaskLabel } from "../ui/taskGraphCliSubscriptions";
+
+function makeTask(type: string, title?: string): ITask {
+  return { type, title } as unknown as ITask;
+}
+
+describe("cliTaskLabel", () => {
+  it("prefers the instance title over the class type name", () => {
+    expect(cliTaskLabel(makeTask("BootstrapDownloadTask", "Download submissions"))).toBe(
+      "Download submissions"
+    );
+  });
+
+  it("distinguishes two instances of the same task class", () => {
+    const a = makeTask("BootstrapDownloadTask", "Download submissions");
+    const b = makeTask("BootstrapDownloadTask", "Download facts");
+    expect([cliTaskLabel(a), cliTaskLabel(b)]).toEqual(["Download submissions", "Download facts"]);
+  });
+
+  it("falls back to the type name when no title is set", () => {
+    expect(cliTaskLabel(makeTask("BootstrapDownloadTask"))).toBe("BootstrapDownloadTask");
+  });
+
+  it("treats the Task base class's empty-string title as unset", () => {
+    expect(cliTaskLabel(makeTask("BootstrapDownloadTask", ""))).toBe("BootstrapDownloadTask");
+  });
+
+  it("falls back to Unknown for a task-like object with no type", () => {
+    expect(cliTaskLabel({} as ITask)).toBe("Unknown");
+  });
+});

--- a/examples/cli/src/test/subtask-rows.test.ts
+++ b/examples/cli/src/test/subtask-rows.test.ts
@@ -31,6 +31,25 @@ class OwnedChildTask extends Task<Record<string, never>, Record<string, never>> 
   }
 }
 
+/** The shape sec uses everywhere: own a Workflow, run a pipeline inside it. */
+class OwningWorkflowParentTask extends Task<Record<string, never>, Record<string, never>> {
+  static override readonly type = "OwningWorkflowParentTask";
+  static override readonly category = "Test";
+  static override readonly cacheable = false;
+  static override inputSchema(): never {
+    return SCHEMA;
+  }
+  static override outputSchema(): never {
+    return SCHEMA;
+  }
+  override async execute(_input: Record<string, never>, context: IExecuteContext) {
+    const wf = context.own(new Workflow(), { title: "Inner pipeline" });
+    wf.pipe(new OwnedChildTask() as never);
+    await wf.run({});
+    return {};
+  }
+}
+
 class OwningParentTask extends Task<Record<string, never>, Record<string, never>> {
   static override readonly type = "OwningParentTask";
   static override readonly category = "Test";
@@ -95,6 +114,42 @@ describe("WorkflowRunApp subtask rows", () => {
 
     const output = stripAnsi(stdout.frames.join("\n"));
     expect(output).toContain("OwningParentTask");
+    expect(output).toContain("OwnedChildTask");
+  });
+
+  it("renders the children inside an owned workflow, not just the wrapper row", async () => {
+    const workflow = new Workflow();
+    workflow.pipe(new OwningWorkflowParentTask() as never);
+
+    const stdout = new CapturingStdout();
+    let finished = false;
+    const instance = render(
+      React.createElement(WorkflowRunApp, {
+        graph: workflow.graph,
+        input: {},
+        runExecutor: () => workflow.run({}),
+        onComplete: () => {
+          finished = true;
+        },
+        onError: () => {
+          finished = true;
+        },
+      }),
+      { stdout: stdout as never, patchConsole: false, exitOnCtrlC: false }
+    );
+
+    const deadline = Date.now() + 5000;
+    while (!finished && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    instance.unmount();
+
+    const output = stripAnsi(stdout.frames.join("\n"));
+    expect(output).toContain("OwningWorkflowParentTask");
+    // The owned workflow's own title, from `own(wf, { title })`.
+    expect(output).toContain("Inner pipeline");
+    // The point of the recursion: the work inside the wrapper is visible.
     expect(output).toContain("OwnedChildTask");
   });
 });

--- a/examples/cli/src/ui/TaskRunApp.tsx
+++ b/examples/cli/src/ui/TaskRunApp.tsx
@@ -204,6 +204,7 @@ export function TaskRunApp({
           {showSubtasksSection && (
             <SubtaskRows
               rows={subtasks.rows}
+              tasks={subtasks.tasks}
               iterationSlots={subtasks.iterationSlots}
               overallProgress={subtasks.overallProgress}
               variant="chrome"

--- a/examples/cli/src/ui/TaskRunApp.tsx
+++ b/examples/cli/src/ui/TaskRunApp.tsx
@@ -17,6 +17,7 @@ import { TaskStatusProgressRow } from "./components/TaskStatusProgressRow";
 import { HumanInteractionHost } from "./HumanInteractionHost";
 import { isRedundantSubgraph, SubtaskRows } from "./rows/SubtaskRows";
 import { useSubtaskRows } from "./rows/useSubtaskRows";
+import { cliTaskLabel } from "./taskGraphCliSubscriptions";
 
 interface TaskRunAppProps {
   readonly task: ITask;
@@ -176,7 +177,7 @@ export function TaskRunApp({
 
         <Box flexDirection="column">
           <TaskStatusProgressRow
-            type={taskType}
+            label={cliTaskLabel(task)}
             status={status}
             message={isModelDownloadTask ? undefined : batch.message}
             barProgress={batch.progress}

--- a/examples/cli/src/ui/components/TaskStatusLine.tsx
+++ b/examples/cli/src/ui/components/TaskStatusLine.tsx
@@ -11,7 +11,8 @@ import { useCliTheme } from "../CliThemeContext";
 import { CliSpinner } from "./CliSpinner";
 
 interface TaskStatusLineProps {
-  readonly type: string;
+  /** Display name for the row — a task title, class type name, or an iteration marker. */
+  readonly label: string;
   readonly status: string;
   readonly message?: string;
   /**
@@ -24,7 +25,7 @@ interface TaskStatusLineProps {
 }
 
 export function TaskStatusLine({
-  type,
+  label,
   status,
   message,
   animateStatus = true,
@@ -46,7 +47,7 @@ export function TaskStatusLine({
       )}
       <Text color={bodyColor}>
         {" "}
-        {type}
+        {label}
         {msgText}
       </Text>
     </Text>

--- a/examples/cli/src/ui/components/TaskStatusProgressRow.tsx
+++ b/examples/cli/src/ui/components/TaskStatusProgressRow.tsx
@@ -11,7 +11,8 @@ import { ProgressBar } from "./ProgressBar";
 import { TaskStatusLine } from "./TaskStatusLine";
 
 export interface TaskStatusProgressRowProps {
-  readonly type: string;
+  /** Display name for the row — a task title, class type name, or an iteration marker. */
+  readonly label: string;
   readonly status: string;
   readonly message?: string;
   readonly barProgress: number;
@@ -30,7 +31,7 @@ export interface TaskStatusProgressRowProps {
  * Task status on the left, optional Unicode progress bar on the right (same row).
  */
 export function TaskStatusProgressRow({
-  type,
+  label,
   status,
   message,
   barProgress,
@@ -45,7 +46,7 @@ export function TaskStatusProgressRow({
     <Box flexDirection="row" justifyContent="space-between" width="100%" marginLeft={marginLeft}>
       <Box flexGrow={1} minWidth={0} overflow="hidden">
         <TaskStatusLine
-          type={type}
+          label={label}
           status={status}
           message={message}
           animateStatus={animateStatus}

--- a/examples/cli/src/ui/rows/ChatTaskRow.tsx
+++ b/examples/cli/src/ui/rows/ChatTaskRow.tsx
@@ -100,7 +100,7 @@ export function ChatTaskRow({ task, line }: TaskRowProps): React.ReactElement {
   if (status === "PENDING") {
     return (
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={status}
         message={line.message}
         barProgress={0}
@@ -111,7 +111,7 @@ export function ChatTaskRow({ task, line }: TaskRowProps): React.ReactElement {
   if (status === "COMPLETED") {
     return (
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={status}
         message={`${messages.length} messages`}
         barProgress={100}
@@ -122,7 +122,7 @@ export function ChatTaskRow({ task, line }: TaskRowProps): React.ReactElement {
   if (status === "FAILED") {
     return (
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={status}
         message={line.message ?? "failed"}
         barProgress={line.progress ?? 0}
@@ -137,7 +137,7 @@ export function ChatTaskRow({ task, line }: TaskRowProps): React.ReactElement {
   return (
     <Box flexDirection="column">
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={status}
         message={line.message}
         barProgress={line.progress ?? 0}

--- a/examples/cli/src/ui/rows/DefaultTaskRow.tsx
+++ b/examples/cli/src/ui/rows/DefaultTaskRow.tsx
@@ -23,7 +23,7 @@ export function DefaultTaskRow({ task, line, iterationSlots }: TaskRowProps): Re
   return (
     <Box key={line.id} flexDirection="column">
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={line.status}
         message={line.message}
         barProgress={line.progress ?? 0}

--- a/examples/cli/src/ui/rows/DefaultTaskRow.tsx
+++ b/examples/cli/src/ui/rows/DefaultTaskRow.tsx
@@ -31,7 +31,7 @@ export function DefaultTaskRow({ task, line, iterationSlots }: TaskRowProps): Re
       {sortedSlots.map((slot: IterationSlotRow) => (
         <Box key={`${line.id}-iter-${slot.index}`} flexDirection="column" paddingLeft={2}>
           <TaskStatusProgressRow
-            type={`#${slot.index + 1}`}
+            label={`#${slot.index + 1}`}
             status={iterationSlotToTaskStatus(slot.status)}
             message={slot.status === "completed" ? undefined : slot.message}
             barProgress={slot.progress ?? 0}

--- a/examples/cli/src/ui/rows/DefaultTaskRow.tsx
+++ b/examples/cli/src/ui/rows/DefaultTaskRow.tsx
@@ -40,7 +40,11 @@ export function DefaultTaskRow({ task, line, iterationSlots }: TaskRowProps): Re
         </Box>
       ))}
       {!isRedundantSubgraph(subtasks.rows, line.type) && (
-        <SubtaskRows rows={subtasks.rows} iterationSlots={subtasks.iterationSlots} />
+        <SubtaskRows
+          rows={subtasks.rows}
+          tasks={subtasks.tasks}
+          iterationSlots={subtasks.iterationSlots}
+        />
       )}
     </Box>
   );

--- a/examples/cli/src/ui/rows/StreamingTextRow.tsx
+++ b/examples/cli/src/ui/rows/StreamingTextRow.tsx
@@ -26,7 +26,7 @@ export function StreamingTextRow({ task, line }: TaskRowProps): React.ReactEleme
   return (
     <Box flexDirection="column">
       <TaskStatusProgressRow
-        type={line.type}
+        label={line.label}
         status={line.status}
         message={line.message}
         barProgress={line.progress ?? 0}

--- a/examples/cli/src/ui/rows/SubtaskRows.tsx
+++ b/examples/cli/src/ui/rows/SubtaskRows.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ITask } from "@workglow/task-graph";
 import { Box, Text } from "ink";
 import React from "react";
 import { useCliTheme } from "../CliThemeContext";
@@ -14,6 +15,7 @@ import {
   iterationSlotToTaskStatus,
   sortIterationSlotsForDisplay,
 } from "../taskGraphCliSubscriptions";
+import { useSubtaskRows } from "./useSubtaskRows";
 
 /**
  * A long-running task can own hundreds of subtasks (one generation per eval
@@ -23,9 +25,22 @@ import {
  */
 const MAX_VISIBLE_SUBTASKS = 6;
 
+/**
+ * How many levels of owned subgraph to render beneath a task row. A task that
+ * owns a workflow produces a wrapper row whose own children are the real work,
+ * so one level is never enough — stopping at the wrapper shows "Workflow" and
+ * hides the pipeline inside it. Deeper than this and the breadth cap multiplies
+ * into more rows (and more attach pollers) than a terminal can use.
+ */
+const MAX_SUBTASK_DEPTH = 2;
+
 interface SubtaskRowsProps {
   readonly rows: readonly CliTaskLine[];
   readonly iterationSlots: ReadonlyMap<string, IterationSlotRow[]>;
+  /** Live task per row id; enables recursion into rows that own subgraphs. */
+  readonly tasks?: ReadonlyMap<string, ITask> | undefined;
+  /** Nesting level of this list; recursion stops at {@link MAX_SUBTASK_DEPTH}. */
+  readonly depth?: number;
   /** Aggregate subgraph progress; only rendered in `chrome` mode. */
   readonly overallProgress?: number | undefined;
   /**
@@ -42,9 +57,77 @@ interface SubtaskRowsProps {
  * Shared by {@link DefaultTaskRow} (workflow/graph runs) and `TaskRunApp`
  * (single-task runs) so both views show ownership the same way.
  */
+/**
+ * One subtask row plus, when that subtask owns tasks of its own, its children
+ * indented beneath it. Split out as a component because the subgraph is tracked
+ * with a hook, which cannot be called from inside a `map` over a changing list.
+ */
+function SubtaskRow({
+  line,
+  task,
+  iterationSlots,
+  depth,
+}: {
+  readonly line: CliTaskLine;
+  readonly task: ITask | undefined;
+  readonly iterationSlots: ReadonlyMap<string, IterationSlotRow[]>;
+  readonly depth: number;
+}): React.ReactElement {
+  const slots = iterationSlots.get(line.id);
+  const sortedSlots = slots ? sortIterationSlotsForDisplay(slots) : [];
+  return (
+    <Box flexDirection="column">
+      <TaskStatusProgressRow
+        label={line.label}
+        status={line.status}
+        message={line.message}
+        barProgress={line.progress ?? 0}
+      />
+      {sortedSlots.map((slot) => (
+        <Box key={`${line.id}-iter-${slot.index}`} flexDirection="column" paddingLeft={2}>
+          <TaskStatusProgressRow
+            label={`#${slot.index + 1}`}
+            status={iterationSlotToTaskStatus(slot.status)}
+            message={slot.status === "completed" ? undefined : slot.message}
+            barProgress={slot.progress ?? 0}
+            suppressProgressBar={slot.status !== "running" || slot.progress === undefined}
+          />
+        </Box>
+      ))}
+      {task !== undefined && depth < MAX_SUBTASK_DEPTH && (
+        <NestedSubtaskRows task={task} parentType={line.type} depth={depth} />
+      )}
+    </Box>
+  );
+}
+
+/** Subscribes to one subtask's own subgraph and renders it a level deeper. */
+function NestedSubtaskRows({
+  task,
+  parentType,
+  depth,
+}: {
+  readonly task: ITask;
+  readonly parentType: string;
+  readonly depth: number;
+}): React.ReactElement | null {
+  const nested = useSubtaskRows(task);
+  if (nested.rows.length === 0 || isRedundantSubgraph(nested.rows, parentType)) return null;
+  return (
+    <SubtaskRows
+      rows={nested.rows}
+      tasks={nested.tasks}
+      iterationSlots={nested.iterationSlots}
+      depth={depth + 1}
+    />
+  );
+}
+
 export function SubtaskRows({
   rows,
   iterationSlots,
+  tasks,
+  depth = 0,
   overallProgress,
   variant = "compact",
 }: SubtaskRowsProps): React.ReactElement | null {
@@ -68,31 +151,15 @@ export function SubtaskRows({
         </Box>
       )}
       {hiddenCount > 0 && <Text dimColor>… {hiddenCount} completed</Text>}
-      {visible.map((t) => {
-        const slots = iterationSlots.get(t.id);
-        const sortedSlots = slots ? sortIterationSlotsForDisplay(slots) : [];
-        return (
-          <Box key={t.id} flexDirection="column">
-            <TaskStatusProgressRow
-              label={t.label}
-              status={t.status}
-              message={t.message}
-              barProgress={t.progress ?? 0}
-            />
-            {sortedSlots.map((slot) => (
-              <Box key={`${t.id}-iter-${slot.index}`} flexDirection="column" paddingLeft={2}>
-                <TaskStatusProgressRow
-                  label={`#${slot.index + 1}`}
-                  status={iterationSlotToTaskStatus(slot.status)}
-                  message={slot.status === "completed" ? undefined : slot.message}
-                  barProgress={slot.progress ?? 0}
-                  suppressProgressBar={slot.status !== "running" || slot.progress === undefined}
-                />
-              </Box>
-            ))}
-          </Box>
-        );
-      })}
+      {visible.map((t) => (
+        <SubtaskRow
+          key={t.id}
+          line={t}
+          task={tasks?.get(t.id)}
+          iterationSlots={iterationSlots}
+          depth={depth}
+        />
+      ))}
     </Box>
   );
 

--- a/examples/cli/src/ui/rows/SubtaskRows.tsx
+++ b/examples/cli/src/ui/rows/SubtaskRows.tsx
@@ -74,7 +74,7 @@ export function SubtaskRows({
         return (
           <Box key={t.id} flexDirection="column">
             <TaskStatusProgressRow
-              type={t.type}
+              label={t.label}
               status={t.status}
               message={t.message}
               barProgress={t.progress ?? 0}
@@ -82,7 +82,7 @@ export function SubtaskRows({
             {sortedSlots.map((slot) => (
               <Box key={`${t.id}-iter-${slot.index}`} flexDirection="column" paddingLeft={2}>
                 <TaskStatusProgressRow
-                  type={`#${slot.index + 1}`}
+                  label={`#${slot.index + 1}`}
                   status={iterationSlotToTaskStatus(slot.status)}
                   message={slot.status === "completed" ? undefined : slot.message}
                   barProgress={slot.progress ?? 0}

--- a/examples/cli/src/ui/rows/useSubtaskRows.ts
+++ b/examples/cli/src/ui/rows/useSubtaskRows.ts
@@ -13,9 +13,21 @@ import { subscribeTaskGraphForCli } from "../taskGraphCliSubscriptions";
 export interface SubtaskRowsState {
   /** Owned subtasks in display order (completed → running → pending, then graph order). */
   readonly rows: readonly CliTaskLine[];
+  /**
+   * The live task behind each row, keyed by row id. A row that owns tasks of its
+   * own — an owned workflow wrapping a whole pipeline, say — needs its instance
+   * so the renderer can recurse into that subgraph instead of stopping at the
+   * wrapper row.
+   */
+  readonly tasks: ReadonlyMap<string, ITask>;
   /** Aggregate progress of the subgraph, once it reports any. */
   readonly overallProgress: number | undefined;
   readonly iterationSlots: ReadonlyMap<string, IterationSlotRow[]>;
+}
+
+/** A task in one of these states will never gain children, so stop waiting for them. */
+function isSettled(status: string): boolean {
+  return status === "COMPLETED" || status === "FAILED" || status === "ABORTED";
 }
 
 /**
@@ -40,7 +52,12 @@ export function useSubtaskRows(task: ITask): SubtaskRowsState {
 
     const tryAttach = (): void => {
       if (unsub) return;
-      if (!task.hasChildren() || !task.subGraph) return;
+      if (!task.hasChildren() || !task.subGraph) {
+        // Recursion multiplies these pollers across the tree, and a leaf that
+        // finished childless would otherwise keep waking up for the whole run.
+        if (isSettled(task.status) && attachInterval !== undefined) clearInterval(attachInterval);
+        return;
+      }
       unsub = subscribeTaskGraphForCli(
         task.subGraph,
         setTaskInfos,
@@ -65,13 +82,13 @@ export function useSubtaskRows(task: ITask): SubtaskRowsState {
     };
   }, [task]);
 
-  const order =
-    task.hasChildren() && task.subGraph
-      ? new Map(task.subGraph.getTasks().map((t, i) => [String(t.id), i]))
-      : new Map<string, number>();
+  const children = task.hasChildren() && task.subGraph ? task.subGraph.getTasks() : [];
+  const order = new Map(children.map((t, i) => [String(t.id), i]));
+  const tasks = new Map(children.map((t) => [String(t.id), t]));
 
   return {
     rows: sortCliTaskLinesForDisplay(Array.from(taskInfos.values()), order),
+    tasks,
     overallProgress,
     iterationSlots,
   };

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -9,7 +9,10 @@ import type { Dispatch, SetStateAction } from "react";
 
 export interface CliTaskLine {
   readonly id: string;
+  /** Task class type name. Identity for renderer dispatch — never shown to the user. */
   readonly type: string;
+  /** What the row displays: the instance's `title` when set, else {@link CliTaskLine.type}. */
+  readonly label: string;
   status: string;
   progress?: number;
   message?: string;
@@ -18,6 +21,17 @@ export interface CliTaskLine {
 export interface CliLogLine {
   readonly id: number;
   readonly text: string;
+}
+
+/**
+ * Two instances of one task class are two different jobs (downloading different
+ * files, say), so rows are labelled by the instance's `title` — set per instance
+ * via task config — and fall back to the class type name when there is none.
+ */
+export function cliTaskLabel(task: ITask): string {
+  const title = (task as { title?: string }).title;
+  if (title !== undefined && title.length > 0) return title;
+  return (task as { type?: string }).type ?? "Unknown";
 }
 
 /** Per-index row for iterator tasks (MapTask, ReduceTask, …) shown under the parent task line. */
@@ -65,7 +79,7 @@ export function sortIterationSlotsForDisplay(
 function registerTaskListeners(
   task: ITask,
   taskId: string,
-  taskType: string,
+  taskLabel: string,
   setTaskInfos: Dispatch<SetStateAction<Map<string, CliTaskLine>>>,
   appendCompletedLog?: (text: string) => void
 ): void {
@@ -76,7 +90,7 @@ function registerTaskListeners(
       if (info) {
         next.set(taskId, { ...info, status });
         if (status === "COMPLETED" && appendCompletedLog) {
-          appendCompletedLog(`[COMPLETED] ${taskType}`);
+          appendCompletedLog(`[COMPLETED] ${taskLabel}`);
         }
       }
       return next;
@@ -259,7 +273,12 @@ export function subscribeTaskGraphForCli(
   for (const task of graph.getTasks()) {
     const taskId = String(task.id);
     const taskType = (task as { type?: string }).type ?? "Unknown";
-    initial.set(taskId, { id: taskId, type: taskType, status: "PENDING" });
+    initial.set(taskId, {
+      id: taskId,
+      type: taskType,
+      label: cliTaskLabel(task),
+      status: "PENDING",
+    });
   }
   setTaskInfos(initial);
 
@@ -271,15 +290,16 @@ export function subscribeTaskGraphForCli(
     if (wired.has(taskId)) return;
     wired.add(taskId);
     const taskType = (task as { type?: string }).type ?? "Unknown";
+    const taskLabel = cliTaskLabel(task);
 
     setTaskInfos((prev) => {
       if (prev.has(taskId)) return prev;
       const next = new Map(prev);
-      next.set(taskId, { id: taskId, type: taskType, status: "PENDING" });
+      next.set(taskId, { id: taskId, type: taskType, label: taskLabel, status: "PENDING" });
       return next;
     });
 
-    registerTaskListeners(task, taskId, taskType, setTaskInfos, appendCompletedLog);
+    registerTaskListeners(task, taskId, taskLabel, setTaskInfos, appendCompletedLog);
     if (setIterationSlots) {
       iterationUnsubs.push(registerIterationListeners(task, taskId, setIterationSlots));
     }

--- a/packages/task-graph/src/task/GraphAsTask.ts
+++ b/packages/task-graph/src/task/GraphAsTask.ts
@@ -516,20 +516,27 @@ class ListeningGraphAsTask extends GraphAsTask<any, any> {
   }
 }
 
+// `type` is the wrapper's identity; `title` is what a progress UI shows when the
+// caller passed no title of its own. Without these the base "Group" would label
+// every unnamed subgraph, which says less than the kind of subgraph it is.
 class OwnGraphTask extends ListeningGraphAsTask {
   public static override readonly type = "Own[Graph]";
+  public static override readonly title = "Graph";
 }
 
 class OwnWorkflowTask extends ListeningGraphAsTask {
   public static override readonly type = "Own[Workflow]";
+  public static override readonly title = "Workflow";
 }
 
 class GraphTask extends GraphAsTask {
   public static override readonly type = "Graph";
+  public static override readonly title = "Graph";
 }
 
 class ConvWorkflowTask extends GraphAsTask {
   public static override readonly type = "Workflow";
+  public static override readonly title = "Workflow";
 }
 
 registerGraphWrapperFactory(({ subGraph, isOwned, isWorkflow, config }) => {

--- a/packages/task-graph/src/task/ITask.ts
+++ b/packages/task-graph/src/task/ITask.ts
@@ -45,7 +45,17 @@ export interface IExecuteContext {
    * @param message - Optional human-readable phase / status label.
    */
   updateProgress: (progress: number | undefined, message?: string, ...args: any[]) => Promise<void>;
-  own: <T extends ITask | ITaskGraph | IWorkflow>(i: T) => T;
+  /**
+   * Register a task, graph, or workflow as a child of the running task so it
+   * inherits the registry and abort signal, and shows up under the parent in
+   * progress UIs.
+   *
+   * A graph or workflow is adapted into a wrapper task the caller never sees,
+   * so `config` is the only way to name one — without it every owned workflow
+   * renders as the same anonymous `Own[Workflow]` row. An argument that is
+   * already an `ITask` keeps its own config; name those at construction.
+   */
+  own: <T extends ITask | ITaskGraph | IWorkflow>(i: T, config?: TaskConfig) => T;
   registry: ServiceRegistry;
   /**
    * Input streams for pass-through streaming tasks. Keyed by input port name.

--- a/packages/task-graph/src/task/StreamProcessor.ts
+++ b/packages/task-graph/src/task/StreamProcessor.ts
@@ -16,7 +16,7 @@ import {
 } from "./StreamTypes";
 import { TaskAbortedError, TaskError } from "./TaskError";
 import type { TaskRunContext } from "./TaskRunContext";
-import type { TaskInput, TaskOutput } from "./TaskTypes";
+import type { TaskConfig, TaskInput, TaskOutput } from "./TaskTypes";
 import { TaskStatus } from "./TaskTypes";
 
 /**
@@ -35,7 +35,7 @@ export interface StreamProcessorDeps {
     message?: string,
     ...args: any[]
   ) => Promise<void>;
-  readonly own: <T extends Taskish<any, any>>(i: T) => T;
+  readonly own: <T extends Taskish<any, any>>(i: T, config?: TaskConfig) => T;
 }
 
 /**

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -519,8 +519,8 @@ export class TaskRunner<
   // Protected methods
   // ========================================================================
 
-  protected own<T extends Taskish<any, any>>(i: T): T {
-    const task = ensureTask(i, { isOwned: true });
+  protected own<T extends Taskish<any, any>>(i: T, config: TaskConfig = {}): T {
+    const task = ensureTask(i, { ...config, isOwned: true });
     this.task.subGraph.addTask(task);
     // Propagate parent registry and abort signal to owned ITask instances so
     // that calling task.run() on the returned value inherits this execution context.

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -1,4 +1,5 @@
-import { Task } from "@workglow/task-graph";
+import type { IExecuteContext, TaskOutput } from "@workglow/task-graph";
+import { Task, TaskGraph, Workflow } from "@workglow/task-graph";
 import { describe, expect, it } from "vitest";
 
 import { setLogger } from "@workglow/util";
@@ -43,6 +44,45 @@ describe("Task own functionality", () => {
       // Verify the wrapped graphs have their tasks
       expect(subTasks[1].hasChildren()).toBe(true);
       expect(subTasks[2].hasChildren()).toBe(true);
+    });
+  });
+
+  describe("own(taskish, config)", () => {
+    // A graph/workflow is adapted into a wrapper task the caller never sees, so
+    // config is the only way to name one. Without it every owned workflow shares
+    // the type name "Own[Workflow]" and progress UIs cannot tell them apart.
+    class NamingTask extends Task {
+      public static override readonly type = "NamingTask";
+      public static override readonly title = "Naming";
+
+      override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+        context.own(new Workflow(), { title: "First pass" });
+        context.own(new Workflow(), { title: "Second pass" });
+        context.own(new TaskGraph(), { title: "A graph" });
+        context.own(new Workflow());
+        return {};
+      }
+    }
+
+    it("titles owned graphs and workflows, keeping the wrapper type intact", async () => {
+      const task = new NamingTask();
+      await task.run();
+
+      const owned = task.subGraph.getTasks();
+      expect(owned.map((t) => t.title)).toEqual([
+        "First pass",
+        "Second pass",
+        "A graph",
+        // No title passed — falls back to the wrapper class's static title.
+        "Workflow",
+      ]);
+      // `type` stays the wrapper identity; only the display title varies.
+      expect(owned.map((t) => t.type)).toEqual([
+        "Own[Workflow]",
+        "Own[Workflow]",
+        "Own[Graph]",
+        "Own[Workflow]",
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

This change improves the CLI task display by showing task instance titles (when configured) instead of always showing the class type name. This allows users to distinguish between multiple instances of the same task class (e.g., two "DownloadTask" instances downloading different files).

## Key Changes

- **New `cliTaskLabel()` function** in `taskGraphCliSubscriptions.ts` that returns a task's instance title if set, falling back to the class type name, or "Unknown" as a last resort
- **Updated `CliTaskLine` interface** to include a `label` field (display name) separate from `type` (class identity)
- **Refactored task listener registration** to use `taskLabel` instead of `taskType` for user-facing messages (e.g., completion logs)
- **Updated all task row components** (`ChatTaskRow`, `DefaultTaskRow`, `StreamingTextRow`, `SubtaskRows`, `TaskStatusLine`, `TaskStatusProgressRow`) to use the new `label` prop instead of `type`
- **Enhanced `IExecuteContext.own()` signature** to accept an optional `TaskConfig` parameter, allowing callers to configure owned tasks/graphs/workflows (particularly useful for naming anonymous owned workflows)
- **Added comprehensive test coverage** for `cliTaskLabel()` behavior with 5 test cases covering title preference, fallback logic, and edge cases

## Implementation Details

- The `label` field is computed once when tasks are registered and stored in `CliTaskLine` for efficient rendering
- Empty string titles are treated as unset (same as undefined), matching the Task base class convention
- The change is backward compatible—all existing code paths continue to work, with improved UX for configured task titles
- Test file added at `examples/cli/src/test/cliTaskLabel.test.ts` with full coverage of the labeling logic

https://claude.ai/code/session_01D9HvGjLQ2SGHo1nYxSUrUa