### PR TITLE
Fix listener cleanup and ownership tracking for task reuse

### DIFF
--- a/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
+++ b/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
@@ -8,13 +8,12 @@ import type { ITask, TaskOutput } from "@workglow/task-graph";
 import { Task, TaskGraph } from "@workglow/task-graph";
 import { EventEmitter } from "@workglow/util";
 import { describe, expect, it } from "vitest";
+import type { CliTaskLine, IterationSlotRow } from "../ui/taskGraphCliSubscriptions";
 import {
   FULL_SLOT_TRACKING_MAX,
   MAX_RUNNING_ROWS,
   registerIterationListeners,
   subscribeTaskGraphForCli,
-  type CliTaskLine,
-  type IterationSlotRow,
 } from "../ui/taskGraphCliSubscriptions";
 
 // Minimal task stub: registerIterationListeners only touches `task.events`.
@@ -22,14 +21,12 @@ function makeTask(): { events: EventEmitter<Record<string, (...args: never[]) =>
   return { events: new EventEmitter() };
 }
 
-// Drives the React-style setState updater against a local Map so we can assert
-// the retained slot state after emitting iterator events.
-function makeSink() {
-  let state = new Map<string, IterationSlotRow[]>();
-  const setter = (
-    updater: (prev: Map<string, IterationSlotRow[]>) => Map<string, IterationSlotRow[]>
-  ) => {
-    state = updater(state);
+// Drives a React-style setState — value or updater, as the real Dispatch accepts
+// — against a local Map so we can assert the retained state after emitting events.
+function makeSink<V>() {
+  let state = new Map<string, V>();
+  const setter = (updater: Map<string, V> | ((prev: Map<string, V>) => Map<string, V>)) => {
+    state = typeof updater === "function" ? updater(state) : updater;
   };
   return { setter, get: () => state };
 }
@@ -37,7 +34,7 @@ function makeSink() {
 describe("registerIterationListeners", () => {
   it("keeps full completed/running/pending slots for small loops", () => {
     const task = makeTask();
-    const sink = makeSink();
+    const sink = makeSink<IterationSlotRow[]>();
     registerIterationListeners(task as unknown as ITask, "t1", sink.setter as never);
 
     const N = 5;
@@ -56,7 +53,7 @@ describe("registerIterationListeners", () => {
 
   it("tracks only running iterations (bounded) for huge loops", () => {
     const task = makeTask();
-    const sink = makeSink();
+    const sink = makeSink<IterationSlotRow[]>();
     registerIterationListeners(task as unknown as ITask, "big", sink.setter as never);
 
     const N = FULL_SLOT_TRACKING_MAX * 5000; // way past the full-tracking threshold
@@ -79,7 +76,7 @@ describe("registerIterationListeners", () => {
 
   it("updates progress in place for a running huge-loop iteration", () => {
     const task = makeTask();
-    const sink = makeSink();
+    const sink = makeSink<IterationSlotRow[]>();
     registerIterationListeners(task as unknown as ITask, "big", sink.setter as never);
 
     const N = 1_000_000;
@@ -101,24 +98,13 @@ describe("subscribeTaskGraphForCli", () => {
     }
   }
 
-  function makeInfoSink() {
-    let state = new Map<string, CliTaskLine>();
-    const setter = (
-      updater:
-        Map<string, CliTaskLine> | ((prev: Map<string, CliTaskLine>) => Map<string, CliTaskLine>)
-    ) => {
-      state = typeof updater === "function" ? updater(state) : updater;
-    };
-    return { setter, get: () => state };
-  }
-
   // The point of `disown` is bounding retention, so the UI that follows it must
   // not itself accumulate: an own/run/disown/own cycle over N jobs on one reused
   // task instance would otherwise stack a status+progress pair per cycle.
   it("drops a removed task's listeners so re-owning does not stack them", () => {
     const graph = new TaskGraph();
-    const infos = makeInfoSink();
-    const slots = makeSink();
+    const infos = makeSink<CliTaskLine>();
+    const slots = makeSink<IterationSlotRow[]>();
 
     const unsubscribe = subscribeTaskGraphForCli(
       graph,
@@ -163,8 +149,8 @@ describe("subscribeTaskGraphForCli", () => {
 
   it("clears a removed task's retained iteration slots", () => {
     const graph = new TaskGraph();
-    const infos = makeInfoSink();
-    const slots = makeSink();
+    const infos = makeSink<CliTaskLine>();
+    const slots = makeSink<IterationSlotRow[]>();
 
     const unsubscribe = subscribeTaskGraphForCli(
       graph,
@@ -194,8 +180,8 @@ describe("subscribeTaskGraphForCli", () => {
     const children = [new Noop(), new Noop()];
     for (const c of children) owner.subGraph.addTask(c);
 
-    const infos = makeInfoSink();
-    const slots = makeSink();
+    const infos = makeSink<CliTaskLine>();
+    const slots = makeSink<IterationSlotRow[]>();
     const unsubscribe = subscribeTaskGraphForCli(
       owner.subGraph,
       infos.setter as never,
@@ -219,8 +205,8 @@ describe("subscribeTaskGraphForCli", () => {
 
   it("detaches every task's listeners on unsubscribe", () => {
     const graph = new TaskGraph();
-    const infos = makeInfoSink();
-    const slots = makeSink();
+    const infos = makeSink<CliTaskLine>();
+    const slots = makeSink<IterationSlotRow[]>();
 
     const first = new Noop();
     const second = new Noop();

--- a/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
+++ b/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITask } from "@workglow/task-graph";
+import type { ITask, TaskOutput } from "@workglow/task-graph";
+import { Task, TaskGraph } from "@workglow/task-graph";
 import { EventEmitter } from "@workglow/util";
 import { describe, expect, it } from "vitest";
 import {
   FULL_SLOT_TRACKING_MAX,
   MAX_RUNNING_ROWS,
   registerIterationListeners,
+  subscribeTaskGraphForCli,
+  type CliTaskLine,
   type IterationSlotRow,
 } from "../ui/taskGraphCliSubscriptions";
 
@@ -86,5 +89,118 @@ describe("registerIterationListeners", () => {
     const slots = sink.get().get("big")!;
     expect(slots).toHaveLength(1);
     expect(slots[0]).toMatchObject({ index: 42, status: "running", progress: 70, message: "half" });
+  });
+});
+
+describe("subscribeTaskGraphForCli", () => {
+  class Noop extends Task {
+    public static override readonly type = "CliSubNoopTask";
+    public static override readonly title = "Noop";
+    override async execute(): Promise<TaskOutput> {
+      return {};
+    }
+  }
+
+  function makeInfoSink() {
+    let state = new Map<string, CliTaskLine>();
+    const setter = (
+      updater:
+        Map<string, CliTaskLine> | ((prev: Map<string, CliTaskLine>) => Map<string, CliTaskLine>)
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+    };
+    return { setter, get: () => state };
+  }
+
+  // The point of `disown` is bounding retention, so the UI that follows it must
+  // not itself accumulate: an own/run/disown/own cycle over N jobs on one reused
+  // task instance would otherwise stack a status+progress pair per cycle.
+  it("drops a removed task's listeners so re-owning does not stack them", () => {
+    const graph = new TaskGraph();
+    const infos = makeInfoSink();
+    const slots = makeSink();
+
+    const unsubscribe = subscribeTaskGraphForCli(
+      graph,
+      infos.setter as never,
+      undefined,
+      () => {},
+      slots.setter as never
+    );
+
+    const task = new Noop();
+    const id = String(task.id);
+
+    for (let i = 0; i < 5; i++) {
+      graph.addTask(task);
+      expect(infos.get().has(id)).toBe(true);
+      // Exactly one subscription per event, however many cycles have run.
+      expect(task.events.listenerCount("status")).toBe(1);
+      expect(task.events.listenerCount("progress")).toBe(1);
+      expect(task.events.listenerCount("iteration_start")).toBe(1);
+
+      graph.removeTask(task.id);
+      expect(infos.get().has(id)).toBe(false);
+      expect(task.events.listenerCount("status")).toBe(0);
+      expect(task.events.listenerCount("progress")).toBe(0);
+      expect(task.events.listenerCount("iteration_start")).toBe(0);
+    }
+
+    unsubscribe();
+  });
+
+  it("clears a removed task's retained iteration slots", () => {
+    const graph = new TaskGraph();
+    const infos = makeInfoSink();
+    const slots = makeSink();
+
+    const unsubscribe = subscribeTaskGraphForCli(
+      graph,
+      infos.setter as never,
+      undefined,
+      () => {},
+      slots.setter as never
+    );
+
+    const task = new Noop();
+    const id = String(task.id);
+    graph.addTask(task);
+    task.events.emit("iteration_start", 0 as never, 3 as never);
+    expect(slots.get().has(id)).toBe(true);
+
+    graph.removeTask(task.id);
+    expect(slots.get().has(id)).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("detaches every task's listeners on unsubscribe", () => {
+    const graph = new TaskGraph();
+    const infos = makeInfoSink();
+    const slots = makeSink();
+
+    const first = new Noop();
+    const second = new Noop();
+    graph.addTask(first);
+
+    const unsubscribe = subscribeTaskGraphForCli(
+      graph,
+      infos.setter as never,
+      undefined,
+      () => {},
+      slots.setter as never
+    );
+    // Wired at subscribe time and mid-run alike.
+    graph.addTask(second);
+    expect(first.events.listenerCount("status")).toBe(1);
+    expect(second.events.listenerCount("status")).toBe(1);
+
+    unsubscribe();
+
+    for (const t of [first, second]) {
+      expect(t.events.listenerCount("status")).toBe(0);
+      expect(t.events.listenerCount("progress")).toBe(0);
+      expect(t.events.listenerCount("iteration_start")).toBe(0);
+    }
   });
 });

--- a/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
+++ b/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
@@ -141,10 +141,22 @@ describe("subscribeTaskGraphForCli", () => {
 
       graph.removeTask(task.id);
       expect(infos.get().has(id)).toBe(false);
-      expect(task.events.listenerCount("status")).toBe(0);
-      expect(task.events.listenerCount("progress")).toBe(0);
-      expect(task.events.listenerCount("iteration_start")).toBe(0);
+      for (const ev of [
+        "status",
+        "progress",
+        "iteration_start",
+        "iteration_complete",
+        "iteration_progress",
+      ] as const) {
+        expect(task.events.listenerCount(ev)).toBe(0);
+      }
     }
+
+    // Inert, not merely detached: a late event writes nothing back.
+    task.events.emit("status", "COMPLETED" as never);
+    task.events.emit("iteration_start", 0 as never, 3 as never);
+    expect(infos.get().has(id)).toBe(false);
+    expect(slots.get().has(id)).toBe(false);
 
     unsubscribe();
   });

--- a/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
+++ b/examples/cli/src/test/taskGraphCliSubscriptions.test.ts
@@ -174,6 +174,37 @@ describe("subscribeTaskGraphForCli", () => {
     unsubscribe();
   });
 
+  // `useSubtaskRows` points this same subscription at a task's subGraph, and
+  // that graph is cleared task-by-task by `regenerateGraph()` between runs —
+  // a removal path that never goes through `disown`.
+  it("detaches listeners when a subgraph is cleared by regenerateGraph", () => {
+    const owner = new Noop();
+    const children = [new Noop(), new Noop()];
+    for (const c of children) owner.subGraph.addTask(c);
+
+    const infos = makeInfoSink();
+    const slots = makeSink();
+    const unsubscribe = subscribeTaskGraphForCli(
+      owner.subGraph,
+      infos.setter as never,
+      undefined,
+      () => {},
+      slots.setter as never
+    );
+    expect(infos.get().size).toBe(2);
+
+    owner.regenerateGraph();
+
+    expect(infos.get().size).toBe(0);
+    for (const c of children) {
+      expect(c.events.listenerCount("status")).toBe(0);
+      expect(c.events.listenerCount("progress")).toBe(0);
+      expect(c.events.listenerCount("iteration_start")).toBe(0);
+    }
+
+    unsubscribe();
+  });
+
   it("detaches every task's listeners on unsubscribe", () => {
     const graph = new TaskGraph();
     const infos = makeInfoSink();

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ITask, TaskGraph, TaskIdType } from "@workglow/task-graph";
+import type { ITask, TaskGraph, TaskIdType, TaskStatus } from "@workglow/task-graph";
 import type { Dispatch, SetStateAction } from "react";
 
 export interface CliTaskLine {
@@ -84,7 +84,7 @@ function registerTaskListeners(
   setTaskInfos: Dispatch<SetStateAction<Map<string, CliTaskLine>>>,
   appendCompletedLog?: (text: string) => void
 ): () => void {
-  const onStatus = (status: string): void => {
+  const onStatus = (status: TaskStatus): void => {
     setTaskInfos((prev) => {
       const next = new Map(prev);
       const info = next.get(taskId);

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -76,14 +76,15 @@ export function sortIterationSlotsForDisplay(
   });
 }
 
+/** Returns an unsubscribe: a task released with `disown` must not keep its listeners. */
 function registerTaskListeners(
   task: ITask,
   taskId: string,
   taskLabel: string,
   setTaskInfos: Dispatch<SetStateAction<Map<string, CliTaskLine>>>,
   appendCompletedLog?: (text: string) => void
-): void {
-  task.events.on("status", (status: string) => {
+): () => void {
+  const onStatus = (status: string): void => {
     setTaskInfos((prev) => {
       const next = new Map(prev);
       const info = next.get(taskId);
@@ -95,9 +96,9 @@ function registerTaskListeners(
       }
       return next;
     });
-  });
+  };
 
-  task.events.on("progress", (progress: number | undefined, message?: string) => {
+  const onProgress = (progress: number | undefined, message?: string): void => {
     setTaskInfos((prev) => {
       const next = new Map(prev);
       const info = next.get(taskId);
@@ -106,7 +107,15 @@ function registerTaskListeners(
       }
       return next;
     });
-  });
+  };
+
+  task.events.on("status", onStatus);
+  task.events.on("progress", onProgress);
+
+  return () => {
+    task.events.off("status", onStatus);
+    task.events.off("progress", onProgress);
+  };
 }
 
 /**
@@ -282,13 +291,17 @@ export function subscribeTaskGraphForCli(
   }
   setTaskInfos(initial);
 
-  const wired = new Set<string>();
-  const iterationUnsubs: Array<() => void> = [];
+  // Keyed by task id, holding that task's unsubscribes. The `disown` support
+  // means the same instance can be owned, released, and owned again once per
+  // job; without dropping its listeners on release, re-wiring would stack a new
+  // pair on every cycle and the loop would retain listeners without bound.
+  const wired = new Map<string, Array<() => void>>();
 
   const wire = (task: ITask): void => {
     const taskId = String(task.id);
     if (wired.has(taskId)) return;
-    wired.add(taskId);
+    const unsubs: Array<() => void> = [];
+    wired.set(taskId, unsubs);
     const taskType = (task as { type?: string }).type ?? "Unknown";
     const taskLabel = cliTaskLabel(task);
 
@@ -299,9 +312,9 @@ export function subscribeTaskGraphForCli(
       return next;
     });
 
-    registerTaskListeners(task, taskId, taskLabel, setTaskInfos, appendCompletedLog);
+    unsubs.push(registerTaskListeners(task, taskId, taskLabel, setTaskInfos, appendCompletedLog));
     if (setIterationSlots) {
-      iterationUnsubs.push(registerIterationListeners(task, taskId, setIterationSlots));
+      unsubs.push(registerIterationListeners(task, taskId, setIterationSlots));
     }
   };
 
@@ -315,13 +328,26 @@ export function subscribeTaskGraphForCli(
   };
 
   // A task released with `context.disown` is gone from the graph, so its row is
-  // stale — drop it, and un-wire the id so the same task owned again later
-  // (a reused node re-registered per batch) gets a fresh row rather than being
-  // silently skipped by the `wired` guard.
+  // stale — drop it, detach its listeners, and un-wire the id so the same task
+  // owned again later (a reused node re-registered per batch) gets a fresh row
+  // and a fresh single subscription rather than being silently skipped by the
+  // `wired` guard.
   const onTaskRemoved = (taskId: TaskIdType): void => {
     const id = String(taskId);
-    wired.delete(id);
+    const unsubs = wired.get(id);
+    if (unsubs) {
+      for (const u of unsubs) {
+        u();
+      }
+      wired.delete(id);
+    }
     setTaskInfos((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+    setIterationSlots?.((prev) => {
       if (!prev.has(id)) return prev;
       const next = new Map(prev);
       next.delete(id);
@@ -343,9 +369,12 @@ export function subscribeTaskGraphForCli(
   graph.on("start", onGraphStart);
 
   return () => {
-    for (const u of iterationUnsubs) {
-      u();
+    for (const unsubs of wired.values()) {
+      for (const u of unsubs) {
+        u();
+      }
     }
+    wired.clear();
     graph.off("task_added", onTaskAdded);
     graph.off("task_removed", onTaskRemoved);
     graph.off("graph_progress", onGraphProgress);

--- a/examples/cli/src/ui/taskGraphCliSubscriptions.ts
+++ b/examples/cli/src/ui/taskGraphCliSubscriptions.ts
@@ -84,15 +84,17 @@ function registerTaskListeners(
   setTaskInfos: Dispatch<SetStateAction<Map<string, CliTaskLine>>>,
   appendCompletedLog?: (text: string) => void
 ): () => void {
+  // Each returns `prev` untouched when the row is gone: a task released with
+  // `disown` can still emit as it settles, and a fresh Map for a write that
+  // lands nowhere is a re-render of the whole task list for nothing.
   const onStatus = (status: TaskStatus): void => {
     setTaskInfos((prev) => {
+      const info = prev.get(taskId);
+      if (!info) return prev;
       const next = new Map(prev);
-      const info = next.get(taskId);
-      if (info) {
-        next.set(taskId, { ...info, status });
-        if (status === "COMPLETED" && appendCompletedLog) {
-          appendCompletedLog(`[COMPLETED] ${taskLabel}`);
-        }
+      next.set(taskId, { ...info, status });
+      if (status === "COMPLETED" && appendCompletedLog) {
+        appendCompletedLog(`[COMPLETED] ${taskLabel}`);
       }
       return next;
     });
@@ -100,11 +102,10 @@ function registerTaskListeners(
 
   const onProgress = (progress: number | undefined, message?: string): void => {
     setTaskInfos((prev) => {
+      const info = prev.get(taskId);
+      if (!info) return prev;
       const next = new Map(prev);
-      const info = next.get(taskId);
-      if (info) {
-        next.set(taskId, { ...info, progress, message });
-      }
+      next.set(taskId, { ...info, progress, message });
       return next;
     });
   };

--- a/examples/web/src/graph/TaskNode.tsx
+++ b/examples/web/src/graph/TaskNode.tsx
@@ -112,24 +112,55 @@ export function TaskNode(props: NodeProps<Node<TaskNodeData, string>>) {
     );
 
     if (task.hasChildren()) {
-      const tasks = task.subGraph.getTasks();
-      tasks.forEach((subTask) => {
-        unsubscribes.push(subTask.subscribe("progress", updateConsolidatedProgress));
-        unsubscribes.push(subTask.subscribe("status", updateConsolidatedProgress));
-      });
+      // Keyed by subtask id rather than appended to `unsubscribes`, so a subtask
+      // released with `context.disown` can actually be dropped. An append-only
+      // list would retain every subtask the subgraph ever held — and a reused
+      // instance owned again would stack a second pair of subscriptions, so an
+      // own/disown loop over N jobs would recompute progress N times per event.
+      const subTaskUnsubs = new Map<string, () => void>();
 
-      // Subscribe to subgraph events to handle new tasks
+      const wireSubTask = (subTask: ITask): void => {
+        const id = String(subTask.id);
+        if (subTaskUnsubs.has(id)) return;
+        const unsubs = [
+          subTask.subscribe("progress", updateConsolidatedProgress),
+          subTask.subscribe("status", updateConsolidatedProgress),
+        ];
+        subTaskUnsubs.set(id, () => {
+          for (const u of unsubs) u();
+        });
+      };
+
+      for (const subTask of task.subGraph.getTasks()) {
+        wireSubTask(subTask);
+      }
+
       unsubscribes.push(
-        task.subGraph.subscribe("task_added", () => {
+        task.subGraph.subscribe("task_added", (taskId) => {
           setSubTasks(task.subGraph.getTasks());
-          // Subscribe to new task's progress
-          const newTasks = task.subGraph.getTasks();
-          const lastTask = newTasks[newTasks.length - 1];
-          unsubscribes.push(lastTask.subscribe("progress", updateConsolidatedProgress));
-          unsubscribes.push(lastTask.subscribe("status", updateConsolidatedProgress));
+          // The added task, not whatever sorts last: re-adding a disowned
+          // instance moves it to the tail, so `getTasks()[length - 1]` would
+          // re-subscribe an already-wired task.
+          const added = task.subGraph.getTask(taskId);
+          if (added) wireSubTask(added);
           updateConsolidatedProgress();
         })
       );
+
+      unsubscribes.push(
+        task.subGraph.subscribe("task_removed", (taskId) => {
+          const id = String(taskId);
+          subTaskUnsubs.get(id)?.();
+          subTaskUnsubs.delete(id);
+          setSubTasks(task.subGraph.getTasks());
+          updateConsolidatedProgress();
+        })
+      );
+
+      unsubscribes.push(() => {
+        for (const u of subTaskUnsubs.values()) u();
+        subTaskUnsubs.clear();
+      });
     }
 
     unsubscribes.push(

--- a/examples/web/src/graph/TaskNode.tsx
+++ b/examples/web/src/graph/TaskNode.tsx
@@ -111,57 +111,62 @@ export function TaskNode(props: NodeProps<Node<TaskNodeData, string>>) {
       })
     );
 
-    if (task.hasChildren()) {
-      // Keyed by subtask id rather than appended to `unsubscribes`, so a subtask
-      // released with `context.disown` can actually be dropped. An append-only
-      // list would retain every subtask the subgraph ever held — and a reused
-      // instance owned again would stack a second pair of subscriptions, so an
-      // own/disown loop over N jobs would recompute progress N times per event.
-      const subTaskUnsubs = new Map<string, () => void>();
+    // Wired unconditionally, not behind `hasChildren()`: a task typically owns
+    // its first child partway through `execute()`, long after this effect ran,
+    // and the effect never re-runs because `task.subGraph` is created once and
+    // kept. Gating here would leave dynamically-owned subtasks unsubscribed.
+    //
+    // Keyed by subtask id rather than appended to `unsubscribes`, so a subtask
+    // released with `context.disown` can actually be dropped. An append-only
+    // list would retain every subtask the subgraph ever held — and a reused
+    // instance owned again would stack a second pair of subscriptions, so an
+    // own/disown loop over N jobs would recompute progress N times per event.
+    const subTaskUnsubs = new Map<string, () => void>();
 
-      const wireSubTask = (subTask: ITask): void => {
-        const id = String(subTask.id);
-        if (subTaskUnsubs.has(id)) return;
-        const unsubs = [
-          subTask.subscribe("progress", updateConsolidatedProgress),
-          subTask.subscribe("status", updateConsolidatedProgress),
-        ];
-        subTaskUnsubs.set(id, () => {
-          for (const u of unsubs) u();
-        });
-      };
-
-      for (const subTask of task.subGraph.getTasks()) {
-        wireSubTask(subTask);
-      }
-
-      unsubscribes.push(
-        task.subGraph.subscribe("task_added", (taskId) => {
-          setSubTasks(task.subGraph.getTasks());
-          // The added task, not whatever sorts last: re-adding a disowned
-          // instance moves it to the tail, so `getTasks()[length - 1]` would
-          // re-subscribe an already-wired task.
-          const added = task.subGraph.getTask(taskId);
-          if (added) wireSubTask(added);
-          updateConsolidatedProgress();
-        })
-      );
-
-      unsubscribes.push(
-        task.subGraph.subscribe("task_removed", (taskId) => {
-          const id = String(taskId);
-          subTaskUnsubs.get(id)?.();
-          subTaskUnsubs.delete(id);
-          setSubTasks(task.subGraph.getTasks());
-          updateConsolidatedProgress();
-        })
-      );
-
-      unsubscribes.push(() => {
-        for (const u of subTaskUnsubs.values()) u();
-        subTaskUnsubs.clear();
+    const wireSubTask = (subTask: ITask): void => {
+      const id = String(subTask.id);
+      if (subTaskUnsubs.has(id)) return;
+      const unsubs = [
+        subTask.subscribe("progress", updateConsolidatedProgress),
+        subTask.subscribe("status", updateConsolidatedProgress),
+      ];
+      subTaskUnsubs.set(id, () => {
+        for (const u of unsubs) u();
       });
+    };
+
+    for (const subTask of task.subGraph.getTasks()) {
+      wireSubTask(subTask);
     }
+
+    unsubscribes.push(
+      task.subGraph.subscribe("task_added", (taskId) => {
+        setSubTasks(task.subGraph.getTasks());
+        setIsExpandable(true);
+        // The added task, not whatever sorts last: re-adding a disowned
+        // instance moves it to the tail, so `getTasks()[length - 1]` would
+        // re-subscribe an already-wired task.
+        const added = task.subGraph.getTask(taskId);
+        if (added) wireSubTask(added);
+        updateConsolidatedProgress();
+      })
+    );
+
+    unsubscribes.push(
+      task.subGraph.subscribe("task_removed", (taskId) => {
+        const id = String(taskId);
+        subTaskUnsubs.get(id)?.();
+        subTaskUnsubs.delete(id);
+        setSubTasks(task.subGraph.getTasks());
+        setIsExpandable(task.hasChildren());
+        updateConsolidatedProgress();
+      })
+    );
+
+    unsubscribes.push(() => {
+      for (const u of subTaskUnsubs.values()) u();
+      subTaskUnsubs.clear();
+    });
 
     unsubscribes.push(
       task.subscribe("regenerate", () => {

--- a/packages/task-graph/src/task-graph/Conversions.ts
+++ b/packages/task-graph/src/task-graph/Conversions.ts
@@ -128,8 +128,11 @@ export function ensureTask<I extends DataPorts, O extends DataPorts>(
   if (arg instanceof Task) {
     return arg;
   }
+  // `isOwned` is a wrapper-construction flag, not task config: every branch
+  // below has to keep it out of the config it forwards, or `Task`'s config
+  // validation rejects the unknown property.
+  const { isOwned, ...cleanConfig } = config;
   if (arg instanceof TaskGraph) {
-    const { isOwned, ...cleanConfig } = config;
     return graphWrapperFactory()({
       subGraph: arg,
       isOwned: Boolean(isOwned),
@@ -138,7 +141,6 @@ export function ensureTask<I extends DataPorts, O extends DataPorts>(
     });
   }
   if (isWorkflowLike(arg)) {
-    const { isOwned, ...cleanConfig } = config;
     return graphWrapperFactory()({
       subGraph: arg.graph,
       isOwned: Boolean(isOwned),
@@ -146,5 +148,5 @@ export function ensureTask<I extends DataPorts, O extends DataPorts>(
       config: cleanConfig,
     });
   }
-  return convertPipeFunctionToTask(arg as PipeFunction<I, O>, config);
+  return convertPipeFunctionToTask(arg as PipeFunction<I, O>, cleanConfig);
 }

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -45,6 +45,15 @@ function hasRunConfig(i: unknown): i is { runConfig: Partial<IRunConfig> } {
 }
 
 /**
+ * Whether `own` can record a value's wrapper against it. Everything `Taskish`
+ * admits is WeakMap-keyable — a pipe function included, which `typeof === "object"`
+ * alone would exclude, leaving its wrapper unnameable and so undisownable.
+ */
+function isOwnTrackable(i: unknown): i is object {
+  return i !== null && (typeof i === "object" || typeof i === "function");
+}
+
+/**
  * Responsible for running tasks
  * Manages the execution lifecycle of individual tasks
  */
@@ -532,17 +541,25 @@ export class TaskRunner<
 
   /**
    * Whether the wrapper {@link own} recorded for a value is still in the
-   * subgraph. A `regenerateGraph()` between runs empties the subgraph without
-   * touching {@link ownedWrappers}, so a recorded wrapper is not proof of
-   * current ownership — re-owning the same long-lived workflow on a re-run is
-   * legitimate, and only a wrapper still present is a genuine double-`own`.
+   * subgraph. Clearing the subgraph — a graph run's `resetGraph`, or an explicit
+   * `regenerateGraph()` — does not touch {@link ownedWrappers}, so a recorded
+   * wrapper is not proof of current ownership, and only one still present is a
+   * genuine double-`own`.
+   *
+   * Note this makes a *reset* the thing that licenses re-owning, not a re-run:
+   * a bare second `task.run()` leaves the subgraph populated, so re-owning the
+   * same value there is rejected — exactly as owning a plain `ITask` twice
+   * already was, by the duplicate subgraph id.
    */
   private isStillOwned(wrapper: ITask): boolean {
-    return this.task.hasChildren() && this.task.subGraph.getTask(wrapper.id) !== undefined;
+    // A map lookup, where `hasChildren()` would materialize the whole child
+    // array on every own/disown. Reading the subgraph cannot create a stray one
+    // here: a recorded wrapper means `own` already built it.
+    return this.task.subGraph.getTask(wrapper.id) !== undefined;
   }
 
   protected own<T extends Taskish<any, any>>(i: T, config: TaskConfig = {}): T {
-    const trackable = i !== null && typeof i === "object";
+    const trackable = isOwnTrackable(i);
     if (trackable) {
       // `ensureTask` returns a plain ITask as-is, so owning one twice throws on
       // the duplicate subgraph id. A graph or workflow is adapted into a *fresh*
@@ -605,7 +622,7 @@ export class TaskRunner<
    * is harmless.
    */
   protected disown<T extends Taskish<any, any>>(i: T): void {
-    if (i === null || typeof i !== "object") return;
+    if (!isOwnTrackable(i)) return;
     const wrapper = this.ownedWrappers.get(i);
     if (wrapper === undefined) return;
     // Drop the record even when the wrapper is already gone (a subgraph reset

--- a/packages/task-graph/src/task/TaskRunner.ts
+++ b/packages/task-graph/src/task/TaskRunner.ts
@@ -530,10 +530,38 @@ export class TaskRunner<
    */
   private readonly ownedWrappers = new WeakMap<object, ITask>();
 
+  /**
+   * Whether the wrapper {@link own} recorded for a value is still in the
+   * subgraph. A `regenerateGraph()` between runs empties the subgraph without
+   * touching {@link ownedWrappers}, so a recorded wrapper is not proof of
+   * current ownership — re-owning the same long-lived workflow on a re-run is
+   * legitimate, and only a wrapper still present is a genuine double-`own`.
+   */
+  private isStillOwned(wrapper: ITask): boolean {
+    return this.task.hasChildren() && this.task.subGraph.getTask(wrapper.id) !== undefined;
+  }
+
   protected own<T extends Taskish<any, any>>(i: T, config: TaskConfig = {}): T {
+    const trackable = i !== null && typeof i === "object";
+    if (trackable) {
+      // `ensureTask` returns a plain ITask as-is, so owning one twice throws on
+      // the duplicate subgraph id. A graph or workflow is adapted into a *fresh*
+      // wrapper each call, so the second `own` would silently succeed and
+      // overwrite the recorded wrapper — stranding the first in the subgraph
+      // with nothing left that can name it for `disown`. Fail the same way.
+      const previous = this.ownedWrappers.get(i);
+      if (previous !== undefined) {
+        if (this.isStillOwned(previous)) {
+          throw new TaskConfigurationError(
+            `own(): value is already owned by task ${String(this.task.config?.id)} as subgraph task ${String(previous.id)}. Call disown() before owning it again.`
+          );
+        }
+        this.ownedWrappers.delete(i);
+      }
+    }
     const task = ensureTask(i, { ...config, isOwned: true });
     this.task.subGraph.addTask(task);
-    if (i !== null && typeof i === "object") {
+    if (trackable) {
       this.ownedWrappers.set(i, task);
     }
     // Propagate parent registry and abort signal to owned ITask instances so
@@ -579,8 +607,11 @@ export class TaskRunner<
   protected disown<T extends Taskish<any, any>>(i: T): void {
     if (i === null || typeof i !== "object") return;
     const wrapper = this.ownedWrappers.get(i);
-    if (wrapper === undefined || !this.task.hasChildren()) return;
+    if (wrapper === undefined) return;
+    // Drop the record even when the wrapper is already gone (a subgraph reset
+    // between runs), so the value can be owned again.
     this.ownedWrappers.delete(i);
+    if (!this.isStillOwned(wrapper)) return;
     this.task.subGraph.removeTask(wrapper.id);
     if ((this.task.constructor as typeof Task).hasDynamicEntitlements) {
       this.task.emit("entitlementChange", this.task.entitlements());

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -230,6 +230,40 @@ describe("Task own functionality", () => {
       expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Shared"]);
     });
 
+    // A wrapper can leave the subgraph without going through `disown` — a
+    // direct `removeTask`, or the `regenerateGraph()` clear between runs. The
+    // record is then stale, and disowning it must not try to remove an id the
+    // graph no longer has.
+    it("is a no-op when the wrapper was already removed by other means", async () => {
+      class ExternalRemovalTask extends Task {
+        public static override readonly type = "ExternalRemovalTask";
+        public static override readonly title = "External removal";
+
+        public thrown: unknown;
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const a = context.own(new Workflow(), { title: "A" });
+          context.own(new Workflow(), { title: "B" });
+          // Drop A's wrapper directly. B's remains, so the subgraph is still
+          // non-empty and a `hasChildren()`-only guard would wave this through.
+          const wrapperA = this.subGraph.getTasks().find((t) => t.title === "A")!;
+          this.subGraph.removeTask(wrapperA.id);
+          try {
+            context.disown(a);
+          } catch (err) {
+            this.thrown = err;
+          }
+          return {};
+        }
+      }
+
+      const task = new ExternalRemovalTask();
+      await task.run();
+
+      expect(task.thrown).toBeUndefined();
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["B"]);
+    });
+
     it("is a no-op for a value this context never owned", async () => {
       class StrayDisownTask extends Task {
         public static override readonly type = "StrayDisownTask";

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -149,6 +149,87 @@ describe("Task own functionality", () => {
       expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Kept"]);
     });
 
+    // A workflow is adapted into a fresh wrapper on every `own`, so a second
+    // `own` used to overwrite the recorded wrapper and strand the first in the
+    // subgraph with nothing able to name it for `disown`. Owning a plain ITask
+    // twice has always thrown on the duplicate subgraph id; both now do.
+    it("rejects owning the same workflow twice without disowning", async () => {
+      class DoubleOwnTask extends Task {
+        public static override readonly type = "DoubleOwnTask";
+        public static override readonly title = "Double own";
+
+        public ownError: unknown;
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const wf = new Workflow();
+          context.own(wf, { title: "First" });
+          try {
+            context.own(wf, { title: "Second" });
+          } catch (err) {
+            this.ownError = err;
+          }
+          return {};
+        }
+      }
+
+      const task = new DoubleOwnTask();
+      await task.run();
+
+      expect(task.ownError).toBeInstanceOf(Error);
+      expect(String((task.ownError as Error).message)).toContain("already owned");
+      // The first registration is intact — not replaced by an unreachable second.
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["First"]);
+    });
+
+    it("allows re-owning the same workflow after disowning it", async () => {
+      class ReownTask extends Task {
+        public static override readonly type = "ReownTask";
+        public static override readonly title = "Reown";
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const wf = new Workflow();
+          for (let i = 0; i < 3; i++) {
+            context.own(wf, { title: `Pass ${i}` });
+            expect(this.subGraph.getTasks()).toHaveLength(1);
+            context.disown(wf);
+          }
+          return {};
+        }
+      }
+
+      const task = new ReownTask();
+      await task.run();
+      expect(task.subGraph.getTasks()).toHaveLength(0);
+    });
+
+    // `regenerateGraph()` empties the subgraph between runs without touching the
+    // wrapper bookkeeping, so a task that owns a long-lived workflow must not be
+    // told on its second run that the workflow is still owned.
+    it("re-owns a long-lived workflow across runs after the subgraph is reset", async () => {
+      const shared = new Workflow();
+
+      class RerunOwnerTask extends Task {
+        public static override readonly type = "RerunOwnerTask";
+        public static override readonly title = "Rerun owner";
+        public static override cacheable = false;
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          context.own(shared, { title: "Shared" });
+          return {};
+        }
+      }
+
+      const task = new RerunOwnerTask();
+      await task.run();
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Shared"]);
+
+      task.regenerateGraph();
+      expect(task.subGraph.getTasks()).toHaveLength(0);
+
+      await task.run();
+      expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Shared"]);
+    });
+
     it("is a no-op for a value this context never owned", async () => {
       class StrayDisownTask extends Task {
         public static override readonly type = "StrayDisownTask";

--- a/packages/test/src/test/task/OwnTask.test.ts
+++ b/packages/test/src/test/task/OwnTask.test.ts
@@ -202,6 +202,44 @@ describe("Task own functionality", () => {
       expect(task.subGraph.getTasks()).toHaveLength(0);
     });
 
+    // A bare second `run()` does NOT reset the subgraph — only a graph run
+    // (`TaskGraphRunner.resetGraph`) or an explicit `regenerateGraph()` does —
+    // so the first wrapper is still there and the second `own` is a genuine
+    // double-`own`. This is the consistency the rejection buys: before it, a
+    // plain ITask threw `NodeAlreadyExistsError` here while a workflow silently
+    // reached a two-wrapper subgraph, the second of which nothing could name.
+    it("rejects owning across bare re-runs the same way for a task and a workflow", async () => {
+      const sharedTask = new SimpleTask();
+      const sharedWorkflow = new Workflow();
+
+      const makeOwner = (type: string, owned: () => Parameters<IExecuteContext["own"]>[0]) =>
+        class extends Task {
+          public static override readonly type = type;
+          public static override readonly title = "Bare rerun owner";
+          public static override cacheable = false;
+          override async execute(
+            _input: TaskOutput,
+            context: IExecuteContext
+          ): Promise<TaskOutput> {
+            context.own(owned());
+            return {};
+          }
+        };
+
+      for (const [label, Owner] of [
+        ["task", makeOwner("BareRerunOwnsTask", () => sharedTask)],
+        ["workflow", makeOwner("BareRerunOwnsWorkflow", () => sharedWorkflow)],
+      ] as const) {
+        const task = new Owner();
+        await task.run();
+        expect(task.subGraph.getTasks(), label).toHaveLength(1);
+
+        await expect(task.run(), label).rejects.toThrow();
+        // Crucially: still one wrapper, not a silently accumulated second.
+        expect(task.subGraph.getTasks(), label).toHaveLength(1);
+      }
+    });
+
     // `regenerateGraph()` empties the subgraph between runs without touching the
     // wrapper bookkeeping, so a task that owns a long-lived workflow must not be
     // told on its second run that the workflow is still owned.
@@ -281,6 +319,36 @@ describe("Task own functionality", () => {
       const task = new StrayDisownTask();
       await task.run();
       expect(task.subGraph.getTasks().map((t) => t.title)).toEqual(["Kept"]);
+    });
+
+    // `Taskish` admits a pipe function, and `ensureTask` wraps one in a task like
+    // any other — but the wrapper is nameable only if `own` records it, and a
+    // function is not `typeof "object"`.
+    it("owns and disowns a pipe function", async () => {
+      class FnOwnerTask extends Task {
+        public static override readonly type = "FnOwnerTask";
+        public static override readonly title = "Fn owner";
+
+        public counts: number[] = [];
+
+        override async execute(_input: TaskOutput, context: IExecuteContext): Promise<TaskOutput> {
+          const fn = async (input: TaskOutput): Promise<TaskOutput> => input;
+          for (let i = 0; i < 3; i++) {
+            context.own(fn as never, { title: `Pass ${i}` });
+            this.counts.push(this.subGraph.getTasks().length);
+            context.disown(fn as never);
+            this.counts.push(this.subGraph.getTasks().length);
+          }
+          return {};
+        }
+      }
+
+      const task = new FnOwnerTask();
+      await task.run();
+
+      // Never accumulates: one wrapper while owned, none once disowned.
+      expect(task.counts).toEqual([1, 0, 1, 0, 1, 0]);
+      expect(task.subGraph.getTasks()).toHaveLength(0);
     });
   });
 

--- a/packages/test/src/test/util/dataUri.test.ts
+++ b/packages/test/src/test/util/dataUri.test.ts
@@ -53,6 +53,28 @@ describe("dataUriToBlob", () => {
     expect(await dataUriToBlob("data:text/plain,50%zz off")!.text()).toBe("50%zz off");
   });
 
+  // The body is percent-decoded before it is base64-decoded, so a base64 URI
+  // that round-tripped through `encodeURIComponent` (or a URL query) still
+  // decodes — `atob` on the raw `%3D` would throw and lose the payload.
+  test("percent-decodes a base64 payload before decoding it", async () => {
+    expect(await dataUriToBlob("data:text/plain;base64,SGVsbG8%3D")!.text()).toBe("Hello");
+    expect(await dataUriToBlob("data:text/plain;base64,PDw%2FPz8%2BPg%3D%3D")!.text()).toBe(
+      "<<???>>"
+    );
+  });
+
+  // The data-URL processor allows spaces between the `;` and `base64`; missing
+  // that spelling would hand back the base64 *text* as the blob's bytes.
+  test("recognizes base64 with spaces before the token", async () => {
+    const blob = dataUriToBlob("data:image/png; base64,SGVsbG8=");
+    expect(blob!.type).toBe("image/png");
+    expect(await blob!.text()).toBe("Hello");
+  });
+
+  test("trims whitespace around the header", () => {
+    expect(dataUriToBlob("data: text/plain ,hi")!.type).toBe("text/plain");
+  });
+
   test("defaults the mime type when the header omits one", async () => {
     const blob = dataUriToBlob("data:,plain");
     expect(blob!.type).toBe("text/plain");

--- a/packages/test/src/test/util/dataUri.test.ts
+++ b/packages/test/src/test/util/dataUri.test.ts
@@ -28,6 +28,31 @@ describe("dataUriToBlob", () => {
     expect(await blob!.text()).toBe("hello world");
   });
 
+  // A non-base64 payload is percent-encoded *bytes*, not text, so it must not be
+  // UTF-8 validated on the way through — 0x89 opens every PNG and is not legal
+  // UTF-8 on its own. `fetch()` decodes this URI; so must we.
+  test("decodes a percent-encoded binary (non-UTF-8) payload", async () => {
+    const blob = dataUriToBlob("data:image/png,%89PNG%0D%0A%1A%0A%FF%FE");
+    expect(blob).toBeDefined();
+    expect(blob!.type).toBe("image/png");
+
+    const bytes = new Uint8Array(await blob!.arrayBuffer());
+    expect(Array.from(bytes)).toEqual([137, 80, 78, 71, 13, 10, 26, 10, 255, 254]);
+  });
+
+  test("decodes percent-encoded multi-byte UTF-8 and literal non-ASCII alike", async () => {
+    expect(await dataUriToBlob("data:text/plain,%E2%9C%93%20caf%C3%A9")!.text()).toBe("✓ café");
+    // Unescaped characters are UTF-8 encoded, per the data-URL processor.
+    expect(await dataUriToBlob("data:text/plain,café")!.text()).toBe("café");
+  });
+
+  // WHATWG percent-decode (and therefore `fetch()`) emits a `%` that is not
+  // followed by two hex digits literally rather than failing.
+  test("passes through a lone percent sign instead of failing", async () => {
+    expect(await dataUriToBlob("data:text/plain,100%")!.text()).toBe("100%");
+    expect(await dataUriToBlob("data:text/plain,50%zz off")!.text()).toBe("50%zz off");
+  });
+
   test("defaults the mime type when the header omits one", async () => {
     const blob = dataUriToBlob("data:,plain");
     expect(blob!.type).toBe("text/plain");

--- a/packages/util/src/media/dataUri.ts
+++ b/packages/util/src/media/dataUri.ts
@@ -21,24 +21,51 @@ export function dataUriToBlob(dataUri: string): Blob | undefined {
   const comma = dataUri.indexOf(",");
   if (comma < 0) return undefined;
 
-  const header = dataUri.slice("data:".length, comma);
+  // The data-URL processor strips whitespace around the media type and allows
+  // spaces between the `;` and `base64`, so `data:image/png; base64,…` is a
+  // base64 URI. Missing that spelling decodes the base64 *text* as the payload.
+  const header = dataUri.slice("data:".length, comma).trim();
   const payload = dataUri.slice(comma + 1);
-  const isBase64 = /;base64$/i.test(header);
-  const mime = header.replace(/;base64$/i, "").split(";")[0] || "text/plain";
+  const isBase64 = BASE64_SUFFIX.test(header);
+  const mime = (header.replace(BASE64_SUFFIX, "").split(";")[0] ?? "").trim() || "text/plain";
 
   try {
-    const bytes = isBase64 ? base64ToBytes(payload) : percentDecodeToBytes(payload);
-    return new Blob([bytes.buffer as ArrayBuffer], { type: mime });
+    // The body is percent-decoded first and base64-decoded second, so a base64
+    // payload that was itself percent-encoded (`%2B` for `+`, `%3D` for `=` —
+    // what happens when a data URI round-trips through `encodeURIComponent` or
+    // a URL query) decodes exactly as `fetch()` decodes it. Only pay for the
+    // extra pass when there is an escape to decode.
+    const decoded = payload.includes("%") ? percentDecodeToBytes(payload) : undefined;
+    const bytes = isBase64
+      ? base64ToBytes(decoded === undefined ? payload : isomorphicDecode(decoded))
+      : (decoded ?? TEXT_ENCODER.encode(payload));
+    return new Blob([bytes], { type: mime });
   } catch {
     return undefined;
   }
 }
 
-function base64ToBytes(base64: string): Uint8Array {
+/** `;` + zero or more spaces + `base64`, anchored to the end of the header. */
+const BASE64_SUFFIX = /; *base64$/i;
+
+const TEXT_ENCODER = new TextEncoder();
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
+}
+
+/** Bytes → the string of the same code points, which is what `atob` consumes. */
+function isomorphicDecode(bytes: Uint8Array): string {
+  // Chunked: spreading a multi-megabyte payload into one call overflows the stack.
+  const CHUNK = 0x8000;
+  let out = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    out += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return out;
 }
 
 /** ASCII hex digit → value, or -1. */
@@ -63,8 +90,8 @@ function hexValue(byte: number | undefined): number {
  * WHATWG percent-decode (and therefore `fetch()`) rather than throwing.
  * Unescaped characters are UTF-8 encoded, as the data-URL processor specifies.
  */
-function percentDecodeToBytes(payload: string): Uint8Array {
-  const input = new TextEncoder().encode(payload);
+function percentDecodeToBytes(payload: string): Uint8Array<ArrayBuffer> {
+  const input = TEXT_ENCODER.encode(payload);
   const out = new Uint8Array(input.length);
   let length = 0;
   for (let i = 0; i < input.length; i++) {
@@ -82,7 +109,7 @@ function percentDecodeToBytes(payload: string): Uint8Array {
     out[length++] = (high << 4) | low;
     i += 2;
   }
-  // Exact-size copy: the caller hands `.buffer` to Blob, which would otherwise
-  // include the slack left by collapsed escape sequences.
-  return out.slice(0, length);
+  // A view, not a copy: `Blob` copies what it is handed, so the slack left by
+  // collapsed escape sequences is dropped without a second pass over the bytes.
+  return out.subarray(0, length);
 }

--- a/packages/util/src/media/dataUri.ts
+++ b/packages/util/src/media/dataUri.ts
@@ -27,9 +27,7 @@ export function dataUriToBlob(dataUri: string): Blob | undefined {
   const mime = header.replace(/;base64$/i, "").split(";")[0] || "text/plain";
 
   try {
-    const bytes = isBase64
-      ? base64ToBytes(payload)
-      : new TextEncoder().encode(decodeURIComponent(payload));
+    const bytes = isBase64 ? base64ToBytes(payload) : percentDecodeToBytes(payload);
     return new Blob([bytes.buffer as ArrayBuffer], { type: mime });
   } catch {
     return undefined;
@@ -41,4 +39,50 @@ function base64ToBytes(base64: string): Uint8Array {
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
+}
+
+/** ASCII hex digit → value, or -1. */
+function hexValue(byte: number | undefined): number {
+  if (byte === undefined) return -1;
+  if (byte >= 0x30 && byte <= 0x39) return byte - 0x30; // 0-9
+  if (byte >= 0x41 && byte <= 0x46) return byte - 0x37; // A-F
+  if (byte >= 0x61 && byte <= 0x66) return byte - 0x57; // a-f
+  return -1;
+}
+
+/**
+ * Percent-decodes the payload to raw bytes, byte-by-byte.
+ *
+ * Deliberately not `decodeURIComponent`: that decodes to a *string*, so it
+ * UTF-8-validates the escaped bytes and throws `URIError` on any sequence that
+ * is not valid UTF-8. Non-base64 data URIs are allowed to carry arbitrary
+ * binary — `data:image/png,%89PNG%0D%0A...` is legal and `fetch()` decodes it
+ * fine — so validating as text would reject well-formed input.
+ *
+ * A `%` not followed by two hex digits is emitted literally, matching the
+ * WHATWG percent-decode (and therefore `fetch()`) rather than throwing.
+ * Unescaped characters are UTF-8 encoded, as the data-URL processor specifies.
+ */
+function percentDecodeToBytes(payload: string): Uint8Array {
+  const input = new TextEncoder().encode(payload);
+  const out = new Uint8Array(input.length);
+  let length = 0;
+  for (let i = 0; i < input.length; i++) {
+    const byte = input[i]!;
+    if (byte !== 0x25 /* % */) {
+      out[length++] = byte;
+      continue;
+    }
+    const high = hexValue(input[i + 1]);
+    const low = hexValue(input[i + 2]);
+    if (high < 0 || low < 0) {
+      out[length++] = byte;
+      continue;
+    }
+    out[length++] = (high << 4) | low;
+    i += 2;
+  }
+  // Exact-size copy: the caller hands `.buffer` to Blob, which would otherwise
+  // include the slack left by collapsed escape sequences.
+  return out.slice(0, length);
 }


### PR DESCRIPTION
## Summary

This PR fixes memory leaks and correctness issues in task lifecycle management, particularly when tasks are reused across multiple runs or ownership cycles. It addresses three main areas: CLI subscription listener cleanup, task ownership validation, and percent-decoding of data URIs.

## Key Changes

### CLI Subscription Listener Management
- Modified `registerTaskListeners()` to return an unsubscribe function instead of being a void operation
- Changed `wired` tracking from a `Set<string>` to a `Map<string, Array<() => void>>` to store unsubscribe functions per task
- Updated `onTaskRemoved()` to call all stored unsubscribe functions when a task is removed, preventing listener accumulation on task reuse
- Extended `onTaskRemoved()` to also clear iteration slots for removed tasks
- Updated the main unsubscribe function to properly clean up all listeners across all wired tasks

**Why**: When a task is owned, run, and then disowned (via `context.disown()`), the same task instance can be re-owned later. Without dropping listeners on disown, re-wiring would stack new listener pairs on every cycle, causing unbounded memory growth and duplicate event handling.

### Task Ownership Validation
- Added `isStillOwned()` helper to distinguish between a wrapper recorded in `ownedWrappers` and one still present in the subgraph
- Modified `own()` to detect and reject double-ownership of the same workflow/graph without an intervening `disown()`, throwing a `TaskConfigurationError`
- Updated `disown()` to always delete the wrapper record (even if already removed from subgraph) so values can be re-owned after `regenerateGraph()`

**Why**: A workflow or graph is adapted into a fresh wrapper on each `own()` call. Without validation, a second `own()` would silently overwrite the recorded wrapper, stranding the first wrapper in the subgraph with no way to name it for `disown()`. The `regenerateGraph()` method empties the subgraph between runs without touching wrapper bookkeeping, so re-owning a long-lived workflow on a re-run must be allowed.

### Data URI Percent-Decoding
- Replaced `decodeURIComponent()` with a custom `percentDecodeToBytes()` function in `dataUriToBlob()`
- Implemented `hexValue()` helper to parse ASCII hex digits
- The new decoder handles arbitrary binary data (non-UTF-8) without validation, matching `fetch()` behavior
- Handles malformed escapes (lone `%` not followed by two hex digits) by emitting them literally per WHATWG spec

**Why**: `decodeURIComponent()` decodes to a string and UTF-8-validates the escaped bytes, rejecting well-formed binary data URIs like PNG images. Non-base64 data URIs can carry arbitrary binary, and `fetch()` decodes them without validation. The custom decoder preserves this behavior.

## Tests Added

- `subscribeTaskGraphForCli` test suite with three cases:
  - Verifies listeners are dropped on task removal and not stacked on re-ownership
  - Confirms iteration slots are cleared when tasks are removed
  - Ensures all listeners are detached on unsubscribe
- `OwnTask.test.ts` additions:
  - Rejects owning the same workflow twice without disowning
  - Allows re-owning after disowning
  - Supports re-owning long-lived workflows across runs after subgraph reset
- `dataUri.test.ts` additions:
  - Decodes percent-encoded binary (non-UTF-8) payloads
  - Handles mixed percent-encoded UTF-8 and literal non-ASCII
  - Passes through malformed escapes instead of failing

https://claude.ai/code/session_015wmS9yPfrhm563BAGSPiWZ