### PR TITLE
fix(build): declare the meta-package's runtime dependency on its deps' JS

### DIFF
--- a/packages/workglow/turbo.json
+++ b/packages/workglow/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build-js": {
+      "dependsOn": ["^build-js", "^build-types"]
+    }
+  }
+}


### PR DESCRIPTION
One new file, `packages/workglow/turbo.json`.

## The bug

`turbo.json` declares:

```json
"build-js": { "dependsOn": ["^build-types"] }
```

For every ordinary package that is **correct**. `bun build --packages=external` marks `@workglow/*` external and never resolves them, so a dependency's JS genuinely is not needed — only its types.

`packages/workglow` is the sole exception. Its `build-js` is `bun run build.ts`, which calls `assertNoExportCollisions` → `detect-export-collisions.ts:importSource()`, and that **dynamically imports each barrel's dependencies** — it executes their built JS. So it has a runtime dependency on `^build-js` while declaring only `^build-types`, and nothing stops the bundle step from starting before any dependency has emitted `dist/*.js`.

Note `build-example` in the same file already gets this right: `["build-js", "build-types", "^build-js", "^build-types"]`.

## Evidence

Structural, from `turbo run build-js --dry=json` — no need to win or lose a race:

| | `workglow#build-js` declared dependencies |
|---|---|
| before | **25** — every one a `build-types`, not a single `build-js` |
| after | **50** — the same 25 plus each dependency's `build-js` |

## What it looks like when it bites

A cold tree (fresh clone, new worktree, CI cache miss) under enough load that a dependency's bundle has not finished:

```
error: Cannot resolve "export * from \"@workglow/ai\"" in packages/workglow/src/common.ts
    at importSource (packages/workglow/detect-export-collisions.ts:79:15)
```

The message names a *package export*, so it reads like a code or barrel error rather than an ordering one. It also **walks**: each retry gets one dependency further as turbo caches the ones that finished — `@workglow/ai`, then `Cannot find module '@workglow/task-graph' from packages/ai/dist/bun.js`, then `@workglow/mcp/tasks`. That moving target is what makes it expensive to diagnose.

Because it is a race, it is load-dependent: it reproduces on a busy or genuinely cold machine and hides on an idle one with warm caches. That is exactly why the fix is justified from the declared graph above rather than from a reproduction.

## Why scoped to the package

Adding `^build-js` to the **root** `build-js` would be one line, but it serializes JS bundling topologically for all 40+ packages to satisfy a constraint exactly one of them has, losing parallelism repo-wide. A Package Configuration (`extends: ["//"]`) keeps every other package building JS in parallel and makes only the meta-package wait.

This is the first package-level `turbo.json` in the repo.

**Alternative worth considering, not taken here:** split `assertNoExportCollisions` into its own task (say `check-exports`) with `dependsOn: ["^build-js"]`, leaving `build-js` as pure bundling. That is conceptually cleaner — the bundling genuinely has no such dependency, only the *verification* does — but it costs a new script plus a pipeline entry, so it seemed worth raising rather than doing unilaterally.

## Verification

```
$ bun run build
 Tasks:    84 successful, 84 total
```

Caching is unaffected: `dependsOn` participates in task ordering and hashing, not in `inputs`/`outputs`, so no cache entries are invalidated beyond the meta-package's own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwyJuFrJnibKvrrk8Fa4Fn)_